### PR TITLE
docs: add 8 Architecture Decision Records

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for WikiMind.
+ADRs document key architecture decisions, explaining *why* choices were made
+so future contributors do not re-debate settled questions.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](adr-001-fastapi-async-sqlite.md) | FastAPI + async SQLite for local-first daemon | Accepted |
+| [ADR-002](adr-002-arq-fakeredis.md) | ARQ + fakeredis for job queue | Accepted |
+| [ADR-003](adr-003-multi-provider-llm-router.md) | Multi-provider LLM router with fallback | Accepted |
+| [ADR-004](adr-004-markdown-files-sqlite-metadata.md) | Plain markdown files + SQLite metadata | Accepted |
+| [ADR-005](adr-005-confidence-tagged-claims.md) | Confidence-tagged claims | Accepted |
+| [ADR-006](adr-006-chunked-compilation.md) | Chunked compilation for large documents | Accepted |
+| [ADR-007](adr-007-structured-json-prompt-contract.md) | Structured JSON prompt contract | Accepted |
+| [ADR-008](adr-008-pydantic-basesettings.md) | Pydantic BaseSettings for configuration | Accepted |
+
+## ADR Format
+
+Each ADR follows a consistent structure:
+
+- **Status** -- Accepted, Superseded, or Deprecated
+- **Context** -- The problem or decision point
+- **Decision** -- What was chosen and why
+- **Alternatives Considered** -- What was evaluated and rejected
+- **Consequences** -- What this enables, constrains, or risks

--- a/docs/adr/adr-001-fastapi-async-sqlite.md
+++ b/docs/adr/adr-001-fastapi-async-sqlite.md
@@ -1,0 +1,70 @@
+# ADR-001: FastAPI + async SQLite for local-first daemon
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind runs as a local daemon on the user's machine, serving a REST + WebSocket
+API on `localhost:7842`. The framework choice directly affects startup time, async
+support, developer productivity, and the ability to run without external services.
+
+The database must store metadata (sources, articles, jobs, cost logs) while article
+content lives as plain markdown files on disk (see ADR-004). The database therefore
+needs to handle structured queries and relationships, not large blobs of text.
+
+A core design principle is **zero-dependency startup**: a new user runs `make dev`
+and has a working system without installing Postgres, Redis, or any other service.
+
+## Decision
+
+We chose **FastAPI** as the web framework and **SQLite** (via aiosqlite + SQLModel)
+as the metadata database.
+
+FastAPI provides native async support, automatic OpenAPI documentation, and Pydantic
+integration for request/response validation. Its dependency injection system via
+`Depends()` keeps route handlers thin and testable. WebSocket support is built in,
+which we use for real-time job progress events.
+
+SQLite is embedded, requires no server process, and stores everything in a single
+file at `~/.wikimind/db/wikimind.db`. This makes backups trivial (copy one file),
+supports the local-first privacy model, and eliminates deployment complexity.
+We use `aiosqlite` for async I/O so database calls do not block the event loop.
+
+## Alternatives Considered
+
+**Django** -- Full-featured but heavyweight for a local daemon. Its ORM is
+synchronous by default, admin interface is unnecessary for a desktop app, and
+startup time is noticeably slower. Django's batteries-included philosophy adds
+dependencies we do not need.
+
+**Flask** -- Lightweight but lacks native async support and requires additional
+libraries (Flask-SocketIO, Flask-SQLAlchemy) to match FastAPI's built-in
+capabilities. No automatic OpenAPI generation.
+
+**PostgreSQL** -- Superior for multi-user server deployments but requires a
+separate process, installation, and configuration. Violates the zero-dependency
+startup principle. Our data volume (metadata for a personal wiki) never exceeds
+what SQLite handles well.
+
+**DuckDB** -- Excellent for analytics workloads but less mature for OLTP-style
+read/write patterns. Limited async driver support at the time of this decision.
+
+## Consequences
+
+**Enables:**
+- Single-binary-like deployment: one `uvicorn` process serves everything
+- Zero external dependencies for development or production
+- Trivial backup and portability (copy `~/.wikimind/` to another machine)
+- Tests use in-memory SQLite with no setup
+
+**Constrains:**
+- SQLite write concurrency is limited to one writer at a time; the ARQ worker
+  and the API server must coordinate via WAL mode
+- If WikiMind ever becomes multi-user, SQLite will need to be replaced with
+  Postgres (but the SQLModel abstraction makes this a manageable migration)
+
+**Risks:**
+- WAL mode contention under heavy parallel compilation jobs; mitigated by
+  limiting `max_jobs=4` in the ARQ worker configuration

