### PR TITLE
feat: surface source provenance in search results and Q&A answers

### DIFF
--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -4,19 +4,19 @@ from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
-from wikimind.models import QueryRequest
+from wikimind.models import QueryRequest, QueryResponse
 from wikimind.services.query import QueryService, get_query_service
 
 router = APIRouter()
 
 
-@router.post("")
+@router.post("", response_model=QueryResponse)
 async def ask(
     request: QueryRequest,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
 ):
-    """Ask a question against the wiki."""
+    """Ask a question against the wiki and receive an answer with citations."""
     return await service.ask(request, session)
 
 

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, Depends, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
-from wikimind.models import ArticleResponse, GraphResponse
+from wikimind.models import ArticleResponse, ArticleSummaryResponse, GraphResponse
 from wikimind.services.wiki import WikiService, get_wiki_service
 
 router = APIRouter()
 
 
-@router.get("/articles")
+@router.get("/articles", response_model=list[ArticleSummaryResponse])
 async def list_articles(
     concept: str | None = None,
     confidence: str | None = None,
@@ -19,7 +19,7 @@ async def list_articles(
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
 ):
-    """List wiki articles with optional filtering."""
+    """List wiki articles with optional filtering and source provenance."""
     return await service.list_articles(session, concept=concept, confidence=confidence, limit=limit, offset=offset)
 
 
@@ -29,7 +29,7 @@ async def get_article(
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
 ):
-    """Get full article with content and backlinks."""
+    """Get full article with content, backlinks, and source provenance."""
     return await service.get_article(slug, session)
 
 
@@ -42,14 +42,14 @@ async def get_graph(
     return await service.get_graph(session)
 
 
-@router.get("/search")
+@router.get("/search", response_model=list[ArticleSummaryResponse])
 async def search(
     q: str = Query(..., min_length=2),
     limit: int = 20,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
 ):
-    """Full-text search across wiki articles."""
+    """Full-text search across wiki articles with source provenance."""
     return await service.search(q, session, limit=limit)
 
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -315,8 +315,35 @@ class QueryRequest(BaseModel):
     file_back: bool = False  # Auto-save answer to wiki
 
 
+class SourceResponse(BaseModel):
+    """Provenance view of a raw ingested source exposed via the API.
+
+    Trimmed view of :class:`Source` suitable for embedding in article and
+    Q&A responses so callers can trace claims back to their origin
+    (URL, PDF filename, upload date, etc.).
+    """
+
+    id: str
+    source_type: SourceType
+    title: str | None
+    source_url: str | None
+    ingested_at: datetime
+
+
+class ArticleSourceSummary(BaseModel):
+    """Minimal source descriptor returned with listing/search endpoints.
+
+    A lightweight summary used when the full :class:`SourceResponse` is
+    overkill — e.g. article list and search result payloads.
+    """
+
+    id: str
+    source_type: SourceType
+    title: str | None
+
+
 class ArticleResponse(BaseModel):
-    """Full article response with content and backlinks."""
+    """Full article response with content, backlinks, and source provenance."""
 
     id: str
     slug: str
@@ -328,8 +355,62 @@ class ArticleResponse(BaseModel):
     backlinks_in: list[str] = []
     backlinks_out: list[str] = []
     content: str  # Full .md content
+    sources: list[SourceResponse] = []
     created_at: datetime
     updated_at: datetime
+
+
+class ArticleSummaryResponse(BaseModel):
+    """Summary article response for list and search endpoints.
+
+    Includes a lightweight list of sources so that callers can surface
+    provenance directly in search/listing views without fetching the full
+    article content.
+    """
+
+    id: str
+    slug: str
+    title: str
+    summary: str | None
+    confidence: ConfidenceLevel | None
+    linter_score: float | None
+    sources: list[ArticleSourceSummary] = []
+    created_at: datetime
+    updated_at: datetime
+
+
+class CitationArticleRef(BaseModel):
+    """Minimal reference to an article used inside a :class:`CitationResponse`."""
+
+    slug: str
+    title: str
+
+
+class CitationResponse(BaseModel):
+    """A single Q&A citation: an article plus the sources it was compiled from."""
+
+    article: CitationArticleRef
+    sources: list[SourceResponse] = []
+
+
+class QueryResponse(BaseModel):
+    """Q&A response enriched with a full Answer → Article → Source citation chain.
+
+    Mirrors the persisted :class:`Query` record fields while adding a
+    resolved ``citations`` list so clients can see which articles were
+    used and which original sources those articles came from.
+    """
+
+    id: str
+    question: str
+    answer: str
+    confidence: str | None
+    source_article_ids: str | None
+    related_article_ids: str | None
+    filed_back: bool
+    filed_article_id: str | None
+    created_at: datetime
+    citations: list[CitationResponse] = []
 
 
 class GraphNode(BaseModel):

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -2,16 +2,153 @@
 
 Wraps the QA agent, manages query persistence, and coordinates the
 file-back workflow that promotes Q&A answers into wiki articles.
+Q&A responses are enriched with full Answer → Article → Source citation
+chains so callers can trace every answer back to the raw source it came
+from.
 """
 
 import json
 
+import structlog
 from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.engine.qa_agent import QAAgent
-from wikimind.models import Query, QueryRequest, QueryResult
+from wikimind.models import (
+    Article,
+    CitationArticleRef,
+    CitationResponse,
+    Query,
+    QueryRequest,
+    QueryResponse,
+    QueryResult,
+    Source,
+    SourceResponse,
+)
+
+log = structlog.get_logger()
+
+
+def _parse_source_ids(raw: str | None) -> list[str]:
+    """Parse the JSON-encoded ``Article.source_ids`` field into a list of IDs.
+
+    Mirrors the helper in :mod:`wikimind.services.wiki` so the query
+    service does not need to import private helpers from a sibling
+    module. Returns an empty list when the field is missing or malformed.
+
+    Args:
+        raw: Raw JSON string stored on :attr:`Article.source_ids`.
+
+    Returns:
+        List of source UUID strings (possibly empty).
+    """
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        log.warning("Failed to parse Article.source_ids JSON", raw=raw)
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed if item]
+
+
+def _parse_article_titles(raw: str | None) -> list[str]:
+    """Parse the JSON-encoded ``Query.source_article_ids`` field.
+
+    Despite the column name, the QA agent persists *article titles*
+    here (the LLM cites by title, not by UUID). This helper decodes
+    the JSON list defensively.
+
+    Args:
+        raw: Raw JSON string stored on :attr:`Query.source_article_ids`.
+
+    Returns:
+        List of article title strings (possibly empty).
+    """
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        log.warning("Failed to parse Query.source_article_ids JSON", raw=raw)
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed if item]
+
+
+async def _build_citations(query: Query, session: AsyncSession) -> list[CitationResponse]:
+    """Resolve a Q&A record into a full citation chain.
+
+    Walks ``Query.source_article_ids`` (which the QA agent populates with
+    article titles), looks up each cited :class:`Article` by exact title
+    match, then fetches every :class:`Source` referenced by the
+    article's ``source_ids`` JSON column. Articles that cannot be
+    resolved are skipped.
+
+    Args:
+        query: The persisted Query record.
+        session: Async database session.
+
+    Returns:
+        Resolved citation list with full source provenance for each
+        cited article.
+    """
+    titles = _parse_article_titles(query.source_article_ids)
+    if not titles:
+        return []
+
+    article_result = await session.execute(select(Article).where(Article.title.in_(titles)))  # type: ignore[attr-defined]
+    articles_by_title = {a.title: a for a in article_result.scalars().all()}
+
+    citations: list[CitationResponse] = []
+    for title in titles:
+        article = articles_by_title.get(title)
+        if article is None:
+            continue
+        source_ids = _parse_source_ids(article.source_ids)
+        sources: list[Source] = []
+        if source_ids:
+            src_result = await session.execute(
+                select(Source).where(Source.id.in_(source_ids)),  # type: ignore[attr-defined]
+            )
+            by_id = {s.id: s for s in src_result.scalars().all()}
+            sources = [by_id[sid] for sid in source_ids if sid in by_id]
+        citations.append(
+            CitationResponse(
+                article=CitationArticleRef(slug=article.slug, title=article.title),
+                sources=[
+                    SourceResponse(
+                        id=s.id,
+                        source_type=s.source_type,
+                        title=s.title,
+                        source_url=s.source_url,
+                        ingested_at=s.ingested_at,
+                    )
+                    for s in sources
+                ],
+            ),
+        )
+    return citations
+
+
+def _to_query_response(query: Query, citations: list[CitationResponse]) -> QueryResponse:
+    """Project a persisted :class:`Query` plus citations into a :class:`QueryResponse`."""
+    return QueryResponse(
+        id=query.id,
+        question=query.question,
+        answer=query.answer,
+        confidence=query.confidence,
+        source_article_ids=query.source_article_ids,
+        related_article_ids=query.related_article_ids,
+        filed_back=query.filed_back,
+        filed_article_id=query.filed_article_id,
+        created_at=query.created_at,
+        citations=citations,
+    )
 
 
 class QueryService:
@@ -20,17 +157,25 @@ class QueryService:
     def __init__(self) -> None:
         self._qa_agent = QAAgent()
 
-    async def ask(self, request: QueryRequest, session: AsyncSession) -> Query:
+    async def ask(self, request: QueryRequest, session: AsyncSession) -> QueryResponse:
         """Ask a question against the wiki and persist the result.
+
+        After the QA agent answers and persists the :class:`Query`
+        record, this method resolves each cited article title back to
+        its :class:`Article` row and then to the underlying
+        :class:`Source` records, returning a fully expanded
+        Answer → Article → Source citation chain.
 
         Args:
             request: The query request with question and options.
             session: Async database session.
 
         Returns:
-            The persisted Query record with answer.
+            :class:`QueryResponse` with answer text and resolved citations.
         """
-        return await self._qa_agent.answer(request, session)
+        query = await self._qa_agent.answer(request, session)
+        citations = await _build_citations(query, session)
+        return _to_query_response(query, citations)
 
     async def query_history(self, session: AsyncSession, limit: int = 50) -> list[Query]:
         """List past queries ordered by most recent first.

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -1,12 +1,15 @@
 """Retrieve wiki articles, build the knowledge graph, and search content.
 
 Centralizes all article retrieval, full-text search, concept taxonomy,
-and health report generation so route handlers stay thin.
+and health report generation so route handlers stay thin. Article and
+search responses are enriched with source provenance so callers can
+trace each compiled article back to its raw ingested sources.
 """
 
 import json
 from pathlib import Path
 
+import structlog
 from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -15,12 +18,18 @@ from wikimind.config import get_settings
 from wikimind.models import (
     Article,
     ArticleResponse,
+    ArticleSourceSummary,
+    ArticleSummaryResponse,
     Backlink,
     Concept,
     GraphEdge,
     GraphNode,
     GraphResponse,
+    Source,
+    SourceResponse,
 )
+
+log = structlog.get_logger()
 
 
 def _read_article_content(file_path: str) -> str:
@@ -38,6 +47,98 @@ def _read_article_content(file_path: str) -> str:
         return ""
 
 
+def _parse_source_ids(raw: str | None) -> list[str]:
+    """Parse the JSON-encoded ``Article.source_ids`` field into a list of IDs.
+
+    Returns an empty list when the field is missing, empty, or malformed.
+    Malformed values are logged but never raised so a single broken record
+    cannot break listing or search responses.
+
+    Args:
+        raw: Raw JSON string stored on :attr:`Article.source_ids`.
+
+    Returns:
+        List of source UUID strings (possibly empty).
+    """
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        log.warning("Failed to parse Article.source_ids JSON", raw=raw)
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed if item]
+
+
+async def _fetch_sources(session: AsyncSession, source_ids: list[str]) -> list[Source]:
+    """Fetch :class:`Source` records for a list of source IDs, preserving order.
+
+    Missing rows (e.g. a source was deleted after the article was compiled)
+    are silently dropped — callers receive only the sources that still
+    exist in the database.
+
+    Args:
+        session: Async database session.
+        source_ids: List of source UUIDs to fetch.
+
+    Returns:
+        Source records in the same order as ``source_ids``, with any
+        missing IDs omitted.
+    """
+    if not source_ids:
+        return []
+    result = await session.execute(select(Source).where(Source.id.in_(source_ids)))  # type: ignore[attr-defined]
+    by_id = {s.id: s for s in result.scalars().all()}
+    return [by_id[sid] for sid in source_ids if sid in by_id]
+
+
+def _to_source_response(source: Source) -> SourceResponse:
+    """Project a :class:`Source` row into the API-facing :class:`SourceResponse`."""
+    return SourceResponse(
+        id=source.id,
+        source_type=source.source_type,
+        title=source.title,
+        source_url=source.source_url,
+        ingested_at=source.ingested_at,
+    )
+
+
+def _to_source_summary(source: Source) -> ArticleSourceSummary:
+    """Project a :class:`Source` row into the lightweight summary form."""
+    return ArticleSourceSummary(
+        id=source.id,
+        source_type=source.source_type,
+        title=source.title,
+    )
+
+
+async def _build_article_summary(article: Article, session: AsyncSession) -> ArticleSummaryResponse:
+    """Build an :class:`ArticleSummaryResponse` for list and search payloads.
+
+    Args:
+        article: The article ORM row.
+        session: Async database session used to fetch the article's sources.
+
+    Returns:
+        Summary response with a minimal source list attached.
+    """
+    source_ids = _parse_source_ids(article.source_ids)
+    sources = await _fetch_sources(session, source_ids)
+    return ArticleSummaryResponse(
+        id=article.id,
+        slug=article.slug,
+        title=article.title,
+        summary=article.summary,
+        confidence=article.confidence,
+        linter_score=article.linter_score,
+        sources=[_to_source_summary(s) for s in sources],
+        created_at=article.created_at,
+        updated_at=article.updated_at,
+    )
+
+
 class WikiService:
     """Provide article retrieval, search, graph building, and health reporting."""
 
@@ -48,8 +149,12 @@ class WikiService:
         confidence: str | None = None,
         limit: int = 50,
         offset: int = 0,
-    ) -> list[Article]:
+    ) -> list[ArticleSummaryResponse]:
         """List wiki articles with optional filtering by concept or confidence.
+
+        Each returned summary embeds a lightweight list of source
+        descriptors so callers can show provenance directly in listing
+        views without fetching the full article.
 
         Args:
             session: Async database session.
@@ -59,23 +164,30 @@ class WikiService:
             offset: Pagination offset.
 
         Returns:
-            List of Article records.
+            List of :class:`ArticleSummaryResponse` records with sources
+            populated.
         """
         query = select(Article).offset(offset).limit(limit)
         if confidence:
             query = query.where(Article.confidence == confidence)
         result = await session.execute(query)
