### PR TITLE
test(e2e): Playwright Ask loop + mock LLM provider + CI — PR 3 of 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,17 @@
 # WIKIMIND_LLM__OLLAMA__ENABLED=true
 # WIKIMIND_LLM__ANTHROPIC__ENABLED=false
 
+# ------------------------------------------------------------------
+# Mock LLM provider (for CI and local e2e testing ONLY)
+#
+# When enabled AND set as the default provider, the router returns
+# deterministic canned JSON responses instead of calling any real
+# LLM API. Do not enable in production. See src/wikimind/engine/llm_router.py.
+#
+# WIKIMIND_LLM__MOCK__ENABLED=true
+# WIKIMIND_LLM__DEFAULT_PROVIDER=mock
+# ------------------------------------------------------------------
+
 # ----------------------------------------------------------------------------
 # AWS / R2 Sync (optional, future use)
 # ----------------------------------------------------------------------------

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,180 @@
+# ===============================================================
+# 🎭  Playwright e2e — Ask loop
+# ===============================================================
+#
+#   - runs the React + Vite frontend against the real FastAPI backend
+#   - uses the deterministic mock LLM provider (no API keys, no Redis)
+#   - seeds the wiki with one fixture article before the test
+#   - executes on every push / PR to *main* that touches backend or frontend
+# ---------------------------------------------------------------
+
+name: Playwright e2e
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/wikimind/**"
+      - "apps/web/**"
+      - "pyproject.toml"
+      - ".github/workflows/e2e.yml"
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - "src/wikimind/**"
+      - "apps/web/**"
+      - "pyproject.toml"
+      - ".github/workflows/e2e.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Playwright Ask loop
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      WIKIMIND_LLM__MOCK__ENABLED: "true"
+      WIKIMIND_LLM__DEFAULT_PROVIDER: "mock"
+      WIKIMIND_DATA_DIR: "/tmp/wikimind-e2e"
+
+    steps:
+      # -----------------------------------------------------------
+      # 0️⃣  Checkout
+      # -----------------------------------------------------------
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # -----------------------------------------------------------
+      # 1️⃣  Set up Python
+      # -----------------------------------------------------------
+      - name: 🐍  Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # -----------------------------------------------------------
+      # 2️⃣  Install Python dependencies
+      # -----------------------------------------------------------
+      - name: 📦  Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      # -----------------------------------------------------------
+      # 3️⃣  Set up Node
+      # -----------------------------------------------------------
+      - name: ⚙️  Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      # -----------------------------------------------------------
+      # 4️⃣  Install frontend dependencies
+      # -----------------------------------------------------------
+      - name: 📦  Install frontend dependencies
+        working-directory: apps/web
+        run: npm ci
+
+      # -----------------------------------------------------------
+      # 5️⃣  Install Playwright browsers (+ apt deps for chromium)
+      # -----------------------------------------------------------
+      - name: 🎭  Install Playwright browsers
+        working-directory: apps/web
+        run: npx playwright install --with-deps chromium
+
+      # -----------------------------------------------------------
+      # 6️⃣  Start backend in the background
+      # -----------------------------------------------------------
+      - name: 🚀  Start backend
+        run: |
+          python -m uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 &
+          echo "Waiting for backend to become ready..."
+          for i in {1..30}; do
+            if curl -sf http://127.0.0.1:7842/docs > /dev/null 2>&1; then
+              echo "Backend ready after ${i}s"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "❌ Backend failed to start within 30s"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      # -----------------------------------------------------------
+      # 7️⃣  Seed the wiki with a fixture article
+      # -----------------------------------------------------------
+      #
+      # The ingest endpoint triggers an in-process async compile (there
+      # is no Redis worker in CI), so the article does not exist until
+      # the compile finishes. With the mock provider this takes ~100ms,
+      # but we poll for up to 30s to absorb cold-start jitter.
+      # -----------------------------------------------------------
+      - name: 🌱  Seed wiki with fixture article
+        run: |
+          curl -sf -X POST http://127.0.0.1:7842/ingest/text \
+            -H "Content-Type: application/json" \
+            -d '{"content":"WikiMind is a personal LLM-powered knowledge OS that ingests sources, compiles them into wiki articles, and answers questions against the wiki. It closes the Karpathy loop by filing conversations back into the wiki as new articles.","title":"WikiMind Overview","auto_compile":true}'
+          echo ""
+          echo "Waiting for in-process compile to complete..."
+          for i in {1..30}; do
+            count=$(curl -sf http://127.0.0.1:7842/wiki/articles | python3 -c "import sys, json; print(len(json.load(sys.stdin)))")
+            if [ "$count" -gt 0 ]; then
+              echo "Wiki seeded with ${count} article(s) after ${i}s"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "❌ No article appeared in the wiki within 30s of ingest"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      # -----------------------------------------------------------
+      # 8️⃣  Run Playwright (webServer auto-launches the Vite dev server)
+      # -----------------------------------------------------------
+      - name: 🎯  Run Playwright e2e
+        working-directory: apps/web
+        env:
+          CI: "true"
+        run: npm run e2e
+
+      # -----------------------------------------------------------
+      # 9️⃣  Upload Playwright HTML report on failure
+      # -----------------------------------------------------------
+      - name: 📤  Upload Playwright HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # -----------------------------------------------------------
+      # 🔟  Upload Playwright test-results (traces / screenshots)
+      # -----------------------------------------------------------
+      - name: 📤  Upload Playwright test-results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: apps/web/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,6 +18,7 @@
         "zustand": "^4.5.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.15",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -975,6 +976,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -4608,6 +4625,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
@@ -21,6 +22,7 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.15",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "line",
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/apps/web/tests/e2e/ask-loop.spec.ts
+++ b/apps/web/tests/e2e/ask-loop.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The Karpathy loop closure test, end-to-end through the actual UI.
+ *
+ * Prerequisites:
+ *   - The FastAPI backend must be running on http://localhost:7842 with
+ *     at least one Article already ingested in the wiki database.
+ *   - The frontend dev server is launched automatically by Playwright's
+ *     webServer config in playwright.config.ts.
+ *
+ * If this test fails, the user-facing Ask loop is broken at some layer.
+ */
+test("user can ask, follow up, and save a thread to the wiki", async ({ page }) => {
+  // --- Open the Ask view ---
+  await page.goto("/ask");
+  await expect(
+    page.getByRole("heading", { name: /conversations/i }),
+  ).toBeVisible();
+  // Empty-state message until a question is asked
+  await expect(
+    page.getByText(/ask a question to start a new conversation/i),
+  ).toBeVisible();
+
+  // --- Ask the first question ---
+  const input = page.getByPlaceholder(/ask a question about your wiki/i);
+  await input.fill("What is the WikiMind project about?");
+  await input.press("Enter");
+
+  // The first turn card (TurnCard or PendingTurnCard) appears
+  await expect(page.locator("article").first()).toBeVisible({ timeout: 30_000 });
+
+  // Wait for the pending state to resolve into a real answer.
+  // The PendingTurnCard's "Thinking…" label disappears once the real
+  // TurnCard replaces it, so we wait for that transition.
+  await expect(page.getByText(/thinking…/i)).toHaveCount(0, { timeout: 60_000 });
+
+  // The new conversation appears in the sidebar
+  await expect(
+    page.locator("aside").getByText(/what is the wikimind project about/i),
+  ).toBeVisible();
+
+  // --- Ask a follow-up question ---
+  await input.fill("How does it close the loop?");
+  await input.press("Enter");
+
+  // Two turn cards should eventually be present (Q1 + Q2 real + transient pending).
+  // Playwright's toHaveCount waits for stability, and the pending card replaces
+  // itself with the real card at the same DOM position, so the stable count is 2.
+  await expect(page.locator("article")).toHaveCount(2, { timeout: 60_000 });
+  await expect(page.getByText(/thinking…/i)).toHaveCount(0, { timeout: 60_000 });
+
+  // --- Save the thread to the wiki ---
+  const saveButton = page.getByRole("button", { name: /save thread to wiki/i });
+  await expect(saveButton).toBeVisible();
+  await saveButton.click();
+
+  // Toast appears in the top-right of the main area with the expected title.
+  // This is the pushToast path from AskView.tsx, NOT window.alert.
+  await expect(page.getByText("Saved thread to wiki")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // After save, the button label transitions to "Update wiki article"
+  await expect(
+    page.getByRole("button", { name: /update wiki article/i }),
+  ).toBeVisible();
+});

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -77,6 +77,18 @@ class OllamaConfig(LLMProviderConfig):
     enabled: bool = False
 
 
+class MockConfig(LLMProviderConfig):
+    """Deterministic mock provider for CI and local e2e testing.
+
+    Never returns a real LLM call. Must be explicitly enabled and
+    must be set as the default provider to be selected. Disabled
+    by default so it can never silently intercept real traffic.
+    """
+
+    model: str = "mock-1"
+    enabled: bool = False
+
+
 class LLMConfig(BaseModel):
     """LLM configuration across providers."""
 
@@ -88,6 +100,7 @@ class LLMConfig(BaseModel):
     google: GoogleConfig = Field(default_factory=GoogleConfig)
     ollama: OllamaConfig = Field(default_factory=OllamaConfig)
     ollama_base_url: str = "http://localhost:11434"
+    mock: MockConfig = Field(default_factory=MockConfig)
 
 
 class SyncConfig(BaseModel):

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -15,7 +15,7 @@ import openai
 import structlog
 
 from wikimind.config import get_api_key, get_settings
-from wikimind.models import CompletionRequest, CompletionResponse, CostLog, Provider
+from wikimind.models import CompletionRequest, CompletionResponse, CostLog, Provider, TaskType
 
 log = structlog.get_logger()
 
@@ -38,6 +38,9 @@ PRICING = {
     },
     Provider.OLLAMA: {
         "*": {"input": 0.0, "output": 0.0},  # Free — local
+    },
+    Provider.MOCK: {
+        "*": {"input": 0.0, "output": 0.0},  # Free — deterministic
     },
 }
 