--- a/docs/adr/adr-002-arq-fakeredis.md
+++ b/docs/adr/adr-002-arq-fakeredis.md
@@ -1,0 +1,71 @@
+# ADR-002: ARQ + fakeredis for job queue
+
+## Status
+
+Accepted
+
+## Context
+
+Source compilation is the most expensive operation in WikiMind: each source
+requires one or more LLM API calls that can take 5-30 seconds. This work must
+happen asynchronously so the API remains responsive. We need a job queue that
+supports async Python, provides job progress tracking, and integrates with our
+WebSocket event bus to push real-time status updates to the UI.
+
+Consistent with ADR-001, we want zero-dependency startup. A new developer should
+not need to install or run Redis just to work on WikiMind locally.
+
+## Decision
+
+We chose **ARQ** as the async job queue and use **fakeredis** as the default
+broker for local development.
+
+ARQ is a lightweight async-native job queue built on Redis. It supports job
+priorities, timeouts (`job_timeout=300`), result retention (`keep_result=3600`),
+cron scheduling (weekly linter runs), and integrates naturally with our async
+codebase. The worker runs as a separate process via
+`arq wikimind.jobs.worker.WorkerSettings`.
+
+For local development, `get_redis_settings()` returns localhost settings. In CI
+and dev environments, we rely on fakeredis or a local Redis instance. In
+production, a real `REDIS_URL` environment variable points to an actual Redis
+server.
+
+Job functions (`compile_source`, `lint_wiki`) emit WebSocket events at each
+progress stage (10%, 30%, 50%, 80%, 100%) so the UI can show live compilation
+status.
+
+## Alternatives Considered
+
+**Celery** -- The most popular Python task queue, but it is synchronous by design.
+Running async code in Celery requires workarounds (`asgiref.sync_to_async` or
+running a nested event loop). It also pulls in a large dependency tree and
+requires a separate broker (RabbitMQ or Redis). Overweight for a local-first app.
+
+**RQ (Redis Queue)** -- Simpler than Celery but also synchronous. No native
+async support, no built-in cron scheduling, and limited job progress reporting.
+
+**Dramatiq** -- Good middleware system but, like Celery, primarily synchronous.
+The async story requires third-party extensions.
+
+**In-process asyncio.Queue** -- Simplest option but jobs would not survive
+process restarts, and there would be no isolation between the API server and
+worker. A hung LLM call could block the event loop.
+
+## Consequences
+
+**Enables:**
+- Non-blocking compilation: users can ingest multiple sources and watch
+  progress in real time via WebSocket
+- Cron-scheduled linter runs (Monday 2am) without a separate scheduler
+- Clean separation between API process and worker process
+- `max_jobs=4` prevents overwhelming the LLM API with parallel requests
+
+**Constrains:**
+- ARQ requires a Redis-compatible broker; in production, Redis must be available
+- Job state is ephemeral (Redis-based); long-term job history is tracked in the
+  SQLite `job` table instead
+
+**Risks:**
+- fakeredis does not perfectly replicate Redis behavior in edge cases; integration
+  tests should run against real Redis in CI

