### PR TITLE
feat: add Docling PDF adapter with fitz fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,13 @@ search = [
 transcribe = [
     "openai-whisper>=20240930",
 ]
+parse-advanced = [
+    # Docling enables structured PDF parsing (heading hierarchy, tables, OCR
+    # fallback, multi-column layouts). Optional because it pulls in ~500MB of
+    # ML models on first use. The PDF adapter falls back to pymupdf when
+    # docling is not installed. See issue #57.
+    "docling>=2.0",
+]
 dev = [
     "wikimind[test,lint]",
 ]

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 import fitz
@@ -32,6 +33,50 @@ from wikimind.config import get_settings
 from wikimind.models import DocumentChunk, IngestStatus, NormalizedDocument, Source, SourceType
 
 log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Optional Docling integration (issue #57)
+#
+# Docling is a structured PDF parser that preserves heading hierarchy, tables,
+# multi-column layouts, and OCR'd text. It is opt-in via the ``parse-advanced``
+# extras group because it pulls in ~500MB of ML models on first use. When
+# docling is not installed the PDF adapter falls back to ``fitz`` plain-text
+# extraction (the previous behaviour), so the test suite and lightweight
+# installs continue to work without modification.
+# ---------------------------------------------------------------------------
+
+try:
+    from docling.document_converter import DocumentConverter as _DocumentConverter
+
+    _DOCLING_AVAILABLE = True
+except ImportError:
+    _DocumentConverter = None  # type: ignore[assignment,misc]
+    _DOCLING_AVAILABLE = False
+
+# Lazy-initialized singleton converter — instantiating ``DocumentConverter``
+# triggers ML model loading (slow, ~500MB), so we defer it until the first PDF
+# is actually ingested.
+_docling_converter: Any = None
+
+
+def _get_docling_converter() -> Any:
+    """Lazy-initialize the Docling converter singleton.
+
+    Loads the underlying ML models on first call. Subsequent calls return the
+    cached converter so model initialization only happens once per process.
+
+    Returns:
+        The shared :class:`docling.document_converter.DocumentConverter`
+        instance. Typed as :class:`Any` because docling is an optional
+        dependency that may not be installed.
+    """
+    global _docling_converter
+    if _docling_converter is None:
+        if _DocumentConverter is None:  # pragma: no cover - guarded by caller
+            raise RuntimeError("Docling is not installed. Install with: pip install -e '.[parse-advanced]'")
+        _docling_converter = _DocumentConverter()
+    return _docling_converter
 
 
 def estimate_tokens(text: str) -> int:
@@ -185,7 +230,19 @@ class URLAdapter:
 
 
 class PDFAdapter:
-    """Adapter for ingesting PDF files."""
+    """Adapter for ingesting PDF files.
+
+    Uses :mod:`docling` for structured extraction (heading hierarchy, tables,
+    OCR fallback, multi-column layouts) when the ``parse-advanced`` extras
+    group is installed. Falls back to plain-text extraction via
+    :mod:`fitz` (pymupdf) when docling is not available, preserving the
+    behaviour the project shipped with before issue #57.
+
+    Both branches honour the dual-file lineage convention from issue #59: the
+    raw ``.pdf`` bytes are written to ``~/.wikimind/raw/{source_id}.pdf`` and
+    the cleaned extraction is written to ``~/.wikimind/raw/{source_id}.txt``,
+    with ``Source.file_path`` pointing at the latter.
+    """
 
     async def ingest(
         self,
@@ -193,8 +250,19 @@ class PDFAdapter:
         filename: str,
         session: AsyncSession,
     ) -> tuple[Source, NormalizedDocument]:
-        """Ingest a PDF file and return source and normalized document."""
-        log.info("Ingesting PDF", filename=filename)
+        """Ingest a PDF file and return source and normalized document.
+
+        Args:
+            file_bytes: Raw PDF binary contents.
+            filename: Original upload filename, used for the source title.
+            session: Async database session.
+
+        Returns:
+            A tuple of the persisted :class:`Source` row and the in-memory
+            :class:`NormalizedDocument` ready for compilation.
+        """
+        extractor = "docling" if _DOCLING_AVAILABLE else "fitz"
+        log.info("Ingesting PDF", filename=filename, extractor=extractor)
 
         # Create source record
         source = Source(
@@ -213,14 +281,17 @@ class PDFAdapter:
         settings = get_settings()
         raw_dir = Path(settings.data_dir) / "raw"
         raw_dir.mkdir(parents=True, exist_ok=True)
-        (raw_dir / f"{source.id}.pdf").write_bytes(file_bytes)
+        raw_pdf_path = raw_dir / f"{source.id}.pdf"
+        raw_pdf_path.write_bytes(file_bytes)
 
-        # Extract text — plain text is the most reliable format across PDFs
-        doc = fitz.open(stream=file_bytes, filetype="pdf")
-        pages_text: list[str] = [str(page.get_text()) for page in doc]
-        doc.close()
+        # Extract text — prefer Docling for structured output (markdown with
+        # heading hierarchy, table-aware), fall back to fitz plain text when
+        # docling is not installed.
+        if _DOCLING_AVAILABLE:
+            clean_text, page_count = self._extract_via_docling(raw_pdf_path)
+        else:
+            clean_text, page_count = self._extract_via_fitz(file_bytes)
 
-        clean_text = "\n\n".join(pages_text)
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(clean_text, encoding="utf-8")
         source.file_path = str(text_path)
@@ -238,8 +309,57 @@ class PDFAdapter:
             chunks=chunk_text(clean_text, source.id),
         )
 
-        log.info("PDF ingested", title=source.title, tokens=token_count, pages=len(pages_text))
+        log.info(
+            "PDF ingested",
+            title=source.title,
+            tokens=token_count,
+            pages=page_count,
+            extractor=extractor,
+        )
         return source, normalized
+
+    @staticmethod
+    def _extract_via_fitz(file_bytes: bytes) -> tuple[str, int]:
+        """Extract plain text from a PDF using :mod:`fitz` (pymupdf).
+
+        This is the fallback path used when docling is not installed. It
+        produces the exact same output the adapter shipped with prior to
+        issue #57 — pages joined with a blank line.
+
+        Args:
+            file_bytes: Raw PDF binary contents.
+
+        Returns:
+            A tuple of ``(cleaned_text, page_count)``.
+        """
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+        pages_text: list[str] = [str(page.get_text()) for page in doc]
+        doc.close()
+        return "\n\n".join(pages_text), len(pages_text)
+
+    @staticmethod
+    def _extract_via_docling(raw_pdf_path: Path) -> tuple[str, int]:
+        """Extract structured markdown from a PDF using :mod:`docling`.
+
+        Docling preserves heading hierarchy, tables, multi-column layouts,
+        and OCR'd text in images. The result is markdown — a strict
+        improvement over fitz plain text for slide decks and academic papers.
+
+        Args:
+            raw_pdf_path: Path to the saved raw PDF on disk. Docling reads
+                from a path rather than a byte stream.
+
+        Returns:
+            A tuple of ``(markdown_text, page_count)``.
+        """
+        converter = _get_docling_converter()
+        result = converter.convert(str(raw_pdf_path))
+        markdown = result.document.export_to_markdown()
+        # Docling exposes pages on the document; fall back to 0 if the
+        # attribute is missing on a future release.
+        pages = getattr(result.document, "pages", None)
+        page_count = len(pages) if pages is not None else 0
+        return markdown, page_count
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pdf_adapter.py
+++ b/tests/unit/test_pdf_adapter.py
@@ -1,0 +1,228 @@
+"""Tests for the PDF ingest adapter — covers both docling and fitz branches.
+
+The adapter prefers docling when available and falls back to fitz plain-text
+extraction otherwise (see issue #57). Both branches must produce a valid
+``NormalizedDocument`` and honour the dual-file lineage convention from
+issue #59 (raw ``.pdf`` + cleaned ``.txt`` on disk).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import fitz
+import pytest
+
+from wikimind.config import Settings, get_settings
+from wikimind.ingest import service as ingest_service
+from wikimind.ingest.service import PDFAdapter
+from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_pdf_bytes(pages: list[str]) -> bytes:
+    """Construct a tiny in-memory PDF using fitz with one page per string.
+
+    Args:
+        pages: One string per page; the string is rendered as plain text.
+
+    Returns:
+        Raw PDF bytes ready to feed to ``PDFAdapter.ingest``.
+    """
+    doc = fitz.open()
+    for body in pages:
+        page = doc.new_page()
+        page.insert_text((72, 72), body)
+    data = doc.tobytes()
+    doc.close()
+    return bytes(data)
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``get_settings().data_dir`` at a tmp directory for one test.
+
+    The settings function is ``lru_cache``d, so we override it on the
+    ``ingest.service`` module attribute the adapter actually calls instead of
+    trying to bust the cache.
+    """
+    fake_settings = Settings(data_dir=str(tmp_path))
+    monkeypatch.setattr(ingest_service, "get_settings", lambda: fake_settings)
+    # Pre-create raw_dir so the assertions can rely on it existing.
+    (tmp_path / "raw").mkdir(parents=True, exist_ok=True)
+    # Drop the global lru_cache too in case anything else hits it during the
+    # test (defensive — the monkeypatch above is the primary mechanism).
+    get_settings.cache_clear()
+    yield tmp_path
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Fitz fallback path — what every CI run exercises today
+# ---------------------------------------------------------------------------
+
+
+class TestPDFAdapterFitzFallback:
+    """Behaviour when docling is not installed (the CI default)."""
+
+    async def test_fitz_extract_static_helper(self) -> None:
+        """``_extract_via_fitz`` returns plain text and the page count."""
+        pdf_bytes = _build_pdf_bytes(["Hello world", "Second page body"])
+
+        clean_text, page_count = PDFAdapter._extract_via_fitz(pdf_bytes)
+
+        assert page_count == 2
+        assert "Hello world" in clean_text
+        assert "Second page body" in clean_text
+        # Pages are joined with a blank line — preserves the pre-#57 format.
+        assert "\n\n" in clean_text
+
+    async def test_ingest_uses_fitz_when_docling_missing(
+        self,
+        db_session,
+        isolated_data_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``_DOCLING_AVAILABLE`` is False the fitz branch produces a doc."""
+        monkeypatch.setattr(ingest_service, "_DOCLING_AVAILABLE", False)
+
+        pdf_bytes = _build_pdf_bytes(["Fallback page text"])
+        adapter = PDFAdapter()
+
+        source, doc = await adapter.ingest(pdf_bytes, "fallback.pdf", db_session)
+
+        assert isinstance(source, Source)
+        assert isinstance(doc, NormalizedDocument)
+        assert source.source_type == SourceType.PDF
+        assert source.title == "fallback"
+        assert source.status == IngestStatus.PROCESSING
+        assert "Fallback page text" in doc.clean_text
+        assert doc.estimated_tokens > 0
+        assert doc.chunks  # at least one chunk
+
+    async def test_ingest_writes_dual_files(
+        self,
+        db_session,
+        isolated_data_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both the raw ``.pdf`` and the cleaned ``.txt`` must be persisted."""
+        monkeypatch.setattr(ingest_service, "_DOCLING_AVAILABLE", False)
+
+        pdf_bytes = _build_pdf_bytes(["Lineage check page"])
+        adapter = PDFAdapter()
+
+        source, _doc = await adapter.ingest(pdf_bytes, "lineage.pdf", db_session)
+
+        raw_pdf = isolated_data_dir / "raw" / f"{source.id}.pdf"
+        raw_txt = isolated_data_dir / "raw" / f"{source.id}.txt"
+
+        assert raw_pdf.exists(), "raw .pdf binary should be saved alongside .txt"
+        assert raw_pdf.read_bytes() == pdf_bytes
+        assert raw_txt.exists(), "cleaned .txt should be saved for the worker"
+        assert "Lineage check page" in raw_txt.read_text(encoding="utf-8")
+        assert source.file_path == str(raw_txt)
+
+
+# ---------------------------------------------------------------------------
+# Docling path — exercised by mocking the converter (docling not in CI)
+# ---------------------------------------------------------------------------
+
+
+class TestPDFAdapterDoclingPath:
+    """Behaviour when docling is available — converter is mocked."""
+
+    async def test_extract_via_docling_calls_converter(
+        self,
+        isolated_data_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_extract_via_docling`` delegates to the singleton converter."""
+        fake_doc = MagicMock()
+        fake_doc.export_to_markdown.return_value = "# Heading\n\nBody text\n"
+        fake_doc.pages = [object(), object(), object()]
+
+        fake_result = MagicMock()
+        fake_result.document = fake_doc
+
+        fake_converter = MagicMock()
+        fake_converter.convert.return_value = fake_result
+
+        monkeypatch.setattr(
+            ingest_service,
+            "_get_docling_converter",
+            lambda: fake_converter,
+        )
+
+        raw_pdf = isolated_data_dir / "raw" / "fake.pdf"
+        raw_pdf.write_bytes(b"%PDF-1.4 fake")
+
+        clean_text, page_count = PDFAdapter._extract_via_docling(raw_pdf)
+
+        fake_converter.convert.assert_called_once_with(str(raw_pdf))
+        assert clean_text == "# Heading\n\nBody text\n"
+        assert page_count == 3
+
+    async def test_ingest_uses_docling_when_available(
+        self,
+        db_session,
+        isolated_data_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``_DOCLING_AVAILABLE`` is True the docling branch is taken."""
+        monkeypatch.setattr(ingest_service, "_DOCLING_AVAILABLE", True)
+
+        markdown = "# Slide deck\n\n## Section one\n\nA structured body.\n"
+        fake_doc = MagicMock()
+        fake_doc.export_to_markdown.return_value = markdown
+        fake_doc.pages = [object()]
+        fake_result = MagicMock()
+        fake_result.document = fake_doc
+        fake_converter = MagicMock()
+        fake_converter.convert.return_value = fake_result
+        monkeypatch.setattr(
+            ingest_service,
+            "_get_docling_converter",
+            lambda: fake_converter,
+        )
+
+        pdf_bytes = _build_pdf_bytes(["ignored — docling reads the file path"])
+        adapter = PDFAdapter()
+
+        source, doc = await adapter.ingest(pdf_bytes, "deck.pdf", db_session)
+
+        # The converter must have been invoked against the saved raw .pdf,
+        # not against the in-memory bytes.
+        raw_pdf_path = isolated_data_dir / "raw" / f"{source.id}.pdf"
+        fake_converter.convert.assert_called_once_with(str(raw_pdf_path))
+
+        assert doc.clean_text == markdown
+        assert "# Slide deck" in doc.clean_text
+        assert source.file_path == str(isolated_data_dir / "raw" / f"{source.id}.txt")
+        assert (isolated_data_dir / "raw" / f"{source.id}.txt").read_text(encoding="utf-8") == markdown
+
+
+# ---------------------------------------------------------------------------
+# Module-level detection flag
+# ---------------------------------------------------------------------------
+
+
+class TestDoclingDetectionFlag:
+    def test_module_constant_is_boolean(self) -> None:
+        """``_DOCLING_AVAILABLE`` is set at import time and is a bool."""
+        assert isinstance(ingest_service._DOCLING_AVAILABLE, bool)
+
+    def test_get_converter_raises_when_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Calling ``_get_docling_converter`` without docling raises clearly."""
+        monkeypatch.setattr(ingest_service, "_DocumentConverter", None)
+        monkeypatch.setattr(ingest_service, "_docling_converter", None)
+
+        with pytest.raises(RuntimeError, match="Docling is not installed"):
+            ingest_service._get_docling_converter()


### PR DESCRIPTION
## Summary

- Adds optional IBM Docling support to `PDFAdapter` for structured PDF parsing — preserves heading hierarchy, tables, OCR'd text in images, and multi-column layouts
- Keeps the existing `fitz` (pymupdf) path as a fallback so default installs and CI continue to work without the heavy ML dependency
- Docling is opt-in via a new `parse-advanced` extras group (`pip install -e ".[parse-advanced]"`) because it pulls in ~500MB of models on first use

Closes #57

## Changes

### `pyproject.toml`
- New optional dependency group `parse-advanced = ["docling>=2.0"]`

### `src/wikimind/ingest/service.py`
- Module-level `_DOCLING_AVAILABLE` flag detected once at import time via a `try`/`except ImportError` block
- Lazy-initialized singleton `_get_docling_converter()` that only loads ML models on the first PDF ingest, raising a clear `RuntimeError` if docling is missing
- `PDFAdapter.ingest` picks the extractor based on `_DOCLING_AVAILABLE`, splits extraction into two static helpers `_extract_via_fitz` and `_extract_via_docling`, and logs which extractor is in use
- Class docstring updated to document both branches and the dual-file lineage from #59
- Both branches still write the raw `.pdf` and the cleaned `.txt` to `~/.wikimind/raw/` with `Source.file_path` pointing at the `.txt`

### `tests/unit/test_pdf_adapter.py` (new)
- `_build_pdf_bytes` helper constructs an in-memory PDF with `fitz` for hermetic tests
- `isolated_data_dir` fixture monkeypatches `get_settings` so file-system writes go to a `tmp_path`
- `TestPDFAdapterFitzFallback` covers the fitz branch end-to-end (extract helper, ingest, dual-file persistence)
- `TestPDFAdapterDoclingPath` mocks the converter and exercises the docling branch — verifies the converter is called with the saved raw PDF path and the markdown output is written to the `.txt` sidecar
- `TestDoclingDetectionFlag` covers the module constant and the `RuntimeError` raised when docling is unavailable

## Test plan

- [x] `pytest tests/unit/test_pdf_adapter.py` — 7 new tests pass
- [x] `pytest` full suite — 45 tests pass (38 existing + 7 new), no regressions
- [x] `ruff check src/` clean
- [x] `ruff format --check src/` clean
- [x] `mypy src/wikimind` clean
- [x] `pydocstyle src/wikimind` clean
- [x] `pre-commit run --files <changed>` clean
- [ ] Reviewer to install `pip install -e ".[parse-advanced]"` and run a live extraction against `Digital Sovereignty Deck_2026.pdf` to confirm the 2-5x token improvement noted in the issue

## Notes

- The fitz fallback path produces byte-identical output to the pre-#57 behaviour (pages joined with `\n\n`), so existing PDF ingest tests and downstream chunking assumptions are unchanged
- Docling reads from a file path rather than a byte stream, which is why the raw `.pdf` is saved to disk before extraction in the docling branch — this also matches the lineage convention from #59
- No changes to `worker.py` are needed — it only reads the cleaned `.txt` sidecar and is format-agnostic by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)