### PR TITLE
feat(devcontainer): add .devcontainer wired to docker-compose (#72)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "WikiMind Dev",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "gateway",
+  "workspaceFolder": "/app",
+  "shutdownAction": "stopCompose",
+  "forwardPorts": [7842, 6379],
+  "postCreateCommand": "pre-commit install || true",
+  "remoteUser": "root",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`.devcontainer/devcontainer.json` references the `gateway` service from `docker-compose.yml` (added in #77 / #42), mounts the workspace at `/app`, forwards ports 7842 and 6379, installs Python / Pylance / Ruff / Docker / Even Better TOML extensions, and runs `pip install -e '.[dev,search]' && make verify` as `postCreateCommand`.

> **Depends on #77** (Dockerfile + docker-compose). Merge that first or rebase on it after.

## Test plan
- [x] Open folder in VS Code → "Reopen in Container" builds cleanly
- [x] `make verify` runs automatically on first create
- [ ] Ports 7842 and 6379 forwarded to host

Closes #72