### PR TITLE
feat: add security headers and error handling middleware

### DIFF
--- a/src/wikimind/errors.py
+++ b/src/wikimind/errors.py
@@ -1,0 +1,45 @@
+"""Custom exception hierarchy for WikiMind domain errors.
+
+Each exception carries a machine-readable ``code`` attribute that maps to the
+``error.code`` field in the standard JSON error envelope, making it easy for
+clients to branch on error type without parsing human-readable messages.
+"""
+
+
+class WikiMindError(Exception):
+    """Base exception for all WikiMind domain errors."""
+
+    code: str = "wikimind_error"
+    status_code: int = 500
+
+    def __init__(self, message: str = "An unexpected error occurred") -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class IngestError(WikiMindError):
+    """Raised when source ingestion fails (bad URL, parse failure, etc.)."""
+
+    code: str = "ingest_failed"
+    status_code: int = 400
+
+
+class CompilationError(WikiMindError):
+    """Raised when the LLM compiler cannot produce a wiki article."""
+
+    code: str = "compilation_failed"
+    status_code: int = 500
+
+
+class QueryError(WikiMindError):
+    """Raised when a user query cannot be answered (missing context, bad input)."""
+
+    code: str = "query_failed"
+    status_code: int = 400
+
+
+class ConfigError(WikiMindError):
+    """Raised when application configuration is invalid or missing."""
+
+    code: str = "config_error"
+    status_code: int = 500

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -7,16 +7,20 @@ registers all routers, and configures CORS for Electron and web dev servers.
 from contextlib import asynccontextmanager
 
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from wikimind.api.routes import ingest, jobs, query, wiki, ws
 from wikimind.api.routes import settings as settings_router
 from wikimind.config import get_settings
 from wikimind.database import close_db, init_db
+from wikimind.errors import WikiMindError
 from wikimind.middleware.correlation import CorrelationIdMiddleware
+from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
 from wikimind.middleware.request_logging import RequestLoggingMiddleware
+from wikimind.middleware.security_headers import SecurityHeadersMiddleware
 
 log = structlog.get_logger()
 
@@ -46,8 +50,12 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Middleware is evaluated bottom-to-top: correlation runs first, then
-# request logging, then CORS.
+# ---------------------------------------------------------------------------
+# Middleware stack — evaluated bottom-to-top.
+# Request flow: Correlation → Logging → SecurityHeaders → ErrorHandling → CORS → routes
+# ---------------------------------------------------------------------------
+app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 
@@ -71,6 +79,27 @@ app.include_router(query.router, prefix="/query", tags=["Query"])
 app.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
 app.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
 app.include_router(ws.router, tags=["WebSocket"])
+
+
+# ---------------------------------------------------------------------------
+# Exception handlers — catch domain errors raised inside route handlers
+# ---------------------------------------------------------------------------
+
+
+@app.exception_handler(WikiMindError)
+async def wikimind_error_handler(request: Request, exc: WikiMindError) -> JSONResponse:
+    """Map WikiMindError subclasses to the standard JSON error envelope."""
+    request_id = getattr(request.state, "request_id", "unknown")
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "error": {
+                "code": exc.code,
+                "message": exc.message,
+                "request_id": request_id,
+            }
+        },
+    )
 
 
 @app.get("/health")

--- a/src/wikimind/middleware/__init__.py
+++ b/src/wikimind/middleware/__init__.py
@@ -1,0 +1,10 @@
+"""Middleware stack for the WikiMind gateway.
+
+Provides security headers, error handling, and other cross-cutting
+concerns applied to every HTTP request.
+"""
+
+from wikimind.middleware.error_handling import ErrorHandlingMiddleware
+from wikimind.middleware.security_headers import SecurityHeadersMiddleware
+
+__all__ = ["ErrorHandlingMiddleware", "SecurityHeadersMiddleware"]

--- a/src/wikimind/middleware/error_handling.py
+++ b/src/wikimind/middleware/error_handling.py
@@ -1,0 +1,63 @@
+"""Catch-all error handling middleware for consistent JSON error responses.
+
+Ensures that unhandled exceptions never leak stack traces to callers and
+always produce the standard ``{"error": {"code", "message", "request_id"}}``
+envelope.  WikiMindError subclasses are mapped to appropriate HTTP status
+codes; everything else becomes a generic 500.
+"""
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from wikimind.errors import WikiMindError
+
+log = structlog.get_logger()
+
+
+class ErrorHandlingMiddleware(BaseHTTPMiddleware):
+    """Return a uniform JSON error envelope for any unhandled exception."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Wrap the downstream handler, catching all exceptions."""
+        try:
+            return await call_next(request)
+        except WikiMindError as exc:
+            request_id = _get_request_id(request)
+            log.warning(
+                "domain_error",
+                code=exc.code,
+                message=exc.message,
+                request_id=request_id,
+                path=request.url.path,
+            )
+            return _error_response(exc.status_code, exc.code, exc.message, request_id)
+        except Exception as exc:
+            request_id = _get_request_id(request)
+            log.exception(
+                "unhandled_error",
+                error=str(exc),
+                request_id=request_id,
+                path=request.url.path,
+            )
+            return _error_response(500, "internal_error", "An unexpected error occurred", request_id)
+
+
+def _get_request_id(request: Request) -> str:
+    """Extract the request ID set by correlation middleware, falling back to 'unknown'."""
+    return getattr(request.state, "request_id", "unknown")
+
+
+def _error_response(status_code: int, code: str, message: str, request_id: str) -> JSONResponse:
+    """Build the standard WikiMind error envelope."""
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error": {
+                "code": code,
+                "message": message,
+                "request_id": request_id,
+            }
+        },
+    )