@@ -168,6 +171,100 @@ class OllamaProvider:
         )
 
 
+class MockProvider:
+    """Deterministic mock provider for CI e2e testing.
+
+    Returns canned JSON keyed off the TaskType so callers that expect
+    CompilationResult / QueryResult shapes can parse the response
+    without a real LLM. Zero cost, zero network, fully deterministic.
+
+    Must be explicitly enabled via ``WIKIMIND_LLM__MOCK__ENABLED=true``
+    AND set as the default provider via ``WIKIMIND_LLM__DEFAULT_PROVIDER=mock``
+    to be selected — disabled by default so it cannot silently
+    intercept real traffic.
+    """
+
+    def __init__(self) -> None:
+        # No config needed; all responses are canned
+        pass
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Return a deterministic canned response matching the request's task type."""
+        start = time.monotonic()
+        content = self._response_for(request)
+        latency_ms = int((time.monotonic() - start) * 1000)
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.MOCK,
+            model_used=model,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=latency_ms,
+        )
+
+    @staticmethod
+    def _response_for(request: CompletionRequest) -> str:
+        """Return a canned response body matching the task's expected shape."""
+        if request.task_type == TaskType.COMPILE:
+            return json.dumps(_MOCK_COMPILE_RESPONSE)
+        if request.task_type == TaskType.QA:
+            return json.dumps(_MOCK_QA_RESPONSE)
+        if request.task_type == TaskType.LINT:
+            return json.dumps(_MOCK_LINT_RESPONSE)
+        # Unknown task type: return an empty JSON object so parse_json_response
+        # doesn't crash. Tests that need specific shapes should add a mock
+        # for their task type.
+        return "{}"
+
+
+# Canned responses used by MockProvider. Defined at module level so tests
+# can import and assert against them directly.
+_MOCK_COMPILE_RESPONSE: dict = {
+    "title": "Mock Article",
+    "summary": "A deterministic summary produced by the mock LLM provider for testing.",
+    "key_claims": [
+        {
+            "claim": "This article was produced by the mock LLM provider.",
+            "confidence": "sourced",
+            "quote": "mock provider",
+        }
+    ],
+    "concepts": ["testing", "mock"],
+    "backlink_suggestions": [],
+    "open_questions": ["What is real?"],
+    "article_body": (
+        "## Mock Article\n\n"
+        "This article was produced by the mock LLM provider for deterministic "
+        "e2e testing.\n\n"
+        "## Details\n\n"
+        "The mock provider returns canned responses regardless of input, "
+        "enabling CI to run the full Ask loop without a real LLM API."
+    ),
+}
+
+_MOCK_QA_RESPONSE: dict = {
+    "answer": (
+        "This is a mock answer from the WikiMind mock LLM provider. "
+        "Your question was received and processed deterministically "
+        "for testing purposes."
+    ),
+    "confidence": "high",
+    "sources": ["Mock Article"],
+    "related_articles": [],
+    "new_article_suggested": None,
+    "follow_up_questions": [],
+}
+
+_MOCK_LINT_RESPONSE: dict = {
+    "contradictions": [],
+    "stale_claims": [],
+    "orphan_articles": [],
+    "missing_pages": [],
+    "data_gaps": [],
+}
+
+
 # ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
