### PR TITLE
refactor: introduce service layer between routes and business logic

### DIFF
--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -1,52 +1,46 @@
 """Endpoints for ingesting sources (URLs, PDFs, text) into the knowledge base."""
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
-from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
-from wikimind.ingest.service import IngestService
 from wikimind.models import IngestTextRequest, IngestURLRequest, Source
+from wikimind.services.ingest import IngestService, get_ingest_service
 
 router = APIRouter()
-ingest_service = IngestService()
 
 
 @router.post("/url", response_model=Source)
 async def ingest_url(
     request: IngestURLRequest,
     session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
 ):
     """Ingest a web URL or YouTube video."""
-    try:
-        source = await ingest_service.ingest_url(request.url, session)
-        return source
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    return await service.ingest_url(request.url, session)
 
 
 @router.post("/pdf", response_model=Source)
 async def ingest_pdf(
     file: UploadFile = File(...),
     session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
 ):
     """Upload and ingest a PDF."""
     if not file.filename or not file.filename.endswith(".pdf"):
         raise HTTPException(status_code=400, detail="File must be a PDF")
-
     contents = await file.read()
-    source = await ingest_service.ingest_pdf(contents, file.filename, session)
-    return source
+    return await service.ingest_pdf(contents, file.filename, session)
 
 
 @router.post("/text", response_model=Source)
 async def ingest_text(
     request: IngestTextRequest,
     session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
 ):
     """Ingest raw text or a note."""
-    source = await ingest_service.ingest_text(request.content, request.title, session)
-    return source
+    return await service.ingest_text(request.content, request.title, session)
 
 
 @router.get("/sources")
@@ -55,36 +49,27 @@ async def list_sources(
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
 ):
     """List all ingested sources."""
-    query = select(Source).offset(offset).limit(limit)
-    if status:
-        query = query.where(Source.status == status)
-    result = await session.execute(query)
-    return result.scalars().all()
+    return await service.list_sources(session, status=status, limit=limit, offset=offset)
 
 
 @router.get("/sources/{source_id}", response_model=Source)
 async def get_source(
     source_id: str,
     session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
 ):
     """Get source by ID."""
-    source = await session.get(Source, source_id)
-    if not source:
-        raise HTTPException(status_code=404, detail="Source not found")
-    return source
+    return await service.get_source(source_id, session)
 
 
 @router.delete("/sources/{source_id}")
 async def delete_source(
     source_id: str,
     session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
 ):
     """Delete a source by ID."""
-    source = await session.get(Source, source_id)
-    if not source:
-        raise HTTPException(status_code=404, detail="Source not found")
-    await session.delete(source)
-    await session.commit()
-    return {"deleted": source_id}
+    return await service.delete_source(source_id, session)

--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
-from wikimind.jobs.worker import enqueue_compile, enqueue_lint
-from wikimind.models import Job
+from wikimind.services.compiler import CompilerService, get_compiler_service
 
 router = APIRouter()
 
@@ -18,37 +16,42 @@ async def list_jobs(
     status: str | None = None,
     limit: int = 20,
     session: AsyncSession = Depends(get_session),
+    service: CompilerService = Depends(get_compiler_service),
 ):
     """List jobs with optional status filter."""
-    query = select(Job).order_by(Job.queued_at.desc()).limit(limit)  # type: ignore[attr-defined]
-    if status:
-        query = query.where(Job.status == status)
-    result = await session.execute(query)
-    return result.scalars().all()
+    return await service.list_jobs(session, status=status, limit=limit)
 
 
 @router.get("/{job_id}")
-async def get_job(job_id: str, session: AsyncSession = Depends(get_session)):
+async def get_job(
+    job_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: CompilerService = Depends(get_compiler_service),
+):
     """Get job by ID."""
-    job = await session.get(Job, job_id)
-    return job
+    return await service.get_job(job_id, session)
 
 
 @router.post("/compile/{source_id}")
-async def trigger_compile(source_id: str, session: AsyncSession = Depends(get_session)):
+async def trigger_compile(
+    source_id: str,
+    service: CompilerService = Depends(get_compiler_service),
+):
     """Trigger compilation for a source."""
