### PR TITLE
chore(tooling): align pre-commit ruff with pyproject + bump rev (#82)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,12 @@ repos:
 
   # ── Ruff (lint + format) ──────────────────────────────────────────────────
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.9
     hooks:
       - id: ruff
-        args: [--fix]
+        args: ["--config=pyproject.toml", "--fix"]
       - id: ruff-format
+        args: ["--config=pyproject.toml"]
 
   # ── Doc sync (local hooks) ────────────────────────────────────────────────
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "greenlet>=3.0.0",
 ]
 lint = [
-    "ruff>=0.7.0",
+    "ruff>=0.15.9",
     "mypy>=1.12.0",
     "pylint>=3.3.0",
     "pylint-pydantic>=0.3.0",


### PR DESCRIPTION
## Summary

Closes #82.

The issue body recommends "Option A": add `--config=pyproject.toml` to the pre-commit ruff hook so it reads the project's ruleset. **Option A alone does not fix the bug.** There is a second, deeper layer of drift:

- The pre-commit hook is pinned at `astral-sh/ruff-pre-commit@v0.8.6`. In ruff 0.8.6, `PLC0415` (`import-outside-top-level`) is **preview-only** — `ruff rule PLC0415` against the cached v0.8.6 binary returns "This rule is in preview and is not stable. The --preview flag is required for use."
- The venv ruff is **0.15.9**, where `PLC0415` is **stable** and on by default (verified in this PR's worktree).
- So even after pointing the hook at `pyproject.toml`, the v0.8.6 ruff would still treat `PLC0415` as preview, decide every `# noqa: PLC0415` is "unused", and strip it — re-creating the exact churn the issue describes.

This PR applies all three parts of the fix together so neither layer (config discovery OR version) can drift independently.

## Fix (three parts)

1. **`.pre-commit-config.yaml` — config discovery**: pass `--config=pyproject.toml` to both the `ruff` and `ruff-format` hooks so they read the same ruleset as the venv ruff.
2. **`.pre-commit-config.yaml` — version bump**: bump `astral-sh/ruff-pre-commit` from `v0.8.6` to `v0.15.9` (latest stable, matches the venv ruff). PLC0415 is stable in this version.
3. **`pyproject.toml` — venv floor**: raise the `lint` extra from `ruff>=0.7.0` to `ruff>=0.15.9` so the venv ruff cannot drift backward below the hook version.

## Verification

- Created a temporary probe file `tests/unit/test_plc0415_drift_probe_REMOVE_ME.py` with `import math  # noqa: PLC0415` inside a function.
- Ran `pre-commit run ruff --files tests/unit/test_plc0415_drift_probe_REMOVE_ME.py`:
  - Hook ran the new ruff 0.15.9 environment (verified by inspecting `~/.cache/pre-commit/repo*/py_env-python3.12/bin/ruff --version`).
  - **The `# noqa: PLC0415` was NOT stripped.** No "unused noqa" diagnostic.
- Ran the same hook a second time → idempotent, no file churn.
- Negative-tested by stripping the `# noqa` from a scratch file and running the new ruff binary against it: `PLC0415 \`import\` should be at the top-level of a file` — confirming the rule is actually enforced when not silenced.
- Ran `make verify` with the probe present → **green** (216 passed, 95.32% coverage).
- Deleted the probe file; ran `make verify` again → **green**.
- Ran the new `ruff` and `ruff-format` hooks with `--all-files` → both pass with zero churn against the entire codebase.

## Test plan

- [x] `pre-commit run ruff --all-files` passes (no churn)
- [x] `pre-commit run ruff-format --all-files` passes (no churn)
- [x] `make verify` is green
- [x] `# noqa: PLC0415` survives a pre-commit pass

## Constraints honored

- No source code in `src/wikimind/` touched.
- No test files touched (probe file was deleted before commit).
- No new ruff rules; ruleset selection in `[tool.ruff.lint]` unchanged.
- No `--no-verify`, no force-push, no amend.