### PR TITLE
refactor: standardize raw + cleaned file lineage across all ingest adapters

### DIFF
--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -1,8 +1,18 @@
 """WikiMind Ingest Service.
 
 Source adapters for all supported input types. Each adapter fetches or reads raw
-content, persists a Source record and raw file, and returns the Source. Compilation
-is scheduled separately by the service layer, not by adapters.
+content, persists a ``Source`` record alongside both the original raw file and a
+cleaned ``.txt`` extraction, and returns the source. Compilation is scheduled
+separately by the service layer, not by adapters.
+
+File lineage convention (see issue #59):
+
+* Every adapter writes the cleaned text to ``~/.wikimind/raw/{source_id}.txt``
+  and points ``Source.file_path`` at it. The compile worker only reads ``.txt``.
+* Adapters whose original payload is not already plain text additionally write
+  the raw bytes to ``~/.wikimind/raw/{source_id}.{ext}`` (``.html`` for URL,
+  ``.pdf`` for PDF). Text and YouTube payloads are already plain text, so the
+  raw and clean files are the same ``.txt`` file.
 """
 
 from __future__ import annotations
@@ -143,6 +153,7 @@ class URLAdapter:
         # keep the raw HTML alongside it for reference/reprocessing.
         settings = get_settings()
         raw_dir = Path(settings.data_dir) / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
         (raw_dir / f"{source.id}.html").write_text(html, encoding="utf-8")
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(downloaded, encoding="utf-8")
@@ -195,11 +206,14 @@ class PDFAdapter:
         await session.commit()
         await session.refresh(source)
 
-        # Save raw file
+        # Save the raw PDF binary alongside the extracted plain text. The
+        # worker only ever reads the .txt file (see issue #59), so file_path
+        # always points at the cleaned text. The raw .pdf is kept for lineage
+        # and future re-extraction (e.g. Docling — see issue #57).
         settings = get_settings()
-        raw_path = Path(settings.data_dir) / "raw" / f"{source.id}.pdf"
-        raw_path.write_bytes(file_bytes)
-        source.file_path = str(raw_path)
+        raw_dir = Path(settings.data_dir) / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / f"{source.id}.pdf").write_bytes(file_bytes)
 
         # Extract text — plain text is the most reliable format across PDFs
         doc = fitz.open(stream=file_bytes, filetype="pdf")
@@ -207,6 +221,10 @@ class PDFAdapter:
         doc.close()
 
         clean_text = "\n\n".join(pages_text)
+        text_path = raw_dir / f"{source.id}.txt"
+        text_path.write_text(clean_text, encoding="utf-8")
+        source.file_path = str(text_path)
+
         token_count = estimate_tokens(clean_text)
         source.token_count = token_count
         session.add(source)
@@ -251,11 +269,15 @@ class TextAdapter:
         await session.commit()
         await session.refresh(source)
 
-        # Save raw
+        # Pasted text is already plain text, so the raw and cleaned files are
+        # the same .txt file. file_path always points at the .txt the worker
+        # reads (see issue #59).
         settings = get_settings()
-        raw_path = Path(settings.data_dir) / "raw" / f"{source.id}.txt"
-        raw_path.write_text(content, encoding="utf-8")
-        source.file_path = str(raw_path)
+        raw_dir = Path(settings.data_dir) / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        text_path = raw_dir / f"{source.id}.txt"
+        text_path.write_text(content, encoding="utf-8")
+        source.file_path = str(text_path)
         session.add(source)
         await session.commit()
 
@@ -302,10 +324,14 @@ class YouTubeAdapter:
         await session.commit()
         await session.refresh(source)
 
+        # YouTube transcripts are already plain text, so the raw and cleaned
+        # files are the same .txt. There is no separate raw video payload.
         settings = get_settings()