--- a/src/wikimind/middleware/security_headers.py
+++ b/src/wikimind/middleware/security_headers.py
@@ -1,0 +1,34 @@
+"""HTTP security headers applied to every non-WebSocket response.
+
+Adds a baseline set of headers that mitigate common browser-side
+attacks (click-jacking, MIME-sniffing, reflected XSS) without
+requiring per-route opt-in.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_SECURITY_HEADERS: dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "X-XSS-Protection": "1; mode=block",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+}
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Inject browser-security headers into every HTTP response."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Add security headers, skipping WebSocket upgrade requests."""
+        # WebSocket upgrades use a different response path; headers are irrelevant.
+        if request.headers.get("upgrade", "").lower() == "websocket":
+            return await call_next(request)
+
+        response = await call_next(request)
+
+        for name, value in _SECURITY_HEADERS.items():
+            response.headers[name] = value
+
+        return response

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,74 @@
+"""Tests for custom exception hierarchy."""
+
+from wikimind.errors import CompilationError, ConfigError, IngestError, QueryError, WikiMindError
+
+
+class TestWikiMindError:
+    """Tests for the base WikiMindError."""
+
+    def test_default_message(self):
+        exc = WikiMindError()
+        assert exc.message == "An unexpected error occurred"
+
+    def test_custom_message(self):
+        exc = WikiMindError("something broke")
+        assert exc.message == "something broke"
+        assert str(exc) == "something broke"
+
+    def test_default_code(self):
+        assert WikiMindError.code == "wikimind_error"
+
+    def test_default_status_code(self):
+        assert WikiMindError.status_code == 500
+
+
+class TestIngestError:
+    """Tests for IngestError."""
+
+    def test_code(self):
+        assert IngestError.code == "ingest_failed"
+
+    def test_status_code(self):
+        assert IngestError.status_code == 400
+
+    def test_is_wikimind_error(self):
+        assert issubclass(IngestError, WikiMindError)
+
+
+class TestCompilationError:
+    """Tests for CompilationError."""
+
+    def test_code(self):
+        assert CompilationError.code == "compilation_failed"
+
+    def test_status_code(self):
+        assert CompilationError.status_code == 500
+
+    def test_is_wikimind_error(self):
+        assert issubclass(CompilationError, WikiMindError)
+
+
+class TestQueryError:
+    """Tests for QueryError."""
+
+    def test_code(self):
+        assert QueryError.code == "query_failed"
+
+    def test_status_code(self):
+        assert QueryError.status_code == 400
+
+    def test_is_wikimind_error(self):
+        assert issubclass(QueryError, WikiMindError)
+
+
+class TestConfigError:
+    """Tests for ConfigError."""
+
+    def test_code(self):
+        assert ConfigError.code == "config_error"
+
+    def test_status_code(self):
+        assert ConfigError.status_code == 500
+
+    def test_is_wikimind_error(self):
+        assert issubclass(ConfigError, WikiMindError)

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,0 +1,23 @@
+"""Tests for security headers and error handling middleware."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_security_headers_present(client):
+    """Security headers should appear on every HTTP response."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["X-XSS-Protection"] == "1; mode=block"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+
+@pytest.mark.asyncio
+async def test_error_handling_returns_json_on_404(client):
+    """Non-existent routes should still return well-formed responses."""
+    response = await client.get("/nonexistent")
+    assert response.status_code == 404
+    # FastAPI's default 404 is JSON — middleware should not interfere
+    assert response.headers["content-type"].startswith("application/json")


### PR DESCRIPTION
## Summary
- Add `SecurityHeadersMiddleware` that injects `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy` headers on every HTTP response (skips WebSocket upgrades)
- Add `ErrorHandlingMiddleware` that catches unhandled exceptions and returns a consistent `{"error": {"code", "message", "request_id"}}` JSON envelope — no stack traces leak to callers
- Add custom exception hierarchy (`WikiMindError` → `IngestError`, `CompilationError`, `QueryError`, `ConfigError`) with machine-readable codes and appropriate HTTP status mappings

## Changes
- **`src/wikimind/errors.py`** — Custom exception hierarchy with `code` and `status_code` attributes
- **`src/wikimind/middleware/__init__.py`** — Package init re-exporting middleware classes
- **`src/wikimind/middleware/security_headers.py`** — `SecurityHeadersMiddleware` using Starlette `BaseHTTPMiddleware`
- **`src/wikimind/middleware/error_handling.py`** — `ErrorHandlingMiddleware` with structlog logging
- **`src/wikimind/main.py`** — Register middleware (SecurityHeaders → ErrorHandling → CORS → routes) and `WikiMindError` exception handler
- **`tests/unit/test_errors.py`** — 16 tests covering exception hierarchy codes, status codes, and inheritance
- **`tests/unit/test_middleware.py`** — 2 integration tests verifying security headers appear and error handling does not break standard responses

## Test plan
- [x] All 28 tests pass (`make test`)
- [x] `make lint` — ruff clean
- [x] `make format-check` — formatting clean
- [x] `make typecheck` — mypy clean
- [x] `make pyright` — basedpyright clean
- [x] `make docstyle` — pydocstyle clean
- [x] Security headers verified on `/health` response
- [x] Error handling middleware does not interfere with normal 404 responses

Closes #39