-    job_id = await enqueue_compile(source_id)
-    return {"job_id": job_id, "status": "queued"}
+    return await service.trigger_compile(source_id)
 
 
 @router.post("/lint")
-async def trigger_lint(session: AsyncSession = Depends(get_session)):
+async def trigger_lint(
+    service: CompilerService = Depends(get_compiler_service),
+):
     """Trigger wiki linting."""
-    job_id = await enqueue_lint()
-    return {"job_id": job_id, "status": "queued"}
+    return await service.trigger_lint()
 
 
 @router.post("/reindex")
-async def trigger_reindex(session: AsyncSession = Depends(get_session)):
+async def trigger_reindex(
+    service: CompilerService = Depends(get_compiler_service),
+):
     """Trigger wiki reindexing."""
-    return {"status": "queued", "message": "Reindex job enqueued"}
+    return await service.trigger_reindex()

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -1,60 +1,40 @@
 """Endpoints for asking questions against the wiki and filing answers back."""
 
-import json
-
-from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import select
+from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
-from wikimind.engine.qa_agent import QAAgent
-from wikimind.models import Query, QueryRequest, QueryResult
+from wikimind.models import QueryRequest
+from wikimind.services.query import QueryService, get_query_service
 
 router = APIRouter()
-qa_agent = QAAgent()
 
 
 @router.post("")
 async def ask(
     request: QueryRequest,
     session: AsyncSession = Depends(get_session),
+    service: QueryService = Depends(get_query_service),
 ):
     """Ask a question against the wiki."""
-    query = await qa_agent.answer(request, session)
-    return query
+    return await service.ask(request, session)
 
 
 @router.get("/history")
 async def query_history(
     limit: int = 50,
     session: AsyncSession = Depends(get_session),
+    service: QueryService = Depends(get_query_service),
 ):
     """List past queries."""
-    result = await session.execute(select(Query).order_by(Query.created_at.desc()).limit(limit))  # type: ignore[attr-defined]
-    return result.scalars().all()
+    return await service.query_history(session, limit=limit)
 
 
 @router.post("/{query_id}/file-back")
 async def file_back(
     query_id: str,
     session: AsyncSession = Depends(get_session),
+    service: QueryService = Depends(get_query_service),
 ):
     """Save a past answer as a wiki article."""
-    query = await session.get(Query, query_id)
-    if not query:
-        raise HTTPException(status_code=404, detail="Query not found")
-
-    result = QueryResult(
-        answer=query.answer,
-        confidence=query.confidence or "medium",
-        sources=json.loads(query.source_article_ids or "[]"),
-        related_articles=json.loads(query.related_article_ids or "[]"),
-    )
-
-    article_id = await qa_agent._file_back(query.question, result, session)
-    query.filed_back = True
-    query.filed_article_id = article_id
-    session.add(query)
-    await session.commit()
-
-    return {"filed": True, "article_id": article_id}
+    return await service.file_back(query_id, session)

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -1,33 +1,13 @@
 """Endpoints for browsing wiki articles, knowledge graph, and search."""
 
-import json
-from pathlib import Path
-
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlmodel import select
+from fastapi import APIRouter, Depends, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from wikimind.config import get_settings
 from wikimind.database import get_session
-from wikimind.models import (
-    Article,
-    ArticleResponse,
-    Backlink,
-    Concept,
-    GraphEdge,
-    GraphNode,
-    GraphResponse,
-)
+from wikimind.models import ArticleResponse, GraphResponse
+from wikimind.services.wiki import WikiService, get_wiki_service
 
 router = APIRouter()
-
-
-def _read_article_content(file_path: str) -> str:
-    """Read article markdown content from disk."""
-    try:
-        return Path(file_path).read_text(encoding="utf-8")
-    except Exception:
-        return ""
 
 
 @router.get("/articles")
@@ -37,83 +17,29 @@ async def list_articles(
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
 ):
     """List wiki articles with optional filtering."""
-    query = select(Article).offset(offset).limit(limit)
-    if confidence:
-        query = query.where(Article.confidence == confidence)
-    result = await session.execute(query)
-    articles = result.scalars().all()
-    return articles
+    return await service.list_articles(session, concept=concept, confidence=confidence, limit=limit, offset=offset)
 
 
 @router.get("/articles/{slug}", response_model=ArticleResponse)
 async def get_article(
     slug: str,
     session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
 ):
     """Get full article with content and backlinks."""
