### PR TITLE
fix(ingest): honor auto_compile=false flag (#81)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -35,14 +35,27 @@ paths:
       tags:
       - Ingest
       summary: Ingest Pdf
-      description: Upload and ingest a PDF.
+      description: 'Upload and ingest a PDF.
+
+
+        The ``auto_compile`` query parameter (default ``True``) controls whether the
+
+        source is enqueued for background compilation immediately after upload.'
       operationId: ingest_pdf_ingest_pdf_post
+      parameters:
+      - name: auto_compile
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: true
+          title: Auto Compile
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/Body_ingest_pdf_ingest_pdf_post'
-        required: true
       responses:
         '200':
           description: Successful Response

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -17,20 +17,25 @@ async def ingest_url(
     service: IngestService = Depends(get_ingest_service),
 ):
     """Ingest a web URL or YouTube video."""
-    return await service.ingest_url(request.url, session)
+    return await service.ingest_url(request.url, session, auto_compile=request.auto_compile)
 
 
 @router.post("/pdf", response_model=Source)
 async def ingest_pdf(
     file: UploadFile = File(...),
+    auto_compile: bool = True,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
 ):
-    """Upload and ingest a PDF."""
+    """Upload and ingest a PDF.
+
+    The ``auto_compile`` query parameter (default ``True``) controls whether the
+    source is enqueued for background compilation immediately after upload.
+    """
     if not file.filename or not file.filename.endswith(".pdf"):
         raise HTTPException(status_code=400, detail="File must be a PDF")
     contents = await file.read()
-    return await service.ingest_pdf(contents, file.filename, session)
+    return await service.ingest_pdf(contents, file.filename, session, auto_compile=auto_compile)
 
 
 @router.post("/text", response_model=Source)
@@ -40,7 +45,7 @@ async def ingest_text(
     service: IngestService = Depends(get_ingest_service),
 ):
     """Ingest raw text or a note."""
-    return await service.ingest_text(request.content, request.title, session)
+    return await service.ingest_text(request.content, request.title, session, auto_compile=request.auto_compile)
 
 
 @router.get("/sources")

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -29,12 +29,15 @@ class IngestService:
     def __init__(self) -> None:
         self._adapter = IngestAdapter()
 
-    async def ingest_url(self, url: str, session: AsyncSession) -> Source:
-        """Ingest a URL (web page or YouTube) and schedule compilation.
+    async def ingest_url(self, url: str, session: AsyncSession, *, auto_compile: bool = True) -> Source:
+        """Ingest a URL (web page or YouTube) and optionally schedule compilation.
 
         Args:
             url: The URL to ingest.
             session: Async database session.
+            auto_compile: When ``True`` (default), schedule background compilation
+                immediately after persisting the source. When ``False``, persist
+                only — the caller can compile later via the compile API.
 
         Returns:
             The persisted Source record.
@@ -47,37 +50,60 @@ class IngestService:
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
-        await self._schedule_compile(source)
+        if auto_compile:
+            await self._schedule_compile(source)
         return source
 
-    async def ingest_pdf(self, file_bytes: bytes, filename: str, session: AsyncSession) -> Source:
-        """Ingest a PDF file and schedule compilation.
+    async def ingest_pdf(
+        self,
+        file_bytes: bytes,
+        filename: str,
+        session: AsyncSession,
+        *,
+        auto_compile: bool = True,
+    ) -> Source:
+        """Ingest a PDF file and optionally schedule compilation.
 
         Args:
             file_bytes: Raw PDF bytes.
             filename: Original filename.
             session: Async database session.
+            auto_compile: When ``True`` (default), schedule background compilation
+                immediately after persisting the source. When ``False``, persist
+                only.
 
         Returns:
             The persisted Source record.
         """
         source = await self._adapter.ingest_pdf(file_bytes, filename, session)
-        await self._schedule_compile(source)
+        if auto_compile:
+            await self._schedule_compile(source)
         return source
 
-    async def ingest_text(self, content: str, title: str | None, session: AsyncSession) -> Source:
-        """Ingest raw text content and schedule compilation.
+    async def ingest_text(
+        self,
+        content: str,
+        title: str | None,
+        session: AsyncSession,
+        *,
+        auto_compile: bool = True,
+    ) -> Source:
+        """Ingest raw text content and optionally schedule compilation.
 
         Args:
             content: The text content to ingest.
             title: Optional title for the source.
             session: Async database session.
+            auto_compile: When ``True`` (default), schedule background compilation
+                immediately after persisting the source. When ``False``, persist
+                only.
 
         Returns:
             The persisted Source record.
         """
         source = await self._adapter.ingest_text(content, title, session)
-        await self._schedule_compile(source)
+        if auto_compile:
+            await self._schedule_compile(source)
         return source
 
     @staticmethod

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -70,6 +70,121 @@ async def test_ingest_service_pdf_and_text(db_session) -> None:
         await svc.ingest_text("c", "t", db_session)
 
 
+# ----- IngestService: auto_compile=False short-circuits scheduling (issue #81) -----
+
+
+async def test_ingest_service_url_auto_compile_false_skips_schedule(db_session) -> None:
+    """auto_compile=False must NOT enqueue a compile job for URL ingest."""
+    svc = IngestService()
+    src = Source(source_type=SourceType.URL, source_url="http://x", id="src-url")
+    svc._adapter = MagicMock()
+    svc._adapter.ingest_url = AsyncMock(return_value=src)
+    with patch("wikimind.services.ingest.get_background_compiler") as gbc:
+        schedule_compile = AsyncMock(return_value="job-1")
+        gbc.return_value.schedule_compile = schedule_compile
+        result = await svc.ingest_url("http://x", db_session, auto_compile=False)
+    assert result is src
+    schedule_compile.assert_not_awaited()
+
+
+async def test_ingest_service_pdf_auto_compile_false_skips_schedule(db_session) -> None:
+    """auto_compile=False must NOT enqueue a compile job for PDF ingest."""
+    svc = IngestService()
+    src = Source(source_type=SourceType.PDF, id="src-pdf")
+    svc._adapter = MagicMock()
+    svc._adapter.ingest_pdf = AsyncMock(return_value=src)
+    with patch("wikimind.services.ingest.get_background_compiler") as gbc:
+        schedule_compile = AsyncMock(return_value="job-2")
+        gbc.return_value.schedule_compile = schedule_compile
+        result = await svc.ingest_pdf(b"x", "f.pdf", db_session, auto_compile=False)
+    assert result is src
+    schedule_compile.assert_not_awaited()
+
+
+async def test_ingest_service_text_auto_compile_false_skips_schedule(db_session) -> None:
+    """auto_compile=False must NOT enqueue a compile job for text ingest."""
+    svc = IngestService()
+    src = Source(source_type=SourceType.TEXT, id="src-text")
+    svc._adapter = MagicMock()
+    svc._adapter.ingest_text = AsyncMock(return_value=src)
+    with patch("wikimind.services.ingest.get_background_compiler") as gbc:
+        schedule_compile = AsyncMock(return_value="job-3")
+        gbc.return_value.schedule_compile = schedule_compile
+        result = await svc.ingest_text("hello", "t", db_session, auto_compile=False)
+    assert result is src
+    schedule_compile.assert_not_awaited()
+
+
+async def test_ingest_service_text_auto_compile_default_schedules(db_session) -> None:
+    """Default behavior (auto_compile omitted) must still schedule a compile."""
+    svc = IngestService()
+    src = Source(source_type=SourceType.TEXT, id="src-default")
+    svc._adapter = MagicMock()
+    svc._adapter.ingest_text = AsyncMock(return_value=src)
+    with patch("wikimind.services.ingest.get_background_compiler") as gbc:
+        schedule_compile = AsyncMock(return_value="job-4")
+        gbc.return_value.schedule_compile = schedule_compile
+        await svc.ingest_text("hello", "t", db_session)
+    schedule_compile.assert_awaited_once_with("src-default")
+
+
+async def test_ingest_route_text_auto_compile_false_skips_schedule(client) -> None:
+    """End-to-end: POST /ingest/text with auto_compile=False must not schedule."""
+    fake_src = Source(source_type=SourceType.TEXT, id="route-text", title="x")
+    svc = get_ingest_service()
+    with (
+        patch.object(svc, "_adapter") as adapter,
+        patch("wikimind.services.ingest.get_background_compiler") as gbc,
+    ):
+        adapter.ingest_text = AsyncMock(return_value=fake_src)
+        schedule_compile = AsyncMock(return_value="job-r1")
+        gbc.return_value.schedule_compile = schedule_compile
+        resp = await client.post(
+            "/ingest/text",
+            json={"content": "hello", "title": "x", "auto_compile": False},
+        )
+    assert resp.status_code == 200
+    schedule_compile.assert_not_awaited()
+
+
+async def test_ingest_route_url_auto_compile_false_skips_schedule(client) -> None:
+    """End-to-end: POST /ingest/url with auto_compile=False must not schedule."""
+    fake_src = Source(source_type=SourceType.URL, id="route-url", source_url="http://x")
+    svc = get_ingest_service()
+    with (
+        patch.object(svc, "_adapter") as adapter,
+        patch("wikimind.services.ingest.get_background_compiler") as gbc,
+    ):
+        adapter.ingest_url = AsyncMock(return_value=fake_src)
+        schedule_compile = AsyncMock(return_value="job-r2")
+        gbc.return_value.schedule_compile = schedule_compile
+        resp = await client.post(
+            "/ingest/url",
+            json={"url": "http://x", "auto_compile": False},
+        )
+    assert resp.status_code == 200
+    schedule_compile.assert_not_awaited()
+
+
+async def test_ingest_route_pdf_auto_compile_false_skips_schedule(client) -> None:
+    """End-to-end: POST /ingest/pdf?auto_compile=false must not schedule."""
+    fake_src = Source(source_type=SourceType.PDF, id="route-pdf", title="f")
+    svc = get_ingest_service()
+    with (
+        patch.object(svc, "_adapter") as adapter,
+        patch("wikimind.services.ingest.get_background_compiler") as gbc,
+    ):
+        adapter.ingest_pdf = AsyncMock(return_value=fake_src)
+        schedule_compile = AsyncMock(return_value="job-r3")
+        gbc.return_value.schedule_compile = schedule_compile
+        resp = await client.post(
+            "/ingest/pdf?auto_compile=false",
+            files={"file": ("doc.pdf", b"%PDF-1.4...", "application/pdf")},
+        )
+    assert resp.status_code == 200
+    schedule_compile.assert_not_awaited()
+
+
 async def test_ingest_service_list_sources(db_session) -> None:
     svc = IngestService()
     db_session.add(Source(source_type=SourceType.TEXT, title="t", status=IngestStatus.PENDING))


### PR DESCRIPTION
## Summary

`auto_compile` on `IngestURLRequest` / `IngestTextRequest` was declared but never read — every successful ingest still enqueued a background compile job, burning ~$0.006 in LLM tokens per request even when the caller explicitly opted out.

- Routes now thread `request.auto_compile` to `IngestService.ingest_url` / `ingest_text`.
- The PDF route accepts a new `auto_compile` query parameter (matches the existing multipart/file-upload style — the route is `UploadFile`-based, so a query param is the cleanest fit).
- `IngestService.ingest_url` / `ingest_pdf` / `ingest_text` accept a keyword-only `auto_compile: bool = True` and short-circuit `_schedule_compile` when false.
- `docs/openapi.yaml` regenerated to surface the new PDF query parameter.

Closes #81

## Test plan

- [x] Service-layer unit tests for all three ingest paths assert `schedule_compile` is **never** awaited when `auto_compile=False`.
- [x] Default-behavior test confirms the omitted-flag case still schedules a compile (regression guard).
- [x] End-to-end FastAPI test-client tests for `POST /ingest/url`, `POST /ingest/text` (JSON `auto_compile: false`), and `POST /ingest/pdf?auto_compile=false` (query param) all assert no compile is enqueued.
- [x] `make verify` green: lint, format, mypy, pydocstyle, 223 tests passing, 95.60% coverage (floor 80%).