--- a/docs/adr/adr-003-multi-provider-llm-router.md
+++ b/docs/adr/adr-003-multi-provider-llm-router.md
@@ -1,0 +1,69 @@
+# ADR-003: Multi-provider LLM router with fallback
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind depends heavily on LLM API calls for compilation, Q&A, linting, and
+indexing. No single provider is always the best choice: providers have outages,
+pricing changes, rate limits, and different quality/cost trade-offs. Users also
+have strong preferences -- some want to use only Anthropic, others want local
+models via Ollama for privacy.
+
+We need a unified interface that lets the rest of the codebase call "the LLM"
+without knowing which provider is behind it, while supporting automatic failover,
+cost tracking per call, and budget enforcement.
+
+## Decision
+
+We built an **LLMRouter** class (`src/wikimind/engine/llm_router.py`) that
+provides a single `complete()` method. The router:
+
+1. **Selects a provider** using a priority order: preferred provider (per-request)
+   then default provider (from settings), then any remaining enabled provider.
+2. **Falls back automatically** when a provider fails and `fallback_enabled=True`.
+3. **Tracks cost per call** by computing USD cost from a pricing table
+   (per-model input/output token rates) and writing a `CostLog` entry to SQLite.
+4. **Exposes provider-specific classes** (`AnthropicProvider`, `OpenAIProvider`,
+   `OllamaProvider`) that implement a common `complete(request, model)` interface.
+
+Each `CompletionResponse` includes `provider_used`, `model_used`, `input_tokens`,
+`output_tokens`, `cost_usd`, and `latency_ms` so callers always know what happened.
+
+Supported providers: Anthropic (Claude), OpenAI (GPT-4o), Google (Gemini), and
+Ollama (local models, zero cost).
+
+## Alternatives Considered
+
+**LiteLLM** -- Popular multi-provider proxy that supports 100+ models. However,
+it adds a significant dependency, runs its own proxy process, and we need tighter
+control over cost tracking and fallback logic. LiteLLM also abstracts away token
+counts in ways that make per-call cost logging harder.
+
+**LangChain** -- Provides LLM abstractions but brings a large dependency tree,
+frequent breaking changes, and abstractions that do not align with our simple
+request/response model. We only need completion calls, not chains or agents.
+
+**Direct SDK calls everywhere** -- Simplest approach but scatters provider logic
+across the codebase, makes fallback impossible, and requires duplicating cost
+tracking in every call site.
+
+## Consequences
+
+**Enables:**
+- Users can switch providers via a single config change (`llm.default_provider`)
+- Automatic failover when a provider has an outage
+- Per-call cost tracking in the `costlog` table for budget monitoring
+- Ollama support gives users a fully offline, zero-API-cost option
+- Monthly budget enforcement (`monthly_budget_usd`) prevents runaway costs
+
+**Constrains:**
+- New providers require a new class implementing the `complete()` interface and
+  an entry in the `PRICING` dictionary
+- Pricing must be manually updated when providers change rates
+
+**Risks:**
+- Fallback to a cheaper/weaker model may produce lower-quality compilation;
+  mitigated by letting users disable fallback or pin a specific provider