@@ -202,7 +299,7 @@ class LLMRouter:
         cfg = getattr(self.settings.llm, provider.value, None)
         if not cfg or not cfg.enabled:
             return False
-        if provider == Provider.OLLAMA:
+        if provider in (Provider.OLLAMA, Provider.MOCK):
             return True  # No API key needed
         return bool(get_api_key(provider.value))
 
@@ -213,6 +310,8 @@ class LLMRouter:
             return OpenAIProvider()
         elif provider == Provider.OLLAMA:
             return OllamaProvider(self.settings.llm.ollama_base_url)
+        elif provider == Provider.MOCK:
+            return MockProvider()
         else:
             raise ValueError(f"Provider {provider} not implemented yet")
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -77,6 +77,7 @@ class Provider(StrEnum):
     OPENAI = "openai"
     GOOGLE = "google"
     OLLAMA = "ollama"
+    MOCK = "mock"
 
 
 class TaskType(StrEnum):

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -9,14 +10,25 @@ import pytest
 
 from wikimind.engine import llm_router as llm_router_mod
 from wikimind.engine.llm_router import (
+    _MOCK_COMPILE_RESPONSE,
+    _MOCK_LINT_RESPONSE,
+    _MOCK_QA_RESPONSE,
     AnthropicProvider,
     LLMRouter,
+    MockProvider,
     OllamaProvider,
     OpenAIProvider,
     _calc_cost,
     get_llm_router,
 )