-        raw_path = Path(settings.data_dir) / "raw" / f"{source.id}.txt"
-        raw_path.write_text(transcript_text, encoding="utf-8")
-        source.file_path = str(raw_path)
+        raw_dir = Path(settings.data_dir) / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        text_path = raw_dir / f"{source.id}.txt"
+        text_path.write_text(transcript_text, encoding="utf-8")
+        source.file_path = str(text_path)
         session.add(source)
         await session.commit()
 

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -5,6 +5,12 @@ Runs as a separate process in production: ``arq wikimind.jobs.worker.WorkerSetti
 
 In dev mode (no Redis), the same job functions are called in-process by
 ``BackgroundCompiler`` via ``asyncio.create_task()``.
+
+The worker is intentionally agnostic to source format. Every ingest adapter
+(URL, PDF, text, YouTube) writes a cleaned ``.txt`` file alongside the source
+record (see ``wikimind.ingest.service`` and issue #59), and ``Source.file_path``
+always points at that ``.txt``. The worker therefore just reads the file as
+UTF-8 text — it never re-parses HTML, PDFs, or transcripts.
 """
 
 from __future__ import annotations
@@ -15,7 +21,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
-import fitz
 import structlog
 from arq import cron
 from arq.connections import RedisSettings
@@ -41,25 +46,10 @@ from wikimind.models import (
     JobType,
     NormalizedDocument,
     Source,
-    SourceType,
     TaskType,
 )
 
 log = structlog.get_logger()
-
-
-def _extract_source_content(raw_path: Path, source_type: SourceType) -> str:
-    """Re-extract text from a raw source file by routing to the correct parser.
-
-    Text and YouTube sources are stored as UTF-8 and read directly.
-    PDFs are stored as binary and must be extracted via pymupdf.
-    """
-    if source_type == SourceType.PDF:
-        doc = fitz.open(str(raw_path))
-        pages: list[str] = [str(page.get_text()) for page in doc]
-        doc.close()
-        return "\n\n".join(pages)
-    return raw_path.read_text(encoding="utf-8", errors="replace")
 
 
 # ---------------------------------------------------------------------------
@@ -90,12 +80,14 @@ async def compile_source(ctx, source_id: str):
         await emit_job_progress(job.id, 10, "Reading source...")
 
         try:
-            # Re-read the raw file — route binary formats through their extractor
+            # Every adapter writes a cleaned .txt and stores its path on the
+            # Source record (see issue #59). The worker is format-agnostic and
+            # just reads UTF-8 text — no PDF/HTML re-extraction here.
             if not source.file_path:
-                raise ValueError("No raw file path for source")
+                raise ValueError("No cleaned text file path for source")
 
-            raw_path = Path(source.file_path)
-            content = _extract_source_content(raw_path, source.source_type)
+            text_path = Path(source.file_path)
+            content = text_path.read_text(encoding="utf-8")
 
             await emit_job_progress(job.id, 30, "Normalizing content...")
 

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -2,14 +2,20 @@
 
 Routes delegate to this service for all ingest operations. The service
 coordinates adapter selection, source persistence, and background compilation
-scheduling via BackgroundCompiler.
+scheduling via ``BackgroundCompiler``. It also owns the lifecycle of the raw
+and cleaned files written by adapters under ``~/.wikimind/raw/`` (see issue
+#59) and removes them on delete.
 """
+
+from contextlib import suppress
+from pathlib import Path
 
 import structlog
 from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from wikimind.config import get_settings
 from wikimind.ingest.service import IngestService as IngestAdapter
 from wikimind.jobs.background import get_background_compiler
 from wikimind.models import Source
@@ -120,7 +126,13 @@ class IngestService:
         return source
 
     async def delete_source(self, source_id: str, session: AsyncSession) -> dict[str, str]:
-        """Delete a source by ID.
+        """Delete a source by ID and remove its raw and cleaned files from disk.
+
+        Adapters write a cleaned ``{id}.txt`` and may also write a sibling raw
+        file (``{id}.html`` for URL, ``{id}.pdf`` for PDF). Both are removed
+        when the source is deleted so the raw directory does not accumulate
+        orphaned files. Missing files are tolerated — deletion of the database
+        row is the source of truth.
 
         Args:
             source_id: The source UUID.
@@ -135,9 +147,32 @@ class IngestService:
         source = await session.get(Source, source_id)
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")
+
+        self._remove_source_files(source)
+
         await session.delete(source)
         await session.commit()
         return {"deleted": source_id}
+
+    @staticmethod
+    def _remove_source_files(source: Source) -> None:
+        """Remove the cleaned ``.txt`` file and any sibling raw file for a source.
+
+        The cleaned file path is read from ``Source.file_path``. The raw file
+        is discovered by scanning ``~/.wikimind/raw/`` for siblings sharing the
+        ``{source_id}`` stem (e.g. ``{id}.pdf``, ``{id}.html``). Missing files
+        are silently ignored — this method is best-effort cleanup.
+        """
+        if source.file_path:
+            with suppress(OSError):
+                Path(source.file_path).unlink(missing_ok=True)
+
+        raw_dir = Path(get_settings().data_dir) / "raw"
+        if not raw_dir.is_dir():
+            return
+        for sibling in raw_dir.glob(f"{source.id}.*"):
+            with suppress(OSError):
+                sibling.unlink(missing_ok=True)
 
 
 _ingest_service: IngestService | None = None


### PR DESCRIPTION
## Summary

Standardizes the file lineage convention across every ingest adapter so the compile worker no longer needs to know about source formats. Each adapter now writes a cleaned `{id}.txt` (what the worker reads) plus, when applicable, the original raw bytes (`{id}.html` for URL, `{id}.pdf` for PDF) under `~/.wikimind/raw/`. The worker becomes format-agnostic and the delete endpoint cleans up both files.

## Changes

- **`src/wikimind/ingest/service.py`**
  - Module docstring documents the new lineage convention.
  - **PDF adapter**: now writes the raw `{id}.pdf` *and* a cleaned `{id}.txt` extracted via fitz, and points `Source.file_path` at the `.txt` (previously pointed at the `.pdf`, forcing the worker to re-extract).
  - **URL adapter**: ensures `raw/` exists before writing (already wrote both files).
  - **Text / YouTube adapters**: ensure `raw/` exists; payloads are already plain text so raw and clean are the same `.txt`. Variable renamed `raw_path` -> `text_path` to reflect that `file_path` always points at the cleaned text.

- **`src/wikimind/jobs/worker.py`**
  - Removed `_extract_source_content()` helper.
  - Removed `import fitz` and `SourceType` from the worker (no longer needed).
  - `compile_source()` just does `text_path.read_text(encoding="utf-8")` — no more routing by `SourceType`.
  - Module docstring documents that the worker is intentionally format-agnostic and references issue #59.

- **`src/wikimind/services/ingest.py`**
  - `delete_source()` now removes the cleaned `.txt` plus any sibling raw file at `~/.wikimind/raw/{source_id}.*` so the raw directory does not accumulate orphans. Best-effort cleanup — missing files are tolerated, the database row remains the source of truth.
  - New private helper `_remove_source_files()` encapsulates the disk cleanup.
  - Module docstring updated to mention raw + clean file lifecycle ownership.

The `Source` model is intentionally **unchanged** — no new columns, just a clearer convention for what `file_path` points at.

## Test plan

- [x] `make verify` (lint + format-check + mypy + basedpyright + pydocstyle + pytest) — all green
  - ruff check: passed
  - ruff format --check: 36 files already formatted
  - mypy: success, no issues in 36 files
  - basedpyright: 0 errors, 0 warnings
  - pydocstyle: clean
  - pytest: 30 passed
- [x] `pre-commit run --all-files` — all hooks passed
- [ ] Manual: ingest a PDF, confirm both `~/.wikimind/raw/{id}.pdf` and `~/.wikimind/raw/{id}.txt` exist and `Source.file_path` ends in `.txt`
- [ ] Manual: ingest a URL, confirm both `.html` and `.txt` exist
- [ ] Manual: `DELETE /ingest/sources/{id}` removes both files from disk

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)