-    result = await session.execute(select(Article).where(Article.slug == slug))
-    article = result.scalar_one_or_none()
-    if not article:
-        raise HTTPException(status_code=404, detail="Article not found")
-
-    # Get backlinks
-    bl_in = await session.execute(select(Backlink).where(Backlink.target_article_id == article.id))
-    bl_out = await session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-
-    return ArticleResponse(
-        id=article.id,
-        slug=article.slug,
-        title=article.title,
-        summary=article.summary,
-        confidence=article.confidence,
-        linter_score=article.linter_score,
-        concepts=[],
-        backlinks_in=[b.source_article_id for b in bl_in.scalars().all()],
-        backlinks_out=[b.target_article_id for b in bl_out.scalars().all()],
-        content=_read_article_content(article.file_path),
-        created_at=article.created_at,
-        updated_at=article.updated_at,
-    )
+    return await service.get_article(slug, session)
 
 
 @router.get("/graph", response_model=GraphResponse)
-async def get_graph(session: AsyncSession = Depends(get_session)):
-    """Full knowledge graph — nodes and edges."""
-    articles_result = await session.execute(select(Article))
-    articles = articles_result.scalars().all()
-
-    backlinks_result = await session.execute(select(Backlink))
-    backlinks = backlinks_result.scalars().all()
-
-    # Count connections per article
-    connection_counts: dict[str, int] = {}
-    for bl in backlinks:
-        connection_counts[bl.source_article_id] = connection_counts.get(bl.source_article_id, 0) + 1
-        connection_counts[bl.target_article_id] = connection_counts.get(bl.target_article_id, 0) + 1
-
-    nodes = [
-        GraphNode(
-            id=a.id,
-            label=a.title,
-            concept_cluster=None,
-            connection_count=connection_counts.get(a.id, 0),
-            confidence=a.confidence,
-        )
-        for a in articles
-    ]
-
-    edges = [
-        GraphEdge(
-            source=bl.source_article_id,
-            target=bl.target_article_id,
-            context=bl.context,
-        )
-        for bl in backlinks
-    ]
-
-    return GraphResponse(nodes=nodes, edges=edges)
+async def get_graph(
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+):
+    """Full knowledge graph -- nodes and edges."""
+    return await service.get_graph(session)
 
 
 @router.get("/search")
@@ -121,48 +47,25 @@ async def search(
     q: str = Query(..., min_length=2),
     limit: int = 20,
     session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
 ):
     """Full-text search across wiki articles."""
-    result = await session.execute(select(Article))
-    all_articles = result.scalars().all()
-
-    q_lower = q.lower()
-    matches = []
-    for article in all_articles:
-        content = _read_article_content(article.file_path)
-        if q_lower in article.title.lower() or q_lower in content.lower():
-            # Score: title match = 10, content match = 1 per occurrence
-            score = 10 if q_lower in article.title.lower() else 0
-            score += content.lower().count(q_lower)
-            matches.append({"article": article, "score": score})
-
-    matches.sort(key=lambda x: x["score"], reverse=True)
-    return [m["article"] for m in matches[:limit]]
+    return await service.search(q, session, limit=limit)
 
 
 @router.get("/concepts")
-async def get_concepts(session: AsyncSession = Depends(get_session)):
+async def get_concepts(
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+):
     """Concept taxonomy tree."""
-    result = await session.execute(select(Concept))
-    return result.scalars().all()
+    return await service.get_concepts(session)
 
 
 @router.get("/health")
-async def get_health(session: AsyncSession = Depends(get_session)):
+async def get_health(
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+):
     """Latest wiki health report from linter."""
-    settings = get_settings()
-    health_path = Path(settings.data_dir) / "wiki" / "_meta" / "health.json"
-
-    if health_path.exists():
-        return json.loads(health_path.read_text())
-
-    # No linter run yet
-    articles_result = await session.execute(select(Article))
-    articles = articles_result.scalars().all()
-
-    return {
-        "generated_at": None,
-        "total_articles": len(articles),
-        "total_sources": 0,
-        "message": "Run the linter to generate a health report",
-    }
+    return await service.get_health(session)