-        return list(result.scalars().all())
+        articles = list(result.scalars().all())
+        return [await _build_article_summary(a, session) for a in articles]
 
     async def get_article(self, slug: str, session: AsyncSession) -> ArticleResponse:
-        """Retrieve a full article by slug, including content and backlinks.
+        """Retrieve a full article by slug, including content, backlinks, and sources.
+
+        The returned response embeds full :class:`SourceResponse` records
+        for every raw source the article was compiled from. Sources that
+        no longer exist in the database (e.g. deleted after compilation)
+        are silently omitted.
 
         Args:
             slug: The article URL slug.
             session: Async database session.
 
         Returns:
-            ArticleResponse with content and backlink data.
+            :class:`ArticleResponse` with content, backlink, and source data.
 
         Raises:
             HTTPException: If the article is not found.
@@ -88,6 +200,9 @@ class WikiService:
         bl_in = await session.execute(select(Backlink).where(Backlink.target_article_id == article.id))
         bl_out = await session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
 
+        source_ids = _parse_source_ids(article.source_ids)
+        sources = await _fetch_sources(session, source_ids)
+
         return ArticleResponse(
             id=article.id,
             slug=article.slug,
@@ -99,6 +214,7 @@ class WikiService:
             backlinks_in=[b.source_article_id for b in bl_in.scalars().all()],
             backlinks_out=[b.target_article_id for b in bl_out.scalars().all()],
             content=_read_article_content(article.file_path),
+            sources=[_to_source_response(s) for s in sources],
             created_at=article.created_at,
             updated_at=article.updated_at,
         )