--- a/docs/adr/adr-004-markdown-files-sqlite-metadata.md
+++ b/docs/adr/adr-004-markdown-files-sqlite-metadata.md
@@ -1,0 +1,84 @@
+# ADR-004: Plain markdown files + SQLite metadata
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind produces wiki articles from ingested sources. We need to decide where
+and how article content is stored. The storage choice affects portability,
+version control friendliness, human readability, backup simplicity, and the
+ability to use external tools (editors, grep, git) on the knowledge base.
+
+The product vision emphasizes: "your knowledge is yours" -- no lock-in, export
+everything as plain text, human-readable, and git-friendly.
+
+## Decision
+
+Article content is stored as **plain markdown files** in the filesystem at
+`~/.wikimind/wiki/{concept}/{slug}.md`. Structured metadata (source records,
+article records, concepts, backlinks, jobs, cost logs) is stored in **SQLite**
+(see ADR-001).
+
+Each `.md` file includes YAML frontmatter with machine-readable metadata
+(title, slug, source URL, source type, compilation timestamp, concepts,
+confidence level). The article body contains summary, key claims, analysis,
+open questions, related links, and sources.
+
+The filesystem layout is:
+```
+~/.wikimind/wiki/
+  index.md
+  {concept}/
+    {slug}.md
+  _meta/
+    backlinks.json
+    concepts.json
+    health.json
+```
+
+SQLite stores the relationships and queryable fields (Article table with slug,
+title, file_path, concept_ids, confidence, linter_score, summary, source_ids).
+The `.md` file is the source of truth for content; the database is the source
+of truth for relationships and search indexes.
+
+## Alternatives Considered
+
+**All-in-database** -- Store article content as TEXT columns in SQLite. Simpler
+architecture but loses human readability, git-friendliness, and the ability to
+edit articles with any text editor. Users could not `grep` their knowledge base
+or diff changes over time.
+
+**Obsidian vault format** -- Use Obsidian's `[[wikilink]]` convention. We
+actually do use `[[backlink]]` syntax in the Related section, but we chose not
+to couple the entire storage format to Obsidian. Our frontmatter schema is
+richer (confidence levels, source attribution) and we need SQLite for query
+performance.
+
+**JSON files** -- Machine-readable but not human-readable. Defeats the purpose
+of a wiki that users can browse with any tool.
+
+**CMS/database-only (Notion-style)** -- Proprietary storage that locks users
+in. Explicitly rejected by the product vision.
+
+## Consequences
+
+**Enables:**
+- Users can browse, edit, and search their wiki with any text editor or CLI tool
+- `git init` in `~/.wikimind/wiki/` gives full version history for free
+- Backup is a directory copy; migration is a file copy
+- Content survives even if WikiMind is uninstalled -- it is just markdown files
+- External tools (Obsidian, VS Code, grep) work out of the box
+
+**Constrains:**
+- Full-text search requires either reading files from disk or maintaining a
+  separate search index (ChromaDB embeddings planned)
+- Renames/moves must update both the file and the database record
+- Two sources of truth (files + database) can drift; the linter detects this
+
+**Risks:**
+- Filesystem operations are not transactional with database writes; a crash
+  mid-save could leave the file written but the database not updated (or vice
+  versa). Mitigated by writing the file first, then committing the database
+  record.

--- a/docs/adr/adr-005-confidence-tagged-claims.md
+++ b/docs/adr/adr-005-confidence-tagged-claims.md
@@ -1,0 +1,74 @@
+# ADR-005: Confidence-tagged claims
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind compiles raw sources into structured wiki articles using LLMs. LLMs
+can hallucinate, editorialize, and blend source material with their own
+inferences. Users of a personal knowledge base need to know whether a claim
+comes directly from the source, was inferred by the LLM, or represents the
+original author's stated opinion.
+
+Without confidence tagging, a wiki full of LLM-compiled articles becomes an
+unreliable mix of facts and inferences with no way to distinguish between them.
+
+## Decision
+
+Every claim extracted during compilation receives a **confidence classification**
+from the `ConfidenceLevel` enum:
+
+- **sourced** -- Claim directly attributable to the source material, optionally
+  with a short verbatim quote (under 15 words)
+- **mixed** -- Combination of source material and LLM inference
+- **inferred** -- LLM synthesis not directly stated in the source
+- **opinion** -- The original author's stated opinion, not a factual claim
+
+The compiler prompt instructs the LLM to classify each claim explicitly. The
+`CompiledClaim` model enforces the schema: `claim`, `confidence`, and optional
+`quote`. Each article also receives an overall confidence level computed from
+the ratio of sourced claims (>=80% sourced = SOURCED overall, >=40% = MIXED,
+otherwise INFERRED).
+
+In the wiki article `.md` file, claims are rendered with their confidence
+inline: `**Claim text** *(sourced)*`. The UI surfaces confidence badges on
+articles and individual claims.
+
+## Alternatives Considered
+
+**No confidence tagging** -- Simpler but makes the wiki unreliable. Users
+cannot distinguish LLM fabrication from source material. This is a
+non-starter for professionals whose "knowledge is their product."
+
+**Binary sourced/unsourced** -- Too coarse. There is a meaningful difference
+between "the LLM inferred this from context" and "the author explicitly stated
+this as their opinion." The four-level scheme captures these distinctions.
+
+**Numeric confidence scores (0.0-1.0)** -- More granular but harder for
+users to interpret and for the LLM to produce consistently. Discrete
+categories are easier to display in the UI and more reliable from the LLM.
+
+**Source-only (no LLM inference)** -- Would produce a summary, not a wiki
+article. The value of WikiMind is synthesis across sources, which requires
+inference. Tagging the inference makes it transparent rather than hidden.
+
+## Consequences
+
+**Enables:**
+- Users can trust sourced claims and scrutinize inferred ones
+- The linter can flag articles with low confidence for review
+- The Q&A agent can weight sourced claims higher in answers
+- Contradiction detection can compare claims at the same confidence level
+- The health dashboard shows confidence distribution across the wiki
+
+**Constrains:**
+- The LLM must be prompted carefully to produce consistent classifications;
+  prompt engineering is critical for reliability
+- The four-level enum may need expansion if new confidence levels emerge
+
+**Risks:**
+- LLMs may misclassify confidence levels, especially at the sourced/inferred
+  boundary. Mitigated by including the optional `quote` field so users can
+  verify sourced claims against the original text.

