### PR TITLE
fix: decouple ingest from compilation (#55)

### DIFF
--- a/docs/adr/adr-009-decoupled-ingest-compilation.md
+++ b/docs/adr/adr-009-decoupled-ingest-compilation.md
@@ -1,0 +1,82 @@
+# ADR-009: Decoupled ingest and compilation
+
+## Status
+
+Accepted
+
+## Context
+
+Ingest endpoints were crashing with `redis.exceptions.ConnectionError` because
+`IngestService._enqueue_compilation()` called `arq.create_pool()` which tried
+to connect to Redis on localhost:6379. The fakeredis library listed in
+dependencies cannot work with ARQ across processes (ARQ workers run in a
+separate process with separate memory, so an in-process fake broker is
+invisible to the worker). This meant every ingest call failed without a running
+Redis instance, breaking the zero-dependency dev experience promised by ADR-001.
+
+Ingest and compilation are fundamentally different operations:
+
+- **Ingest** is fast I/O: fetch a URL, save a file, persist a Source row.
+  Typical latency is under 100 ms.
+- **Compilation** is slow LLM work: read the raw file, call an LLM API, parse
+  the response, save an Article. Typical latency is 10-30 seconds.
+
+Coupling them via a synchronous `await enqueue_compile()` in the ingest path
+meant that ingest could not succeed unless the job queue broker was reachable.
+
+## Decision
+
+Decouple ingest from compilation. Ingest saves the source and returns
+immediately. Compilation is scheduled asynchronously by a new
+`BackgroundCompiler` class (`wikimind.jobs.background`).
+
+`BackgroundCompiler` has two modes:
+
+1. **Dev mode** (no `REDIS_URL` environment variable): uses
+   `asyncio.create_task()` to run `compile_source()` in the same process as
+   the API server. No Redis required.
+2. **Prod mode** (`REDIS_URL` is set): uses `arq.create_pool()` to enqueue
+   the job via Redis, where a separate ARQ worker picks it up.
+
+Both modes emit WebSocket progress events identically because the underlying
+`compile_source()` and `lint_wiki()` job functions are the same.
+
+The service layer (`wikimind.services.ingest`) calls
+`background_compiler.schedule_compile(source.id)` after the adapter returns.
+The compiler service (`wikimind.services.compiler`) uses `BackgroundCompiler`
+for `trigger_compile()` and `trigger_lint()`.
+
+## Alternatives Considered
+
+**fakeredis wired into ARQ** -- fakeredis runs in-process. ARQ workers run as
+a separate process (`arq wikimind.jobs.worker.WorkerSettings`). The worker
+process would have its own fakeredis instance with no jobs in it. This
+fundamentally cannot work for cross-process job dispatch.
+
+**Synchronous compilation in the ingest path** -- Would block the API for
+10-30 seconds per ingest call, making the UI unresponsive and preventing
+parallel ingestion.
+
+**Always require Redis** -- Adds an infrastructure dependency for local
+development, violating the zero-dependency principle from ADR-001.
+
+## Consequences
+
+**Enables:**
+- Zero-dependency dev startup: `make dev` works without Redis
+- Ingest endpoints return immediately (< 100 ms) in all environments
+- Same user experience in dev and prod: WebSocket progress events fire in both
+  modes
+- The ARQ worker still works unchanged in production
+
+**Constrains:**
+- In dev mode, compilation runs in the API server process. A hung LLM call
+  will not block the event loop (it is async) but will consume memory. This is
+  acceptable for local development.
+- `asyncio.create_task()` fire-and-forget means dev-mode compilation failures
+  are logged but not surfaced via the HTTP response. This matches the prod
+  behavior where ARQ job failures are also asynchronous.
+
+**Supersedes:**
+- ADR-002 (ARQ + fakeredis): fakeredis is no longer used for job dispatch.
+  ARQ remains the production queue, but dev mode uses in-process async tasks.

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -1,7 +1,8 @@
 """WikiMind Ingest Service.
 
-Source adapters for all supported input types.
-All adapters produce NormalizedDocument.
+Source adapters for all supported input types. Each adapter fetches or reads raw
+content, persists a Source record and raw file, and returns the Source. Compilation
+is scheduled separately by the service layer, not by adapters.
 """
 
 from __future__ import annotations
@@ -17,7 +18,6 @@ import trafilatura
 from sqlmodel.ext.asyncio.session import AsyncSession
 from youtube_transcript_api import YouTubeTranscriptApi
 
-import wikimind.jobs.worker as _worker
 from wikimind.config import get_settings
 from wikimind.models import DocumentChunk, IngestStatus, NormalizedDocument, Source, SourceType
 
@@ -335,7 +335,11 @@ class YouTubeAdapter:
 
 
 class IngestService:
-    """Orchestrate ingestion across all adapters."""
+    """Orchestrate ingestion across all adapters.
+
+    Adapters save the source and return immediately. Compilation is scheduled
+    separately by the outer service layer (see ``wikimind.services.ingest``).
+    """
 
     def __init__(self):
         self.url_adapter = URLAdapter()
@@ -346,26 +350,18 @@ class IngestService:
     async def ingest_url(self, url: str, session: AsyncSession) -> Source:
         """Ingest a URL, routing to the appropriate adapter."""
         if "youtube.com" in url or "youtu.be" in url:
-            source, doc = await self.youtube_adapter.ingest(url, session)
+            source, _doc = await self.youtube_adapter.ingest(url, session)
         else:
-            source, doc = await self.url_adapter.ingest(url, session)
+            source, _doc = await self.url_adapter.ingest(url, session)
 
-        await self._enqueue_compilation(source, doc)
         return source
 
     async def ingest_pdf(self, file_bytes: bytes, filename: str, session: AsyncSession) -> Source:
         """Ingest a PDF file."""
-        source, doc = await self.pdf_adapter.ingest(file_bytes, filename, session)
-        await self._enqueue_compilation(source, doc)
+        source, _doc = await self.pdf_adapter.ingest(file_bytes, filename, session)
         return source
 
     async def ingest_text(self, content: str, title: str | None, session: AsyncSession) -> Source:
         """Ingest raw text content."""
-        source, doc = await self.text_adapter.ingest(content, title, session)
-        await self._enqueue_compilation(source, doc)
+        source, _doc = await self.text_adapter.ingest(content, title, session)
         return source
-
-    async def _enqueue_compilation(self, source: Source, doc: NormalizedDocument):
-        """Queue compilation job. Worker picks it up asynchronously."""
-        await _worker.enqueue_compile(source.id)
-        log.info("Compilation enqueued", source_id=source.id)

--- a/src/wikimind/jobs/background.py
+++ b/src/wikimind/jobs/background.py
@@ -1,0 +1,103 @@
+"""Async background compiler that dispatches compilation jobs.
+
+In dev mode (no REDIS_URL), runs compile_source() in-process via
+asyncio.create_task(). In prod mode, enqueues via ARQ + Redis.
+This decouples ingest from compilation so ingest never blocks on Redis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import structlog
+from arq import create_pool
+from arq.connections import RedisSettings
+
+from wikimind.jobs.worker import compile_source, lint_wiki
+
+log = structlog.get_logger()
+
+
+class BackgroundCompiler:
+    """Schedule compilation and lint jobs in dev (in-process) or prod (ARQ/Redis) mode."""
+
+    def __init__(self) -> None:
+        self._redis_url: str | None = os.environ.get("REDIS_URL")
+
+    @property
+    def is_prod(self) -> bool:
+        """Return True when a real Redis URL is configured."""
+        return self._redis_url is not None
+
+    async def schedule_compile(self, source_id: str) -> str:
+        """Schedule a compilation job for the given source.
+
+        Args:
+            source_id: The source UUID to compile.
+
+        Returns:
+            A placeholder job ID string.
+        """
+        job_id = str(uuid.uuid4())
+
+        if self.is_prod:
+            await self._enqueue_arq("compile_source", source_id)
+        else:
+            asyncio.create_task(self._run_compile_in_process(source_id))  # noqa: RUF006
+
+        log.info("compile scheduled", source_id=source_id, mode="arq" if self.is_prod else "in-process")
+        return job_id
+
+    async def schedule_lint(self) -> str:
+        """Schedule a wiki lint job.
+
+        Returns:
+            A placeholder job ID string.
+        """
+        job_id = str(uuid.uuid4())
+
+        if self.is_prod:
+            await self._enqueue_arq("lint_wiki")
+        else:
+            asyncio.create_task(self._run_lint_in_process())  # noqa: RUF006
+
+        log.info("lint scheduled", mode="arq" if self.is_prod else "in-process")
+        return job_id
+
+    async def _enqueue_arq(self, func_name: str, *args: object) -> None:
+        """Enqueue a job via ARQ Redis pool."""
+        settings = RedisSettings.from_dsn(self._redis_url)  # type: ignore[arg-type]
+        pool = await create_pool(settings)
+        try:
+            await pool.enqueue_job(func_name, *args)
+        finally:
+            await pool.close()
+
+    @staticmethod
+    async def _run_compile_in_process(source_id: str) -> None:
+        """Run compile_source directly in the current event loop."""
+        try:
+            await compile_source({}, source_id)
+        except Exception:
+            log.exception("in-process compilation failed", source_id=source_id)
+
+    @staticmethod
+    async def _run_lint_in_process() -> None:
+        """Run lint_wiki directly in the current event loop."""
+        try:
+            await lint_wiki({})
+        except Exception:
+            log.exception("in-process lint failed")
+
+
+_background_compiler: BackgroundCompiler | None = None
+
+
+def get_background_compiler() -> BackgroundCompiler:
+    """Return a singleton BackgroundCompiler instance."""
+    global _background_compiler
+    if _background_compiler is None:
+        _background_compiler = BackgroundCompiler()
+    return _background_compiler

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -1,20 +1,22 @@
 """WikiMind Job Worker.
 
-ARQ async job queue workers.
-Runs as a separate process: `arq wikimind.jobs.worker.WorkerSettings`
+ARQ async job queue workers for compilation and linting.
+Runs as a separate process in production: ``arq wikimind.jobs.worker.WorkerSettings``
+
+In dev mode (no Redis), the same job functions are called in-process by
+``BackgroundCompiler`` via ``asyncio.create_task()``.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
 import structlog
-from arq import create_pool, cron
+from arq import cron
 from arq.connections import RedisSettings
 from sqlmodel import select
 
@@ -229,32 +231,21 @@ Return valid JSON only:
 
 
 # ---------------------------------------------------------------------------
-# Enqueue helpers — called from API routes
+# Redis settings — only used when REDIS_URL is set (production ARQ worker)
 # ---------------------------------------------------------------------------
 
 
-async def enqueue_compile(source_id: str) -> str:
-    """Enqueue a compilation job. Returns job ID."""
-    redis = await create_pool(get_redis_settings())
-    await redis.enqueue_job("compile_source", source_id)
-    await redis.close()
-    return str(uuid.uuid4())  # Placeholder — ARQ generates its own IDs
-
-
-async def enqueue_lint() -> str:
-    """Enqueue a wiki linting job. Returns job ID."""
-    redis = await create_pool(get_redis_settings())
-    await redis.enqueue_job("lint_wiki")
-    await redis.close()
-    return str(uuid.uuid4())
-
-
 def get_redis_settings() -> RedisSettings:
-    """Use fakeredis in dev, real Redis in prod."""
+    """Return ARQ RedisSettings from the REDIS_URL environment variable.
+
+    Only called when running the ARQ worker process in production.
+    Falls back to localhost:6379 so the WorkerSettings class can still
+    be imported without error, but the worker will fail to start without
+    a reachable Redis instance.
+    """
     redis_url = os.environ.get("REDIS_URL")
     if redis_url:
         return RedisSettings.from_dsn(redis_url)
-    # Default: fakeredis (no Redis install needed)
     return RedisSettings(host="localhost", port=6379)
 
 
@@ -264,7 +255,7 @@ def get_redis_settings() -> RedisSettings:
 
 
 class WorkerSettings:
-    """ARQ worker configuration."""
+    """ARQ worker configuration for production (requires Redis)."""
 
     functions: ClassVar[list] = [compile_source, lint_wiki]
     redis_settings = get_redis_settings()

--- a/src/wikimind/services/compiler.py
+++ b/src/wikimind/services/compiler.py
@@ -1,13 +1,13 @@
 """Manage compilation jobs and article persistence.
 
-Wraps the compilation engine and job queue, providing a clean interface
+Wraps the BackgroundCompiler and job queue, providing a clean interface
 for triggering compilation, linting, and reindexing from API routes.
 """
 
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from wikimind.jobs.worker import enqueue_compile, enqueue_lint
+from wikimind.jobs.background import get_background_compiler
 from wikimind.models import Job
 
 
@@ -44,7 +44,7 @@ class CompilerService:
         return await session.get(Job, job_id)
 
     async def trigger_compile(self, source_id: str) -> dict[str, str]:
-        """Enqueue a compilation job for a source.
+        """Schedule a compilation job for a source.
 
         Args:
             source_id: The source UUID to compile.
@@ -52,16 +52,18 @@ class CompilerService:
         Returns:
             Dict with job_id and status.
         """
-        job_id = await enqueue_compile(source_id)
+        bg = get_background_compiler()
+        job_id = await bg.schedule_compile(source_id)
         return {"job_id": job_id, "status": "queued"}
 
     async def trigger_lint(self) -> dict[str, str]:
-        """Enqueue a wiki linting job.
+        """Schedule a wiki linting job.
 
         Returns:
             Dict with job_id and status.
         """
-        job_id = await enqueue_lint()
+        bg = get_background_compiler()
+        job_id = await bg.schedule_lint()
         return {"job_id": job_id, "status": "queued"}
 
     async def trigger_reindex(self) -> dict[str, str]:

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -1,25 +1,30 @@
 """Orchestrate source ingestion across URL, PDF, text, and YouTube adapters.
 
 Routes delegate to this service for all ingest operations. The service
-coordinates adapter selection, source persistence, and compilation enqueue.
+coordinates adapter selection, source persistence, and background compilation
+scheduling via BackgroundCompiler.
 """
 
+import structlog
 from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.ingest.service import IngestService as IngestAdapter
+from wikimind.jobs.background import get_background_compiler
 from wikimind.models import Source
+
+log = structlog.get_logger()
 
 
 class IngestService:
-    """Orchestrate source ingestion and compilation enqueue."""
+    """Orchestrate source ingestion and background compilation scheduling."""
 
     def __init__(self) -> None:
         self._adapter = IngestAdapter()
 
     async def ingest_url(self, url: str, session: AsyncSession) -> Source:
-        """Ingest a URL (web page or YouTube) and enqueue compilation.
+        """Ingest a URL (web page or YouTube) and schedule compilation.
 
         Args:
             url: The URL to ingest.
@@ -32,12 +37,15 @@ class IngestService:
             HTTPException: If ingestion fails due to invalid input or network error.
         """
         try:
-            return await self._adapter.ingest_url(url, session)
+            source = await self._adapter.ingest_url(url, session)
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
+        await self._schedule_compile(source.id)
+        return source
+
     async def ingest_pdf(self, file_bytes: bytes, filename: str, session: AsyncSession) -> Source:
-        """Ingest a PDF file and enqueue compilation.
+        """Ingest a PDF file and schedule compilation.
 
         Args:
             file_bytes: Raw PDF bytes.
@@ -47,10 +55,12 @@ class IngestService:
         Returns:
             The persisted Source record.
         """
-        return await self._adapter.ingest_pdf(file_bytes, filename, session)
+        source = await self._adapter.ingest_pdf(file_bytes, filename, session)
+        await self._schedule_compile(source.id)
+        return source
 
     async def ingest_text(self, content: str, title: str | None, session: AsyncSession) -> Source:
-        """Ingest raw text content and enqueue compilation.
+        """Ingest raw text content and schedule compilation.
 
         Args:
             content: The text content to ingest.
@@ -60,7 +70,16 @@ class IngestService:
         Returns:
             The persisted Source record.
         """
-        return await self._adapter.ingest_text(content, title, session)
+        source = await self._adapter.ingest_text(content, title, session)
+        await self._schedule_compile(source.id)
+        return source
+
+    @staticmethod
+    async def _schedule_compile(source_id: str) -> None:
+        """Schedule background compilation for a source."""
+        compiler = get_background_compiler()
+        await compiler.schedule_compile(source_id)
+        log.info("compilation scheduled", source_id=source_id)
 
     async def list_sources(
         self, session: AsyncSession, status: str | None = None, limit: int = 50, offset: int = 0


### PR DESCRIPTION
## Summary

- **Decoupled ingest from compilation**: ingest endpoints now save the source and return immediately (< 100ms), instead of blocking on a Redis connection to enqueue compilation
- **Added `BackgroundCompiler`** (`src/wikimind/jobs/background.py`): dispatches compilation via `asyncio.create_task()` in dev (no Redis needed) or ARQ+Redis in prod (`REDIS_URL` set)
- **Removed broken `enqueue_compile()`/`enqueue_lint()`** from `worker.py` that crashed with `redis.exceptions.ConnectionError` on every ingest call

## Changes

| File | What changed |
|------|-------------|
| `src/wikimind/jobs/background.py` | **New** -- `BackgroundCompiler` class with `schedule_compile()` and `schedule_lint()` |
| `src/wikimind/ingest/service.py` | Removed `_enqueue_compilation()` and `import wikimind.jobs.worker` -- ingest no longer triggers compilation |
| `src/wikimind/services/ingest.py` | Calls `BackgroundCompiler.schedule_compile()` after adapter saves source |
| `src/wikimind/services/compiler.py` | Uses `BackgroundCompiler` instead of old `enqueue_compile`/`enqueue_lint` |
| `src/wikimind/jobs/worker.py` | Removed `enqueue_compile()`, `enqueue_lint()`, unused `uuid`/`create_pool` imports; kept job functions and `WorkerSettings` |
| `docs/adr/adr-009-decoupled-ingest-compilation.md` | ADR documenting the architectural decision |

## Test plan

- [x] `make lint` -- passes (ruff)
- [x] `make format-check` -- passes
- [x] `make typecheck` -- passes (mypy)
- [x] `make pyright` -- passes (basedpyright)
- [x] `make docstyle` -- passes (pydocstyle)
- [x] `make test` -- 30/30 tests pass
- [ ] Manual: `make dev` then `curl -X POST localhost:7842/ingest/text -H 'Content-Type: application/json' -d '{"content": "Transformers are a neural network architecture.", "title": "Test"}'` returns 200 with Source record

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)