@@ -147,8 +263,17 @@ class WikiService:
 
         return GraphResponse(nodes=nodes, edges=edges)
 
-    async def search(self, q: str, session: AsyncSession, limit: int = 20) -> list[Article]:
+    async def search(
+        self,
+        q: str,
+        session: AsyncSession,
+        limit: int = 20,
+    ) -> list[ArticleSummaryResponse]:
         """Full-text search across wiki article titles and content.
+
+        Returned summaries embed lightweight source descriptors so users
+        can see at a glance which raw source(s) each matched article was
+        compiled from.
 
         Args:
             q: Search query string (minimum 2 characters).
@@ -156,22 +281,24 @@ class WikiService:
             limit: Maximum number of results.
 
         Returns:
-            List of matching Article records, ordered by relevance score.
+            Matching articles as :class:`ArticleSummaryResponse` records,
+            ordered by relevance score.
         """
         result = await session.execute(select(Article))
         all_articles = result.scalars().all()
 
         q_lower = q.lower()
-        matches = []
+        scored: list[tuple[int, Article]] = []
         for article in all_articles:
             content = _read_article_content(article.file_path)
             if q_lower in article.title.lower() or q_lower in content.lower():
                 score = 10 if q_lower in article.title.lower() else 0
                 score += content.lower().count(q_lower)