--- a/docs/adr/adr-006-chunked-compilation.md
+++ b/docs/adr/adr-006-chunked-compilation.md
@@ -1,0 +1,74 @@
+# ADR-006: Chunked compilation for large documents
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind ingests sources of widely varying sizes: a short blog post may be 2K
+tokens, while a research paper or long-form transcript can exceed 100K tokens.
+LLM context windows have practical limits -- even models with 200K token windows
+produce lower-quality output when the input is very long. We also need to control
+cost: a single 100K-token compilation at Claude Sonnet rates costs roughly $0.30
+in input tokens alone.
+
+We need a strategy for handling documents that exceed a reasonable single-call
+threshold while maintaining coherence in the final compiled article.
+
+## Decision
+
+The `Compiler` class splits documents at **80,000 estimated tokens** into chunks
+and compiles each chunk independently, then merges the results.
+
+The chunking strategy (`chunk_text` in `ingest/service.py`) splits on markdown
+headings (`#`, `##`, `###`) to preserve semantic boundaries, with a fallback to
+splitting at 4,000-token intervals. Each `DocumentChunk` retains its heading
+path (e.g., `["Introduction", "Key Claims"]`) for context.
+
+The merge strategy (`_merge_chunk_results`) combines results by:
+- Concatenating all key claims (capped at 20)
+- Unioning concepts and backlink suggestions (capped at 10 each)
+- Deduplicating open questions (capped at 5)
+- Joining article bodies with horizontal rules
+- Using the first chunk's summary as the article summary
+
+A maximum of 10 chunks are compiled per document to bound cost and latency.
+
+## Alternatives Considered
+
+**Map-reduce with a synthesis pass** -- Compile chunks independently, then run
+a final LLM call to synthesize a unified article. Produces more coherent output
+but doubles the LLM cost and adds latency. We plan to add this as an optional
+"deep compile" mode in the future.
+
+**Truncation** -- Simply cut the document at 80K tokens and compile what fits.
+Loses information from the rest of the document, which is unacceptable for
+research papers where key findings often appear in later sections.
+
+**Sliding window with overlap** -- Overlap chunks by 500 tokens to preserve
+context across boundaries. Adds complexity and increases total tokens sent.
+The heading-based splitting already preserves semantic context well enough.
+
+**RAG-only (no full compilation)** -- Embed chunks and retrieve relevant ones
+at query time instead of compiling upfront. Loses the "living wiki" value
+proposition -- users want articles they can read, not just a retrieval system.
+
+## Consequences
+
+**Enables:**
+- Documents of any length can be compiled without hitting context limits
+- Cost is predictable: roughly proportional to document length
+- Heading-aware chunking preserves the document's logical structure
+- The 10-chunk cap prevents runaway costs on extremely large documents
+
+**Constrains:**
+- Merged articles may have some redundancy across chunk boundaries
+- The first chunk's summary may not represent the full document well
+- Cross-chunk references (e.g., "as mentioned in Section 3") are lost
+
+**Risks:**
+- 80K token threshold is a heuristic; some models could handle more. This
+  should be configurable per provider in the future.
+- Heading-based splitting may produce very uneven chunks if the document has
+  few headings. The 4K-token fallback mitigates this.