--- a/src/wikimind/services/__init__.py
+++ b/src/wikimind/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer providing business logic between API routes and domain engines."""

--- a/src/wikimind/services/compiler.py
+++ b/src/wikimind/services/compiler.py
@@ -1,0 +1,84 @@
+"""Manage compilation jobs and article persistence.
+
+Wraps the compilation engine and job queue, providing a clean interface
+for triggering compilation, linting, and reindexing from API routes.
+"""
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.jobs.worker import enqueue_compile, enqueue_lint
+from wikimind.models import Job
+
+
+class CompilerService:
+    """Coordinate compilation job management and status tracking."""
+
+    async def list_jobs(self, session: AsyncSession, status: str | None = None, limit: int = 20) -> list[Job]:
+        """List jobs with optional status filtering.
+
+        Args:
+            session: Async database session.
+            status: Optional status filter (queued, running, complete, failed).
+            limit: Maximum number of results.
+
+        Returns:
+            List of Job records ordered by queue time descending.
+        """
+        query = select(Job).order_by(Job.queued_at.desc()).limit(limit)  # type: ignore[attr-defined]
+        if status:
+            query = query.where(Job.status == status)
+        result = await session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_job(self, job_id: str, session: AsyncSession) -> Job | None:
+        """Retrieve a single job by ID.
+
+        Args:
+            job_id: The job UUID.
+            session: Async database session.
+
+        Returns:
+            The Job record, or None if not found.
+        """
+        return await session.get(Job, job_id)
+
+    async def trigger_compile(self, source_id: str) -> dict[str, str]:
+        """Enqueue a compilation job for a source.
+
+        Args:
+            source_id: The source UUID to compile.
+
+        Returns:
+            Dict with job_id and status.
+        """
+        job_id = await enqueue_compile(source_id)
+        return {"job_id": job_id, "status": "queued"}
+
+    async def trigger_lint(self) -> dict[str, str]:
+        """Enqueue a wiki linting job.
+
+        Returns:
+            Dict with job_id and status.
+        """
+        job_id = await enqueue_lint()
+        return {"job_id": job_id, "status": "queued"}
+
+    async def trigger_reindex(self) -> dict[str, str]:
+        """Enqueue a wiki reindexing job.
+
+        Returns:
+            Dict with status and message.
+        """
+        return {"status": "queued", "message": "Reindex job enqueued"}
+
+
+_compiler_service: CompilerService | None = None
+
+
+def get_compiler_service() -> CompilerService:
+    """Return a singleton CompilerService instance for FastAPI dependency injection."""
+    global _compiler_service
+    if _compiler_service is None:
+        _compiler_service = CompilerService()
+    return _compiler_service

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -1,0 +1,132 @@
+"""Orchestrate source ingestion across URL, PDF, text, and YouTube adapters.
+
+Routes delegate to this service for all ingest operations. The service
+coordinates adapter selection, source persistence, and compilation enqueue.
+"""
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.ingest.service import IngestService as IngestAdapter
+from wikimind.models import Source
+
+
+class IngestService:
+    """Orchestrate source ingestion and compilation enqueue."""
+
+    def __init__(self) -> None:
+        self._adapter = IngestAdapter()
+
+    async def ingest_url(self, url: str, session: AsyncSession) -> Source:
+        """Ingest a URL (web page or YouTube) and enqueue compilation.
+
+        Args:
+            url: The URL to ingest.
+            session: Async database session.
+
+        Returns:
+            The persisted Source record.
+
+        Raises:
+            HTTPException: If ingestion fails due to invalid input or network error.
+        """
+        try:
+            return await self._adapter.ingest_url(url, session)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+    async def ingest_pdf(self, file_bytes: bytes, filename: str, session: AsyncSession) -> Source:
+        """Ingest a PDF file and enqueue compilation.
+
+        Args:
+            file_bytes: Raw PDF bytes.
+            filename: Original filename.
+            session: Async database session.
+
+        Returns:
+            The persisted Source record.
+        """
+        return await self._adapter.ingest_pdf(file_bytes, filename, session)
+
+    async def ingest_text(self, content: str, title: str | None, session: AsyncSession) -> Source:
+        """Ingest raw text content and enqueue compilation.
+
+        Args:
+            content: The text content to ingest.
+            title: Optional title for the source.
+            session: Async database session.
+
+        Returns:
+            The persisted Source record.
+        """
+        return await self._adapter.ingest_text(content, title, session)
+
+    async def list_sources(
+        self, session: AsyncSession, status: str | None = None, limit: int = 50, offset: int = 0
+    ) -> list[Source]:
+        """List ingested sources with optional status filtering.
+
+        Args:
+            session: Async database session.
+            status: Optional status filter.
+            limit: Maximum number of results.
+            offset: Pagination offset.
+
+        Returns:
+            List of Source records.
+        """
+        query = select(Source).offset(offset).limit(limit)
+        if status:
+            query = query.where(Source.status == status)
+        result = await session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_source(self, source_id: str, session: AsyncSession) -> Source:
+        """Retrieve a single source by ID.
+
+        Args:
+            source_id: The source UUID.
+            session: Async database session.
+
+        Returns:
+            The Source record.
+
+        Raises:
+            HTTPException: If the source is not found.
+        """
+        source = await session.get(Source, source_id)
+        if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
+        return source
+
+    async def delete_source(self, source_id: str, session: AsyncSession) -> dict[str, str]:
+        """Delete a source by ID.
+
+        Args:
+            source_id: The source UUID.
+            session: Async database session.
+
+        Returns:
+            Confirmation dict with the deleted ID.
+
+        Raises:
+            HTTPException: If the source is not found.
+        """
+        source = await session.get(Source, source_id)
+        if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
+        await session.delete(source)
+        await session.commit()
+        return {"deleted": source_id}
+
+
+_ingest_service: IngestService | None = None
+
+
+def get_ingest_service() -> IngestService:
+    """Return a singleton IngestService instance for FastAPI dependency injection."""
+    global _ingest_service
+    if _ingest_service is None:
+        _ingest_service = IngestService()
+    return _ingest_service

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -1,0 +1,91 @@
+"""Handle question answering against the wiki and file-back to articles.
+
+Wraps the QA agent, manages query persistence, and coordinates the
+file-back workflow that promotes Q&A answers into wiki articles.
+"""
+
+import json
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.qa_agent import QAAgent
+from wikimind.models import Query, QueryRequest, QueryResult
+
+
+class QueryService:
+    """Orchestrate wiki Q&A, query history, and answer file-back."""
+
+    def __init__(self) -> None:
+        self._qa_agent = QAAgent()
+
+    async def ask(self, request: QueryRequest, session: AsyncSession) -> Query:
+        """Ask a question against the wiki and persist the result.
+
+        Args:
+            request: The query request with question and options.
+            session: Async database session.
+
+        Returns:
+            The persisted Query record with answer.
+        """
+        return await self._qa_agent.answer(request, session)
+
+    async def query_history(self, session: AsyncSession, limit: int = 50) -> list[Query]:
+        """List past queries ordered by most recent first.
+
+        Args:
+            session: Async database session.
+            limit: Maximum number of results.
+
+        Returns:
+            List of Query records.
+        """
+        result = await session.execute(
+            select(Query).order_by(Query.created_at.desc()).limit(limit)  # type: ignore[attr-defined]
+        )
+        return list(result.scalars().all())
+
+    async def file_back(self, query_id: str, session: AsyncSession) -> dict[str, object]:
+        """Promote a past Q&A answer into a wiki article.
+
+        Args:
+            query_id: The query UUID to file back.
+            session: Async database session.
+
+        Returns:
+            Dict confirming the file-back with the new article ID.
+
+        Raises:
+            HTTPException: If the query is not found.
+        """
+        query = await session.get(Query, query_id)
+        if not query:
+            raise HTTPException(status_code=404, detail="Query not found")
+
+        result = QueryResult(
+            answer=query.answer,
+            confidence=query.confidence or "medium",
+            sources=json.loads(query.source_article_ids or "[]"),
+            related_articles=json.loads(query.related_article_ids or "[]"),
+        )
+
+        article_id = await self._qa_agent._file_back(query.question, result, session)
+        query.filed_back = True
+        query.filed_article_id = article_id
+        session.add(query)
+        await session.commit()
+
+        return {"filed": True, "article_id": article_id}
+
+
+_query_service: QueryService | None = None
+
+
+def get_query_service() -> QueryService:
+    """Return a singleton QueryService instance for FastAPI dependency injection."""
+    global _query_service
+    if _query_service is None:
+        _query_service = QueryService()
+    return _query_service

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -1,0 +1,223 @@
+"""Retrieve wiki articles, build the knowledge graph, and search content.
+
+Centralizes all article retrieval, full-text search, concept taxonomy,
+and health report generation so route handlers stay thin.
+"""
+
+import json
+from pathlib import Path
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import get_settings
+from wikimind.models import (
+    Article,
+    ArticleResponse,
+    Backlink,
+    Concept,
+    GraphEdge,
+    GraphNode,
+    GraphResponse,
+)
+
+
+def _read_article_content(file_path: str) -> str:
+    """Read article markdown content from disk.
+
+    Args:
+        file_path: Absolute path to the article markdown file.
+
+    Returns:
+        The file content, or an empty string if the file cannot be read.
+    """
+    try:
+        return Path(file_path).read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+class WikiService:
+    """Provide article retrieval, search, graph building, and health reporting."""
+
+    async def list_articles(
+        self,
+        session: AsyncSession,
+        concept: str | None = None,
+        confidence: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Article]:
+        """List wiki articles with optional filtering by concept or confidence.
+
+        Args:
+            session: Async database session.
+            concept: Optional concept filter (unused, reserved for future).
+            confidence: Optional confidence level filter.
+            limit: Maximum number of results.
+            offset: Pagination offset.
+
+        Returns:
+            List of Article records.
+        """
+        query = select(Article).offset(offset).limit(limit)
+        if confidence:
+            query = query.where(Article.confidence == confidence)
+        result = await session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_article(self, slug: str, session: AsyncSession) -> ArticleResponse:
+        """Retrieve a full article by slug, including content and backlinks.
+
+        Args:
+            slug: The article URL slug.
+            session: Async database session.
+
+        Returns:
+            ArticleResponse with content and backlink data.
+
+        Raises:
+            HTTPException: If the article is not found.
+        """
+        result = await session.execute(select(Article).where(Article.slug == slug))
+        article = result.scalar_one_or_none()
+        if not article:
+            raise HTTPException(status_code=404, detail="Article not found")
+
+        bl_in = await session.execute(select(Backlink).where(Backlink.target_article_id == article.id))
+        bl_out = await session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+
+        return ArticleResponse(
+            id=article.id,
+            slug=article.slug,
+            title=article.title,
+            summary=article.summary,
+            confidence=article.confidence,
+            linter_score=article.linter_score,
+            concepts=[],
+            backlinks_in=[b.source_article_id for b in bl_in.scalars().all()],
+            backlinks_out=[b.target_article_id for b in bl_out.scalars().all()],
+            content=_read_article_content(article.file_path),
+            created_at=article.created_at,
+            updated_at=article.updated_at,
+        )
+
+    async def get_graph(self, session: AsyncSession) -> GraphResponse:
+        """Build the full knowledge graph from articles and backlinks.
+
+        Args:
+            session: Async database session.
+
+        Returns:
+            GraphResponse containing nodes and edges.
+        """
+        articles_result = await session.execute(select(Article))
+        articles = articles_result.scalars().all()
+
+        backlinks_result = await session.execute(select(Backlink))
+        backlinks = backlinks_result.scalars().all()
+
+        connection_counts: dict[str, int] = {}
+        for bl in backlinks:
+            connection_counts[bl.source_article_id] = connection_counts.get(bl.source_article_id, 0) + 1
+            connection_counts[bl.target_article_id] = connection_counts.get(bl.target_article_id, 0) + 1
+
+        nodes = [
+            GraphNode(
+                id=a.id,
+                label=a.title,
+                concept_cluster=None,
+                connection_count=connection_counts.get(a.id, 0),
+                confidence=a.confidence,
+            )
+            for a in articles
+        ]
+
+        edges = [
+            GraphEdge(
+                source=bl.source_article_id,
+                target=bl.target_article_id,
+                context=bl.context,
+            )
+            for bl in backlinks
+        ]
+
+        return GraphResponse(nodes=nodes, edges=edges)
+
+    async def search(self, q: str, session: AsyncSession, limit: int = 20) -> list[Article]:
+        """Full-text search across wiki article titles and content.
+
+        Args:
+            q: Search query string (minimum 2 characters).
+            session: Async database session.
+            limit: Maximum number of results.
+
+        Returns:
+            List of matching Article records, ordered by relevance score.
+        """
+        result = await session.execute(select(Article))
+        all_articles = result.scalars().all()
+
+        q_lower = q.lower()
+        matches = []
+        for article in all_articles:
+            content = _read_article_content(article.file_path)
+            if q_lower in article.title.lower() or q_lower in content.lower():
+                score = 10 if q_lower in article.title.lower() else 0
+                score += content.lower().count(q_lower)
+                matches.append({"article": article, "score": score})
+
+        matches.sort(key=lambda x: x["score"], reverse=True)
+        return [m["article"] for m in matches[:limit]]
+
+    async def get_concepts(self, session: AsyncSession) -> list[Concept]:
+        """Retrieve the full concept taxonomy tree.
+
+        Args:
+            session: Async database session.
+
+        Returns:
+            List of Concept records.
+        """
+        result = await session.execute(select(Concept))
+        return list(result.scalars().all())
+
+    async def get_health(self, session: AsyncSession) -> dict:
+        """Return the latest wiki health report from the linter.
+
+        If no linter run has been performed yet, returns a stub report
+        with the current article count and a prompt to run the linter.
+
+        Args:
+            session: Async database session.
+
+        Returns:
+            Health report dict.
+        """
+        settings = get_settings()
+        health_path = Path(settings.data_dir) / "wiki" / "_meta" / "health.json"
+
+        if health_path.exists():
+            return json.loads(health_path.read_text())
+
+        articles_result = await session.execute(select(Article))
+        articles = articles_result.scalars().all()
+
+        return {
+            "generated_at": None,
+            "total_articles": len(articles),
+            "total_sources": 0,
+            "message": "Run the linter to generate a health report",
+        }
+
+
+_wiki_service: WikiService | None = None
+
+
+def get_wiki_service() -> WikiService:
+    """Return a singleton WikiService instance for FastAPI dependency injection."""
+    global _wiki_service
+    if _wiki_service is None:
+        _wiki_service = WikiService()
+    return _wiki_service


### PR DESCRIPTION
## Summary

- Extract business logic from 4 route files into dedicated service classes (`IngestService`, `CompilerService`, `QueryService`, `WikiService`) under `src/wikimind/services/`
- Route handlers now delegate to services via FastAPI `Depends()`, keeping each handler under 10 lines
- Services accept `AsyncSession` as a parameter (injected, not created internally), making them testable

## Changes

**New files:**
- `src/wikimind/services/__init__.py` -- package init
- `src/wikimind/services/ingest.py` -- `IngestService` wrapping ingest adapters + source CRUD + compilation enqueue
- `src/wikimind/services/compiler.py` -- `CompilerService` wrapping job listing, compile/lint/reindex triggers
- `src/wikimind/services/query.py` -- `QueryService` wrapping Q&A agent + query history + file-back workflow
- `src/wikimind/services/wiki.py` -- `WikiService` wrapping article retrieval, search, graph building, health reports

**Refactored files:**
- `src/wikimind/api/routes/ingest.py` -- thin routes delegating to `IngestService`
- `src/wikimind/api/routes/jobs.py` -- thin routes delegating to `CompilerService`
- `src/wikimind/api/routes/query.py` -- thin routes delegating to `QueryService`
- `src/wikimind/api/routes/wiki.py` -- thin routes delegating to `WikiService`

## Test plan

- [x] `ruff check` passes (0 errors)
- [x] `ruff format --check` passes (0 reformatted)
- [x] `mypy` passes (0 issues)
- [x] `basedpyright` passes (only pre-existing SQLModel `table=True` errors in models.py)
- [x] `pydocstyle` passes (0 violations)
- [x] `pytest` passes (28/28 tests)
- [ ] Manual smoke test: start gateway and verify all endpoints respond correctly

Closes #40