-from wikimind.models import CompletionRequest, CompletionResponse, Provider, TaskType
+from wikimind.models import (
+    CompilationResult,
+    CompletionRequest,
+    CompletionResponse,
+    Provider,
+    QueryResult,
+    TaskType,
+)
 
 
 def _req(**kw) -> CompletionRequest:
@@ -281,3 +293,72 @@ def test_get_llm_router_singleton() -> None:
         r2 = get_llm_router()
     assert r1 is r2
     llm_router_mod._router = None
+
+
+class TestMockProvider:
+    """MockProvider returns canned JSON matching each task's Pydantic contract."""
+
+    @pytest.mark.asyncio
+    async def test_compile_response_parses_into_compilation_result(self) -> None:
+        provider = MockProvider()
+        request = CompletionRequest(
+            system="system",
+            messages=[{"role": "user", "content": "compile this source"}],
+            max_tokens=2048,
+            temperature=0.3,
+            response_format="json",
+            task_type=TaskType.COMPILE,
+        )
+
+        response = await provider.complete(request, model="mock-1")
+
+        assert response.provider_used == Provider.MOCK
+        assert response.cost_usd == 0.0
+        assert response.input_tokens == 0
+        assert response.output_tokens == 0
+
+        data = json.loads(response.content)
+        assert data == _MOCK_COMPILE_RESPONSE
+        result = CompilationResult(**data)
+        assert result.title == "Mock Article"
+        assert len(result.key_claims) >= 1
+
+    @pytest.mark.asyncio
+    async def test_qa_response_parses_into_query_result(self) -> None:
+        provider = MockProvider()
+        request = CompletionRequest(
+            system="system",
+            messages=[{"role": "user", "content": "what is mocking?"}],
+            max_tokens=2048,
+            temperature=0.3,
+            response_format="json",
+            task_type=TaskType.QA,
+        )
+
+        response = await provider.complete(request, model="mock-1")
+
+        assert response.provider_used == Provider.MOCK
+        data = json.loads(response.content)
+        assert data == _MOCK_QA_RESPONSE
+        result = QueryResult(**data)
+        assert result.confidence == "high"
+        assert "mock" in result.answer.lower()
+
+    @pytest.mark.asyncio
+    async def test_lint_response_is_valid_json(self) -> None:
+        provider = MockProvider()
+        request = CompletionRequest(
+            system="system",
+            messages=[{"role": "user", "content": "lint the wiki"}],
+            max_tokens=2048,
+            temperature=0.3,
+            response_format="json",
+            task_type=TaskType.LINT,
+        )
+
+        response = await provider.complete(request, model="mock-1")
+
+        data = json.loads(response.content)
+        assert data == _MOCK_LINT_RESPONSE
+        assert "contradictions" in data
+        assert data["contradictions"] == []


### PR DESCRIPTION
## Summary

PR 3 of 3 — the final piece of the Ask vertical slice. Adds end-to-end Playwright coverage for the Ask UI loop, plus the two pieces of infrastructure that make it runnable in CI: a deterministic mock LLM provider and a new GitHub Actions workflow.

This PR's scope expanded beyond the original plan (\"install Playwright, write the test, open the PR\") because the plan didn't address how to actually run e2e in CI. See \"Why mock\" below.

## What's in the PR

### Frontend — Playwright infrastructure (c9e23e5, 84c769f)