--- a/docs/adr/adr-007-structured-json-prompt-contract.md
+++ b/docs/adr/adr-007-structured-json-prompt-contract.md
@@ -1,0 +1,87 @@
+# ADR-007: Structured JSON prompt contract
+
+## Status
+
+Accepted
+
+## Context
+
+The WikiMind compiler transforms raw sources into wiki articles via LLM calls.
+The LLM output must be programmatically parsed to extract structured data:
+title, summary, key claims with confidence tags, concepts, backlink suggestions,
+open questions, and the full article body. The output format directly determines
+whether downstream code can reliably process the result.
+
+Free-form markdown output would require fragile regex parsing, would vary between
+LLM providers, and would make it impossible to enforce schema requirements like
+the confidence classification on every claim.
+
+## Decision
+
+All LLM compilation output follows a **strict JSON schema** defined in the system
+prompt (`COMPILER_SYSTEM_PROMPT` in `engine/compiler.py`). The schema matches
+the `CompilationResult` Pydantic model exactly:
+
+```json
+{
+  "title": "string",
+  "summary": "string",
+  "key_claims": [{"claim": "string", "confidence": "sourced|inferred|opinion", "quote": "string|null"}],
+  "concepts": ["string"],
+  "backlink_suggestions": ["string"],
+  "open_questions": ["string"],
+  "article_body": "string (markdown)"
+}
+```
+
+The system prompt explicitly instructs: "You MUST respond with valid JSON only.
+No preamble, no markdown fences." The `response_format="json"` field in
+`CompletionRequest` enables provider-native JSON mode where available (OpenAI's
+`response_format: {type: json_object}`). The router's `parse_json_response`
+method handles edge cases like markdown fences wrapping the JSON.
+
+The response is parsed via `CompilationResult(**data)`, which validates the
+schema using Pydantic. Invalid responses are caught and logged.
+
+## Alternatives Considered
+
+**Free-form markdown with parsing** -- Let the LLM output a markdown article
+and parse structure from headings and conventions. Brittle, provider-dependent,
+and cannot enforce claim-level confidence tags. Would require maintaining
+complex parsing logic that breaks when the LLM varies its output format.
+
+**XML output** -- More verbose than JSON, no native provider support for XML
+mode, and adds parsing complexity without benefit. JSON is the lingua franca
+of structured LLM output.
+
+**Function calling / tool use** -- Anthropic and OpenAI support structured
+output via tool definitions. More reliable than raw JSON prompting but locks
+us into provider-specific APIs, complicating the multi-provider router
+(ADR-003). JSON prompting works across all providers including Ollama.
+
+**Multiple sequential calls** -- First call extracts claims, second generates
+article body, third suggests backlinks. More reliable per-step but multiplies
+cost and latency by 3x. A single call with a clear schema works well enough.
+
+## Consequences
+
+**Enables:**
+- Deterministic parsing: `CompilationResult(**json.loads(response))` always works
+  or fails cleanly
+- Schema validation via Pydantic catches malformed output before it reaches the
+  database
+- Consistent output across providers (Anthropic, OpenAI, Ollama)
+- The confidence classification (ADR-005) is enforced structurally, not by
+  convention
+
+**Constrains:**
+- The `article_body` field contains markdown as a JSON string, which means
+  newlines and quotes must be escaped. This occasionally causes parse failures
+  with less capable models.
+- Schema changes require updating both the prompt and the Pydantic model
+
+**Risks:**
+- Smaller/local models (Ollama) may struggle to produce valid JSON consistently.
+  Mitigated by the `parse_json_response` fallback that strips markdown fences,
+  and by the fallback mechanism in ADR-003 which can retry with a more capable
+  provider.