-                matches.append({"article": article, "score": score})
+                scored.append((score, article))
 
-        matches.sort(key=lambda x: x["score"], reverse=True)
-        return [m["article"] for m in matches[:limit]]
+        scored.sort(key=lambda item: item[0], reverse=True)
+        top = [article for _, article in scored[:limit]]
+        return [await _build_article_summary(a, session) for a in top]
 
     async def get_concepts(self, session: AsyncSession) -> list[Concept]:
         """Retrieve the full concept taxonomy tree.

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -1,0 +1,106 @@
+"""Tests for the QueryService citation chain resolution."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wikimind.models import Article, Query, Source, SourceType
+from wikimind.services.query import _build_citations
+
+
+async def _seed(db_session, tmp_path: Path) -> tuple[Query, Article, Source]:
+    """Persist a Source, an Article that references it, and a Query that cites the article."""
+    file_path = tmp_path / "cited.md"
+    file_path.write_text("# Cited\n\nClaim about IBM.", encoding="utf-8")
+
+    source = Source(
+        source_type=SourceType.PDF,
+        title="20260312_MikeO_AILabsGeneralTalk",
+        source_url=None,
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    article = Article(
+        slug="ibm-agentic-ai-labs",
+        title="IBM Agentic AI Labs",
+        file_path=str(file_path),
+        summary="A summary",
+        source_ids=json.dumps([source.id]),
+    )
+    db_session.add(article)
+    await db_session.flush()
+
+    query = Query(
+        question="What is IBM Agentic AI Labs?",
+        answer="It is a research lab.",
+        confidence="high",
+        source_article_ids=json.dumps([article.title]),
+        related_article_ids=json.dumps([]),
+    )
+    db_session.add(query)
+    await db_session.commit()
+    await db_session.refresh(query)
+
+    return query, article, source
+
+
+@pytest.mark.asyncio
+class TestQueryCitations:
+    async def test_build_citations_resolves_full_chain(self, db_session, tmp_path):
+        query, article, source = await _seed(db_session, tmp_path)
+
+        citations = await _build_citations(query, db_session)
+
+        assert len(citations) == 1
+        citation = citations[0]
+        assert citation.article.slug == article.slug
+        assert citation.article.title == article.title
+        assert len(citation.sources) == 1
+        assert citation.sources[0].id == source.id
+        assert citation.sources[0].source_type == SourceType.PDF
+        assert citation.sources[0].title == "20260312_MikeO_AILabsGeneralTalk"
+
+    async def test_build_citations_skips_unknown_article_titles(self, db_session, tmp_path):
+        """A Query that cites a title with no matching article yields no citations."""
+        query = Query(
+            question="What about Foo?",
+            answer="Unknown.",
+            confidence="low",
+            source_article_ids=json.dumps(["No Such Article"]),
+            related_article_ids=json.dumps([]),
+        )
+        db_session.add(query)
+        await db_session.commit()
+
+        citations = await _build_citations(query, db_session)
+        assert citations == []
+
+    async def test_build_citations_handles_empty_source_ids(self, db_session, tmp_path):
+        """An article with no sources still appears in the citation list, with empty sources."""
+        file_path = tmp_path / "empty-sources.md"
+        file_path.write_text("# Empty", encoding="utf-8")
+        article = Article(
+            slug="empty-sources",
+            title="Empty Sources Article",
+            file_path=str(file_path),
+            source_ids=None,
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        query = Query(
+            question="Empty?",
+            answer="Yes.",
+            confidence="medium",
+            source_article_ids=json.dumps([article.title]),
+            related_article_ids=json.dumps([]),
+        )
+        db_session.add(query)
+        await db_session.commit()
+
+        citations = await _build_citations(query, db_session)
+        assert len(citations) == 1
+        assert citations[0].article.title == article.title
+        assert citations[0].sources == []

--- a/tests/unit/test_wiki_service.py
+++ b/tests/unit/test_wiki_service.py
@@ -1,0 +1,126 @@
+"""Tests for the WikiService source-provenance enrichment."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wikimind.models import Article, Source, SourceType
+from wikimind.services.wiki import WikiService
+
+
+async def _seed_article_with_sources(db_session, tmp_path: Path) -> tuple[Article, list[Source]]:
+    """Create one article on disk and two persisted sources it references."""
+    file_path = tmp_path / "test-article.md"
+    file_path.write_text("# Test Article\n\nSome content about Langflow.", encoding="utf-8")
+
+    pdf_source = Source(
+        source_type=SourceType.PDF,
+        title="20260312_MikeO_AILabsGeneralTalk",
+        source_url=None,
+    )
+    url_source = Source(
+        source_type=SourceType.URL,
+        title="IBM Agentic AI Labs",
+        source_url="https://example.com/ibm",
+    )
+    db_session.add(pdf_source)
+    db_session.add(url_source)
+    await db_session.flush()
+
+    article = Article(
+        slug="ibm-agentic-ai-labs",
+        title="IBM Agentic AI Labs",
+        file_path=str(file_path),
+        summary="Summary about IBM Agentic AI Labs.",
+        source_ids=json.dumps([pdf_source.id, url_source.id]),
+    )
+    db_session.add(article)
+    await db_session.commit()
+    await db_session.refresh(article)
+    return article, [pdf_source, url_source]
+
+
+@pytest.mark.asyncio
+class TestArticleProvenance:
+    async def test_get_article_includes_full_source_provenance(self, db_session, tmp_path):
+        article, sources = await _seed_article_with_sources(db_session, tmp_path)
+        service = WikiService()
+
+        response = await service.get_article(article.slug, db_session)
+
+        assert response.slug == article.slug
+        assert len(response.sources) == 2
+        ids = {s.id for s in response.sources}
+        assert ids == {sources[0].id, sources[1].id}
+
+        pdf = next(s for s in response.sources if s.source_type == SourceType.PDF)
+        assert pdf.title == "20260312_MikeO_AILabsGeneralTalk"
+        assert pdf.source_url is None
+        assert pdf.ingested_at is not None
+
+        url = next(s for s in response.sources if s.source_type == SourceType.URL)
+        assert url.source_url == "https://example.com/ibm"
+
+    async def test_list_articles_includes_source_summaries(self, db_session, tmp_path):
+        article, sources = await _seed_article_with_sources(db_session, tmp_path)
+        service = WikiService()
+
+        results = await service.list_articles(db_session)
+
+        assert len(results) == 1
+        summary = results[0]
+        assert summary.slug == article.slug
+        assert len(summary.sources) == 2
+        types = {s.source_type for s in summary.sources}
+        assert types == {SourceType.PDF, SourceType.URL}
+        # Lightweight summary does not expose ingested_at / source_url.
+        assert all(s.title is not None for s in summary.sources)
+
+    async def test_search_includes_source_summaries(self, db_session, tmp_path):
+        article, _ = await _seed_article_with_sources(db_session, tmp_path)
+        service = WikiService()
+
+        results = await service.search("Langflow", db_session)
+
+        assert len(results) == 1
+        match = results[0]
+        assert match.slug == article.slug
+        assert len(match.sources) == 2
+
+    async def test_get_article_handles_missing_sources_gracefully(self, db_session, tmp_path):
+        """An article that references a deleted source still returns successfully."""
+        file_path = tmp_path / "orphan.md"
+        file_path.write_text("# Orphan", encoding="utf-8")
+        article = Article(
+            slug="orphan-article",
+            title="Orphan Article",
+            file_path=str(file_path),
+            source_ids=json.dumps(["does-not-exist-uuid"]),
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        service = WikiService()
+        response = await service.get_article("orphan-article", db_session)
+
+        assert response.slug == "orphan-article"
+        assert response.sources == []
+
+    async def test_get_article_handles_missing_source_ids_field(self, db_session, tmp_path):
+        """An article with no source_ids JSON returns an empty sources list."""
+        file_path = tmp_path / "no-sources.md"
+        file_path.write_text("# No sources", encoding="utf-8")
+        article = Article(
+            slug="no-source-article",
+            title="No Source Article",
+            file_path=str(file_path),
+            source_ids=None,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        service = WikiService()
+        response = await service.get_article("no-source-article", db_session)
+
+        assert response.sources == []


### PR DESCRIPTION
## Summary

Surfaces full Answer → Article → Source provenance through the WikiMind API so users can trace every claim back to its raw source (URL, PDF filename, upload date) — no more opaque JSON UUID strings.

Closes #60.

## Changes

### Models (`src/wikimind/models.py`)
- New `SourceResponse` — id / type / title / url / ingested_at view of `Source`.
- New `ArticleSourceSummary` — lightweight source descriptor for list/search payloads.
- New `ArticleSummaryResponse` — list/search article shape that embeds `ArticleSourceSummary`.
- New `CitationArticleRef` and `CitationResponse` — Q&A citation chain types.
- New `QueryResponse` — Q&A response that mirrors `Query` plus a resolved `citations` list.
- `ArticleResponse` now carries a `sources: list[SourceResponse]`.

### Wiki service (`src/wikimind/services/wiki.py`)
- Helpers `_parse_source_ids`, `_fetch_sources`, `_to_source_response`, `_to_source_summary`, and `_build_article_summary` keep the JSON-string parsing and Source lookup logic in one place.
- `get_article` parses `Article.source_ids` JSON, fetches matching `Source` rows, and embeds them in the response.
- `list_articles` and `search` now return `list[ArticleSummaryResponse]` with per-article source summaries.
- Missing sources (deleted after compilation) and malformed JSON are handled gracefully with structured logging.

### Query service (`src/wikimind/services/query.py`)
- `ask` now returns `QueryResponse` with a fully resolved citation chain.
- `_build_citations` looks up cited articles by title (the QA agent stores titles, not IDs, in `Query.source_article_ids`), then fetches their `Source` records via the article's `source_ids` JSON column.
- Articles that cannot be resolved are skipped; articles with no sources still appear in the citation list with an empty `sources`.

### Routes
- `GET /wiki/articles`, `GET /wiki/search` declare `response_model=list[ArticleSummaryResponse]`.
- `POST /query` declares `response_model=QueryResponse`.

### Tests
- `tests/unit/test_wiki_service.py` (5 tests) — verifies `get_article`, `list_articles`, and `search` embed sources, plus graceful handling of missing/empty source IDs.
- `tests/unit/test_query_service.py` (3 tests) — verifies `_build_citations` resolves the full chain, skips unknown article titles, and handles articles with no sources.

## Test plan

- [x] `make verify` (ruff + ruff format + mypy + basedpyright + pydocstyle + pytest) — all 38 tests pass.
- [x] `make pre-commit` — all hooks pass.
- [x] New tests assert that `ArticleResponse.sources` is populated with the expected `SourceResponse` records.
- [x] New tests assert that `_build_citations` resolves Answer → Article → Source for a Q&A query.