- `@playwright/test` added as a devDependency in `apps/web`
- `apps/web/playwright.config.ts` — single chromium project, reuses existing dev server locally but launches one in CI, 60s timeout headroom on LLM calls
- `apps/web/tests/e2e/ask-loop.spec.ts` — **one test** that drives the full loop:
  1. Open \`/ask\`, verify empty state
  2. Ask \"What is the WikiMind project about?\" → wait for turn card + sidebar entry
  3. Ask follow-up \"How does it close the loop?\" → verify 2 turn cards
  4. Click \"Save thread to wiki\" → verify success toast
  5. Verify button label transitions from \"Save thread to wiki\" → \"Update wiki article\"
- \`npm run e2e\` script added
- Assertions use role/text locators, not brittle CSS selectors

### Backend — mock LLM provider (217b7b0)

New \`MockProvider\` class in \`src/wikimind/engine/llm_router.py\` that returns canned JSON matching each TaskType's Pydantic contract:

- \`TaskType.COMPILE\` → \`CompilationResult\` shape (title, summary, key_claims, concepts, article_body, ...)
- \`TaskType.QA\` → \`QueryResult\` shape (answer, confidence, sources, ...)
- \`TaskType.LINT\` → linter shape (contradictions, orphans, missing_pages, ...)

**Env-gated, disabled by default** — activating the mock requires BOTH \`WIKIMIND_LLM__MOCK__ENABLED=true\` AND \`WIKIMIND_LLM__DEFAULT_PROVIDER=mock\`. It cannot silently intercept production traffic. The provider is NOT part of the auto-enable logic (it doesn't activate based on absence of real API keys).

Touched files:
- \`src/wikimind/models.py\` — added \`Provider.MOCK\` enum value
- \`src/wikimind/config.py\` — added \`MockConfig\` (inherits \`LLMProviderConfig\`, \`enabled: bool = False\`)
- \`src/wikimind/engine/llm_router.py\` — \`MockProvider\` class, PRICING entry (zero cost), wired into \`_get_provider_instance\` and \`_is_provider_available\`
- \`tests/unit/test_llm_router.py\` — 3 tests asserting each canned response parses into its target Pydantic model
- \`.env.example\` — documented mock provider env block (commented out)

**Test results:** 254/254 backend tests passing (was 251). Ruff + mypy clean. Doc-sync clean.

### CI — Playwright workflow (fe3bd4a)

New \`.github/workflows/e2e.yml\`:

1. Checkout
2. Setup Python 3.12 + Node 20 (with pip + npm caches)
3. Install backend deps (\`pip install -e \".[dev]\"\`)
4. Install frontend deps (\`npm ci\`)
5. Install chromium with \`--with-deps\` for Ubuntu
6. **Start backend in background** with mock provider env vars and an isolated \`WIKIMIND_DATA_DIR=/tmp/wikimind-e2e\`; poll \`/docs\` until ready
7. **Seed the wiki** via \`POST /ingest/text\` with a fixture article; poll \`/wiki/articles\` until the in-process compile finishes (mock makes this ~100ms but give 30s headroom)
8. \`npm run e2e\`
9. Upload \`playwright-report/\` and \`test-results/\` artifacts on failure

Matches existing \`test.yml\` conventions: emoji step headers, paths filter, concurrency group, draft-skip guard, \`persist-credentials: false\`.

## Why mock (not real LLM via secrets)

The e2e test's job is to verify **UI wiring and data flow** end-to-end. Prompt quality is a separate concern that belongs in an eval harness, not in a gate on every PR.

Real LLM in CI has three problems:
1. Cost — $0.01-0.05 per run, compounds with PR volume
2. Flakiness — provider outages cause false-negative CI runs
3. Secret blast radius — any CI workflow with API keys is a leak vector

Mock provider has none of these and costs ~60 lines of provider code plus 40 lines of canned JSON. The downside is real — the mock doesn't exercise the actual LLM prompts, so prompt regressions won't be caught here. That's the intended trade-off and belongs in a separate provider-eval harness (not in this PR, not in CI every PR).

## Deliberate deviations from the original plan spec

1. **Scope expansion**: original Task 3.3 was \"push + open PR\"; this PR adds the mock provider and CI workflow as necessary prerequisites. Without them, the e2e test is local-only and adds zero CI value.
2. **Dialog handler**: the plan's test used \`page.once(\"dialog\", ...)\` to accept a \`window.alert\` toast. PR 2 replaced \`window.alert\` with \`pushToast\` via the existing \`useWebSocketStore\`. The test now asserts toast text via \`page.getByText(\"Saved thread to wiki\")\` instead — no browser dialog involved.

## Test plan

- [ ] CI e2e workflow green on this PR (the workflow runs itself against this PR's code)
- [ ] \`pytest\` in \`test.yml\` stays green (no backend regressions from the mock provider)
- [ ] Local \`npm run e2e\` passes against a real backend with real LLM (optional sanity check, not required for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)