--- a/docs/adr/adr-008-pydantic-basesettings.md
+++ b/docs/adr/adr-008-pydantic-basesettings.md
@@ -1,0 +1,85 @@
+# ADR-008: Pydantic BaseSettings for configuration
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind needs to manage a variety of configuration: server host/port, data
+directory paths, LLM provider selection and model names, API keys for multiple
+providers, cloud sync settings, and database options. Configuration must support
+environment variables (for CI/CD and containers), `.env` files (for local
+development), and secure handling of API keys that must never appear in logs.
+
+The configuration layer was recently refactored to consolidate scattered settings
+into a single, validated, type-safe configuration object.
+
+## Decision
+
+We use **Pydantic BaseSettings** (`pydantic-settings`) as the configuration
+foundation, with the following design:
+
+1. **Environment-first**: All settings are loaded from environment variables
+   with the `WIKIMIND_` prefix via `SettingsConfigDict(env_prefix="WIKIMIND_")`.
+   A `.env` file is loaded automatically when present.
+
+2. **SecretStr for API keys**: All API key fields (`anthropic_api_key`,
+   `openai_api_key`, `google_api_key`, AWS credentials) use `SecretStr`, which
+   prevents accidental exposure in logs, repr output, or serialization.
+
+3. **Keyring fallback**: The `get_api_key()` function checks settings (env vars)
+   first, then falls back to the OS keychain via the `keyring` library. This
+   lets users store keys securely without `.env` files on their personal machine
+   while still supporting env vars in CI/CD.
+
+4. **Nested configuration**: Related settings are grouped into `BaseModel`
+   subclasses (`LLMConfig`, `SyncConfig`, `DatabaseConfig`, `ServerConfig`)
+   for clarity and validation.
+
+5. **Cached singleton**: `get_settings()` uses `@lru_cache(maxsize=1)` to ensure
+   settings are loaded once and reused across the application.
+
+## Alternatives Considered
+
+**Plain environment variables (os.environ)** -- No validation, no type safety,
+no default values, no nesting, no protection against logging secrets. Requires
+manual parsing everywhere.
+
+**TOML/YAML config file only** -- Works for static configuration but does not
+support environment variable overrides for deployment. Would require a separate
+mechanism for secrets management. We do plan to support a `settings.toml` for
+non-sensitive settings in the future, layered under env vars.
+
+**dynaconf** -- Feature-rich configuration library with multi-source support.
+However, it adds a significant dependency, has its own learning curve, and
+duplicates functionality that Pydantic BaseSettings provides natively. Since
+we already depend on Pydantic for models, BaseSettings is the natural choice.
+
+**python-decouple** -- Lightweight env/ini reader but lacks type validation,
+nested config support, and secret protection. Insufficient for our needs.
+
+**Vault/AWS Secrets Manager** -- Enterprise secrets management. Overkill for
+a local-first application. The keyring fallback provides similar security for
+individual users without requiring cloud infrastructure.
+
+## Consequences
+
+**Enables:**
+- Type-safe configuration with validation errors at startup, not at runtime
+- API keys never appear in logs or error messages thanks to SecretStr
+- Flexible key storage: env vars for CI/CD, keyring for personal machines
+- Derived paths (`wiki_dir`, `raw_dir`, `db_dir`) computed from `data_dir`
+- `ensure_dirs()` called at startup guarantees directory structure exists
+- `get_security_status()` provides a production readiness check
+
+**Constrains:**
+- Adding a new setting requires updating the `Settings` class and
+  documenting the corresponding `WIKIMIND_*` environment variable
+- The `lru_cache` means settings cannot be changed at runtime without
+  clearing the cache (acceptable for a daemon that restarts on config changes)
+
+**Risks:**
+- The keyring library behavior varies across operating systems; some Linux
+  environments may not have a keyring backend configured. Mitigated by
+  always checking env vars first and only falling back to keyring.


### PR DESCRIPTION
## Summary
- Add `docs/adr/` directory with 8 Architecture Decision Records documenting key architectural choices
- Each ADR explains the context, decision, alternatives considered, and consequences
- Includes index README with links to all ADRs

## Changes
- **ADR-001**: FastAPI + async SQLite for local-first daemon
- **ADR-002**: ARQ + fakeredis for job queue
- **ADR-003**: Multi-provider LLM router with fallback
- **ADR-004**: Plain markdown files + SQLite metadata
- **ADR-005**: Confidence-tagged claims
- **ADR-006**: Chunked compilation for large documents
- **ADR-007**: Structured JSON prompt contract
- **ADR-008**: Pydantic BaseSettings for configuration

## Test plan
- [ ] Verify all markdown files render correctly on GitHub
- [ ] Verify internal links in README.md resolve to correct ADR files
- [ ] Confirm no trailing whitespace or missing EOF newlines (pre-commit checks)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)