### PR TITLE
fix(qa_agent): drop ConfidenceLevel coercion on file-back path

### DIFF
--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -17,7 +17,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.config import get_settings
 from wikimind.engine.llm_router import get_llm_router
-from wikimind.models import Article, CompletionRequest, ConfidenceLevel, Query, QueryRequest, QueryResult, TaskType
+from wikimind.models import Article, CompletionRequest, Query, QueryRequest, QueryResult, TaskType
 
 log = structlog.get_logger()
 
@@ -227,12 +227,16 @@ compiled: {datetime.utcnow().isoformat()}
 
         file_path.write_text(content, encoding="utf-8")
 
+        # Q&A answer confidence ("high"/"medium"/"low") is a different concept
+        # from Article.confidence (sourced/mixed/inferred/opinion), so we leave
+        # the article-level confidence unset on filed-back answers. The agent's
+        # confidence string is preserved on the originating Query row.
         article = Article(
             slug=slug,
             title=f"Q: {question[:80]}",
             file_path=str(file_path),
             summary=result.answer[:200],
-            confidence=ConfidenceLevel(result.confidence) if result.confidence else None,
+            confidence=None,
         )
         session.add(article)
         await session.commit()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests — exercise multiple modules together against in-memory infra."""

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -1,0 +1,119 @@
+"""End-to-end integration test for the Q&A → file-back loop.
+
+Regression coverage for issue #84: the previous implementation of
+``QAAgent._file_back`` coerced ``QueryResult.confidence`` (one of
+``"high" | "medium" | "low"``) into the ``ConfidenceLevel`` enum (whose
+members are ``sourced/mixed/inferred/opinion``), which raised ``ValueError``
+on the real file-back path. Existing unit tests in
+``tests/unit/test_qa_agent.py`` mocked ``_file_back`` itself and never
+exercised the bug.
+
+This test wires the agent up against the real in-memory database, seeds an
+Article so retrieval has something to find, and runs the full
+``answer(file_back=True)`` path with only the LLM router mocked.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine import qa_agent as qa_mod
+from wikimind.engine.qa_agent import QAAgent
+from wikimind.models import (
+    Article,
+    CompletionResponse,
+    Provider,
+    Query,
+    QueryRequest,
+)
+
+
+async def test_ask_with_file_back_creates_article_end_to_end(
+    db_session: AsyncSession,
+    tmp_path,
+) -> None:
+    """``answer(file_back=True)`` must persist a Query and a filed Article.
+
+    Exercises the real loop: retrieve context → query LLM (mocked at the
+    router boundary) → persist Query row → file back as Article. Asserts
+    that no exception is raised (regression for #84) and that the
+    Query → Article linkage is intact in the DB.
+    """
+    # Seed an article so _retrieve_context returns a non-empty list and the
+    # agent takes the _query_llm branch (not the empty-context shortcut).
+    article_md = tmp_path / "knowledge.md"
+    article_md.write_text(
+        "# Knowledge\n\nThe wikimind project answers questions from sources.",
+        encoding="utf-8",
+    )
+    seed = Article(
+        slug="knowledge",
+        title="Knowledge",
+        file_path=str(article_md),
+        summary="seed article",
+    )
+    db_session.add(seed)
+    await db_session.commit()
+
+    # Build a QAAgent with the LLM router and settings patched at construction
+    # time, mirroring the helper used by tests/unit/test_qa_agent.py.
+    with (
+        patch.object(qa_mod, "get_llm_router"),
+        patch.object(qa_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
+    ):
+        agent = QAAgent()
+
+    # Mock the router boundary: complete() returns an envelope, and
+    # parse_json_response yields a canned QueryResult dict whose
+    # confidence is "high" — the exact value that used to crash _file_back.
+    fake_response = CompletionResponse(
+        content="{}",
+        provider_used=Provider.ANTHROPIC,
+        model_used="test-model",
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=0.0,
+        latency_ms=0,
+    )
+    agent.router.complete = AsyncMock(return_value=fake_response)
+    agent.router.parse_json_response = lambda _resp: {
+        "answer": "Yes, wikimind answers questions from sources.",
+        "confidence": "high",
+        "sources": ["Knowledge"],
+        "related_articles": [],
+        "follow_up_questions": [],
+    }
+
+    request = QueryRequest(
+        question="Does wikimind answer questions from sources?",
+        file_back=True,
+    )
+
+    # Real call — must not raise. Pre-fix this raised ValueError because
+    # ConfidenceLevel("high") is not a member of the enum.
+    query = await agent.answer(request, db_session)
+
+    # Query row was persisted with the agent-confidence string preserved.
+    assert query.id is not None
+    assert query.confidence == "high"
+
+    # File-back populated the linkage fields.
+    assert query.filed_back is True
+    assert query.filed_article_id is not None
+
+    # The filed Article actually exists in the DB at the linked id.
+    filed = await db_session.get(Article, query.filed_article_id)
+    assert filed is not None
+    assert filed.title.startswith("Q: ")
+    # Per Option 2: article-level confidence is left unset on filed-back
+    # answers because Q&A confidence and Article confidence are different
+    # concepts. The Query row carries the agent's confidence string instead.
+    assert filed.confidence is None
+
+    # Sanity: the Query row is queryable end-to-end via the session.
+    fetched = (await db_session.execute(select(Query).where(Query.id == query.id))).scalar_one()
+    assert fetched.filed_article_id == filed.id


### PR DESCRIPTION
Closes #84

## Summary

`QAAgent._file_back` was calling `ConfidenceLevel(result.confidence)` where `result.confidence` is the Q&A agent's `"high"`/`"medium"`/`"low"` string. The `ConfidenceLevel` enum members are `sourced`/`mixed`/`inferred`/`opinion`, so this raised `ValueError` on every real file-back call. Existing unit tests in `tests/unit/test_qa_agent.py` mocked `_file_back` itself (see the comment in `test_answer_with_context_and_file_back`), which is why the bug never surfaced in CI.

This is a Phase-1 prerequisite for the upcoming Ask UI work.

## Fix — Option 2 (recommended in the issue)

Don't set `Article.confidence` on filed-back answers — leave it `None`.

**Why Option 2:** Q&A answer confidence and `Article.confidence` describe different things. `Article.confidence` describes how a compiled article relates to its sources (set by the compiler). The Q&A agent's confidence describes how confident the agent is that the answer is in the wiki. Conflating them was the original bug. The `Query` row already stores the agent's confidence string, so filed-back answers leave `Article.confidence` unset. The article type is still disambiguated by the `type: qa-answer` frontmatter that `_file_back` writes into the markdown.

The `ConfidenceLevel` enum, the `QueryResult` schema, and the Q&A prompt contract are all unchanged.

## Integration test

Adds `tests/integration/test_qa_loop_integration.py` (and `tests/integration/__init__.py`) — the first test in `tests/integration/`. The test exercises the full loop end-to-end with only the LLM router boundary mocked:

1. Seeds an `Article` row in the in-memory DB so `_retrieve_context` returns a non-empty list and the agent takes the real `_query_llm` branch (not the empty-context shortcut).
2. Patches `agent.router.complete` and `agent.router.parse_json_response` to return a canned `QueryResult` with `confidence="high"` — the exact value that used to crash `_file_back`.
3. Calls `agent.answer(QueryRequest(question=..., file_back=True), session)`.
4. Asserts: no exception raised, `query.confidence == "high"`, `query.filed_back is True`, `query.filed_article_id` is set, and the `Article` row exists at that id with `confidence is None` (the Option 2 contract).

Existing unit tests are untouched — they're allowed to keep mocking `_file_back`.

## Test plan

- [x] `make verify` green locally — 217 passed, 95.32% coverage (qa_agent.py at 100%)
- [x] New integration test fails on the pre-fix code path (verified by reading the bug — `ConfidenceLevel("high")` raises `ValueError`) and passes on the fixed code
- [x] All existing `tests/unit/test_qa_agent.py` tests still pass