### PR TITLE
feat(engine): wikilink resolution Tasks 2/3/5 + Epic 3/linter specs (#95, #96)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ considered, and the consequences.
 | [010](adr-010-llm-provider-auto-enable.md) | Auto-enable LLM providers when their API key is detected | Accepted |
 | [011](adr-011-conversational-qa-thread-model.md) | Conversational Q&A thread model | Accepted |
 | [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Proposed |
+| [013](adr-013-react-force-graph-2d.md) | react-force-graph-2d for knowledge graph visualization | Proposed |
 
 ## ADR Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ considered, and the consequences.
 | [009](adr-009-decoupled-ingest-compilation.md) | Decoupled ingest and compilation | Accepted |
 | [010](adr-010-llm-provider-auto-enable.md) | Auto-enable LLM providers when their API key is detected | Accepted |
 | [011](adr-011-conversational-qa-thread-model.md) | Conversational Q&A thread model | Accepted |
+| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Proposed |
 
 ## ADR Format
 

--- a/docs/adr/adr-012-knowledge-graph-architecture.md
+++ b/docs/adr/adr-012-knowledge-graph-architecture.md
@@ -1,0 +1,223 @@
+# ADR-012: Knowledge graph architecture
+
+## Status
+
+Proposed
+
+## Context
+
+Epic 3 (manavgup/wikimind#3) adds an interactive knowledge-graph view: nodes
+are compiled wiki articles, edges are the `Backlink` rows populated by #95's
+wikilink resolver. The Karpathy LLM Wiki Pattern gist mentions Obsidian's
+graph view as the visual affordance that makes a wiki feel like *a structure
+you inhabit* rather than a list, but prescribes nothing about how to build it.
+
+Three architectural decision points drive the rest of the implementation and
+are worth locking in before any code is written:
+
+1. **Storage backend** — do we keep the wiki's graph edges in SQLite alongside
+   everything else, or introduce a dedicated graph database (neo4j, Kuzu,
+   dgraph)?
+2. **Layout computation** — does the backend produce positioned nodes, or
+   does it hand raw `{nodes, edges}` to the frontend and let the client-side
+   force simulation compute positions?
+3. **Concept integration** — do concepts appear in the graph as a parallel
+   node type (bipartite graph), or as a coloring layer over article nodes?
+
+These three decisions are interrelated and are recorded together here. The
+detailed design document is
+`docs/superpowers/specs/2026-04-08-knowledge-graph-design.md`; this ADR only
+captures the architecture-level commitments.
+
+## Decision
+
+### 1. Graph storage stays in SQLite
+
+The knowledge graph is served from the existing `Backlink` and `Article`
+tables in SQLite. No new storage system is introduced. `WikiService.get_graph`
+walks the tables, computes node and edge payloads in Python, and returns
+them via `GET /wiki/graph`.
+
+`Backlink` may be extended with additional metadata columns (`created_at`,
+eventually `relation_type` if needed) via the existing
+`database.py:_migrate_added_columns` helper. Composite primary key
+`(source_article_id, target_article_id)` stays as-is.
+
+At personal-wiki scale (O(10³) articles, O(10⁴) edges), every graph query
+envisioned — full graph, N-hop neighborhood, shortest path, concept subgraph
+— runs in well under 100ms as in-memory Python over a few thousand SQLite
+rows.
+
+### 2. Layout is computed client-side
+
+The backend returns pure data: `{nodes: [...], edges: [...]}` with metadata
+but no positions. The frontend's force simulation (via
+`react-force-graph-2d`, itself a wrapper around d3-force) computes positions
+on the client at render time.
+
+The backend stays a rendering-agnostic data provider. It does not compute or
+cache node coordinates. Layout is ephemeral and viewer-dependent — the same
+data may render differently on different screen sizes, with different
+filters applied, or after user interaction.
+
+### 3. Concepts are a coloring layer, not parallel graph nodes
+
+Articles are the only node type in the graph. Each article node carries a
+`concept_cluster` string (its primary concept's name) which the frontend
+maps to a color. Concepts themselves are **not** nodes in the main graph
+view. Article→concept relationships are not edges.
+
+Concepts remain a separate taxonomy surfaced via `GET /wiki/concepts` and the
+existing Wiki Explorer sidebar. A future "concept graph" view could treat
+concepts as nodes in a dedicated visualization, but that is out of scope for
+Epic 3.
+
+## Alternatives Considered
+
+### Storage
+
+**Real graph database (neo4j, Kuzu, dgraph).** Rejected. At personal-wiki
+scale, a graph database is infrastructure in search of a problem. Every
+query Epic 3 needs is a BFS/DFS over a few thousand rows, which Python can
+do in-process in well under 100ms. Adopting a graph database would:
+
+1. Violate ADR-001's zero-dependency-startup principle (`make dev` would
+   require users to install and run neo4j or equivalent).
+2. Introduce a second storage layer with its own consistency story —
+   `Backlink` rows in SQLite would have to stay in sync with graph-DB nodes
+   and edges.
+3. Deliver no benefit until the wiki scales by at least 10². Until then, the
+   complexity tax is paid for imagined future needs.
+
+Revisit this decision if and only if (a) measured graph query latency
+exceeds a few hundred ms on the production user's wiki, and (b) the
+bottleneck is provably graph-query shape rather than something cheaper to
+fix (indexing, caching, query shape itself).
+
+**Materialized adjacency cache in a separate table.** Rejected. A denormalized
+`adjacency_cache` table keyed by `(article_id, depth)` could precompute
+N-hop neighborhoods and accelerate those queries. Rejected because:
+
+1. It's a cache, not a primary store — it has to be invalidated on every
+   compile and every backlink write, which is the kind of bookkeeping bug
+   that silently breaks the graph.
+2. The queries it would accelerate run in <100ms uncached anyway.
+3. Plain in-memory caching of `GET /wiki/graph` (see spec §5f) captures 95%
+   of the benefit with none of the persistence complexity.
+
+### Layout
+
+**Server-computed layout.** Rejected. The backend would run the force
+simulation (via a Python port or a headless renderer), ship positions in
+the response, and the frontend would render them directly. Rejected because:
+
+1. Layout is viewer-dependent — the same graph should lay out differently
+   at different zoom levels, with different filters, after user interaction.
+   Server-computed layout means re-running the simulation on every
+   sub-view, which is expensive and chatty.
+2. It couples a storage/query concern to a rendering concern. The backend
+   becomes responsible for a choice (d3-force vs dagre vs circular) that
+   rightfully belongs to the view layer.
+3. It loses the interactive dynamism — nodes can't spring back when
+   dragged, transitions can't be smooth, because every frame would need a
+   server roundtrip.
+
+**Precomputed, persisted positions.** Rejected for all the reasons above
+plus: storing coordinates in the database commits us to a single layout
+algorithm forever and invents a new schema concern (coordinates need to be
+invalidated any time the graph structure changes, which is every time an
+article is compiled).
+
+### Concept integration
+
+**Concepts as parallel graph nodes (bipartite-ish graph).** Rejected. A
+graph with two node types (article and concept) and two edge types
+(article↔article, article↔concept) is richer in information but worse at
+the visualization's primary job — showing how articles connect *to each
+other*. Concept nodes become high-degree hubs that visually dominate the
+article-to-article structure.
+
+Concretely rejected because:
+
+1. Every downstream graph query becomes ambiguous. "Give me the N-hop
+   neighbors of this article" — does that traverse through concept nodes
+   or not?
+2. It doubles the UI's decision surface (colors, sizes, interactions)
+   for both node types.
+3. Obsidian's graph view, which is the closest mental-model reference for
+   WikiMind users, uses concepts as coloring, not as nodes. Matching that
+   model minimizes user onboarding friction.
+4. Trivial to change later if real usage demands it — add a separate
+   `/graph/concepts` view without touching the main graph.
+
+**Concepts in a second parallel graph (two views side by side).** Rejected
+for MVP on scope grounds. Potentially worth revisiting in a future epic if
+users show concrete interest in browsing by concept structure.
+
+## Consequences
+
+### Enables
+
+- **Zero new infrastructure.** Epic 3 ships as pure code changes against
+  the existing SQLite + FastAPI + React stack. No new services to run, no
+  new skill to learn, no new failure modes.
+- **Full graph available as one API call.** `GET /wiki/graph` is a single
+  round trip that returns everything the viewer needs. Pan, zoom, filter,
+  and hover all happen client-side against in-memory data.
+- **Layout algorithm is swappable.** Because the backend doesn't own
+  layout, the frontend can migrate from `react-force-graph-2d` to
+  `react-force-graph-webgl` (WebGL variant, same API) or to cytoscape.js
+  without any backend change.
+- **Concept coloring degrades gracefully.** If `Concept` rows are sparse or
+  the concept taxonomy (#24) isn't yet populated, `concept_cluster` is
+  `null` and the graph renders in a single color. Still usable, still
+  navigable.
+- **Future graph queries** (N-hop neighborhood, shortest path, cluster
+  subgraph) are BFS/DFS over the existing `Backlink` table, in Python, with
+  no new storage. Each becomes a new route on `/wiki/graph/*` without
+  touching the data model.
+
+### Constrains
+
+- **Backend cannot serve a "pre-arranged" graph.** If users ever ask for
+  persistent node positions ("I want article X to always sit in the top-
+  left"), this ADR needs to be revisited. For now, layout is ephemeral and
+  that is a deliberate choice.
+- **Graph quality is bounded by `Backlink` quality.** Since the edges are
+  exactly the rows in the `Backlink` table, any gap, regression, or false
+  positive in the wikilink resolver (#95) is directly visible in the graph.
+  There is no second source of truth.
+- **`GET /wiki/graph` is a hot endpoint.** It is called on every `/graph`
+  page load and returns potentially the entire article corpus. Keeping it
+  lean is a continuous obligation — new fields on `GraphNode` or
+  `GraphEdge` cost every call.
+- **Scale cliff, if it ever arrives, hits the frontend first.** At ~500
+  article nodes without WebGL, the force simulation becomes sluggish. The
+  backend keeps working fine. Degradation strategy (auto-filter to top-N
+  most-connected, migrate to WebGL renderer) is a frontend concern.
+
+### Risks
+
+- **SQLite-backed storage may become inadequate at unforeseen scale.** If a
+  user imports a large Obsidian vault (thousands of articles, tens of
+  thousands of backlinks) the queries may become slow enough to matter.
+  Mitigation: cache `GET /wiki/graph` in memory (planned in spec §5f);
+  revisit a graph database only if measurements show it's necessary, not
+  preemptively.
+- **The client-side layout commitment makes certain future features
+  harder.** If WikiMind ever needs to render the graph in a non-JS context
+  (CLI, PDF export, server-side screenshot for a social preview), the
+  layout algorithm will have to be re-implemented somewhere that has
+  positions. Mitigation: cross that bridge when we come to it. No current
+  user story wants it.
+- **Concept-as-coloring is a weaker signal than concept-as-node.** A user
+  wanting to browse their wiki by concept hierarchy is better served by
+  the Wiki Explorer's concept sidebar than by the graph. The graph is the
+  *connectivity* view, not the *taxonomy* view. Mitigation: document this
+  clearly in the user-facing copy; consider a second "concept graph" view
+  as a follow-on epic if users ask for it.
+- **Epic 3 is meaningless until #95 ships.** The Backlink table is
+  effectively empty today. If #95 slips, Epic 3's implementation can start
+  (PR 1 data-model polish is independent) but PR 2 (the actual graph view)
+  must wait. Mitigation: track #95 as an explicit hard dependency in the
+  spec and in PR 2's description.

--- a/docs/adr/adr-013-react-force-graph-2d.md
+++ b/docs/adr/adr-013-react-force-graph-2d.md
@@ -1,0 +1,143 @@
+# ADR-013: react-force-graph-2d for knowledge graph visualization
+
+## Status
+
+Proposed
+
+## Context
+
+ADR-012 commits WikiMind's knowledge graph (Epic 3) to a client-side layout
+approach — the browser computes node positions via a force-directed algorithm,
+the backend just ships nodes and edges. That decision leaves the specific
+JavaScript library unresolved. The design spec
+(`docs/superpowers/specs/2026-04-08-knowledge-graph-design.md`) flagged the
+library choice as an open decision to lock in before Epic 3 implementation
+begins.
+
+The choice affects: bundle size, rendering fidelity at scale, React integration
+ergonomics, community health, and the cost of future features (filters,
+highlighting, subgraph views, path queries).
+
+The candidates considered were the four mainstream force-directed graph
+libraries with maintained React bindings: `react-force-graph-2d`, `cytoscape.js`
+(with `react-cytoscapejs`), `sigma.js` (with `react-sigma`), and `vis-network`
+(with `react-graph-vis`).
+
+## Decision
+
+Use **`react-force-graph-2d`** as the single graph rendering library for
+WikiMind's knowledge graph view.
+
+Rationale:
+
+1. **Bundle size** — `react-force-graph-2d` adds ~60KB gzipped, including the
+   d3-force simulation. Cytoscape is ~150KB, vis-network ~180KB, sigma ~90KB
+   but with less React-friendly ergonomics.
+
+2. **React ergonomics** — `react-force-graph-2d` is a first-class React
+   component that takes `graphData={nodes, links}` as a prop and re-renders
+   on update. No imperative setup, no ref gymnastics, no lifecycle
+   workarounds. Matches the rest of the `apps/web` codebase which is
+   declarative TanStack Query + components.
+
+3. **Sensible defaults** — the library ships with acceptable defaults for
+   personal-wiki-scale graphs (50–500 nodes). Zoom, pan, drag, click handlers
+   all work out of the box. No multi-hour tuning session required to get a
+   viable first render.
+
+4. **Scale is adequate for the product** — react-force-graph-2d canvas-backed
+   rendering handles ~500 nodes smoothly and ~2000 nodes with degradation.
+   At personal-wiki scale (expected 50–500 articles for most users, low
+   thousands in extreme cases), this is a non-issue. The WebGL variant
+   (`react-force-graph-3d`) exists as an upgrade path if scale ever becomes a
+   problem.
+
+5. **Separation of layout from data** — the library computes positions
+   client-side, which aligns with ADR-012. The backend never computes or
+   stores coordinates.
+
+6. **Upgrade path** — if 2D proves limiting (unlikely), the same vendor ships
+   `react-force-graph-3d` (WebGL 3D) and `react-force-graph-vr` (WebXR). Same
+   API. Migration is a drop-in component swap, not a rewrite.
+
+## Alternatives considered
+
+### cytoscape.js with `react-cytoscapejs`
+
+**Pros:** Most feature-complete graph library in JS. Rich layout options
+(breadthfirst, circle, grid, concentric, cose, klay). Mature ecosystem with
+plugins for clustering, pathfinding, edge bundling.
+
+**Cons:** ~150KB bundle. Imperative API underneath — the React wrapper is a
+thin shim and you end up reaching for `cy.*` methods for anything non-trivial.
+Overkill for a personal knowledge graph visualization where we want one layout
+(force-directed) and basic interactions. Would spend significant time disabling
+features we don't want.
+
+### sigma.js with `react-sigma`
+
+**Pros:** WebGL-backed rendering handles tens of thousands of nodes. Smallest
+bundle of the four (~90KB). Good for dense graphs.
+
+**Cons:** React integration is newer and less polished. Less documentation.
+Learning curve is steeper — lots of graphology + sigma + react-sigma coordination
+required to do basic things. Performance ceiling is higher than we need at
+personal-wiki scale; paying a complexity tax for scale we won't hit.
+
+### vis-network with `react-graph-vis`
+
+**Pros:** Best looking defaults of the four (rounded nodes, smooth edges, nice
+animations). Stable, widely deployed.
+
+**Cons:** ~180KB bundle — largest of the four. Development has slowed;
+`react-graph-vis` wrapper is maintenance-mode. Uses an older module pattern
+that fights with modern Vite + React 18 builds. Would likely require config
+workarounds.
+
+## Consequences
+
+**Enables:**
+
+- Epic 3 implementation can start immediately — no further library evaluation
+  needed
+- `GraphCanvas.tsx` can be a thin wrapper around `react-force-graph-2d` with
+  the right props; most of the interesting UI work happens in the sidebar
+  (`GraphFilters.tsx`) and detail panel (`GraphDetailPanel.tsx`), not the
+  canvas itself
+- Future features like "click to focus on neighborhood" or "highlight shortest
+  path" work naturally with the library's `onNodeClick` / `linkColor` /
+  `nodeColor` callbacks
+
+**Constrains:**
+
+- Committed to 2D visualization for v1. If users request a 3D view later,
+  migration is a component swap but some of the 2D-specific UI (detail panel
+  positioning, filter interactions) needs review.
+- Locked into a force-directed layout for the main view. Alternative layouts
+  (hierarchical, circular, radial) are harder to implement in
+  `react-force-graph-2d`. If a future use case requires them, a second
+  visualization component (possibly a different library for that specific
+  view) may be needed.
+- Rendering is canvas-based. Accessibility tooling (screen readers) does not
+  work with canvas elements by default. An accessible alternative view
+  (probably a filterable list of articles + their top connections) will need
+  to exist alongside the graph view. This is a known limitation of every
+  force-directed graph library in JS and is not specific to this choice.
+
+**Risks:**
+
+- Library maintenance: `react-force-graph-2d` is maintained primarily by a
+  single developer (@vasturiano). If the project becomes abandoned, migration
+  effort is moderate (days not weeks, because the component boundary is
+  narrow). Monitoring signal: watch commit frequency on the repo.
+- Large graph performance: 2D canvas starts to degrade noticeably beyond ~2000
+  nodes. At personal-wiki scale this is not a concern, but power users with
+  large wikis may hit the ceiling. Mitigation is the `GraphFilters` component
+  — filtering by concept / date / connection count reduces the visible graph
+  to a comfortable size.
+
+## Related
+
+- ADR-012 — knowledge graph architecture (proposed, parent decision)
+- `docs/superpowers/specs/2026-04-08-knowledge-graph-design.md` — Epic 3 design spec
+- Issues #3 (Epic 3), #25 (React UI: Graph view)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -243,20 +243,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/{slug}:
+  /wiki/articles/{id_or_slug}:
     get:
       tags:
       - Wiki
       summary: Get Article
-      description: Get full article with content, backlinks, and source provenance.
-      operationId: get_article_wiki_articles__slug__get
+      description: Get full article by ID or slug, with content, backlinks, and source
+        provenance.
+      operationId: get_article_wiki_articles__id_or_slug__get
       parameters:
-      - name: slug
+      - name: id_or_slug
         in: path
         required: true
         schema:
           type: string
-          title: Slug
+          title: Id Or Slug
       responses:
         '200':
           description: Successful Response

--- a/docs/superpowers/plans/2026-04-08-wiki-linter.md
+++ b/docs/superpowers/plans/2026-04-08-wiki-linter.md
@@ -1,0 +1,2592 @@
+# Wiki Linter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the third pillar of the Karpathy LLM Wiki Pattern (lint) as a structured, per-check, LLM-powered health audit. Replace the existing single-prompt stub in `jobs/worker.py::lint_wiki` with a real `run_lint` pipeline backed by `LintReport` / `LintFinding` tables, expose it via a new `/lint/*` API surface plus compatibility shims on the existing `/jobs/lint` and `/wiki/health` endpoints, and render it in a new `/health` frontend view.
+
+**Architecture:** Multi-PR epic. PR A ships the smallest useful backend slice (data model + contradictions check + API + stub migration, no frontend). PR B ships the health view on top of PR A. PR C adds orphan detection and is gated on #95 merging first. PR D is an optional scheduling polish PR. Each PR is independently testable and independently shippable. The spec lives at `docs/superpowers/specs/2026-04-08-wiki-linter-design.md` — read it before starting any PR.
+
+**Tech Stack:** FastAPI + SQLModel + SQLite (backend); React 18 + Vite + TypeScript + Tailwind + react-query + react-router (frontend); pytest with hermetic fixtures, mocked LLM router (backend tests).
+
+---
+
+## Spec coverage
+
+This plan implements the spec's v1 scope. The decisions it hardcodes:
+
+| Decision | Source |
+|---|---|
+| Per-check function decomposition (not a single mega-prompt) | Spec § Design / Pipeline |
+| Two new tables: `LintReport`, `LintFinding` (and `DismissedFinding` helper) | Spec § Data model |
+| Contradictions check uses LLM per concept-bucket pair, with caps + pair caching | Spec § Check: detect_contradictions |
+| Orphan check is SQL-only and gated on #95 via a config flag | Spec § Check: detect_orphans, § Gating |
+| Missing-pages check DROPPED from v1 | Spec § Non-goals, § Open decisions #3 |
+| All linter LLM calls go through the existing router with `task_type=LINT` | Spec § Current state |
+| Settings live in a new `LinterConfig` Pydantic submodel | Spec § Settings |
+| `POST /jobs/lint` and `GET /wiki/health` reshape as compatibility shims | Spec § Migration from the stub |
+| Dismiss semantics: persistent via content-hash in a `DismissedFinding` table | Spec § Dismiss semantics, § Open decisions #5 |
+| Frontend uses react-query cache keys and WS-event-driven invalidation | Spec § Frontend, § State management |
+
+Open decisions the plan assumes a specific answer for (flagged to the executing engineer so they can stop and ask if the user answered differently in review):
+
+| Assumed answer | Revisit if |
+|---|---|
+| Manual trigger + keep existing weekly cron | User wants on-ingest triggering |
+| Refuse to run when over monthly budget and `respect_monthly_budget=True` | User wants degraded-mode fallback |
+| Persist all LLM confidences, hide `low` by default in UI | User wants to filter at write time |
+| Dismiss is cross-run via content hash | User wants per-report-only dismiss |
+| Ship linter without orphan detection if #95 not merged | User wants linter blocked on #95 |
+| Retain reports forever in v1 | Table growth becomes a real concern |
+
+## Conventions for the implementing engineer
+
+Read `CLAUDE.md` at the repo root before any change. Key rules that bite during linter work specifically:
+
+- **Conventional commits.** Prefix with `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. One logical change per commit.
+- **`make verify` must be green before any push.** Runs ruff lint + format + mypy + pytest with an 80% coverage floor.
+- **No magic numbers.** Every tunable value belongs in `Settings`. The linter has a lot of these (pair caps, cost budgets, cache toggles) — all go in `LinterConfig`, not as inline constants.
+- **Hermetic LLM tests.** Mock the router at the `get_llm_router()` boundary. Never make a real API call from a test. The contradiction check is the main consumer and its tests must stub the router's `complete()` method.
+- **No silent failures.** If a check raises, `run_lint` records the error on the `LintReport` row and continues; it does not swallow exceptions to keep the happy path clean.
+- **Doc-sync hook.** Adding or changing any route triggers `docs/openapi.yaml` regeneration via pre-commit. Do not manually edit the YAML; let the hook do it.
+- **TDD for backend.** Write failing test → run → minimal implementation → run → commit. The plan steps are written this way; follow them.
+- **No TDD for frontend.** The project has no frontend test infrastructure (per the Ask slice spec). Frontend PR B ships behind `lint` + `typecheck` + `build`, with a manual smoke check via the dev server. PR B does not introduce vitest.
+- **Don't expand scope.** Anything not in the spec or this plan is out of scope. If you want to "also fix" something, file an issue.
+
+---
+
+# File Structure
+
+## PR A — Backend data model + contradiction check
+
+### Files to create
+
+| Path | Responsibility |
+|---|---|
+| `src/wikimind/engine/linter/__init__.py` | Re-exports `run_lint`, `detect_contradictions`. |
+| `src/wikimind/engine/linter/runner.py` | `run_lint(session)` orchestrator. Creates the `LintReport`, calls each enabled detection function, persists findings, emits WS event. |
+| `src/wikimind/engine/linter/findings.py` | Pydantic `ContradictionFinding`, `OrphanFinding` in-memory models returned by detection functions. |
+| `src/wikimind/engine/linter/contradictions.py` | `detect_contradictions(session, router, settings)` implementation. |
+| `src/wikimind/engine/linter/pair_cache.py` | Pair-cache helpers: key by `(article_a_id, article_b_id, updated_at_a, updated_at_b)`. |
+| `src/wikimind/engine/linter/prompts.py` | LLM prompt constants (contradiction system prompt, user template). |
+| `src/wikimind/services/linter.py` | `LinterService` with `trigger_run`, `list_reports`, `get_report`, `get_latest`, `dismiss_finding`, plus `get_linter_service()` DI provider. |
+| `src/wikimind/api/routes/lint.py` | `POST /lint/run`, `GET /lint/reports`, `GET /lint/reports/latest`, `GET /lint/reports/{id}`, `POST /lint/findings/{id}/dismiss`. |
+| `tests/unit/test_linter_contradictions.py` | Unit tests for `detect_contradictions` with mocked router. |
+| `tests/unit/test_linter_runner.py` | Unit tests for `run_lint` orchestration (counts, status transitions, failure handling). |
+| `tests/unit/test_linter_service.py` | Unit tests for `LinterService` list/get/dismiss. |
+| `tests/integration/test_lint_api.py` | End-to-end API test for `POST /lint/run` → `GET /lint/reports/latest`. |
+
+### Files to modify
+
+| Path | What changes |
+|---|---|
+| `src/wikimind/config.py` | Add `LinterConfig` Pydantic submodel. Wire it into `Settings` as `linter: LinterConfig`. |
+| `src/wikimind/models.py` | Add `LintSeverity`, `LintFindingKind`, `LintReportStatus` enums; add `LintReport`, `LintFinding`, `DismissedFinding` SQLModel tables; add `LintReportSummary`, `LintReportDetail`, `LintRunResponse`, `DismissResponse` Pydantic response schemas. |
+| `src/wikimind/jobs/worker.py` | Rewrite the body of `lint_wiki` to call `run_lint(session)`. Preserve the `Job` row bookkeeping around the call. Drop the old single-prompt block. |
+| `src/wikimind/api/routes/jobs.py` | Make `POST /jobs/lint` a shim that delegates to `LinterService.trigger_run()`. Add a deprecation docstring. |
+| `src/wikimind/api/routes/wiki.py` | Reshape `GET /wiki/health` to read from the new tables and return a back-compat JSON shape. Add a deprecation docstring. |
+| `src/wikimind/services/wiki.py` | Update `get_health` to query `LintReport` / `LintFinding` and project to the legacy `HealthReport` shape. |
+| `src/wikimind/main.py` | Register the new `lint` router from `api/routes/lint.py`. |
+| `tests/unit/test_linter_jobs.py` (NEW or fold into `tests/unit/test_worker.py` if it exists) | Test that the rewritten `lint_wiki` calls `run_lint`. |
+| `.env.example` | Add `WIKIMIND_LINTER__*` entries matching the new Settings fields. |
+
+## PR B — Frontend health view
+
+### Files to create
+
+| Path | Responsibility |
+|---|---|
+| `apps/web/src/api/lint.ts` | Typed API client methods and interfaces. |
+| `apps/web/src/components/health/HealthView.tsx` | Page container for `/health`. |
+| `apps/web/src/components/health/LintReportSummary.tsx` | Top-card summary: counts, last-run timestamp, "Run lint now" button. |
+| `apps/web/src/components/health/FindingsByKindTabs.tsx` | Tabs grouping findings by kind. |
+| `apps/web/src/components/health/FindingCard.tsx` | One finding with dismiss + links. |
+| `apps/web/src/components/health/RunLintButton.tsx` | Trigger button with in-flight state. |
+
+### Files to modify
+
+| Path | What changes |
+|---|---|
+| `apps/web/src/App.tsx` | Add `<Route path="/health" element={<HealthView />} />`. |
+| `apps/web/src/components/shared/Layout.tsx` | Add "Health" nav link after "Wiki". |
+
+## PR C — Orphan detection (depends on #95)
+
+### Files to create
+
+| Path | Responsibility |
+|---|---|
+| `src/wikimind/engine/linter/orphans.py` | `detect_orphans(session)` — SQL-only, no LLM. |
+| `tests/unit/test_linter_orphans.py` | Unit tests for the orphan check. |
+
+### Files to modify
+
+| Path | What changes |
+|---|---|
+| `src/wikimind/config.py` | Flip `LinterConfig.enable_orphan_detection` default to `True`. |
+| `src/wikimind/engine/linter/runner.py` | Wire `detect_orphans` into the dispatch when the flag is enabled. |
+| `src/wikimind/models.py` | No new tables. Add `OrphanFinding` to the re-export surface if applicable. |
+
+## PR D — Scheduling polish (optional)
+
+### Files to modify
+
+| Path | What changes |
+|---|---|
+| `src/wikimind/jobs/worker.py` | Richer cron config if needed (e.g. weekday override via Settings). |
+| `src/wikimind/config.py` | Add `LinterConfig.cron_weekday` / `cron_hour` if scheduling becomes configurable. |
+
+---
+
+# PR A — Backend data model + contradiction check
+
+**Branch:** `claude/lint-pr-a-backend`
+
+**Definition of done for PR A:** all tasks below complete, `make verify` green, contradiction unit tests hermetic (no real LLM calls), `POST /lint/run` wires through to the ARQ path, `GET /lint/reports/latest` returns the most recent report with findings, existing `POST /jobs/lint` and `GET /wiki/health` still work (as shims), the old single-prompt stub is gone.
+
+## Task A.1: Add LinterConfig submodel
+
+**Files:** Modify `src/wikimind/config.py`
+
+- [ ] **Step 1: Write a test asserting default LinterConfig values**
+
+Add to `tests/unit/test_misc.py` (the existing settings test location):
+
+```python
+def test_linter_config_defaults():
+    from wikimind.config import Settings
+
+    s = Settings()
+    assert s.linter.enable_orphan_detection is False
+    assert s.linter.max_concepts_per_run == 25
+    assert s.linter.max_contradiction_pairs_per_concept == 10
+    assert s.linter.respect_monthly_budget is True
+    assert s.linter.max_cost_per_run_usd == 1.00
+    assert s.linter.enable_pair_cache is True
+```
+
+Run it, confirm it fails:
+
+```bash
+.venv/bin/pytest tests/unit/test_misc.py::test_linter_config_defaults -v
+```
+
+- [ ] **Step 2: Add the `LinterConfig` Pydantic submodel**
+
+In `src/wikimind/config.py`, after the existing `QAConfig` class, add:
+
+```python
+class LinterConfig(BaseModel):
+    """Wiki linter configuration.
+
+    See docs/superpowers/specs/2026-04-08-wiki-linter-design.md § Settings for
+    the rationale behind each field.
+    """
+
+    # #95 gate — orphan detection is a no-op until the Backlink table is populated
+    enable_orphan_detection: bool = False
+
+    # Contradiction detection caps — keep O(LLM calls) bounded per run
+    max_concepts_per_run: int = 25
+    max_contradiction_pairs_per_concept: int = 10
+
+    # LLM behavior for the contradiction prompt
+    contradiction_llm_max_tokens: int = 1024
+    contradiction_llm_temperature: float = 0.2
+
+    # Cost budget enforcement
+    respect_monthly_budget: bool = True
+    max_cost_per_run_usd: float = 1.00
+
+    # Pair-level cache — skip LLM call when neither article's updated_at has changed
+    enable_pair_cache: bool = True
+```
+
+- [ ] **Step 3: Wire `LinterConfig` into `Settings`**
+
+In the same file, find the `Settings` class and add the field next to `qa: QAConfig`:
+
+```python
+    qa: QAConfig = Field(default_factory=QAConfig)
+    linter: LinterConfig = Field(default_factory=LinterConfig)
+```
+
+- [ ] **Step 4: Run the test + lint + typecheck**
+
+```bash
+.venv/bin/pytest tests/unit/test_misc.py::test_linter_config_defaults -v
+.venv/bin/ruff check src/wikimind/config.py
+.venv/bin/mypy src/wikimind/config.py
+```
+
+Expected: test passes, lint clean, typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/config.py tests/unit/test_misc.py
+git commit -m "feat(config): add LinterConfig submodel"
+```
+
+## Task A.2: Add LintReport, LintFinding, DismissedFinding tables
+
+**Files:** Modify `src/wikimind/models.py`
+
+- [ ] **Step 1: Add the StrEnum types**
+
+In `src/wikimind/models.py`, near the existing `JobType` / `JobStatus` / `ConfidenceLevel` StrEnum declarations, add:
+
+```python
+class LintSeverity(StrEnum):
+    """Severity level for a lint finding."""
+
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+
+
+class LintFindingKind(StrEnum):
+    """Kind of lint finding — maps 1:1 to a detection function."""
+
+    CONTRADICTION = "contradiction"
+    ORPHAN = "orphan"
+
+
+class LintReportStatus(StrEnum):
+    """Lifecycle of a lint report."""
+
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+    FAILED = "failed"
+```
+
+- [ ] **Step 2: Add the three new SQLModel tables**
+
+After the existing `Job` table (around the `CostLog`/`SyncLog` area), add:
+
+```python
+class LintReport(SQLModel, table=True):
+    """One run of the wiki linter. All findings from a run FK back to this row.
+
+    See docs/superpowers/specs/2026-04-08-wiki-linter-design.md § Data model.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    generated_at: datetime = Field(default_factory=utcnow_naive, index=True)
+    completed_at: datetime | None = None
+    status: LintReportStatus = LintReportStatus.IN_PROGRESS
+    article_count: int = 0
+    total_findings: int = 0
+    contradictions_count: int = 0
+    orphans_count: int = 0
+    error_message: str | None = None
+    job_id: str | None = Field(default=None, foreign_key="job.id", index=True)
+
+
+class LintFinding(SQLModel, table=True):
+    """One finding from one lint run."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    report_id: str = Field(foreign_key="lintreport.id", index=True)
+    kind: LintFindingKind
+    severity: LintSeverity = LintSeverity.WARN
+    article_id: str | None = Field(default=None, foreign_key="article.id", index=True)
+    related_article_id: str | None = Field(default=None, foreign_key="article.id")
+    description: str
+    raw_json: str = "{}"
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    dismissed: bool = False
+    dismissed_at: datetime | None = None
+    # Stable hash for cross-run dismiss suppression. See § Dismiss semantics.
+    content_hash: str = Field(index=True)
+
+
+class DismissedFinding(SQLModel, table=True):
+    """Cross-run dismiss record — keyed by content hash.
+
+    When a finding is dismissed, its content_hash is persisted here. Future
+    lint runs consult this table at write time and auto-dismiss any finding
+    whose content_hash matches a row here.
+    """
+
+    content_hash: str = Field(primary_key=True)
+    dismissed_at: datetime = Field(default_factory=utcnow_naive)
+    reason: str | None = None
+```
+
+- [ ] **Step 3: Add Pydantic response schemas**
+
+Near the bottom of the file with the other Pydantic API response models (around `HealthReport`), add:
+
+```python
+class LintFindingResponse(BaseModel):
+    """One finding as returned by the API."""
+
+    id: str
+    kind: LintFindingKind
+    severity: LintSeverity
+    article_id: str | None
+    related_article_id: str | None
+    description: str
+    raw_json: str
+    created_at: datetime
+    dismissed: bool
+    dismissed_at: datetime | None
+
+
+class LintReportResponse(BaseModel):
+    """Report metadata without findings — used in list views."""
+
+    id: str
+    generated_at: datetime
+    completed_at: datetime | None
+    status: LintReportStatus
+    article_count: int
+    total_findings: int
+    contradictions_count: int
+    orphans_count: int
+    error_message: str | None
+
+
+class LintReportDetail(BaseModel):
+    """Report metadata plus all (optionally including dismissed) findings."""
+
+    report: LintReportResponse
+    findings: list[LintFindingResponse]
+
+
+class LintRunResponse(BaseModel):
+    """Response shape for POST /lint/run."""
+
+    report_id: str
+    status: LintReportStatus
+
+
+class DismissResponse(BaseModel):
+    """Response shape for POST /lint/findings/{id}/dismiss."""
+
+    finding_id: str
+    dismissed: bool
+```
+
+- [ ] **Step 4: Run lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/models.py
+.venv/bin/mypy src/wikimind/models.py
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/models.py
+git commit -m "feat(models): add LintReport, LintFinding, DismissedFinding tables"
+```
+
+## Task A.3: Verify tables created on startup
+
+**Files:** `tests/unit/test_misc.py`
+
+`SQLModel.metadata.create_all()` in `init_db()` creates new tables automatically. No migration-helper change needed. Verify it actually works end-to-end.
+
+- [ ] **Step 1: Write a test asserting the tables exist after init_db**
+
+Add to `tests/unit/test_misc.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_lint_tables_created_on_init_db(tmp_path, monkeypatch):
+    from wikimind.database import init_db, get_session_factory
+    from sqlalchemy import text
+
+    monkeypatch.setenv("WIKIMIND_DATABASE_URL", f"sqlite+aiosqlite:///{tmp_path}/lint.db")
+
+    await init_db()
+    async with get_session_factory()() as session:
+        # Sanity: the three new tables exist
+        rows = await session.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table'")
+        )
+        table_names = {r[0] for r in rows.all()}
+
+    assert "lintreport" in table_names
+    assert "lintfinding" in table_names
+    assert "dismissedfinding" in table_names
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+.venv/bin/pytest tests/unit/test_misc.py::test_lint_tables_created_on_init_db -v
+```
+
+Expected: passes without any `database.py` change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_misc.py
+git commit -m "test(database): assert lint tables created on init_db"
+```
+
+## Task A.4: Pydantic Finding models
+
+**Files:** Create `src/wikimind/engine/linter/__init__.py`, `src/wikimind/engine/linter/findings.py`
+
+- [ ] **Step 1: Create the linter package**
+
+```bash
+mkdir -p src/wikimind/engine/linter
+```
+
+Create `src/wikimind/engine/linter/__init__.py`:
+
+```python
+"""Wiki linter — Karpathy pattern's third core operation.
+
+See docs/superpowers/specs/2026-04-08-wiki-linter-design.md.
+"""
+
+from wikimind.engine.linter.findings import ContradictionFinding, OrphanFinding
+
+__all__ = ["ContradictionFinding", "OrphanFinding"]
+```
+
+- [ ] **Step 2: Create the typed finding models**
+
+Create `src/wikimind/engine/linter/findings.py`:
+
+```python
+"""Typed in-memory models returned by each detection function.
+
+Each detection function in engine/linter/*.py returns a list of these typed
+Pydantic models. The runner in runner.py converts them to LintFinding SQLModel
+rows at persistence time.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from wikimind.models import LintFindingKind
+
+
+class ContradictionFinding(BaseModel):
+    """One contradictory-claim pair between two articles."""
+
+    kind: Literal[LintFindingKind.CONTRADICTION] = LintFindingKind.CONTRADICTION
+    article_a_id: str
+    article_b_id: str
+    description: str
+    article_a_claim: str
+    article_b_claim: str
+    llm_confidence: str  # "high" | "medium" | "low" (LLM self-assessment)
+
+
+class OrphanFinding(BaseModel):
+    """One article with zero inbound AND zero outbound backlinks."""
+
+    kind: Literal[LintFindingKind.ORPHAN] = LintFindingKind.ORPHAN
+    article_id: str
+    article_title: str
+```
+
+- [ ] **Step 3: Lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/engine/linter/
+.venv/bin/mypy src/wikimind/engine/linter/
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/wikimind/engine/linter/
+git commit -m "feat(linter): add ContradictionFinding and OrphanFinding models"
+```
+
+## Task A.5: Contradiction detection prompts
+
+**Files:** Create `src/wikimind/engine/linter/prompts.py`
+
+- [ ] **Step 1: Add the prompt constants**
+
+Create `src/wikimind/engine/linter/prompts.py`:
+
+```python
+"""LLM prompt templates for the linter.
+
+Prompts are module-level constants so they're covered by ruff and unit-tests
+can assert on their shape. All prompts follow the strict-JSON contract from
+ADR-007.
+"""
+
+from __future__ import annotations
+
+CONTRADICTION_SYSTEM_PROMPT = """You are a wiki health auditor. Given two short wiki articles about the same topic, identify any contradictory assertions between their key claims.
+
+Return STRICT JSON only, no prose, matching this schema exactly:
+
+{
+  "contradictions": [
+    {
+      "description": "one-sentence summary of the contradiction",
+      "article_a_claim": "the specific claim from article A",
+      "article_b_claim": "the specific claim from article B",
+      "confidence": "high" | "medium" | "low"
+    }
+  ]
+}
+
+If there are no contradictions between the two articles, return {"contradictions": []}.
+
+Two claims are contradictory only if they cannot both be simultaneously true about the same underlying subject. Different wordings of the same fact are NOT contradictions. Different aspects of the same topic are NOT contradictions. Be conservative — false positives erode user trust."""
+
+
+CONTRADICTION_USER_TEMPLATE = """Article A: "{article_a_title}"
+Key claims:
+{article_a_claims}
+
+Article B: "{article_b_title}"
+Key claims:
+{article_b_claims}
+
+Identify any contradictory assertions between these articles. Return JSON."""
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+.venv/bin/ruff check src/wikimind/engine/linter/prompts.py
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/wikimind/engine/linter/prompts.py
+git commit -m "feat(linter): add contradiction detection prompts"
+```
+
+## Task A.6: Contradiction detection — first failing test
+
+**Files:** Create `tests/unit/test_linter_contradictions.py`
+
+This task starts the TDD cycle for `detect_contradictions`. Step 1 writes a failing test against a function that does not yet exist.
+
+- [ ] **Step 1: Write the happy-path test**
+
+Create `tests/unit/test_linter_contradictions.py`:
+
+```python
+"""Unit tests for detect_contradictions — all LLM calls are mocked."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import Settings
+from wikimind.engine.linter.contradictions import detect_contradictions
+from wikimind.engine.linter.findings import ContradictionFinding
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_returns_finding_for_mocked_llm_response(
+    seeded_session: AsyncSession,
+    settings: Settings,
+):
+    """Two articles in the same concept bucket, LLM mocked to return a contradiction."""
+    # Router is mocked to return a single contradiction for any complete() call.
+    router = AsyncMock()
+    router.complete.return_value.content = json.dumps(
+        {
+            "contradictions": [
+                {
+                    "description": "Article A says X is true; Article B says X is false.",
+                    "article_a_claim": "X is true.",
+                    "article_b_claim": "X is false.",
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+    router.parse_json_response = lambda r: json.loads(r.content)
+
+    findings = await detect_contradictions(seeded_session, router, settings)
+
+    assert len(findings) == 1
+    assert isinstance(findings[0], ContradictionFinding)
+    assert findings[0].description.startswith("Article A says")
+    assert findings[0].llm_confidence == "high"
+```
+
+This test depends on a `seeded_session` fixture that seeds two articles sharing a concept, and a `settings` fixture. These may already exist in `tests/conftest.py`; if not, create them:
+
+```python
+# tests/conftest.py — add if missing
+
+import pytest
+from wikimind.config import Settings
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings()
+
+
+@pytest.fixture
+async def seeded_session(async_session):
+    """Two articles sharing one concept — ready for contradiction testing."""
+    from wikimind.models import Article, Concept
+    import json as _json
+
+    concept = Concept(name="test-concept", description="for lint tests")
+    async_session.add(concept)
+    await async_session.commit()
+    await async_session.refresh(concept)
+
+    article_a = Article(
+        slug="test-a",
+        title="Test Article A",
+        file_path="/tmp/test_a.md",
+        concept_ids=_json.dumps([concept.id]),
+        summary="X is true.",
+    )
+    article_b = Article(
+        slug="test-b",
+        title="Test Article B",
+        file_path="/tmp/test_b.md",
+        concept_ids=_json.dumps([concept.id]),
+        summary="X is false.",
+    )
+    async_session.add_all([article_a, article_b])
+    await async_session.commit()
+
+    return async_session
+```
+
+(If `async_session` fixture does not exist, check `tests/conftest.py` for whatever the project uses as the standard in-memory SQLite fixture — the Ask slice's `test_qa_loop_integration.py` uses one; copy its setup.)
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_contradictions.py -v
+```
+
+Expected: `ImportError: cannot import name 'detect_contradictions'`. This is the failing test before we write the implementation.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/test_linter_contradictions.py tests/conftest.py
+git commit -m "test(linter): add failing detect_contradictions happy-path test"
+```
+
+## Task A.7: Contradiction detection — minimal implementation
+
+**Files:** Create `src/wikimind/engine/linter/contradictions.py`
+
+- [ ] **Step 1: Write the minimal implementation**
+
+Create `src/wikimind/engine/linter/contradictions.py`:
+
+```python
+"""Contradiction detection check.
+
+For each concept bucket, enumerate article pairs up to the configured cap and
+ask the LLM whether the two articles' key claims contradict each other.
+
+All LLM calls go through the shared router so cost tracking and provider
+fallback are honored. See docs/superpowers/specs/2026-04-08-wiki-linter-design.md
+§ Check: detect_contradictions.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from typing import Any
+
+import structlog
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import Settings
+from wikimind.engine.linter.findings import ContradictionFinding
+from wikimind.engine.linter.prompts import (
+    CONTRADICTION_SYSTEM_PROMPT,
+    CONTRADICTION_USER_TEMPLATE,
+)
+from wikimind.models import Article, CompletionRequest, Concept, TaskType
+
+log = structlog.get_logger()
+
+
+async def detect_contradictions(
+    session: AsyncSession,
+    router: Any,  # LLMRouter — typed loosely to allow mock injection
+    settings: Settings,
+) -> list[ContradictionFinding]:
+    """Detect contradictions between articles within the same concept bucket.
+
+    Returns a list of ContradictionFinding models. Does NOT persist anything —
+    the caller (run_lint) converts these to LintFinding rows.
+    """
+    findings: list[ContradictionFinding] = []
+
+    # Load concepts, most recently updated first, capped per settings.
+    concepts_result = await session.execute(
+        select(Concept).order_by(Concept.created_at.desc()).limit(
+            settings.linter.max_concepts_per_run
+        )
+    )
+    concepts = concepts_result.scalars().all()
+
+    if not concepts:
+        # No concept taxonomy yet — fall back to a single "all articles" bucket
+        # capped at max_contradiction_pairs_per_concept. See spec Open Decision #7.
+        articles_result = await session.execute(
+            select(Article).order_by(Article.updated_at.desc()).limit(
+                settings.linter.max_contradiction_pairs_per_concept * 2
+            )
+        )
+        article_buckets = [list(articles_result.scalars().all())]
+    else:
+        article_buckets = []
+        for concept in concepts:
+            bucket = await _load_articles_for_concept(session, concept.id)
+            article_buckets.append(bucket)
+
+    for bucket in article_buckets:
+        if len(bucket) < 2:
+            continue
+        pairs = list(itertools.combinations(bucket, 2))[
+            : settings.linter.max_contradiction_pairs_per_concept
+        ]
+
+        for article_a, article_b in pairs:
+            try:
+                pair_findings = await _check_pair(
+                    article_a, article_b, router, settings
+                )
+            except Exception as e:  # noqa: BLE001 — LLM failures are logged and skipped
+                log.warning(
+                    "contradiction check failed for pair",
+                    article_a=article_a.id,
+                    article_b=article_b.id,
+                    error=str(e),
+                )
+                continue
+            findings.extend(pair_findings)
+
+    log.info("detect_contradictions complete", finding_count=len(findings))
+    return findings
+
+
+async def _load_articles_for_concept(
+    session: AsyncSession, concept_id: str
+) -> list[Article]:
+    """Return all articles whose concept_ids JSON array contains concept_id."""
+    result = await session.execute(select(Article))
+    all_articles = result.scalars().all()
+    matched: list[Article] = []
+    for article in all_articles:
+        if not article.concept_ids:
+            continue
+        try:
+            concept_ids = json.loads(article.concept_ids)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if concept_id in concept_ids:
+            matched.append(article)
+    return matched
+
+
+async def _check_pair(
+    article_a: Article,
+    article_b: Article,
+    router: Any,
+    settings: Settings,
+) -> list[ContradictionFinding]:
+    """Ask the LLM whether these two articles contradict each other."""
+    user_msg = CONTRADICTION_USER_TEMPLATE.format(
+        article_a_title=article_a.title,
+        article_a_claims=article_a.summary or "(no summary)",
+        article_b_title=article_b.title,
+        article_b_claims=article_b.summary or "(no summary)",
+    )
+
+    request = CompletionRequest(
+        system=CONTRADICTION_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_msg}],
+        max_tokens=settings.linter.contradiction_llm_max_tokens,
+        temperature=settings.linter.contradiction_llm_temperature,
+        response_format="json",
+        task_type=TaskType.LINT,
+    )
+
+    response = await router.complete(request, session=None)  # type: ignore[arg-type]
+    data = router.parse_json_response(response)
+    contradictions = data.get("contradictions", [])
+
+    return [
+        ContradictionFinding(
+            article_a_id=article_a.id,
+            article_b_id=article_b.id,
+            description=c["description"],
+            article_a_claim=c["article_a_claim"],
+            article_b_claim=c["article_b_claim"],
+            llm_confidence=c.get("confidence", "medium"),
+        )
+        for c in contradictions
+    ]
+```
+
+- [ ] **Step 2: Run the happy-path test**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_contradictions.py -v
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/engine/linter/contradictions.py
+.venv/bin/mypy src/wikimind/engine/linter/contradictions.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/wikimind/engine/linter/contradictions.py
+git commit -m "feat(linter): detect_contradictions minimal implementation"
+```
+
+## Task A.8: Contradiction detection — cap and fallback tests
+
+**Files:** Modify `tests/unit/test_linter_contradictions.py`
+
+- [ ] **Step 1: Add a test for the pair cap**
+
+Append to `tests/unit/test_linter_contradictions.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_detect_contradictions_respects_pair_cap(
+    settings: Settings,
+    async_session: AsyncSession,
+):
+    """30 articles in one concept → only max_contradiction_pairs_per_concept calls."""
+    import json as _json
+    from wikimind.models import Article, Concept
+
+    concept = Concept(name="cap-test", description="test")
+    async_session.add(concept)
+    await async_session.commit()
+    await async_session.refresh(concept)
+
+    for i in range(30):
+        async_session.add(
+            Article(
+                slug=f"cap-{i}",
+                title=f"Cap Article {i}",
+                file_path=f"/tmp/cap_{i}.md",
+                concept_ids=_json.dumps([concept.id]),
+                summary=f"Claim {i}.",
+            )
+        )
+    await async_session.commit()
+
+    router = AsyncMock()
+    router.complete.return_value.content = json.dumps({"contradictions": []})
+    router.parse_json_response = lambda r: json.loads(r.content)
+
+    settings.linter.max_contradiction_pairs_per_concept = 5
+    findings = await detect_contradictions(async_session, router, settings)
+
+    assert findings == []
+    assert router.complete.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_handles_llm_failure_gracefully(
+    seeded_session: AsyncSession,
+    settings: Settings,
+):
+    """An LLM exception on one pair is logged and the run continues."""
+    router = AsyncMock()
+    router.complete.side_effect = RuntimeError("provider exhausted")
+    router.parse_json_response = lambda r: {}
+
+    findings = await detect_contradictions(seeded_session, router, settings)
+
+    assert findings == []  # nothing produced, but no exception propagated
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_falls_back_to_all_articles_when_no_concepts(
+    async_session: AsyncSession,
+    settings: Settings,
+):
+    """With no Concept rows, the check uses a single 'all articles' bucket."""
+    from wikimind.models import Article
+
+    async_session.add(
+        Article(
+            slug="solo-a",
+            title="Solo A",
+            file_path="/tmp/solo_a.md",
+            summary="A says X.",
+        )
+    )
+    async_session.add(
+        Article(
+            slug="solo-b",
+            title="Solo B",
+            file_path="/tmp/solo_b.md",
+            summary="B says not-X.",
+        )
+    )
+    await async_session.commit()
+
+    router = AsyncMock()
+    router.complete.return_value.content = json.dumps({"contradictions": []})
+    router.parse_json_response = lambda r: json.loads(r.content)
+
+    findings = await detect_contradictions(async_session, router, settings)
+
+    assert findings == []
+    assert router.complete.call_count == 1  # one pair
+```
+
+- [ ] **Step 2: Run the three new tests**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_contradictions.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_linter_contradictions.py
+git commit -m "test(linter): cover pair cap, LLM failure, empty-concepts fallback"
+```
+
+## Task A.9: Runner — failing test
+
+**Files:** Create `tests/unit/test_linter_runner.py`
+
+- [ ] **Step 1: Write a failing test for the runner**
+
+Create `tests/unit/test_linter_runner.py`:
+
+```python
+"""Unit tests for run_lint — the top-level orchestrator."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import Settings
+from wikimind.engine.linter.runner import run_lint
+from wikimind.models import LintFinding, LintReport, LintReportStatus
+
+
+@pytest.mark.asyncio
+async def test_run_lint_creates_report_with_counts(
+    seeded_session: AsyncSession,
+    settings: Settings,
+):
+    """run_lint creates a LintReport and persists each ContradictionFinding."""
+    router = AsyncMock()
+    router.complete.return_value.content = json.dumps(
+        {
+            "contradictions": [
+                {
+                    "description": "Contradiction found",
+                    "article_a_claim": "X is true",
+                    "article_b_claim": "X is false",
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+    router.parse_json_response = lambda r: json.loads(r.content)
+
+    with patch("wikimind.engine.linter.runner.get_llm_router", return_value=router):
+        report = await run_lint(seeded_session, settings)
+
+    assert report.status == LintReportStatus.COMPLETE
+    assert report.contradictions_count == 1
+    assert report.total_findings == 1
+
+    findings_result = await seeded_session.execute(
+        select(LintFinding).where(LintFinding.report_id == report.id)
+    )
+    findings = findings_result.scalars().all()
+    assert len(findings) == 1
+    assert findings[0].description == "Contradiction found"
+
+
+@pytest.mark.asyncio
+async def test_run_lint_marks_failed_on_exception(
+    seeded_session: AsyncSession,
+    settings: Settings,
+):
+    """If a detection function raises, the report ends in FAILED."""
+    with patch(
+        "wikimind.engine.linter.runner.detect_contradictions",
+        side_effect=RuntimeError("boom"),
+    ):
+        report = await run_lint(seeded_session, settings)
+
+    assert report.status == LintReportStatus.FAILED
+    assert report.error_message is not None
+    assert "boom" in report.error_message
+```
+
+- [ ] **Step 2: Run it, confirm ImportError**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_runner.py -v
+```
+
+Expected: import error. This is the failing test.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/test_linter_runner.py
+git commit -m "test(linter): add failing run_lint orchestrator tests"
+```
+
+## Task A.10: Runner — minimal implementation
+
+**Files:** Create `src/wikimind/engine/linter/runner.py`
+
+- [ ] **Step 1: Write the runner**
+
+```python
+"""Top-level lint runner — orchestrates detection functions and persists the report.
+
+See docs/superpowers/specs/2026-04-08-wiki-linter-design.md § Pipeline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import structlog
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.config import Settings, get_settings
+from wikimind.engine.linter.contradictions import detect_contradictions
+from wikimind.engine.linter.findings import ContradictionFinding
+from wikimind.engine.llm_router import get_llm_router
+from wikimind.models import (
+    Article,
+    DismissedFinding,
+    LintFinding,
+    LintFindingKind,
+    LintReport,
+    LintReportStatus,
+    LintSeverity,
+)
+
+log = structlog.get_logger()
+
+
+async def run_lint(
+    session: AsyncSession,
+    settings: Settings | None = None,
+) -> LintReport:
+    """Execute all enabled checks and persist a LintReport with findings."""
+    settings = settings or get_settings()
+
+    article_count_result = await session.execute(select(Article))
+    article_count = len(article_count_result.scalars().all())
+
+    report = LintReport(
+        status=LintReportStatus.IN_PROGRESS,
+        article_count=article_count,
+    )
+    session.add(report)
+    await session.commit()
+    await session.refresh(report)
+
+    try:
+        router = get_llm_router()
+
+        contradiction_findings = await detect_contradictions(
+            session, router, settings
+        )
+        await _persist_findings(session, report.id, contradiction_findings)
+        report.contradictions_count = len(contradiction_findings)
+
+        # Orphan detection is PR C; keep the counter at 0 for PR A.
+        report.orphans_count = 0
+
+        report.total_findings = report.contradictions_count + report.orphans_count
+        report.status = LintReportStatus.COMPLETE
+        report.completed_at = utcnow_naive()
+
+    except Exception as e:  # noqa: BLE001
+        log.error("run_lint failed", error=str(e))
+        report.status = LintReportStatus.FAILED
+        report.error_message = str(e)
+        report.completed_at = utcnow_naive()
+
+    session.add(report)
+    await session.commit()
+    await session.refresh(report)
+    return report
+
+
+async def _persist_findings(
+    session: AsyncSession,
+    report_id: str,
+    findings: list[ContradictionFinding],
+) -> None:
+    """Convert typed findings to LintFinding rows, honoring cross-run dismiss."""
+    if not findings:
+        return
+
+    # Load all dismissed content hashes up-front — one query, membership test below.
+    dismissed_result = await session.execute(select(DismissedFinding.content_hash))
+    dismissed_hashes = {row for row in dismissed_result.scalars().all()}
+
+    for f in findings:
+        content_hash = _compute_content_hash(f)
+        is_auto_dismissed = content_hash in dismissed_hashes
+        row = LintFinding(
+            report_id=report_id,
+            kind=LintFindingKind.CONTRADICTION,
+            severity=_severity_for_llm_confidence(f.llm_confidence),
+            article_id=f.article_a_id,
+            related_article_id=f.article_b_id,
+            description=f.description,
+            raw_json=json.dumps(
+                {
+                    "article_a_claim": f.article_a_claim,
+                    "article_b_claim": f.article_b_claim,
+                    "llm_confidence": f.llm_confidence,
+                }
+            ),
+            content_hash=content_hash,
+            dismissed=is_auto_dismissed,
+            dismissed_at=utcnow_naive() if is_auto_dismissed else None,
+        )
+        session.add(row)
+    await session.commit()
+
+
+def _compute_content_hash(finding: ContradictionFinding) -> str:
+    """Stable hash for cross-run dismiss suppression."""
+    payload = f"{finding.kind}|{finding.article_a_id}|{finding.article_b_id}|{finding.description}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _severity_for_llm_confidence(llm_confidence: str) -> LintSeverity:
+    """Map LLM self-reported confidence to severity."""
+    return {
+        "high": LintSeverity.ERROR,
+        "medium": LintSeverity.WARN,
+        "low": LintSeverity.INFO,
+    }.get(llm_confidence, LintSeverity.WARN)
+```
+
+- [ ] **Step 2: Update `engine/linter/__init__.py` to re-export `run_lint`**
+
+```python
+from wikimind.engine.linter.findings import ContradictionFinding, OrphanFinding
+from wikimind.engine.linter.runner import run_lint
+
+__all__ = ["ContradictionFinding", "OrphanFinding", "run_lint"]
+```
+
+- [ ] **Step 3: Run the runner tests**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_runner.py -v
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Run all linter tests and lint**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_*.py -v
+.venv/bin/ruff check src/wikimind/engine/linter/
+.venv/bin/mypy src/wikimind/engine/linter/
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/engine/linter/runner.py src/wikimind/engine/linter/__init__.py
+git commit -m "feat(linter): run_lint orchestrator with dismiss suppression"
+```
+
+## Task A.11: LinterService
+
+**Files:** Create `src/wikimind/services/linter.py`, `tests/unit/test_linter_service.py`
+
+- [ ] **Step 1: Write a failing service test**
+
+Create `tests/unit/test_linter_service.py`:
+
+```python
+"""Unit tests for LinterService."""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.models import (
+    DismissedFinding,
+    LintFinding,
+    LintFindingKind,
+    LintReport,
+    LintReportStatus,
+)
+from wikimind.services.linter import LinterService
+
+
+@pytest.mark.asyncio
+async def test_get_latest_returns_most_recent_report(async_session: AsyncSession):
+    service = LinterService()
+
+    # Create two reports — second is newer
+    r1 = LintReport(status=LintReportStatus.COMPLETE, article_count=5)
+    r2 = LintReport(status=LintReportStatus.COMPLETE, article_count=6)
+    async_session.add_all([r1, r2])
+    await async_session.commit()
+    await async_session.refresh(r2)
+
+    detail = await service.get_latest(async_session)
+    assert detail.report.id == r2.id
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_sets_flag_and_creates_dismissed_record(
+    async_session: AsyncSession,
+):
+    service = LinterService()
+
+    report = LintReport(status=LintReportStatus.COMPLETE, article_count=1)
+    async_session.add(report)
+    await async_session.commit()
+    await async_session.refresh(report)
+
+    finding = LintFinding(
+        report_id=report.id,
+        kind=LintFindingKind.CONTRADICTION,
+        description="test",
+        content_hash="abc123",
+    )
+    async_session.add(finding)
+    await async_session.commit()
+    await async_session.refresh(finding)
+
+    result = await service.dismiss_finding(async_session, finding.id)
+    assert result.dismissed is True
+
+    # DismissedFinding row was created
+    dismissed = await async_session.get(DismissedFinding, "abc123")
+    assert dismissed is not None
+```
+
+Run it, confirm ImportError.
+
+- [ ] **Step 2: Implement LinterService**
+
+Create `src/wikimind/services/linter.py`:
+
+```python
+"""Linter service — thin persistence layer over engine/linter/*."""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.jobs.background import BackgroundCompiler
+from wikimind.models import (
+    DismissedFinding,
+    LintFinding,
+    LintFindingResponse,
+    LintReport,
+    LintReportDetail,
+    LintReportResponse,
+    LintRunResponse,
+)
+
+log = structlog.get_logger()
+
+
+class LinterService:
+    """Thin persistence + dispatch for the linter."""
+
+    def __init__(self, background: BackgroundCompiler | None = None) -> None:
+        self._background = background or BackgroundCompiler()
+
+    async def trigger_run(self) -> LintRunResponse:
+        """Schedule a lint run and return a placeholder report id + status.
+
+        The actual LintReport row is created by run_lint inside the worker;
+        this endpoint is fire-and-forget from the caller's perspective. The
+        caller polls GET /lint/reports/latest to see the eventual result.
+        """
+        job_id = await self._background.schedule_lint()
+        log.info("lint run triggered", job_id=job_id)
+        return LintRunResponse(report_id=job_id, status="in_progress")
+
+    async def list_reports(
+        self, session: AsyncSession, limit: int = 20
+    ) -> list[LintReportResponse]:
+        result = await session.execute(
+            select(LintReport).order_by(LintReport.generated_at.desc()).limit(limit)
+        )
+        return [_report_to_response(r) for r in result.scalars().all()]
+
+    async def get_latest(self, session: AsyncSession) -> LintReportDetail:
+        result = await session.execute(
+            select(LintReport).order_by(LintReport.generated_at.desc()).limit(1)
+        )
+        report = result.scalar_one_or_none()
+        if report is None:
+            raise HTTPException(status_code=404, detail="no lint reports yet")
+        return await self._load_detail(session, report, include_dismissed=False)
+
+    async def get_report(
+        self,
+        session: AsyncSession,
+        report_id: str,
+        *,
+        include_dismissed: bool = False,
+    ) -> LintReportDetail:
+        report = await session.get(LintReport, report_id)
+        if report is None:
+            raise HTTPException(status_code=404, detail="report not found")
+        return await self._load_detail(session, report, include_dismissed)
+
+    async def dismiss_finding(
+        self, session: AsyncSession, finding_id: str
+    ) -> LintFindingResponse:
+        finding = await session.get(LintFinding, finding_id)
+        if finding is None:
+            raise HTTPException(status_code=404, detail="finding not found")
+
+        finding.dismissed = True
+        finding.dismissed_at = utcnow_naive()
+        session.add(finding)
+
+        existing = await session.get(DismissedFinding, finding.content_hash)
+        if existing is None:
+            session.add(DismissedFinding(content_hash=finding.content_hash))
+
+        await session.commit()
+        await session.refresh(finding)
+        return _finding_to_response(finding)
+
+    async def _load_detail(
+        self,
+        session: AsyncSession,
+        report: LintReport,
+        include_dismissed: bool,
+    ) -> LintReportDetail:
+        query = select(LintFinding).where(LintFinding.report_id == report.id)
+        if not include_dismissed:
+            query = query.where(LintFinding.dismissed.is_(False))  # type: ignore[attr-defined]
+        findings_result = await session.execute(query)
+        findings = [_finding_to_response(f) for f in findings_result.scalars().all()]
+        return LintReportDetail(report=_report_to_response(report), findings=findings)
+
+
+def get_linter_service() -> LinterService:
+    """DI provider."""
+    return LinterService()
+
+
+def _report_to_response(r: LintReport) -> LintReportResponse:
+    return LintReportResponse(
+        id=r.id,
+        generated_at=r.generated_at,
+        completed_at=r.completed_at,
+        status=r.status,
+        article_count=r.article_count,
+        total_findings=r.total_findings,
+        contradictions_count=r.contradictions_count,
+        orphans_count=r.orphans_count,
+        error_message=r.error_message,
+    )
+
+
+def _finding_to_response(f: LintFinding) -> LintFindingResponse:
+    return LintFindingResponse(
+        id=f.id,
+        kind=f.kind,
+        severity=f.severity,
+        article_id=f.article_id,
+        related_article_id=f.related_article_id,
+        description=f.description,
+        raw_json=f.raw_json,
+        created_at=f.created_at,
+        dismissed=f.dismissed,
+        dismissed_at=f.dismissed_at,
+    )
+```
+
+- [ ] **Step 3: Run tests + lint + typecheck**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_service.py -v
+.venv/bin/ruff check src/wikimind/services/linter.py
+.venv/bin/mypy src/wikimind/services/linter.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/wikimind/services/linter.py tests/unit/test_linter_service.py
+git commit -m "feat(services): add LinterService with list/get/dismiss"
+```
+
+## Task A.12: Lint API routes
+
+**Files:** Create `src/wikimind/api/routes/lint.py`, register in `main.py`
+
+- [ ] **Step 1: Create the lint router**
+
+```python
+"""Lint API routes — /lint/*."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.database import get_session
+from wikimind.models import (
+    DismissResponse,
+    LintReportDetail,
+    LintReportResponse,
+    LintRunResponse,
+)
+from wikimind.services.linter import LinterService, get_linter_service
+
+router = APIRouter(prefix="/lint", tags=["lint"])
+
+
+@router.post("/run", response_model=LintRunResponse)
+async def trigger_lint_run(
+    service: LinterService = Depends(get_linter_service),
+) -> LintRunResponse:
+    """Trigger a lint run. Returns immediately; poll /lint/reports/latest."""
+    return await service.trigger_run()
+
+
+@router.get("/reports", response_model=list[LintReportResponse])
+async def list_reports(
+    limit: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+) -> list[LintReportResponse]:
+    """List recent lint reports ordered by generated_at DESC."""
+    return await service.list_reports(session, limit=limit)
+
+
+@router.get("/reports/latest", response_model=LintReportDetail)
+async def get_latest_report(
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+) -> LintReportDetail:
+    """Get the most recent lint report with its (non-dismissed) findings."""
+    return await service.get_latest(session)
+
+
+@router.get("/reports/{report_id}", response_model=LintReportDetail)
+async def get_report(
+    report_id: str,
+    include_dismissed: bool = Query(False),
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+) -> LintReportDetail:
+    """Get a single lint report with its findings."""
+    return await service.get_report(
+        session, report_id, include_dismissed=include_dismissed
+    )
+
+
+@router.post("/findings/{finding_id}/dismiss", response_model=DismissResponse)
+async def dismiss_finding(
+    finding_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+) -> DismissResponse:
+    """Dismiss a finding permanently (cross-run, keyed by content hash)."""
+    await service.dismiss_finding(session, finding_id)
+    return DismissResponse(finding_id=finding_id, dismissed=True)
+```
+
+- [ ] **Step 2: Register the router in `main.py`**
+
+Find the existing router registration block in `src/wikimind/main.py` and add:
+
+```python
+from wikimind.api.routes import lint as lint_routes
+
+# ... inside create_app() ...
+app.include_router(lint_routes.router)
+```
+
+(Match the exact pattern used by the existing `query`, `ingest`, `wiki`, `jobs` registrations.)
+
+- [ ] **Step 3: Regenerate OpenAPI**
+
+```bash
+make export-openapi
+```
+
+Verify `docs/openapi.yaml` now contains the new `/lint/*` paths.
+
+- [ ] **Step 4: Run lint + typecheck + existing tests**
+
+```bash
+.venv/bin/ruff check src/wikimind/api/routes/lint.py
+.venv/bin/mypy src/wikimind/api/routes/lint.py
+.venv/bin/pytest tests/unit/ -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/api/routes/lint.py src/wikimind/main.py docs/openapi.yaml
+git commit -m "feat(api): add /lint/* routes"
+```
+
+## Task A.13: Integration test for the API
+
+**Files:** Create `tests/integration/test_lint_api.py`
+
+- [ ] **Step 1: Write the end-to-end test**
+
+```python
+"""Integration test: POST /lint/run → run_lint → GET /lint/reports/latest."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from wikimind.models import Article, Concept
+
+
+@pytest.mark.asyncio
+async def test_lint_run_and_latest_report(
+    async_client: AsyncClient,
+    async_session,
+):
+    """The full API path exercises run_lint under a mocked LLM router."""
+    import json as _json
+
+    concept = Concept(name="api-test", description="test")
+    async_session.add(concept)
+    await async_session.commit()
+    await async_session.refresh(concept)
+
+    for i, claim in enumerate(["X is true.", "X is false."]):
+        async_session.add(
+            Article(
+                slug=f"api-{i}",
+                title=f"API Article {i}",
+                file_path=f"/tmp/api_{i}.md",
+                concept_ids=_json.dumps([concept.id]),
+                summary=claim,
+            )
+        )
+    await async_session.commit()
+
+    router = AsyncMock()
+    router.complete.return_value.content = json.dumps(
+        {
+            "contradictions": [
+                {
+                    "description": "A says X; B says not-X",
+                    "article_a_claim": "X is true.",
+                    "article_b_claim": "X is false.",
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+    router.parse_json_response = lambda r: json.loads(r.content)
+
+    with patch("wikimind.engine.linter.runner.get_llm_router", return_value=router):
+        # Trigger a run (in dev mode runs in-process via asyncio.create_task)
+        trigger_response = await async_client.post("/lint/run")
+        assert trigger_response.status_code == 200
+
+        # Wait for the in-process task to finish — fakeredis or in-process dev mode
+        import asyncio
+        await asyncio.sleep(0.5)  # deliberately small; dev mode is fast
+
+        latest_response = await async_client.get("/lint/reports/latest")
+        assert latest_response.status_code == 200
+
+    body = latest_response.json()
+    assert body["report"]["status"] == "complete"
+    assert body["report"]["contradictions_count"] == 1
+    assert len(body["findings"]) == 1
+```
+
+> **Note for the implementer:** the `async_client` fixture pattern comes from the existing Ask slice integration tests (`tests/integration/test_qa_loop_integration.py`). Copy its setup. If the in-process sleep proves flaky, switch to directly calling `run_lint` from the test instead of going through the HTTP trigger — the important assertion is the `/lint/reports/latest` response shape.
+
+- [ ] **Step 2: Run it**
+
+```bash
+.venv/bin/pytest tests/integration/test_lint_api.py -v
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_lint_api.py
+git commit -m "test(lint): integration test for /lint/run → /lint/reports/latest"
+```
+
+## Task A.14: Rewrite the lint_wiki ARQ stub
+
+**Files:** Modify `src/wikimind/jobs/worker.py`
+
+- [ ] **Step 1: Replace the body of `lint_wiki`**
+
+In `src/wikimind/jobs/worker.py`, replace the entire `async def lint_wiki(ctx):` function body with a minimal dispatcher to `run_lint`:
+
+```python
+async def lint_wiki(ctx):
+    """Run the wiki linter via the new structured pipeline.
+
+    See docs/superpowers/specs/2026-04-08-wiki-linter-design.md § Migration
+    from the stub. This replaces the original single-prompt stub.
+    """
+    log.info("lint_wiki started")
+
+    from wikimind.engine.linter.runner import run_lint
+
+    async with get_session_factory()() as session:
+        job = Job(
+            job_type=JobType.LINT_WIKI,
+            status=JobStatus.RUNNING,
+            started_at=utcnow_naive(),
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+
+        try:
+            report = await run_lint(session)
+
+            job.status = JobStatus.COMPLETE
+            job.completed_at = utcnow_naive()
+            job.result_summary = (
+                f"{report.contradictions_count} contradictions, "
+                f"{report.orphans_count} orphans"
+            )
+            session.add(job)
+            await session.commit()
+
+            # Emit WS event so the frontend refetches
+            if report.contradictions_count > 0:
+                await emit_linter_alert(
+                    "contradiction",
+                    [],  # article titles; frontend re-fetches instead of reading this
+                )
+
+            log.info("lint_wiki complete", summary=job.result_summary)
+
+        except Exception as e:  # noqa: BLE001
+            log.error("lint_wiki failed", error=str(e))
+            job.status = JobStatus.FAILED
+            job.error = str(e)
+            job.completed_at = utcnow_naive()
+            session.add(job)
+            await session.commit()
+```
+
+Delete the now-unused imports at the top of the file (`CompletionRequest`, `router`, `TaskType`, `get_llm_router`) **only if** nothing else in the file needs them. Leave them if `compile_source` still uses them.
+
+- [ ] **Step 2: Run the existing worker tests**
+
+```bash
+.venv/bin/pytest tests/ -v -k worker
+```
+
+Expected: whatever existing stub test existed may need an update. If none exists, move on.
+
+- [ ] **Step 3: Run lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/jobs/worker.py
+.venv/bin/mypy src/wikimind/jobs/worker.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/wikimind/jobs/worker.py
+git commit -m "refactor(worker): lint_wiki dispatches to run_lint"
+```
+
+## Task A.15: Reshape `GET /wiki/health` and `POST /jobs/lint` as shims
+
+**Files:** Modify `src/wikimind/services/wiki.py`, `src/wikimind/api/routes/wiki.py`, `src/wikimind/api/routes/jobs.py`
+
+- [ ] **Step 1: Update `WikiService.get_health` to read from the new tables**
+
+In `src/wikimind/services/wiki.py`, find the existing `get_health` method and replace its body with a projection of the latest `LintReport` into the legacy `HealthReport` shape. Roughly:
+
+```python
+async def get_health(self, session: AsyncSession) -> dict:
+    """DEPRECATED. Returns the latest LintReport projected to the legacy HealthReport shape."""
+    from wikimind.models import LintReport
+    from sqlmodel import select
+
+    result = await session.execute(
+        select(LintReport).order_by(LintReport.generated_at.desc()).limit(1)
+    )
+    report = result.scalar_one_or_none()
+    if report is None:
+        return {
+            "generated_at": None,
+            "total_articles": 0,
+            "contradictions": [],
+            "orphaned_articles": [],
+            "stale_articles": [],
+            "gap_suggestions": [],
+            "coverage_scores": {},
+            "cost_this_month_usd": 0.0,
+        }
+
+    return {
+        "generated_at": report.generated_at.isoformat(),
+        "total_articles": report.article_count,
+        "contradictions_count": report.contradictions_count,
+        "orphans_count": report.orphans_count,
+        "total_findings": report.total_findings,
+        "status": report.status,
+        "report_id": report.id,
+    }
+```
+
+(The exact legacy shape is whatever the existing callers read. If the frontend is using field X, keep field X in the projection. PR B migrates the frontend off this shim.)
+
+- [ ] **Step 2: Add a deprecation docstring to `/wiki/health` and `/jobs/lint`**
+
+In `src/wikimind/api/routes/wiki.py`, update the `get_health` endpoint docstring:
+
+```python
+@router.get("/health")
+async def get_health(
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+):
+    """DEPRECATED: use GET /lint/reports/latest. Kept as a compatibility shim."""
+    return await service.get_health(session)
+```
+
+In `src/wikimind/api/routes/jobs.py`, update the `trigger_lint` docstring and delegate to `LinterService`:
+
+```python
+@router.post("/lint")
+async def trigger_lint(
+    service: "LinterService" = Depends(get_linter_service),
+):
+    """DEPRECATED: use POST /lint/run. Kept as a compatibility shim."""
+    return await service.trigger_run()
+```
+
+Import `LinterService` and `get_linter_service` at the top of `jobs.py`.
+
+- [ ] **Step 3: Lint + test**
+
+```bash
+.venv/bin/ruff check src/wikimind/services/wiki.py src/wikimind/api/routes/wiki.py src/wikimind/api/routes/jobs.py
+.venv/bin/pytest tests/ -v -k "health or jobs"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/wikimind/services/wiki.py src/wikimind/api/routes/wiki.py src/wikimind/api/routes/jobs.py
+git commit -m "refactor(api): reshape /wiki/health and /jobs/lint as linter shims"
+```
+
+## Task A.16: Final `make verify` and PR A wrap-up
+
+- [ ] **Step 1: Run the full verification**
+
+```bash
+make verify
+```
+
+Expected: green. Lint, format, typecheck, tests, coverage all pass.
+
+- [ ] **Step 2: Update `.env.example`**
+
+Add to `.env.example`:
+
+```bash
+# Wiki linter
+WIKIMIND_LINTER__ENABLE_ORPHAN_DETECTION=false
+WIKIMIND_LINTER__MAX_CONCEPTS_PER_RUN=25
+WIKIMIND_LINTER__MAX_CONTRADICTION_PAIRS_PER_CONCEPT=10
+WIKIMIND_LINTER__CONTRADICTION_LLM_MAX_TOKENS=1024
+WIKIMIND_LINTER__CONTRADICTION_LLM_TEMPERATURE=0.2
+WIKIMIND_LINTER__RESPECT_MONTHLY_BUDGET=true
+WIKIMIND_LINTER__MAX_COST_PER_RUN_USD=1.00
+WIKIMIND_LINTER__ENABLE_PAIR_CACHE=true
+```
+
+- [ ] **Step 3: Commit and open PR A**
+
+```bash
+git add .env.example
+git commit -m "docs(env): document linter settings"
+git push -u origin claude/lint-pr-a-backend
+gh pr create --title "feat(linter): structured backend + contradiction check (PR A)" --body "$(cat <<'EOF'
+## Summary
+- New `LintReport` / `LintFinding` / `DismissedFinding` tables
+- `engine/linter/` package with `run_lint` + `detect_contradictions`
+- `LinterService` + `/lint/*` API surface
+- `POST /jobs/lint` and `GET /wiki/health` reshape as compatibility shims
+- Weekly ARQ cron now runs the new `run_lint` pipeline
+
+## Spec
+docs/superpowers/specs/2026-04-08-wiki-linter-design.md
+
+## Follow-ups
+- PR B — frontend health view
+- PR C — orphan detection (depends on #95)
+- Drop deprecated shim endpoints after one release
+
+## Test plan
+- [x] `make verify` green
+- [x] Contradiction unit tests hermetic
+- [x] Integration test `/lint/run` → `/lint/reports/latest`
+EOF
+)"
+```
+
+---
+
+# PR B — Frontend health view
+
+**Branch:** `claude/lint-pr-b-frontend`
+
+**Depends on:** PR A merged to main so the backend contract is live.
+
+**Definition of done for PR B:** `/health` route renders the latest lint report from `/lint/reports/latest`, the "Run lint now" button triggers a real `POST /lint/run`, dismiss works, WebSocket `linter.alert` event triggers re-fetch.
+
+## Task B.1: API client module
+
+**Files:** Create `apps/web/src/api/lint.ts`
+
+- [ ] **Step 1: Create the typed client**
+
+```typescript
+// apps/web/src/api/lint.ts
+import { apiClient } from "./client";
+
+export type LintSeverity = "info" | "warn" | "error";
+export type LintFindingKind = "contradiction" | "orphan";
+export type LintReportStatus = "in_progress" | "complete" | "failed";
+
+export interface LintReport {
+  id: string;
+  generated_at: string;
+  completed_at: string | null;
+  status: LintReportStatus;
+  article_count: number;
+  total_findings: number;
+  contradictions_count: number;
+  orphans_count: number;
+  error_message: string | null;
+}
+
+export interface LintFinding {
+  id: string;
+  kind: LintFindingKind;
+  severity: LintSeverity;
+  article_id: string | null;
+  related_article_id: string | null;
+  description: string;
+  raw_json: string;
+  created_at: string;
+  dismissed: boolean;
+  dismissed_at: string | null;
+}
+
+export interface LintReportDetail {
+  report: LintReport;
+  findings: LintFinding[];
+}
+
+export async function runLint(): Promise<{ report_id: string; status: string }> {
+  const response = await apiClient.post("/lint/run");
+  return response.data;
+}
+
+export async function getLatestReport(): Promise<LintReportDetail> {
+  const response = await apiClient.get("/lint/reports/latest");
+  return response.data;
+}
+
+export async function getReport(id: string, includeDismissed = false): Promise<LintReportDetail> {
+  const response = await apiClient.get(`/lint/reports/${id}`, {
+    params: { include_dismissed: includeDismissed },
+  });
+  return response.data;
+}
+
+export async function listReports(limit = 20): Promise<LintReport[]> {
+  const response = await apiClient.get("/lint/reports", { params: { limit } });
+  return response.data;
+}
+
+export async function dismissFinding(id: string): Promise<{ finding_id: string; dismissed: boolean }> {
+  const response = await apiClient.post(`/lint/findings/${id}/dismiss`);
+  return response.data;
+}
+```
+
+Match the existing `apiClient` import path used in `apps/web/src/api/query.ts`.
+
+- [ ] **Step 2: Typecheck + lint**
+
+```bash
+cd apps/web && npm run typecheck && npm run lint
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/api/lint.ts
+git commit -m "feat(web/api): add lint client module"
+```
+
+## Task B.2: HealthView page container
+
+**Files:** Create `apps/web/src/components/health/HealthView.tsx`
+
+- [ ] **Step 1: Create the page container**
+
+```tsx
+// apps/web/src/components/health/HealthView.tsx
+import { useQuery } from "@tanstack/react-query";
+import { getLatestReport } from "../../api/lint";
+import { LintReportSummary } from "./LintReportSummary";
+import { FindingsByKindTabs } from "./FindingsByKindTabs";
+
+export function HealthView() {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["lint", "latest"],
+    queryFn: getLatestReport,
+    retry: false,
+  });
+
+  if (isLoading) {
+    return <div className="p-8">Loading health report…</div>;
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-8">
+        <h1 className="text-2xl font-bold mb-4">Wiki Health</h1>
+        <p className="text-gray-600">No lint reports yet.</p>
+        <LintReportSummary report={null} onRun={() => refetch()} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold">Wiki Health</h1>
+      <LintReportSummary report={data.report} onRun={() => refetch()} />
+      <FindingsByKindTabs findings={data.findings} onChange={() => refetch()} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/components/health/HealthView.tsx
+git commit -m "feat(web/health): HealthView page container"
+```
+
+## Task B.3: LintReportSummary + RunLintButton
+
+**Files:** Create `apps/web/src/components/health/LintReportSummary.tsx`, `apps/web/src/components/health/RunLintButton.tsx`
+
+- [ ] **Step 1: RunLintButton**
+
+```tsx
+// apps/web/src/components/health/RunLintButton.tsx
+import { useState } from "react";
+import { runLint } from "../../api/lint";
+
+interface Props {
+  onComplete: () => void;
+}
+
+export function RunLintButton({ onComplete }: Props) {
+  const [running, setRunning] = useState(false);
+
+  const handleClick = async () => {
+    setRunning(true);
+    try {
+      await runLint();
+      // Give the background job a moment; HealthView re-fetches on WS event
+      setTimeout(() => {
+        setRunning(false);
+        onComplete();
+      }, 2000);
+    } catch (e) {
+      setRunning(false);
+      console.error("lint run failed", e);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={running}
+      className="px-4 py-2 bg-blue-600 text-white rounded disabled:bg-gray-400"
+    >
+      {running ? "Running…" : "Run lint now"}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: LintReportSummary**
+
+```tsx
+// apps/web/src/components/health/LintReportSummary.tsx
+import type { LintReport } from "../../api/lint";
+import { RunLintButton } from "./RunLintButton";
+
+interface Props {
+  report: LintReport | null;
+  onRun: () => void;
+}
+
+export function LintReportSummary({ report, onRun }: Props) {
+  return (
+    <div className="border rounded p-4 bg-white">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          {report ? (
+            <>
+              <p className="text-sm text-gray-500">
+                Last run: {new Date(report.generated_at).toLocaleString()}
+              </p>
+              <p className="text-lg">
+                {report.total_findings} findings · {report.article_count} articles
+              </p>
+            </>
+          ) : (
+            <p className="text-gray-500">No lint report yet.</p>
+          )}
+        </div>
+        <RunLintButton onComplete={onRun} />
+      </div>
+      {report && (
+        <div className="flex space-x-4 text-sm">
+          <span>Contradictions: {report.contradictions_count}</span>
+          <span>Orphans: {report.orphans_count}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/health/LintReportSummary.tsx apps/web/src/components/health/RunLintButton.tsx
+git commit -m "feat(web/health): LintReportSummary + RunLintButton"
+```
+
+## Task B.4: FindingCard + FindingsByKindTabs
+
+**Files:** Create `apps/web/src/components/health/FindingCard.tsx`, `apps/web/src/components/health/FindingsByKindTabs.tsx`
+
+- [ ] **Step 1: FindingCard**
+
+```tsx
+// apps/web/src/components/health/FindingCard.tsx
+import { Link } from "react-router-dom";
+import type { LintFinding } from "../../api/lint";
+import { dismissFinding } from "../../api/lint";
+
+interface Props {
+  finding: LintFinding;
+  onDismiss: () => void;
+}
+
+const severityStyles: Record<LintFinding["severity"], string> = {
+  info: "bg-blue-100 text-blue-800",
+  warn: "bg-yellow-100 text-yellow-800",
+  error: "bg-red-100 text-red-800",
+};
+
+export function FindingCard({ finding, onDismiss }: Props) {
+  const handleDismiss = async () => {
+    await dismissFinding(finding.id);
+    onDismiss();
+  };
+
+  return (
+    <div className="border rounded p-4 bg-white">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <span
+            className={`inline-block px-2 py-0.5 text-xs rounded ${severityStyles[finding.severity]}`}
+          >
+            {finding.severity.toUpperCase()}
+          </span>
+          <p className="mt-2">{finding.description}</p>
+          <div className="mt-2 text-sm text-gray-600 space-x-3">
+            {finding.article_id && (
+              <Link to={`/wiki/${finding.article_id}`} className="underline">
+                Article A
+              </Link>
+            )}
+            {finding.related_article_id && (
+              <Link to={`/wiki/${finding.related_article_id}`} className="underline">
+                Article B
+              </Link>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-sm text-gray-500 hover:text-gray-800"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: FindingsByKindTabs**
+
+```tsx
+// apps/web/src/components/health/FindingsByKindTabs.tsx
+import { useState } from "react";
+import type { LintFinding, LintFindingKind } from "../../api/lint";
+import { FindingCard } from "./FindingCard";
+
+interface Props {
+  findings: LintFinding[];
+  onChange: () => void;
+}
+
+const KINDS: { key: LintFindingKind; label: string }[] = [
+  { key: "contradiction", label: "Contradictions" },
+  { key: "orphan", label: "Orphans" },
+];
+
+export function FindingsByKindTabs({ findings, onChange }: Props) {
+  const [active, setActive] = useState<LintFindingKind>("contradiction");
+  const filtered = findings.filter((f) => f.kind === active);
+
+  return (
+    <div>
+      <div className="flex space-x-2 border-b mb-4">
+        {KINDS.map((k) => {
+          const count = findings.filter((f) => f.kind === k.key).length;
+          return (
+            <button
+              key={k.key}
+              onClick={() => setActive(k.key)}
+              className={`px-4 py-2 ${active === k.key ? "border-b-2 border-blue-600 font-semibold" : "text-gray-600"}`}
+            >
+              {k.label} ({count})
+            </button>
+          );
+        })}
+      </div>
+      <div className="space-y-3">
+        {filtered.length === 0 ? (
+          <p className="text-gray-500 text-sm">No findings of this kind.</p>
+        ) : (
+          filtered.map((f) => (
+            <FindingCard key={f.id} finding={f} onDismiss={onChange} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/health/FindingCard.tsx apps/web/src/components/health/FindingsByKindTabs.tsx
+git commit -m "feat(web/health): FindingCard and FindingsByKindTabs"
+```
+
+## Task B.5: Wire the /health route and nav link
+
+**Files:** Modify `apps/web/src/App.tsx`, `apps/web/src/components/shared/Layout.tsx`
+
+- [ ] **Step 1: Add the route**
+
+In `apps/web/src/App.tsx`, add:
+
+```tsx
+import { HealthView } from "./components/health/HealthView";
+
+// ... inside <Routes>
+<Route path="/health" element={<HealthView />} />
+```
+
+- [ ] **Step 2: Add the nav link**
+
+In `apps/web/src/components/shared/Layout.tsx`, add "Health" after "Wiki" matching the existing nav link style.
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+make dev  # backend
+cd apps/web && npm run dev
+```
+
+Open http://localhost:5173/health, verify the page renders (either the empty state or — after POST /lint/run — a real report with the mocked happy path if you seed one).
+
+- [ ] **Step 4: Frontend verify**
+
+```bash
+cd apps/web && npm run lint && npm run typecheck && npm run build
+```
+
+- [ ] **Step 5: Commit + open PR B**
+
+```bash
+git add apps/web/src/App.tsx apps/web/src/components/shared/Layout.tsx
+git commit -m "feat(web): wire /health route and nav link"
+git push -u origin claude/lint-pr-b-frontend
+gh pr create --title "feat(web/health): health dashboard view (PR B)" --body "..."
+```
+
+---
+
+# PR C — Orphan detection
+
+**Branch:** `claude/lint-pr-c-orphans`
+
+**Depends on:** PR A merged, **and #95 (wikilinks unresolved) merged so the Backlink table is populated by the compiler**.
+
+**Definition of done for PR C:** `detect_orphans` unit-tested with seeded `Backlink` rows; `LinterConfig.enable_orphan_detection` flag flipped to `True` by default; runner dispatches to `detect_orphans` when the flag is enabled; frontend orphan tab shows real findings.
+
+## Task C.1: Failing test for detect_orphans
+
+**Files:** Create `tests/unit/test_linter_orphans.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Unit tests for detect_orphans — pure SQL, no LLM."""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.linter.orphans import detect_orphans
+from wikimind.models import Article, Backlink
+
+
+@pytest.mark.asyncio
+async def test_detect_orphans_finds_article_with_no_links(async_session: AsyncSession):
+    """Seed two articles, one linked and one unlinked; only the unlinked is orphan."""
+    a = Article(slug="linked", title="Linked Article", file_path="/tmp/a.md")
+    b = Article(slug="orphan", title="Orphan Article", file_path="/tmp/b.md")
+    c = Article(slug="target", title="Target Article", file_path="/tmp/c.md")
+    async_session.add_all([a, b, c])
+    await async_session.commit()
+    await async_session.refresh(a)
+    await async_session.refresh(c)
+
+    async_session.add(Backlink(source_article_id=a.id, target_article_id=c.id))
+    await async_session.commit()
+
+    findings = await detect_orphans(async_session)
+
+    orphan_titles = {f.article_title for f in findings}
+    assert "Orphan Article" in orphan_titles
+    assert "Linked Article" not in orphan_titles
+    assert "Target Article" not in orphan_titles
+
+
+@pytest.mark.asyncio
+async def test_detect_orphans_returns_empty_when_no_articles(async_session: AsyncSession):
+    findings = await detect_orphans(async_session)
+    assert findings == []
+```
+
+Run it, confirm it fails (ImportError).
+
+- [ ] **Step 2: Commit failing test**
+
+```bash
+git add tests/unit/test_linter_orphans.py
+git commit -m "test(linter): add failing detect_orphans tests"
+```
+
+## Task C.2: Implement detect_orphans
+
+**Files:** Create `src/wikimind/engine/linter/orphans.py`
+
+- [ ] **Step 1: Write the implementation**
+
+```python
+"""Orphan detection — SQL-only check for articles with no inbound OR outbound backlinks.
+
+Depends on the Backlink table being populated by the compiler (issue #95).
+Disabled by default via LinterConfig.enable_orphan_detection until #95 merges.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import and_, not_
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.linter.findings import OrphanFinding
+from wikimind.models import Article, Backlink
+
+log = structlog.get_logger()
+
+
+async def detect_orphans(session: AsyncSession) -> list[OrphanFinding]:
+    """Return OrphanFinding for each article with zero inbound and zero outbound backlinks."""
+    linked_as_source = select(Backlink.source_article_id)
+    linked_as_target = select(Backlink.target_article_id)
+
+    result = await session.execute(
+        select(Article).where(
+            and_(
+                not_(Article.id.in_(linked_as_source)),  # type: ignore[attr-defined]
+                not_(Article.id.in_(linked_as_target)),  # type: ignore[attr-defined]
+            )
+        )
+    )
+    orphans = result.scalars().all()
+
+    findings = [
+        OrphanFinding(article_id=a.id, article_title=a.title) for a in orphans
+    ]
+    log.info("detect_orphans complete", orphan_count=len(findings))
+    return findings
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_orphans.py -v
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/wikimind/engine/linter/orphans.py
+git commit -m "feat(linter): detect_orphans SQL implementation"
+```
+
+## Task C.3: Wire orphans into run_lint
+
+**Files:** Modify `src/wikimind/engine/linter/runner.py`, `src/wikimind/config.py`
+
+- [ ] **Step 1: Flip the default flag**
+
+In `src/wikimind/config.py`, change:
+
+```python
+    enable_orphan_detection: bool = True
+```
+
+- [ ] **Step 2: Dispatch to detect_orphans in run_lint**
+
+In `runner.py`, inside the `try:` block of `run_lint`, after the contradictions block:
+
+```python
+        if settings.linter.enable_orphan_detection:
+            from wikimind.engine.linter.orphans import detect_orphans
+            orphan_findings = await detect_orphans(session)
+            await _persist_orphan_findings(session, report.id, orphan_findings)
+            report.orphans_count = len(orphan_findings)
+        else:
+            report.orphans_count = 0
+```
+
+Add a `_persist_orphan_findings` helper alongside `_persist_findings`:
+
+```python
+async def _persist_orphan_findings(
+    session: AsyncSession,
+    report_id: str,
+    findings: list,
+) -> None:
+    """Persist OrphanFinding list as LintFinding rows."""
+    import hashlib
+
+    dismissed_result = await session.execute(select(DismissedFinding.content_hash))
+    dismissed_hashes = {row for row in dismissed_result.scalars().all()}
+
+    for f in findings:
+        content_hash = hashlib.sha256(
+            f"orphan|{f.article_id}".encode("utf-8")
+        ).hexdigest()
+        is_auto_dismissed = content_hash in dismissed_hashes
+        row = LintFinding(
+            report_id=report_id,
+            kind=LintFindingKind.ORPHAN,
+            severity=LintSeverity.INFO,
+            article_id=f.article_id,
+            description=f"Orphan article: {f.article_title}",
+            raw_json="{}",
+            content_hash=content_hash,
+            dismissed=is_auto_dismissed,
+            dismissed_at=utcnow_naive() if is_auto_dismissed else None,
+        )
+        session.add(row)
+    await session.commit()
+```
+
+- [ ] **Step 3: Add an integration-level test exercising both checks**
+
+Append to `tests/unit/test_linter_runner.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_run_lint_includes_orphans_when_enabled(
+    async_session: AsyncSession,
+    settings: Settings,
+):
+    from wikimind.models import Article, Backlink
+
+    settings.linter.enable_orphan_detection = True
+
+    # Seed: one unlinked article
+    orphan = Article(slug="lonely", title="Lonely", file_path="/tmp/lonely.md")
+    async_session.add(orphan)
+    await async_session.commit()
+
+    router = AsyncMock()
+    router.complete.return_value.content = json.dumps({"contradictions": []})
+    router.parse_json_response = lambda r: json.loads(r.content)
+
+    with patch("wikimind.engine.linter.runner.get_llm_router", return_value=router):
+        report = await run_lint(async_session, settings)
+
+    assert report.status == LintReportStatus.COMPLETE
+    assert report.orphans_count == 1
+```
+
+- [ ] **Step 4: Run all linter tests**
+
+```bash
+.venv/bin/pytest tests/unit/test_linter_*.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/engine/linter/runner.py src/wikimind/config.py tests/unit/test_linter_runner.py
+git commit -m "feat(linter): wire orphan detection into run_lint"
+```
+
+## Task C.4: `make verify` and open PR C
+
+```bash
+make verify
+git push -u origin claude/lint-pr-c-orphans
+gh pr create --title "feat(linter): orphan detection (PR C)" --body "..."
+```
+
+---
+
+# PR D — Scheduling polish (optional)
+
+**Status:** Deferred until PR A / B / C are live and the existing weekly cron proves insufficient.
+
+**Scope if it becomes necessary:**
+
+- Make the cron weekday/hour configurable via `LinterConfig` (`cron_weekday: int = 0`, `cron_hour: int = 2`).
+- Add a "last run" indicator in the UI showing how recently the cron ran.
+- Optionally add an "on every N ingests" trigger by hooking into `ingest.service` to check the count and schedule a lint after the Nth compile.
+
+Do not build PR D without user confirmation — the default weekly cron from the stub is preserved by PR A and is likely sufficient for v1.
+
+---
+
+# PR E — Missing-page detection (deferred indefinitely)
+
+**Status:** Dropped from v1 per spec § Non-goals and § Open decisions #3.
+
+**If it is later added:**
+
+- Prefer reusing #95's compile-time wikilink resolver over a per-article LLM call.
+- Add `detect_missing_pages` alongside the other checks.
+- Add a new `LintFindingKind.MISSING_PAGE` enum value.
+- Update the frontend `FindingsByKindTabs` to include the new tab.
+- Depends on #95 being merged.
+
+---
+
+# Acceptance checklist (whole epic)
+
+- [ ] PR A merged; `make verify` green; contradiction unit tests hermetic; `/lint/*` routes live; `jobs/worker.py::lint_wiki` uses `run_lint`; back-compat shims on `/jobs/lint` and `/wiki/health` work.
+- [ ] PR B merged; `/health` route renders; "Run lint now" triggers a real lint; dismiss works; WS `linter.alert` event triggers re-fetch.
+- [ ] PR C merged after #95; orphan detection flag defaults to `True`; orphan tab in the UI shows real findings.
+- [ ] PR D deferred unless scheduling becomes a pain point.
+- [ ] PR E deferred indefinitely.
+- [ ] Epic #4 closed, #26 closed, #27 closed in PR B.
+- [ ] All open decisions in the spec answered in PR descriptions.

--- a/docs/superpowers/plans/2026-04-08-wikilink-resolution.md
+++ b/docs/superpowers/plans/2026-04-08-wikilink-resolution.md
@@ -1,0 +1,1690 @@
+# Wikilink Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve `[[wikilinks]]` at compile time (not render time), produce real `Backlink` rows in the database, and close issues #95 and #96 in a single PR. Sets the table for Epic 3 (knowledge graph view) by populating the `Backlink` table for the first time.
+
+**Architecture:** One PR. Adds a deterministic title-normalization module, a pure resolution helper, a compiler post-processing step, a superset article lookup (ID-or-slug), and a frontend simplification that deletes the local slugifier. The spec lives at `docs/superpowers/specs/2026-04-08-wikilink-resolution-design.md` — read it before starting.
+
+**Tech Stack:** FastAPI + SQLModel + SQLite (backend); React 18 + Vite + TypeScript + Tailwind + react-markdown (frontend); pytest with hermetic fixtures (backend tests).
+
+---
+
+## Spec coverage
+
+This plan implements the full spec except the backfill step, which is explicitly deferred to a user decision (see Task 8 — STOP HERE).
+
+| Decision | Source |
+|---|---|
+| Two-stage deterministic resolution (exact → normalized), no fuzzy | Spec § Resolution algorithm |
+| `Backlink` model reused as-is (composite PK already exists) | Spec § Current state |
+| `Backlink` rows created at compile time, not render time | Spec § Compiler post-processing pipeline |
+| Markdown uses `[text](/wiki/<id>)` for resolved, `[[text]]` for unresolved (Option B) | Spec § Markdown generation |
+| Article lookup accepts ID or slug (ID first, slug fallback) | Spec § Backend: article lookup accepts ID or slug |
+| Frontend deletes its local slugifier — single normalizer in one module | Spec § The single normalizer — drift prevention |
+| Unresolved candidates NOT persisted — the markdown body is the record (Option C) | Spec § Storage — where do resolution results live? |
+| Prompt contract is UNCHANGED — only post-processing of LLM output changes | Spec § Goals |
+| Backfill strategy is a user decision — plan STOPS before backfill work | Spec § Backfill strategy, Task 8 below |
+
+## Conventions for the implementing engineer
+
+Read `CLAUDE.md` at the repo root before making any change. Key rules:
+
+- **Conventional commits.** Use `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. One logical change per commit.
+- **`make verify` must be green** before any push. Runs ruff lint + format + mypy + pytest with an 80% coverage floor.
+- **No magic numbers.** Tunable values go in `Settings`, not as inline constants. (None expected for this work — the algorithm is parameter-free.)
+- **No silent failures.** Errors raise; fallback paths log and re-raise. Don't add try/except just to swallow.
+- **Hermetic tests.** Mock the LLM router boundary, never make real API calls. Use existing fixtures in `tests/conftest.py`.
+- **Doc-sync.** If you change a route, the pre-commit hook re-generates `docs/openapi.yaml` for you. The wiki route's path parameter is renamed in Task 5 — OpenAPI will reflect that automatically.
+- **TDD.** Write the failing test → run it to confirm it fails → write minimal implementation → run it to confirm it passes → commit. The steps below are written this way; follow them.
+- **Don't expand scope.** Anything not in this plan or the spec is out of scope. If you find yourself wanting to "also fix" something, file an issue instead.
+
+---
+
+# File Structure
+
+## Files to create
+
+| Path | Responsibility |
+|---|---|
+| `src/wikimind/engine/title_normalizer.py` | Single-source-of-truth `normalize_title(s: str) -> str`. The only title normalizer in the entire codebase. |
+| `src/wikimind/engine/wikilink_resolver.py` | `ResolvedBacklink` dataclass and `resolve_backlink_candidates(candidates, session, exclude_article_id)` pure-function helper. |
+| `tests/unit/test_title_normalizer.py` | Edge-case tests for the normalizer (unicode, underscores, apostrophes, punctuation, long titles). |
+| `tests/unit/test_wikilink_resolver.py` | Unit tests for the two-stage resolution algorithm. |
+| `tests/integration/test_wikilink_resolution_integration.py` | End-to-end test: compile an article referencing an existing one → verify `Backlink` row → verify rendered markdown has a real link → GET by ID returns the article. |
+
+## Files to modify
+
+| Path | What changes |
+|---|---|
+| `src/wikimind/engine/compiler.py` | Import the resolver. Split `_write_article_file` so the "Related" section accepts resolved + unresolved lists. Update `_create_article` and `_replace_article_in_place` to call `resolve_backlink_candidates` and emit `Backlink` rows. |
+| `src/wikimind/services/wiki.py` | `get_article(slug)` → `get_article(id_or_slug)`: try ID first, fall back to slug. Rename the parameter; preserve behaviour for existing slug callers. |
+| `src/wikimind/api/routes/wiki.py` | Rename the path parameter on `GET /wiki/articles/{slug}` → `/wiki/articles/{id_or_slug}`. |
+| `apps/web/src/components/wiki/ArticleReader.tsx` | Delete the local `slugify()` helper. Delete the `data-wikilink` hack. Add a preprocessor that converts remaining `[[...]]` (unresolved) to a dimmed span. Simplify the anchor renderer to use `<Link>` for internal `/wiki/...` hrefs and `<a target="_blank">` for external. |
+| `apps/web/src/index.css` (or equivalent Tailwind config) | Add a `.wikilink-unresolved` style rule — dim color, dotted underline, `cursor: help`. |
+| `tests/unit/test_compiler.py` (if it exists; if not, extend `tests/unit/test_misc.py`) | Add tests for the compiler's new resolution-aware save path. |
+
+---
+
+# Tasks
+
+**Branch:** `claude/wikilink-resolution` (or whatever the implementing agent chooses — single PR, single branch)
+
+**Definition of done:** Tasks 1–7 complete, `make verify` green, integration test passing, commit history tells the TDD story. Task 8 is a STOP marker — do NOT implement the backfill step; file an issue instead.
+
+## Task 1: Verify the Backlink model is sufficient
+
+**Files:**
+- Read-only: `src/wikimind/models.py`
+
+The spec claims `Backlink` already exists with `source_article_id`, `target_article_id`, and optional `context`. Verify before touching anything.
+
+- [ ] **Step 1: Confirm the Backlink model**
+
+Read `src/wikimind/models.py` around line 157. Confirm the shape matches the spec:
+
+```python
+class Backlink(SQLModel, table=True):
+    """Directed link between two wiki articles."""
+
+    source_article_id: str = Field(foreign_key="article.id", primary_key=True)
+    target_article_id: str = Field(foreign_key="article.id", primary_key=True)
+    context: str | None = None  # Sentence where link appears
+```
+
+**If the model matches:** this task is complete, no code change. Proceed to Task 2.
+
+**If the model is different or missing:** stop and report. The plan assumes the composite PK `(source_article_id, target_article_id)`. If the model has a surrogate `id` column instead, tasks 3 and 4 need to be adjusted (the resolver returns target IDs; the save path needs a different duplicate-handling strategy).
+
+- [ ] **Step 2: Confirm no existing code writes Backlink rows**
+
+```bash
+grep -rn "Backlink(" /Users/mg/mg-work/manav/work/ai-experiments/wikimind/src/wikimind/
+```
+
+Expected: references appear in `models.py` and `services/wiki.py` (for reading), but NO construction calls like `Backlink(source_article_id=...)`. If there is a construction call, add a note to the commit message — the plan assumes a green field.
+
+- [ ] **Step 3: No commit**
+
+This task is verification only. Nothing to commit.
+
+## Task 2: Add the title normalizer
+
+**Files:**
+- Create: `src/wikimind/engine/title_normalizer.py`
+- Create: `tests/unit/test_title_normalizer.py`
+
+The single normalizer is the entire #96 fix. It must be pure (no I/O, no state), deterministic, and small.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_title_normalizer.py`:
+
+```python
+"""Tests for the single shared title normalizer."""
+
+import pytest
+
+from wikimind.engine.title_normalizer import normalize_title
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Baseline
+        ("Machine Learning", "machine-learning"),
+        ("machine learning", "machine-learning"),
+        ("MACHINE LEARNING", "machine-learning"),
+        # Whitespace variants collapse
+        ("Machine   Learning", "machine-learning"),
+        ("  Machine Learning  ", "machine-learning"),
+        ("Machine\tLearning", "machine-learning"),
+        ("Machine\nLearning", "machine-learning"),
+        # Underscores become hyphens
+        ("machine_learning", "machine-learning"),
+        ("Machine_Learning_Ops", "machine-learning-ops"),
+        # Punctuation stripped
+        ("Machine Learning!", "machine-learning"),
+        ("Machine Learning?", "machine-learning"),
+        ("Machine Learning.", "machine-learning"),
+        ("Machine, Learning", "machine-learning"),
+        # Apostrophes stripped, not preserved as hyphens
+        ("Karpathy's wiki pattern", "karpathys-wiki-pattern"),
+        ("it's", "its"),
+        # Unicode NFKD + ASCII strip
+        ("Café", "cafe"),
+        ("naïve", "naive"),
+        ("Zürich", "zurich"),
+        # Hyphens preserved
+        ("state-of-the-art", "state-of-the-art"),
+        # Multiple consecutive separators collapse
+        ("foo   ---   bar", "foo-bar"),
+        ("foo___bar", "foo-bar"),
+        # Long titles are not truncated (the resolver does not care about length)
+        ("a" * 200, "a" * 200),
+        # Numbers preserved
+        ("GPT-4o", "gpt-4o"),
+        ("Article 1", "article-1"),
+        # Empty and whitespace-only
+        ("", ""),
+        ("   ", ""),
+        # Symbols dropped
+        ("C++", "c"),
+        ("C#", "c"),
+    ],
+)
+def test_normalize_title(raw: str, expected: str) -> None:
+    assert normalize_title(raw) == expected
+
+
+def test_normalize_title_is_idempotent() -> None:
+    """Normalizing an already-normalized string is a no-op."""
+    once = normalize_title("Machine Learning Operations")
+    twice = normalize_title(once)
+    assert once == twice
+
+
+def test_normalize_title_deterministic() -> None:
+    """Two calls with the same input produce identical output."""
+    a = normalize_title("Karpathy's LLM Wiki Pattern")
+    b = normalize_title("Karpathy's LLM Wiki Pattern")
+    assert a == b
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+```bash
+.venv/bin/pytest tests/unit/test_title_normalizer.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: wikimind.engine.title_normalizer`.
+
+- [ ] **Step 3: Implement the normalizer**
+
+Create `src/wikimind/engine/title_normalizer.py`:
+
+```python
+"""Single source of truth for title normalization.
+
+This is the only title normalizer in the entire WikiMind codebase. Any
+code that needs to compare article titles — the wikilink resolver, the
+knowledge graph builder, future search features — MUST import
+``normalize_title`` from this module. Do NOT add a second normalizer
+anywhere else. Doing so will reintroduce the slug-divergence bug tracked
+in issue #96.
+
+The algorithm is intentionally simple:
+    1. Unicode NFKD decomposition + ASCII strip (so "Café" → "Cafe").
+    2. Lowercase.
+    3. Replace every run of non-alphanumeric characters (except hyphens)
+       with a single hyphen. Underscores count as non-alphanumeric.
+    4. Strip leading and trailing hyphens.
+    5. Collapse consecutive hyphens to one.
+
+The output is suitable for exact-match comparison: two strings produce
+the same output iff they normalize to the same canonical form.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+_NON_ALNUM_HYPHEN = re.compile(r"[^a-z0-9-]+")
+_MULTI_HYPHEN = re.compile(r"-{2,}")
+
+
+def normalize_title(s: str) -> str:
+    """Canonicalize a title for wikilink resolution.
+
+    Args:
+        s: Raw title string. May be empty, contain unicode, contain
+           punctuation, contain mixed whitespace.
+
+    Returns:
+        A lowercase ASCII string containing only ``[a-z0-9-]``. Empty
+        input yields an empty string.
+    """
+    # 1. Unicode → ASCII
+    ascii_form = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    # 2. Lowercase
+    lower = ascii_form.lower()
+    # 3. Replace runs of non-alnum-non-hyphen with a single hyphen
+    hyphenated = _NON_ALNUM_HYPHEN.sub("-", lower)
+    # 4. Strip leading/trailing hyphens
+    stripped = hyphenated.strip("-")
+    # 5. Collapse consecutive hyphens
+    return _MULTI_HYPHEN.sub("-", stripped)
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+```bash
+.venv/bin/pytest tests/unit/test_title_normalizer.py -v
+```
+
+Expected: all tests PASS. If a specific parametrize case fails, adjust the regex — the table above is the contract, not the implementation.
+
+- [ ] **Step 5: Lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/engine/title_normalizer.py tests/unit/test_title_normalizer.py
+.venv/bin/mypy src/wikimind/engine/title_normalizer.py
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/engine/title_normalizer.py tests/unit/test_title_normalizer.py
+git commit -m "feat(engine): add single-source-of-truth title normalizer (#96)"
+```
+
+## Task 3: Add the wikilink resolver
+
+**Files:**
+- Create: `src/wikimind/engine/wikilink_resolver.py`
+- Create: `tests/unit/test_wikilink_resolver.py`
+
+The resolver is a pure function (given the DB session): `list[str] → (list[ResolvedBacklink], list[str])`. It runs the two-stage algorithm and returns resolved + unresolved candidate lists.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_wikilink_resolver.py`:
+
+```python
+"""Tests for the two-stage wikilink resolution algorithm."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.wikilink_resolver import (
+    ResolvedBacklink,
+    resolve_backlink_candidates,
+)
+from wikimind.models import Article, ConfidenceLevel
+
+
+async def _make_article(
+    session: AsyncSession,
+    title: str,
+    slug: str | None = None,
+    created_at: datetime | None = None,
+) -> Article:
+    article = Article(
+        id=str(uuid.uuid4()),
+        slug=slug or title.lower().replace(" ", "-"),
+        title=title,
+        file_path=f"/tmp/{slug or title}.md",
+        confidence=ConfidenceLevel.SOURCED,
+        created_at=created_at or datetime.utcnow(),
+    )
+    session.add(article)
+    await session.commit()
+    await session.refresh(article)
+    return article
+
+
+@pytest.mark.asyncio
+async def test_exact_match_resolves(async_session: AsyncSession) -> None:
+    existing = await _make_article(async_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Machine Learning"], async_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+    assert resolved[0].candidate_text == "Machine Learning"
+    assert resolved[0].target_title == "Machine Learning"
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_case_insensitive_exact_match_resolves(async_session: AsyncSession) -> None:
+    existing = await _make_article(async_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["machine learning"], async_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_normalized_match_resolves(async_session: AsyncSession) -> None:
+    """Stage 2: candidate differs from title by punctuation only."""
+    existing = await _make_article(async_session, "Karpathy's Wiki Pattern")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Karpathys Wiki Pattern"], async_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_underscore_to_space_resolves_via_normalizer(async_session: AsyncSession) -> None:
+    existing = await _make_article(async_session, "Machine Learning Ops")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["machine_learning_ops"], async_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+
+
+@pytest.mark.asyncio
+async def test_no_match_stays_unresolved(async_session: AsyncSession) -> None:
+    await _make_article(async_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Quantum Computing"], async_session
+    )
+    assert resolved == []
+    assert unresolved == ["Quantum Computing"]
+
+
+@pytest.mark.asyncio
+async def test_similar_but_distinct_does_not_match(async_session: AsyncSession) -> None:
+    """"Machine Learning Ops" must NOT match "Machine Learning" — no fuzzy."""
+    await _make_article(async_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Machine Learning Ops"], async_session
+    )
+    assert resolved == []
+    assert unresolved == ["Machine Learning Ops"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_resolved_and_unresolved(async_session: AsyncSession) -> None:
+    await _make_article(async_session, "React")
+    await _make_article(async_session, "TypeScript")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["React", "Redux", "TypeScript", "Zustand"], async_session
+    )
+    assert len(resolved) == 2
+    assert sorted(unresolved) == ["Redux", "Zustand"]
+    resolved_titles = sorted(r.target_title for r in resolved)
+    assert resolved_titles == ["React", "TypeScript"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_candidates_deduped_in_resolved(async_session: AsyncSession) -> None:
+    """Two candidates resolving to the same target produce ONE ResolvedBacklink."""
+    await _make_article(async_session, "React")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["React", "react"], async_session
+    )
+    assert len(resolved) == 1
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_normalized_match_picks_earliest(async_session: AsyncSession) -> None:
+    """Two articles with the same normalized form → pick the earliest created_at."""
+    older = await _make_article(
+        async_session, "Machine Learning", created_at=datetime(2026, 1, 1)
+    )
+    await _make_article(
+        async_session, "machine-learning", created_at=datetime(2026, 2, 1)
+    )
+    resolved, _ = await resolve_backlink_candidates(["Machine Learning"], async_session)
+    assert len(resolved) == 1
+    assert resolved[0].target_id == older.id
+
+
+@pytest.mark.asyncio
+async def test_exclude_self_reference(async_session: AsyncSession) -> None:
+    """A candidate that matches the article currently being compiled is excluded."""
+    self_article = await _make_article(async_session, "Self Article")
+    other = await _make_article(async_session, "Other Article")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Self Article", "Other Article"],
+        async_session,
+        exclude_article_id=self_article.id,
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == other.id
+    assert unresolved == ["Self Article"]
+
+
+@pytest.mark.asyncio
+async def test_empty_candidate_list(async_session: AsyncSession) -> None:
+    resolved, unresolved = await resolve_backlink_candidates([], async_session)
+    assert resolved == []
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_empty_string_candidate_is_unresolved(async_session: AsyncSession) -> None:
+    resolved, unresolved = await resolve_backlink_candidates(["", "   "], async_session)
+    assert resolved == []
+    # Empty strings are dropped, not passed through as unresolved
+    assert unresolved == []
+```
+
+The tests assume a fixture `async_session` exists in `tests/conftest.py`. If not, check the existing test file in `tests/unit/test_misc.py` or similar to see what the project's DB fixture is named and adjust accordingly.
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+```bash
+.venv/bin/pytest tests/unit/test_wikilink_resolver.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError` (module doesn't exist yet).
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `src/wikimind/engine/wikilink_resolver.py`:
+
+```python
+"""Resolve LLM-suggested wikilink candidates against the Article table.
+
+Given a list of candidate title strings (as produced by the compiler
+LLM in ``CompilationResult.backlink_suggestions``) and an async DB
+session, return two lists:
+
+    - ``resolved``: :class:`ResolvedBacklink` rows, each pointing at a
+      real :class:`Article` by ID.
+    - ``unresolved``: candidate strings that matched no article.
+
+The algorithm is deterministic and has exactly two stages:
+
+    1. Exact case-insensitive match against ``Article.title``.
+    2. Normalized match using :func:`normalize_title` on both sides.
+
+There is NO fuzzy matching. See the design spec for rationale
+(docs/superpowers/specs/2026-04-08-wikilink-resolution-design.md).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.title_normalizer import normalize_title
+from wikimind.models import Article
+
+
+@dataclass(frozen=True)
+class ResolvedBacklink:
+    """A successfully resolved wikilink candidate.
+
+    Attributes:
+        candidate_text: The raw string the LLM produced. Preserved
+            verbatim so the rendered markdown can show the LLM's
+            wording if it differs from the canonical title.
+        target_id: The :class:`Article.id` this candidate resolved to.
+        target_title: The canonical :class:`Article.title` of the
+            resolved article. Used by the compiler's markdown writer.
+    """
+
+    candidate_text: str
+    target_id: str
+    target_title: str
+
+
+async def resolve_backlink_candidates(
+    candidates: list[str],
+    session: AsyncSession,
+    exclude_article_id: str | None = None,
+) -> tuple[list[ResolvedBacklink], list[str]]:
+    """Resolve wikilink candidates against the Article table.
+
+    Args:
+        candidates: Raw title strings from
+            :attr:`CompilationResult.backlink_suggestions`. Empty
+            strings and whitespace-only strings are silently dropped.
+        session: Async DB session.
+        exclude_article_id: If set, any candidate that would resolve
+            to this article ID is treated as unresolved. Used by the
+            compiler to prevent self-references when an article is
+            suggested to link to itself.
+
+    Returns:
+        A tuple ``(resolved, unresolved)``. Resolved contains one
+        :class:`ResolvedBacklink` per unique target article (so two
+        candidates pointing at the same article produce one row).
+        Unresolved is the list of candidate strings that matched no
+        article, in input order.
+    """
+    # Drop empty / whitespace-only candidates up front.
+    cleaned = [c.strip() for c in candidates if c and c.strip()]
+    if not cleaned:
+        return [], []
+
+    # Load every Article once. For a single-user personal wiki this is
+    # fine — we expect O(hundreds) of articles at most. If this ever
+    # becomes a bottleneck, narrow the SELECT to (id, title, created_at).
+    result = await session.execute(select(Article).order_by(Article.created_at))
+    all_articles: list[Article] = list(result.scalars().all())
+    if exclude_article_id is not None:
+        all_articles = [a for a in all_articles if a.id != exclude_article_id]
+
+    # Build lookup dicts once per call. Both map canonical form → first article.
+    by_lower: dict[str, Article] = {}
+    by_normalized: dict[str, Article] = {}
+    for article in all_articles:
+        lower_key = article.title.lower()
+        if lower_key not in by_lower:
+            by_lower[lower_key] = article
+        norm_key = normalize_title(article.title)
+        if norm_key and norm_key not in by_normalized:
+            by_normalized[norm_key] = article
+
+    resolved_by_target: dict[str, ResolvedBacklink] = {}
+    unresolved: list[str] = []
+    for candidate in cleaned:
+        target = by_lower.get(candidate.lower())
+        if target is None:
+            norm = normalize_title(candidate)
+            if norm:
+                target = by_normalized.get(norm)
+        if target is None:
+            unresolved.append(candidate)
+            continue
+        # Dedup: two candidates resolving to the same target → one entry.
+        if target.id not in resolved_by_target:
+            resolved_by_target[target.id] = ResolvedBacklink(
+                candidate_text=candidate,
+                target_id=target.id,
+                target_title=target.title,
+            )
+
+    return list(resolved_by_target.values()), unresolved
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+```bash
+.venv/bin/pytest tests/unit/test_wikilink_resolver.py -v
+```
+
+Expected: all tests PASS. If `async_session` fixture doesn't exist, check `tests/conftest.py` for the project's DB fixture name and update the test file accordingly.
+
+- [ ] **Step 5: Lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/engine/wikilink_resolver.py tests/unit/test_wikilink_resolver.py
+.venv/bin/mypy src/wikimind/engine/wikilink_resolver.py
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/engine/wikilink_resolver.py tests/unit/test_wikilink_resolver.py
+git commit -m "feat(engine): add two-stage wikilink resolver (#95)"
+```
+
+## Task 4: Update the compiler's save path to call the resolver and emit Backlink rows
+
+**Files:**
+- Modify: `src/wikimind/engine/compiler.py`
+- Modify / extend: `tests/unit/test_compiler.py` (or `tests/unit/test_misc.py` if the compiler test file does not exist)
+
+This is the main surgical change. `_write_article_file` gains two new parameters (resolved + unresolved lists). `_create_article` and `_replace_article_in_place` call the resolver first and then pass the results into the writer. After the article commit, they add `Backlink` rows for each resolved target.
+
+- [ ] **Step 1: Write a failing test asserting the save path creates Backlink rows**
+
+Add to `tests/unit/test_compiler.py` (or create it). The test uses a direct call to the save methods with a mock `CompilationResult`, so it does not need the LLM router.
+
+```python
+"""Tests for the compiler's resolution-aware save path."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.compiler import Compiler
+from wikimind.models import (
+    Article,
+    Backlink,
+    CompilationResult,
+    CompiledClaim,
+    ConfidenceLevel,
+    IngestStatus,
+    Source,
+    SourceType,
+)
+
+
+def _make_result(
+    title: str,
+    backlink_suggestions: list[str] | None = None,
+) -> CompilationResult:
+    return CompilationResult(
+        title=title,
+        summary="A two-sentence summary. For testing.",
+        key_claims=[
+            CompiledClaim(claim="test claim", confidence=ConfidenceLevel.SOURCED),
+        ],
+        concepts=["test-concept"],
+        backlink_suggestions=backlink_suggestions or [],
+        open_questions=["test question?"],
+        article_body="## Body\n\nTest body content sufficient length.",
+    )
+
+
+async def _make_source(session: AsyncSession) -> Source:
+    source = Source(
+        id=str(uuid.uuid4()),
+        source_type=SourceType.TEXT,
+        title="Test Source",
+        status=IngestStatus.NORMALIZED,
+        ingested_at=datetime.utcnow(),
+    )
+    session.add(source)
+    await session.commit()
+    await session.refresh(source)
+    return source
+
+
+@pytest.mark.asyncio
+async def test_save_creates_backlink_rows_for_resolved_candidates(
+    async_session: AsyncSession, tmp_path
+) -> None:
+    # Seed an existing article that a future candidate will resolve to.
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="existing-article",
+        title="Existing Article",
+        file_path=str(tmp_path / "existing.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    async_session.add(target)
+    await async_session.commit()
+
+    compiler = Compiler()
+    compiler.settings.data_dir = str(tmp_path)  # write wiki files under tmp
+    source = await _make_source(async_session)
+    result = _make_result(
+        "New Article",
+        backlink_suggestions=["Existing Article", "Nonexistent Topic"],
+    )
+    article = await compiler.save_article(result, source, async_session)
+
+    # Backlink row exists for the resolved candidate
+    bl_result = await async_session.execute(
+        select(Backlink).where(Backlink.source_article_id == article.id)
+    )
+    backlinks = list(bl_result.scalars().all())
+    assert len(backlinks) == 1
+    assert backlinks[0].target_article_id == target.id
+    assert backlinks[0].context == "Existing Article"
+
+
+@pytest.mark.asyncio
+async def test_save_markdown_has_resolved_link_and_unresolved_bracket(
+    async_session: AsyncSession, tmp_path
+) -> None:
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="existing-article",
+        title="Existing Article",
+        file_path=str(tmp_path / "existing.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    async_session.add(target)
+    await async_session.commit()
+
+    compiler = Compiler()
+    compiler.settings.data_dir = str(tmp_path)
+    source = await _make_source(async_session)
+    result = _make_result(
+        "New Article",
+        backlink_suggestions=["Existing Article", "Nonexistent Topic"],
+    )
+    article = await compiler.save_article(result, source, async_session)
+
+    from pathlib import Path
+    content = Path(article.file_path).read_text()
+    # Resolved link uses the article ID
+    assert f"[Existing Article](/wiki/{target.id})" in content
+    # Unresolved candidate stays as Obsidian brackets
+    assert "[[Nonexistent Topic]]" in content
+    # The old-style "- [[Existing Article]]" format is gone for the resolved one
+    assert "- [[Existing Article]]" not in content
+
+
+@pytest.mark.asyncio
+async def test_save_handles_duplicate_candidates_without_integrity_error(
+    async_session: AsyncSession, tmp_path
+) -> None:
+    """Two candidates resolving to the same target → one Backlink row, no IntegrityError."""
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="react",
+        title="React",
+        file_path=str(tmp_path / "react.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    async_session.add(target)
+    await async_session.commit()
+
+    compiler = Compiler()
+    compiler.settings.data_dir = str(tmp_path)
+    source = await _make_source(async_session)
+    result = _make_result("New Article", backlink_suggestions=["React", "react"])
+    article = await compiler.save_article(result, source, async_session)
+
+    bl_result = await async_session.execute(
+        select(Backlink).where(Backlink.source_article_id == article.id)
+    )
+    backlinks = list(bl_result.scalars().all())
+    assert len(backlinks) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_skips_backlinks_when_no_candidates(
+    async_session: AsyncSession, tmp_path
+) -> None:
+    compiler = Compiler()
+    compiler.settings.data_dir = str(tmp_path)
+    source = await _make_source(async_session)
+    result = _make_result("Solo Article", backlink_suggestions=[])
+    article = await compiler.save_article(result, source, async_session)
+
+    bl_result = await async_session.execute(
+        select(Backlink).where(Backlink.source_article_id == article.id)
+    )
+    assert list(bl_result.scalars().all()) == []
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+```bash
+.venv/bin/pytest tests/unit/test_compiler.py -v
+```
+
+Expected: FAIL. The current `_create_article` does not call the resolver and does not write `Backlink` rows. The markdown assertion about `[Existing Article](/wiki/<id>)` also fails because the current writer emits `[[Existing Article]]`.
+
+- [ ] **Step 3: Update the compiler**
+
+In `src/wikimind/engine/compiler.py`:
+
+**3a. Add imports at the top** (after the existing imports, keeping the import order — stdlib → third-party → local):
+
+```python
+from sqlalchemy.exc import IntegrityError
+
+from wikimind.engine.wikilink_resolver import (
+    ResolvedBacklink,
+    resolve_backlink_candidates,
+)
+```
+
+**3b. Modify `_create_article`** (currently at `compiler.py:235`). Add a resolution step before writing the file, and a Backlink-creation step after the article is committed:
+
+```python
+async def _create_article(
+    self,
+    result: CompilationResult,
+    source: Source,
+    session: AsyncSession,
+    provider: Provider | None,
+) -> Article:
+    """Create a brand-new article (no existing same-provider article)."""
+    slug = self._generate_unique_slug(result.title)
+
+    # Resolve wikilink candidates BEFORE writing the file so the markdown
+    # knows which links are real and which are dimmed unresolved.
+    resolved, unresolved = await resolve_backlink_candidates(
+        result.backlink_suggestions, session
+    )
+
+    file_path = self._write_article_file(result, source, slug, resolved, unresolved)
+
+    article = Article(
+        slug=slug,
+        title=result.title,
+        file_path=str(file_path),
+        confidence=self._overall_confidence(result),
+        summary=result.summary,
+        source_ids=f'["{source.id}"]',
+        concept_ids=f'["{chr(34).join(result.concepts)}"]',
+        provider=provider,
+    )
+    session.add(article)
+
+    source.status = IngestStatus.COMPILED
+    source.compiled_at = utcnow_naive()
+    session.add(source)
+
+    await session.commit()
+    await session.refresh(article)
+
+    # Create Backlink rows for each resolved candidate. Duplicates are
+    # guarded by the composite PK — catch IntegrityError and skip.
+    await self._persist_backlinks(article.id, resolved, session)
+
+    log.info(
+        "Article saved",
+        slug=slug,
+        title=result.title,
+        provider=provider,
+        resolved_backlinks=len(resolved),
+        unresolved_backlinks=len(unresolved),
+    )
+    return article
+```
+
+**3c. Modify `_replace_article_in_place`** (currently at `compiler.py:268`). Same pattern — resolve, rewrite file, refresh Backlink rows. For the replace path, we also need to clear the old Backlink rows for this source article before inserting the new ones, since the set of resolved candidates may have changed across re-compiles:
+
+```python
+async def _replace_article_in_place(
+    self,
+    existing: Article,
+    result: CompilationResult,
+    source: Source,
+    session: AsyncSession,
+) -> Article:
+    """Replace an existing same-source same-provider article in place."""
+    old_path = Path(existing.file_path)
+    old_path.unlink(missing_ok=True)
+
+    # Resolve candidates against the current wiki, excluding self.
+    resolved, unresolved = await resolve_backlink_candidates(
+        result.backlink_suggestions, session, exclude_article_id=existing.id
+    )
+
+    new_path = self._write_article_file(result, source, existing.slug, resolved, unresolved)
+
+    existing.title = result.title
+    existing.summary = result.summary
+    existing.confidence = self._overall_confidence(result)
+    existing.file_path = str(new_path)
+    existing.concept_ids = f'["{chr(34).join(result.concepts)}"]'
+    existing.updated_at = utcnow_naive()
+    session.add(existing)
+
+    source.status = IngestStatus.COMPILED
+    source.compiled_at = utcnow_naive()
+    session.add(source)
+
+    # Clear stale Backlink rows from the previous compile before inserting
+    # the fresh resolved set. Only the source side is cleared.
+    old_bl = await session.execute(
+        select(Backlink).where(Backlink.source_article_id == existing.id)
+    )
+    for row in old_bl.scalars().all():
+        await session.delete(row)
+
+    await session.commit()
+    await session.refresh(existing)
+
+    await self._persist_backlinks(existing.id, resolved, session)
+
+    log.info(
+        "Article replaced in place",
+        slug=existing.slug,
+        title=result.title,
+        provider=existing.provider,
+        resolved_backlinks=len(resolved),
+        unresolved_backlinks=len(unresolved),
+    )
+    return existing
+```
+
+**3d. Add the `_persist_backlinks` helper** as a new method on `Compiler`:
+
+```python
+async def _persist_backlinks(
+    self,
+    source_article_id: str,
+    resolved: list[ResolvedBacklink],
+    session: AsyncSession,
+) -> None:
+    """Insert one Backlink row per resolved candidate.
+
+    The composite primary key ``(source_article_id, target_article_id)``
+    on :class:`Backlink` rejects duplicates automatically. We catch
+    IntegrityError per-row so one duplicate does not abort the batch.
+    """
+    for rb in resolved:
+        bl = Backlink(
+            source_article_id=source_article_id,
+            target_article_id=rb.target_id,
+            context=rb.candidate_text,
+        )
+        session.add(bl)
+        try:
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            log.debug(
+                "Skipped duplicate backlink",
+                source=source_article_id,
+                target=rb.target_id,
+            )
+```
+
+**3e. Modify `_write_article_file`** signature and body. Current signature is `(result, source, slug)`; new signature is `(result, source, slug, resolved, unresolved)`. The "Related" section block changes:
+
+```python
+def _write_article_file(
+    self,
+    result: CompilationResult,
+    source: Source,
+    slug: str,
+    resolved: list[ResolvedBacklink],
+    unresolved: list[str],
+) -> Path:
+    """Write .md file to wiki directory.
+
+    The "Related" section emits standard markdown links for resolved
+    wikilinks (``[Text](/wiki/<article_id>)``) and Obsidian-style
+    brackets only for unresolved candidates (``[[Text]]``). The
+    frontend's ArticleReader distinguishes the two at render time:
+    resolved become React Router links, unresolved become dimmed spans.
+    """
+    wiki_dir = Path(self.settings.data_dir) / "wiki"
+
+    concept = result.concepts[0] if result.concepts else "general"
+    concept_dir = wiki_dir / slugify(concept)
+    concept_dir.mkdir(parents=True, exist_ok=True)
+
+    file_path = concept_dir / f"{slug}.md"
+
+    # Build the "Related" section: resolved links go through standard
+    # markdown; unresolved candidates keep Obsidian brackets so the
+    # frontend can style them as dead links.
+    related_lines: list[str] = []
+    for rb in resolved:
+        related_lines.append(f"- [{rb.candidate_text}](/wiki/{rb.target_id})")
+    for text in unresolved:
+        related_lines.append(f"- [[{text}]]")
+    backlinks = "\n".join(related_lines)
+
+    claims = "\n".join(
+        [f"- **{c.claim}** *({c.confidence})*" + (f' — "{c.quote}"' if c.quote else "") for c in result.key_claims]
+    )
+    questions = "\n".join([f"- {q}" for q in result.open_questions])
+    concepts_str = ", ".join(result.concepts)
+
+    content = f"""---
+title: "{result.title}"
+slug: {slug}
+source_url: {source.source_url or ""}
+source_type: {source.source_type}
+compiled: {utcnow_naive().isoformat()}
+concepts: [{concepts_str}]
+confidence: {self._overall_confidence(result)}
+---
+
+## Summary
+
+{result.summary}
+
+## Key Claims
+
+{claims}
+
+## Analysis
+
+{result.article_body}
+
+## Open Questions
+
+{questions}
+
+## Related
+
+{backlinks}
+
+## Sources
+
+- {source.title or source.source_url or "Uploaded document"} (ingested {source.ingested_at.strftime("%Y-%m-%d")})
+"""
+
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+```bash
+.venv/bin/pytest tests/unit/test_compiler.py -v
+```
+
+Expected: all four new tests PASS. If the project does not have an `async_session` fixture, check the existing `tests/conftest.py` and adapt the test imports to the available fixture.
+
+- [ ] **Step 5: Run the broader test suite to catch any downstream breakage**
+
+```bash
+.venv/bin/pytest tests/ -x -v
+```
+
+Expected: all existing tests still pass. If an existing test was calling `_write_article_file(result, source, slug)` with the old three-argument signature, update it to pass empty `[]` for resolved and unresolved.
+
+- [ ] **Step 6: Lint + typecheck**
+
+```bash
+.venv/bin/ruff check src/wikimind/engine/compiler.py tests/unit/test_compiler.py
+.venv/bin/mypy src/wikimind/engine/compiler.py
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/wikimind/engine/compiler.py tests/unit/test_compiler.py
+git commit -m "feat(compiler): resolve wikilinks and emit Backlink rows at save time (#95)"
+```
+
+## Task 5: Update backend article lookup to accept ID or slug
+
+**Files:**
+- Modify: `src/wikimind/services/wiki.py`
+- Modify: `src/wikimind/api/routes/wiki.py`
+- Extend: existing test for `get_article` (in `tests/unit/test_wiki_service.py` or similar — check first)
+
+The lookup currently resolves by slug only. The frontend's resolved wikilinks arrive with article IDs in their URLs, so the backend must accept IDs. Slug lookup remains as a fallback for external bookmarks.
+
+- [ ] **Step 1: Find the existing get_article test**
+
+```bash
+grep -rn "get_article\|/wiki/articles/" /Users/mg/mg-work/manav/work/ai-experiments/wikimind/tests/
+```
+
+Note the filename. You will extend it in Step 2.
+
+- [ ] **Step 2: Write failing tests for the new behaviour**
+
+Add two tests to whichever file exercises `get_article`. If none exists, add them to `tests/unit/test_misc.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_article_by_id_returns_article(async_session: AsyncSession, tmp_path) -> None:
+    """Fetching an article by its UUID id returns it."""
+    from wikimind.models import Article, ConfidenceLevel
+    from wikimind.services.wiki import WikiService
+
+    article = Article(
+        slug="my-article",
+        title="My Article",
+        file_path=str(tmp_path / "my-article.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    async_session.add(article)
+    await async_session.commit()
+    await async_session.refresh(article)
+
+    service = WikiService()
+    result = await service.get_article(article.id, async_session)
+    assert result.id == article.id
+    assert result.slug == "my-article"
+
+
+@pytest.mark.asyncio
+async def test_get_article_by_slug_still_works(async_session: AsyncSession, tmp_path) -> None:
+    """Backward compat: slug lookup continues to work after the ID-first rewrite."""
+    from wikimind.models import Article, ConfidenceLevel
+    from wikimind.services.wiki import WikiService
+
+    article = Article(
+        slug="legacy-bookmark",
+        title="Legacy Bookmark",
+        file_path=str(tmp_path / "legacy.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    async_session.add(article)
+    await async_session.commit()
+    await async_session.refresh(article)
+
+    service = WikiService()
+    result = await service.get_article("legacy-bookmark", async_session)
+    assert result.slug == "legacy-bookmark"
+```
+
+- [ ] **Step 3: Run the tests, verify they fail**
+
+```bash
+.venv/bin/pytest tests/unit/test_misc.py::test_get_article_by_id_returns_article -v
+```
+
+Expected: FAIL (current implementation only looks up by slug, so the UUID lookup returns 404).
+
+- [ ] **Step 4: Update the service**
+
+In `src/wikimind/services/wiki.py`, modify `WikiService.get_article` (currently at line 177). Rename the parameter and try ID first:
+
+```python
+async def get_article(self, id_or_slug: str, session: AsyncSession) -> ArticleResponse:
+    """Retrieve a full article by ID or slug.
+
+    Tries the article's UUID first (resolved wikilinks travel by ID
+    via the ``[text](/wiki/<id>)`` markdown format). Falls back to
+    slug lookup for backward compatibility with external bookmarks
+    and the human-facing URL bar.
+
+    Args:
+        id_or_slug: Either an ``Article.id`` UUID or an ``Article.slug``.
+        session: Async database session.
+
+    Returns:
+        :class:`ArticleResponse` with content, backlink, and source data.
+
+    Raises:
+        HTTPException: If no article matches either lookup.
+    """
+    # Try ID first
+    result = await session.execute(select(Article).where(Article.id == id_or_slug))
+    article = result.scalar_one_or_none()
+    if article is None:
+        # Fall back to slug
+        result = await session.execute(select(Article).where(Article.slug == id_or_slug))
+        article = result.scalar_one_or_none()
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    bl_in = await session.execute(select(Backlink).where(Backlink.target_article_id == article.id))
+    bl_out = await session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+
+    source_ids = _parse_source_ids(article.source_ids)
+    sources = await _fetch_sources(session, source_ids)
+
+    return ArticleResponse(
+        id=article.id,
+        slug=article.slug,
+        title=article.title,
+        summary=article.summary,
+        confidence=article.confidence,
+        linter_score=article.linter_score,
+        concepts=[],
+        backlinks_in=[b.source_article_id for b in bl_in.scalars().all()],
+        backlinks_out=[b.target_article_id for b in bl_out.scalars().all()],
+        content=_read_article_content(article.file_path),
+        sources=[_to_source_response(s) for s in sources],
+        created_at=article.created_at,
+        updated_at=article.updated_at,
+    )
+```
+
+- [ ] **Step 5: Update the route**
+
+In `src/wikimind/api/routes/wiki.py`, rename the path parameter:
+
+```python
+@router.get("/articles/{id_or_slug}", response_model=ArticleResponse)
+async def get_article(
+    id_or_slug: str,
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+):
+    """Get full article by ID or slug, with content, backlinks, and sources."""
+    return await service.get_article(id_or_slug, session)
+```
+
+Nothing else in the route file changes.
+
+- [ ] **Step 6: Run the tests, verify they pass**
+
+```bash
+.venv/bin/pytest tests/unit/test_misc.py::test_get_article_by_id_returns_article tests/unit/test_misc.py::test_get_article_by_slug_still_works -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Regenerate OpenAPI (handled automatically by the pre-commit hook, but you can do it manually to see the diff)**
+
+```bash
+make export-openapi
+```
+
+Expected: `docs/openapi.yaml` gets a small diff renaming the path parameter from `slug` to `id_or_slug`. Review and keep.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/wikimind/services/wiki.py src/wikimind/api/routes/wiki.py tests/unit/test_misc.py docs/openapi.yaml
+git commit -m "feat(wiki): accept article ID or slug in get_article lookup (#95)"
+```
+
+## Task 6: Frontend — remove client-side slugify, render unresolved brackets as dimmed spans
+
+**Files:**
+- Modify: `apps/web/src/components/wiki/ArticleReader.tsx`
+- Modify: `apps/web/src/index.css` (or whichever global stylesheet is imported by the app — verify via grep first)
+
+This is the client-side counterpart to the backend fix. The frontend no longer slugifies anything. Resolved wikilinks arrive as standard markdown links (`[text](/wiki/<id>)`), handled natively by react-markdown. Unresolved wikilinks stay as `[[text]]` in the markdown body and are replaced with a dimmed span before react-markdown ever sees them.
+
+- [ ] **Step 1: Find the global stylesheet**
+
+```bash
+grep -rn 'import.*\.css"' /Users/mg/mg-web/manav/work/ai-experiments/wikimind/apps/web/src/main.tsx /Users/mg/mg-web/manav/work/ai-experiments/wikimind/apps/web/src/App.tsx 2>&1 || true
+```
+
+Note the CSS file path. The `.wikilink-unresolved` rule goes there. If the project uses pure Tailwind utility classes (no global rules), use inline Tailwind classes in the preprocessor instead — see Step 3 alternative.
+
+- [ ] **Step 2: Rewrite ArticleReader.tsx**
+
+Open `apps/web/src/components/wiki/ArticleReader.tsx`. Replace its current content with the simplified version below. Key changes:
+
+1. Delete the local `slugify()` helper (lines 19-25 in the current file).
+2. Replace the `preprocessMarkdown` wikilink branch — unresolved brackets become a dimmed span; resolved links pass through as standard markdown.
+3. Simplify the anchor renderer: internal links (`/wiki/...`) use React Router `<Link>`; external links get `target="_blank"`.
+
+```tsx
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import type { ArticleResponse, ConfidenceLevel } from "../../types/api";
+import { ConfidenceBadge } from "./ConfidenceBadge";
+import { Badge } from "../shared/Badge";
+
+interface ArticleReaderProps {
+  article: ArticleResponse;
+}
+
+const CONFIDENCE_TAG_REGEX = /\[(sourced|mixed|inferred|opinion)\]/gi;
+const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
+// Match a YAML frontmatter block at the very start of the document.
+const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Pre-process the markdown to:
+//   1. Strip the YAML frontmatter block emitted by the compiler.
+//   2. Convert unresolved [[wikilinks]] — which is all the compiler
+//      emits for links it could NOT resolve against the article table —
+//      into a dimmed span. Resolved wikilinks arrive as standard
+//      markdown links [text](/wiki/<id>) and need no preprocessing.
+function preprocessMarkdown(content: string): string {
+  return content
+    .replace(FRONTMATTER_REGEX, "")
+    .replace(WIKILINK_REGEX, (_, target: string) => {
+      const safe = escapeHtml(target.trim());
+      return `<span class="wikilink-unresolved" title="Article not yet in wiki">${safe}</span>`;
+    });
+}
+
+export function ArticleReader({ article }: ArticleReaderProps) {
+  const processed = useMemo(
+    () => preprocessMarkdown(article.content ?? ""),
+    [article.content],
+  );
+
+  return (
+    <article className="mx-auto max-w-3xl p-8">
+      <header className="mb-6 border-b border-slate-200 pb-5">
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          {article.confidence ? (
+            <ConfidenceBadge level={article.confidence as ConfidenceLevel} />
+          ) : null}
+          {typeof article.linter_score === "number" ? (
+            <Badge tone="info">
+              Linter {(article.linter_score * 100).toFixed(0)}%
+            </Badge>
+          ) : null}
+          {article.concepts.slice(0, 3).map((concept) => (
+            <Badge key={concept} tone="brand">
+              {concept}
+            </Badge>
+          ))}
+        </div>
+        <h1 className="text-3xl font-bold text-slate-900">{article.title}</h1>
+        {article.summary ? (
+          <p className="mt-2 text-base text-slate-600">{article.summary}</p>
+        ) : null}
+      </header>
+
+      <div className="prose prose-slate max-w-none prose-headings:font-semibold prose-a:text-brand-700">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[rehypeRaw]}
+          components={{
+            a: ({ node: _node, href, children, ...props }) => {
+              // Internal wiki links — resolved wikilinks arrive here from
+              // the compiler's [text](/wiki/<id>) markdown. Use React
+              // Router so navigation stays client-side.
+              if (href?.startsWith("/wiki/")) {
+                return (
+                  <Link
+                    to={href}
+                    className="text-brand-700 underline decoration-dotted underline-offset-2 hover:text-brand-900"
+                  >
+                    {children}
+                  </Link>
+                );
+              }
+              // External link — open in a new tab.
+              return (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-brand-700 underline"
+                  {...props}
+                >
+                  {children}
+                </a>
+              );
+            },
+            li: ({ children }) => (
+              <li>{decorateConfidence(children)}</li>
+            ),
+            p: ({ children }) => <p>{decorateConfidence(children)}</p>,
+          }}
+        >
+          {processed}
+        </ReactMarkdown>
+      </div>
+    </article>
+  );
+}
+
+// Walk text children and replace [sourced]/[inferred]/[opinion]/[mixed]
+// markers with inline confidence badges. Non-string children are passed through.
+function decorateConfidence(children: React.ReactNode): React.ReactNode {
+  if (typeof children === "string") {
+    return splitConfidence(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, idx) => {
+      if (typeof child === "string") {
+        return <span key={idx}>{splitConfidence(child)}</span>;
+      }
+      return child;
+    });
+  }
+  return children;
+}
+
+function splitConfidence(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  CONFIDENCE_TAG_REGEX.lastIndex = 0;
+  while ((match = CONFIDENCE_TAG_REGEX.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    const level = match[1].toLowerCase() as ConfidenceLevel;
+    parts.push(
+      <span key={`${match.index}-${level}`} className="ml-1 align-middle">
+        <ConfidenceBadge level={level} />
+      </span>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+  return parts.length > 0 ? parts : [text];
+}
+```
+
+- [ ] **Step 3: Add the `.wikilink-unresolved` style**
+
+If the project uses a global CSS file (from Step 1), add this rule:
+
+```css
+.wikilink-unresolved {
+  color: rgb(148 163 184); /* slate-400 */
+  text-decoration: underline dotted rgb(148 163 184);
+  text-underline-offset: 2px;
+  cursor: help;
+}
+```
+
+If the project uses pure Tailwind utility classes with no global rules, update the preprocessor span class instead:
+
+```typescript
+return `<span class="text-slate-400 underline decoration-dotted underline-offset-2 cursor-help" title="Article not yet in wiki">${safe}</span>`;
+```
+
+Pick whichever matches the existing project style.
+
+- [ ] **Step 4: Frontend lint + typecheck + build**
+
+```bash
+cd apps/web && pnpm lint && pnpm typecheck && pnpm build
+```
+
+Expected: all three clean. If the build fails on an import that was previously used (e.g. the old `slugify` helper was imported somewhere else), remove the stale import.
+
+- [ ] **Step 5: Manual smoke check (optional but recommended)**
+
+```bash
+cd apps/web && pnpm dev
+```
+
+Open an article in the browser. Verify:
+- The "Related" section renders. Resolved items are underlined brand-color links that navigate on click. Unresolved items are dim slate-400 text with a dotted underline and a "not yet in wiki" tooltip on hover.
+- Clicking a resolved link navigates client-side (no full page reload) to the target article.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/wiki/ArticleReader.tsx apps/web/src/index.css
+git commit -m "fix(web): remove client-side slugify, render unresolved wikilinks as dimmed spans (#95, #96)"
+```
+
+## Task 7: Integration test — end-to-end resolution proof
+
+**Files:**
+- Create: `tests/integration/test_wikilink_resolution_integration.py`
+
+This is the single most important test in the whole plan. If it passes, the fix works end-to-end from compile → DB → markdown → route lookup.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/integration/test_wikilink_resolution_integration.py`:
+
+```python
+"""End-to-end wikilink resolution proof (issue #95).
+
+Steps:
+    1. Seed an existing article "Existing Target".
+    2. Drive the compiler's save path with a mock CompilationResult
+       whose backlink_suggestions includes "Existing Target" (should
+       resolve) and "Nonexistent Topic" (should stay unresolved).
+    3. Assert a Backlink row exists pointing new → target.
+    4. Assert the rendered markdown has [Existing Target](/wiki/<id>).
+    5. Assert the /wiki/articles/{id} route returns the new article
+       (verifies the ID-first lookup works end-to-end).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from wikimind.engine.compiler import Compiler
+from wikimind.main import app
+from wikimind.models import (
+    Article,
+    Backlink,
+    CompilationResult,
+    CompiledClaim,
+    ConfidenceLevel,
+    IngestStatus,
+    Source,
+    SourceType,
+)
+
+
+@pytest.mark.asyncio
+async def test_wikilink_resolution_end_to_end(async_session, tmp_path, monkeypatch) -> None:
+    # 1. Seed an existing target article
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="existing-target",
+        title="Existing Target",
+        file_path=str(tmp_path / "existing-target.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    async_session.add(target)
+
+    # Seed a Source the compiler will mark as COMPILED
+    source = Source(
+        id=str(uuid.uuid4()),
+        source_type=SourceType.TEXT,
+        title="Test Source",
+        status=IngestStatus.NORMALIZED,
+        ingested_at=datetime.utcnow(),
+    )
+    async_session.add(source)
+    await async_session.commit()
+
+    # 2. Drive the save path with a mock CompilationResult
+    compiler = Compiler()
+    compiler.settings.data_dir = str(tmp_path)
+    result = CompilationResult(
+        title="New Compiled Article",
+        summary="Two sentence summary. For integration test.",
+        key_claims=[
+            CompiledClaim(claim="test claim", confidence=ConfidenceLevel.SOURCED)
+        ],
+        concepts=["test"],
+        backlink_suggestions=["Existing Target", "Nonexistent Topic"],
+        open_questions=["test?"],
+        article_body="## Body\n\nTest body content with enough text to be non-trivial.",
+    )
+    article = await compiler.save_article(result, source, async_session)
+
+    # 3. Backlink row exists
+    bl_result = await async_session.execute(
+        select(Backlink).where(Backlink.source_article_id == article.id)
+    )
+    backlinks = list(bl_result.scalars().all())
+    assert len(backlinks) == 1
+    assert backlinks[0].target_article_id == target.id
+
+    # 4. Markdown has the resolved link by ID and the unresolved bracket
+    content = Path(article.file_path).read_text()
+    assert f"[Existing Target](/wiki/{target.id})" in content
+    assert "[[Nonexistent Topic]]" in content
+
+    # 5. ID-first lookup via the HTTP route returns the new article
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/wiki/articles/{article.id}")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["id"] == article.id
+        assert payload["title"] == "New Compiled Article"
+
+        # Also verify the resolved link text appears in the content
+        assert f"[Existing Target](/wiki/{target.id})" in payload["content"]
+
+        # Slug-based lookup still works (backward compat)
+        response_by_slug = await client.get(f"/wiki/articles/{article.slug}")
+        assert response_by_slug.status_code == 200
+        assert response_by_slug.json()["id"] == article.id
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```bash
+.venv/bin/pytest tests/integration/test_wikilink_resolution_integration.py -v
+```
+
+Expected: PASS. If the test is skipped due to a missing fixture (`async_session` or the ASGI transport pattern is different in this project), check `tests/integration/test_qa_loop_integration.py` for the canonical patterns and adapt.
+
+- [ ] **Step 3: Run `make verify` as the final gate**
+
+```bash
+make verify
+```
+
+Expected: lint + format + mypy + full test suite green, coverage ≥ 80%.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_wikilink_resolution_integration.py
+git commit -m "test(integration): end-to-end wikilink resolution proof (#95)"
+```
+
+## Task 8: STOP — migration / backfill decision blocks on user input
+
+**This task is a STOP marker. Do NOT write code.**
+
+Tasks 1–7 implement the forward-only fix: new compiles get real `Backlink` rows and resolved markdown links. Existing articles on disk still contain the old `[[Title]]` text in their "Related" sections — they will render as unresolved (dimmed) spans until the underlying article is re-compiled.
+
+The spec (§ Backfill strategy) flagged three options for what to do about pre-existing articles. Each has different PR-level impact. **The plan explicitly does NOT pick one.**
+
+### The three options — restated for the decision
+
+**Option B1 — Re-compile every existing article on next deploy.**
+- Walk every `Article`, re-run the compiler on the original `Source`, let the normal save path produce resolved wikilinks and `Backlink` rows.
+- **Pro:** Clean knowledge graph on day one.
+- **Con:** LLM cost (every article re-compiled). `updated_at` timestamps change on every row. Provider-based deduplication fingerprints may invalidate. User sees the entire wiki "refresh".
+- **PR-level impact:** +1 job module, +1 startup hook or admin endpoint, nontrivial test surface. **Moderate-large change.**
+
+**Option B2 — Forward only.**
+- Ship this plan (Tasks 1–7) as-is. New articles get real backlinks. Existing articles keep unresolved `[[Title]]` text until re-ingested.
+- **Pro:** Zero disruption. Zero LLM cost. Deterministic. Simplest rollout.
+- **Con:** The knowledge graph starts sparse. Existing articles' "Related" sections stay dimmed until the user triggers a recompile.
+- **PR-level impact:** **Zero.** This is "do nothing extra" beyond Tasks 1–7. This plan IS B2.
+
+**Option B3 — Incremental resolution sweep job.**
+- Add a background job `wikilink_resolution_sweep` that walks existing articles, parses `[[Title]]` tokens from each `.md` file, runs them through the SAME `resolve_backlink_candidates` helper (no LLM call), and — if resolution succeeds now — rewrites the line in the .md file and creates a `Backlink` row.
+- **Pro:** Eventually-consistent knowledge graph. No LLM cost. Re-runnable on a timer or after each ingest.
+- **Con:** Most code of the three options. New job module, new tests, new scheduling hook, new markdown-round-trip edge cases (idempotency, file lock contention).
+- **PR-level impact:** **Moderate.** One new file in `src/wikimind/jobs/`, new tests, a small hook in the ingest-complete signal. Orthogonal to this plan — can ship as a separate follow-up PR.
+
+### What this plan says
+
+**Ship this PR as B2.** Tasks 1–7 close issues #95 and #96 on their own. New articles get the fix. Existing articles fall back to the dimmed-unresolved rendering, which is still strictly better than the current state (404s on every click).
+
+**File a follow-up issue for B3** titled "Incremental wikilink resolution sweep job". Reference this plan and the spec. Do NOT implement it in this PR.
+
+**If the user explicitly chooses B1 during review**, this plan needs a new task (Task 9) that adds the re-compile job — see the spec for rationale and the cost/benefit. That work is out of scope for the current plan.
+
+**Do not proceed past this marker without explicit confirmation from the user on the backfill strategy.**
+
+---
+
+# Final verification checklist
+
+Before opening the PR:
+
+- [ ] All tasks 1–7 committed with TDD-style commit messages
+- [ ] `make verify` green locally
+- [ ] `docs/openapi.yaml` regenerated (happens automatically via pre-commit; check the diff)
+- [ ] Manual smoke check of the Ask → Wiki flow: open an existing article, click a resolved link (should navigate), hover an unresolved span (should show tooltip)
+- [ ] PR description references issues #95, #96, and notes the backfill decision ("shipping B2; B3 filed as follow-up issue #<N>")
+- [ ] No new files outside the file-structure tables above
+- [ ] No changes to the compiler's prompt contract (spec commitment)
+- [ ] The single normalizer is the ONLY title normalizer in the codebase (a grep for `unicodedata.normalize` outside `title_normalizer.py` should find only unrelated uses)
+
+# Success criteria
+
+The PR is ready to land when:
+
+1. `make verify` is green.
+2. The integration test `test_wikilink_resolution_end_to_end` passes in CI.
+3. A fresh compile on a dev wiki produces a `.md` file whose "Related" section has both kinds of links — `[text](/wiki/<id>)` for resolved and `[[text]]` for unresolved — and the `backlink` table gains rows for the resolved entries.
+4. Clicking a resolved link in the frontend navigates to the target article without a 404.
+5. `WikiService.get_graph` returns a non-empty `edges` list for the first time in the project's history.
+
+When (5) happens, Epic 3 (knowledge graph view) becomes unblocked and can start building on top of real `Backlink` data.

--- a/docs/superpowers/specs/2026-04-08-knowledge-graph-design.md
+++ b/docs/superpowers/specs/2026-04-08-knowledge-graph-design.md
@@ -1,0 +1,429 @@
+# Knowledge Graph (Epic 3) — Design
+
+**Date:** 2026-04-08
+**Status:** Proposed (pre-implementation design, open decisions flagged in §9)
+**Author:** Design session against the WikiMind / Karpathy LLM Wiki Pattern
+**Related Epic:** [manavgup/wikimind#3 — Epic 3: Knowledge Graph](https://github.com/manavgup/wikimind/issues/3)
+**Related issues:** [#23 backlink extraction](https://github.com/manavgup/wikimind/issues/23), [#24 concept taxonomy](https://github.com/manavgup/wikimind/issues/24), [#25 Graph UI](https://github.com/manavgup/wikimind/issues/25), [#95 wikilink resolution](https://github.com/manavgup/wikimind/issues/95)
+**Related ADR:** [ADR-012 — Knowledge graph architecture](../../adr/adr-012-knowledge-graph-architecture.md)
+
+## 1. Context
+
+The Karpathy LLM Wiki Pattern gist describes a knowledge OS whose product loop is **Ingest → Query → Lint** and whose long-term payoff is that *explorations compound back into the wiki as new sources*. The gist mentions Obsidian's graph view in passing as the visual affordance that makes a wiki feel like *a structure you inhabit* rather than a list you scroll. It does not prescribe anything beyond that: no storage model, no layout algorithm, no query semantics.
+
+As of main (commit `d57d617`), WikiMind has shipped the full Ask vertical slice (ingest → compile → query → file-back loop, ADR-011). With the loop closed, the question is what to build next that makes the accumulated wiki feel like a single connected artifact rather than a list of compiled articles. Epic 3 is that payoff: an interactive knowledge graph view where the user sees their wiki *as* a graph and can navigate it spatially.
+
+Epic 3 is not just a visualization. It is also a set of graph-native queries that only make sense once the wiki is treated as a graph structure: "what connects these two articles?", "what is the shortest path between A and B?", "which concept clusters are sparsest?" Those queries feed back into the linter's data-gap detection later.
+
+**Dependency on #95 is the blocking constraint.** Today, `src/wikimind/engine/compiler.py` writes `[[Title]]` strings into article markdown bodies based on LLM-guessed `backlink_suggestions`, but **it never creates any `Backlink` table rows**. A grep for `Backlink` against `compiler.py` returns zero hits. The `Backlink` table is effectively empty in any real deployment. Issue #95 is the fix: resolve wikilinks at compile time against the actual article set and persist resolved ones as real `Backlink` rows. Without #95, Epic 3's graph renders as a scatter plot of disconnected dots. **#95 must merge before Epic 3 implementation starts.**
+
+## 2. Current state
+
+### 2a. `Backlink` model
+
+`src/wikimind/models.py:157` defines:
+
+```python
+class Backlink(SQLModel, table=True):
+    """Directed link between two wiki articles."""
+
+    source_article_id: str = Field(foreign_key="article.id", primary_key=True)
+    target_article_id: str = Field(foreign_key="article.id", primary_key=True)
+    context: str | None = None  # Sentence where link appears
+```
+
+Three fields only: `source_article_id`, `target_article_id`, `context`. No `relation_type`. No `weight`/`confidence`. No `created_at`. The composite primary key means there is exactly one directed edge per (source, target) pair — a second mention from the same article to the same target silently dedupes.
+
+`Article` has ORM-side eager-loading helpers (`backlinks_in`, `backlinks_out`) via `selectin` loading, which is what `get_graph` walks.
+
+**Populated in practice?** No. The compiler writes `[[Title]]` strings into the article markdown but never touches the `Backlink` table. The eager-loaded `backlinks_out` lists are empty for every article compiled today. This is exactly what #95 fixes.
+
+### 2b. `GET /wiki/graph` API
+
+Routed at `src/wikimind/api/routes/wiki.py:36` and implemented at `src/wikimind/services/wiki.py:222` (`WikiService.get_graph`). Response model:
+
+```python
+class GraphNode(BaseModel):
+    id: str
+    label: str
+    concept_cluster: str | None   # currently hard-coded to None
+    connection_count: int
+    confidence: ConfidenceLevel | None
+
+class GraphEdge(BaseModel):
+    source: str
+    target: str
+    context: str | None
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+```
+
+The service walks every `Article`, collects their eager-loaded `backlinks_out`, and computes `connection_count` by summing inbound + outbound degree per node. It passes `confidence` through from the `Article` row. **`concept_cluster` is hard-coded to `None`** — the field exists but nothing populates it because the concept-article mapping is not wired into this query. Zero positional hints, zero layout metadata, zero clustering data.
+
+No frontend consumer exists for this endpoint today. A grep of `apps/web/src/api/` for `graph` returns nothing.
+
+### 2c. `apps/web/src/components/graph/`
+
+The directory exists but is empty (`ls apps/web/src/components/graph/` returns no entries). It was created as a placeholder for Epic 3 and has sat unused since the directory was first committed.
+
+### 2d. Concept taxonomy
+
+`src/wikimind/models.py:146`:
+
+```python
+class Concept(SQLModel, table=True):
+    id: str
+    name: str = Field(unique=True, index=True)
+    parent_id: str | None = Field(default=None, foreign_key="concept.id")
+    article_count: int = 0
+    description: str | None = None
+    created_at: datetime
+```
+
+`Article` stores its concepts as a JSON array of concept IDs in `Article.concept_ids`. `GET /wiki/concepts` (`WikiService.get_concepts`) returns the flat concept list. Issue #24 covers the auto-generation of parent/child hierarchy — as of today, the `Concept` table may be populated (from compilation's `CompilationResult.concepts`) but the hierarchy is flat and `parent_id` is typically `NULL`.
+
+### 2e. Issues at a glance
+
+| # | Title | State | Relevance |
+|---|---|---|---|
+| [#3](https://github.com/manavgup/wikimind/issues/3) | Epic 3: Knowledge Graph | Open | This spec |
+| [#23](https://github.com/manavgup/wikimind/issues/23) | Backlink extraction + graph tables | Open | Producer side — superseded by #95 in practice |
+| [#24](https://github.com/manavgup/wikimind/issues/24) | Concept taxonomy auto-generation | Open | Feeds graph coloring / clustering |
+| [#25](https://github.com/manavgup/wikimind/issues/25) | React UI: Graph view | Open | Consumer side — the frontend work in this spec |
+| [#95](https://github.com/manavgup/wikimind/issues/95) | Wikilinks in compiled articles are unresolved | Open | **Hard blocker** — must merge first |
+
+#23 and #95 overlap substantially. #23 is the original "Phase 3" placeholder from the earliest roadmap; #95 is the specific bug-fix filing with detailed evidence. Implementation-wise, closing #95 also closes the meaningful work of #23. This spec treats #95 as the real prerequisite and notes #23 as the historical umbrella.
+
+## 3. Goals for Epic 3
+
+1. **Visualize the wiki as an interactive graph.** Nodes = articles, edges = backlinks. The user opens `/graph`, sees their wiki's connectivity at a glance, pans and zooms, and can navigate from any node into the article view.
+2. **Support graph-native queries.** At minimum: N-hop neighborhood of a given article. Stretch goals: shortest path between two articles, most central article in a concept cluster.
+3. **Use the concept taxonomy for coloring / clustering.** Nodes in the same concept cluster share a color; optionally, layout bias lets them drift toward each other under force simulation.
+4. **Click-to-navigate.** Clicking a node opens a preview panel; double-clicking (or clicking "open in wiki") navigates to the article reader.
+5. **Surface "related but not yet connected" candidates.** Articles that share concepts or are otherwise topically related but have no backlink edges between them are suggestions for the user to explicitly link (or for a future linter to propose).
+
+## 4. Non-goals
+
+- **Not real-time.** Graph staleness is fine. The graph can be rebuilt on demand, regenerated on a cadence, or cached for some short window. A user who ingests a source does not need the graph to update within the same tick.
+- **Not a graph database.** SQLite + the existing `Backlink` table is sufficient at personal-wiki scale (O(10³) articles, O(10⁴) edges upper bound). Moving to neo4j / dgraph / Kuzu violates ADR-001's local-first, zero-dependency-startup principle and buys us nothing at this scale.
+- **Not a social / multi-user graph.** No shared subgraphs, no permissions, no federation. WikiMind is a personal wiki; the graph is personal too.
+- **Not 3D.** 2D force-directed is legible, performant, and scales well. A 3D view is novelty over utility at this stage.
+- **Not a timeline view.** A time-axis layout captures *when* the wiki grew but not *how it connects*. Out of scope here; could be a future epic.
+- **Not editable.** The user cannot drag a node to a new position and expect it to persist. Layout is ephemeral; the underlying data model does not hold coordinates.
+
+## 5. Design
+
+### 5a. Data model decisions
+
+**Is the existing `Backlink` schema sufficient?**
+
+For the MVP of Epic 3 — render nodes and edges, support navigation, color by concept — **yes, it is sufficient as-is**. The three fields (`source_article_id`, `target_article_id`, `context`) give us everything a force-directed layout needs: node identity comes from the `Article` it references, edge direction comes from the primary key ordering, and the `context` sentence is surfaced as a hover tooltip.
+
+However, several extensions are worth considering at spec-review time. Each is justified or rejected below:
+
+| Proposed field | Justification | Recommendation |
+|---|---|---|
+| `relation_type: str` (cites / contradicts / supersedes / elaborates) | Richer edge semantics; enables colored edges in the graph and future semantic queries | **Defer.** Requires LLM changes in the compiler (new classification call per link) and no clear UX yet. Revisit after MVP if users ask. |
+| `weight: float` or `confidence: float` | Allows edge thickness to encode link strength; allows filtering weak links | **Defer.** The compiler has no principled way to assign weights today. Synthetic weights (e.g. "number of mentions") are misleading. Ship with uniform weights, revisit if the graph feels too busy. |
+| `created_at: datetime` | Enables "show me links added in the last week" filter; supports the timeline-view follow-on epic | **Add in PR 1.** Small, cheap, useful, doesn't commit to anything. |
+| `updated_at: datetime` | Only meaningful if edges can be mutated in place; today each re-compile re-creates all backlinks | **Reject.** Not meaningful under current re-compile semantics. |
+
+**Decision:** PR 1 extends `Backlink` with a single new field: `created_at: datetime`. Everything else stays as-is and can be added incrementally if usage justifies it. The extension is a `_migrate_added_columns` entry, nullable-or-defaulted, and has no back-compat implications.
+
+**Where do concepts sit in the graph?**
+
+Two options:
+
+1. **Concepts are a coloring layer.** Each node (article) gets a `concept_cluster` string — typically the name of its primary concept — and the frontend renders all articles in the same cluster in the same color. Concepts do not appear as graph nodes themselves.
+2. **Concepts are parallel nodes.** The graph has two node types: article nodes and concept nodes. Article→concept is an edge. Article↔article is also an edge. The graph is bipartite-ish.
+
+**Decision: concepts are a coloring layer, not a parallel node type.** Rationale:
+
+- Keeps node count equal to article count. Two-type graphs complicate every downstream query ("give me N-hop neighbors" becomes ambiguous — do you traverse through concepts?).
+- Keeps the visual simple. The payoff of a knowledge graph is seeing *articles connected to articles*. Concept-as-node visually drowns this in hub nodes.
+- Matches Obsidian's graph view, which users already have as a mental model.
+- Trivial to upgrade later if it turns out we need it: concepts become nodes in a different view (`/graph/concepts`), not in the main view.
+
+**Orphan articles** (zero backlinks, zero inbound links) sit in the graph as nodes with zero edges. They are still rendered, still clickable, still navigate to the article. They are visually distinct — smaller radius, dimmer color, optional "orphans only" filter. The empty-state copy for a wiki with only orphans is handled in 5e.
+
+### 5b. Graph API
+
+**Current `/wiki/graph` shape** (repeated from §2b for the decision):
+
+```json
+{
+  "nodes": [
+    {"id": "art-123", "label": "Attention Is All You Need",
+     "concept_cluster": null, "connection_count": 5,
+     "confidence": "sourced"}
+  ],
+  "edges": [
+    {"source": "art-123", "target": "art-456",
+     "context": "builds on the self-attention mechanism"}
+  ]
+}
+```
+
+**Extensions for PR 1:**
+
+1. **Populate `concept_cluster`.** Look up each article's primary concept (the first entry in `Article.concept_ids`, parsed as JSON) and set `concept_cluster` to the concept's `name`. Null only if the article has no concepts. This is a join, cached at graph-build time.
+2. **Add node metadata the layout engine will want.** Specifically: `slug` (for navigation without a second lookup) and `updated_at` (for "recently updated" visual emphasis). Both are cheap — already on `Article`.
+3. **Add edge `created_at`.** Once `Backlink.created_at` lands per 5a, expose it on `GraphEdge` so the frontend can filter by recency.
+
+**New endpoints (PR 4):**
+
+| Route | Returns | Purpose |
+|---|---|---|
+| `GET /wiki/graph/neighbors/{article_id}?depth=N` | `GraphResponse` — subgraph of N-hop neighborhood | "Show me everything connected to this article within N hops" |
+| `GET /wiki/graph/path?from={a}&to={b}` | Ordered list of `{article_id, edge_context}` | Shortest path between two articles (BFS over the adjacency derived from Backlink table) |
+| `GET /wiki/graph/cluster/{concept}` | `GraphResponse` — subgraph filtered to one concept | "Show me only the ML concept cluster" |
+
+These are deferred to PR 4 (§10). The MVP (PR 2) only needs the existing `/wiki/graph`.
+
+**Performance consideration.** The current `get_graph` walks every `Article` and every `Backlink`. At personal-wiki scale (<10³ articles) this is a few hundred ms at worst. At larger scale, the endpoint should be cached — see 5f.
+
+### 5c. Layout algorithm
+
+**Decision: force-directed layout, computed client-side.**
+
+Options considered:
+
+1. **Force-directed (d3-force via react-force-graph-2d)** — nodes repel, edges attract, physics simulation settles into an organic layout. Strengths: familiar, good for exploring connectedness, organic clustering falls out naturally. Weaknesses: nondeterministic (same data, different layout each refresh), tricky at scale.
+2. **Hierarchical (dagre).** Good for DAGs with clear root-child relationships. Weakness: wiki backlinks are cyclic graphs, not DAGs. Forcing a hierarchy imposes a structure that isn't there.
+3. **Circular by concept.** Articles grouped in rings by concept. Weakness: loses the *connectivity* signal, which is the whole point.
+
+**Force-directed wins.** It matches Obsidian's existing affordance (so WikiMind users feel at home) and it visually reveals the graph's actual structure — clusters emerge, bridges are obvious, orphans float at the edge.
+
+**Where does layout run?** **Client-side.** The backend returns `{nodes, edges, metadata}`. The frontend's force simulation computes positions. Rationale:
+
+- The layout is ephemeral and viewer-dependent (zoom state, pan state, which node is selected all affect rendering). Computing server-side would mean sending position data with every response and re-running the simulation whenever the viewer wants a different sub-view.
+- `react-force-graph-2d` has a mature, well-tuned simulation. Using it means we get good defaults for free.
+- The backend stays pure-data. Graph layout is a rendering concern.
+
+This is an architectural commitment and is captured in ADR-012.
+
+### 5d. Frontend architecture
+
+**Library choice: `react-force-graph-2d`.**
+
+Options evaluated:
+
+| Library | Pros | Cons | Verdict |
+|---|---|---|---|
+| **react-force-graph-2d** | Thin React wrapper over d3-force + canvas, small API (~20 props), good defaults, optional WebGL variant (`react-force-graph-webgl`) for scale, actively maintained, MIT licensed | Fewer features than cytoscape (no built-in filters, no compound nodes) | **Chosen.** Right scope for MVP. |
+| cytoscape.js | Feature-rich, first-class filtering / styling / layout algorithms, battle-tested | Heavier bundle, more opinionated API, steeper learning curve, overkill for MVP | Rejected for MVP; revisit if we outgrow react-force-graph. |
+| vis-network | Enterprise-y, has a React wrapper | Maintenance is inconsistent, API feels dated, bundle size is large | Rejected. |
+| sigma.js | WebGL-first, scales well | Less idiomatic in React, smaller ecosystem | Rejected. Revisit if scale requires WebGL (see 5f). |
+
+**react-force-graph-2d is the MVP pick.** If/when scale pushes past its 2D-canvas cutoff (~500 nodes without WebGL), migrate to `react-force-graph-webgl` — same API surface, different rendering backend, minimal code change.
+
+This is an open decision flagged in §9 — the user should explicitly lock it in before implementation starts.
+
+**New components under `apps/web/src/components/graph/`:**
+
+| Component | Responsibility |
+|---|---|
+| `GraphView.tsx` | Page container. Two-pane layout: left sidebar (`GraphFilters`), main area (`GraphCanvas`), overlay right panel (`GraphDetailPanel`) when a node is selected. Loads `/wiki/graph` via react-query on mount. Handles URL state (`/graph?selected=<article_id>`). |
+| `GraphCanvas.tsx` | Thin wrapper around `<ForceGraph2D />`. Receives `{nodes, edges, selectedId, onNodeClick, onNodeHover, filters}` as props. Applies visual mapping: node radius ∝ `connection_count`, node color ← `concept_cluster`, node dimness ← orphan state. Handles the physics config (link distance, charge strength) — tuned during implementation. |
+| `GraphFilters.tsx` | Sidebar. Controls: concept filter (multi-select), confidence filter (sourced / mixed / inferred / opinion checkboxes), min connection count (slider), show orphans (toggle), search box to pin a node by title. Filter state lives in the parent via lifted `useState` or zustand — decision deferred to implementation. Filters prune `nodes`/`edges` in memory; do **not** re-fetch. |
+| `GraphDetailPanel.tsx` | Right-side drawer. Appears when a node is selected. Shows: article title, summary, concept tags, confidence chip, inbound/outbound link counts, an "Open in wiki" button that navigates to `/wiki/:slug`, a list of "related but not yet connected" candidates (articles sharing ≥1 concept but with no edge between them). |
+
+**New route:** `/graph` in `apps/web/src/App.tsx`. Optional `/graph?selected=<article_id>` query param for deep-linking to a node.
+
+**New nav link:** "Graph" in `Layout.tsx`, between "Wiki" and the existing right-side links. Visual order: **Inbox → Ask → Wiki → Graph**. The Graph is the spatial version of the Wiki — naturally adjacent.
+
+**New API client method** in `apps/web/src/api/wiki.ts`:
+
+```typescript
+export interface GraphNode { id: string; label: string; slug: string;
+  concept_cluster: string | null; connection_count: number;
+  confidence: string | null; updated_at: string; }
+export interface GraphEdge { source: string; target: string;
+  context: string | null; created_at: string; }
+export interface GraphResponse { nodes: GraphNode[]; edges: GraphEdge[]; }
+export function getGraph(): Promise<GraphResponse>;
+```
+
+### 5e. Interaction model
+
+- **Click node** → `GraphDetailPanel` opens, populated with the node's metadata. URL updates to `/graph?selected=<id>`.
+- **Double-click node** → navigate to `/wiki/:slug` (the article reader).
+- **Hover edge** → tooltip with the source article's `context` snippet (if `Backlink.context` is populated).
+- **Hover node** → highlight the node's immediate neighbors; dim everything else.
+- **Pan + zoom** → mouse drag + scroll wheel / trackpad pinch. Standard `react-force-graph` defaults.
+- **Filter controls** → dynamically prune `nodes` and `edges` in the parent component's state. No re-fetch — the whole graph is already in memory. Filter operations are O(n) per change.
+- **Search / pin** → typing in the search box filters the node list to title matches; selecting a match centers the view on that node and opens its `GraphDetailPanel`.
+- **Keyboard:**
+  - `g` from anywhere → navigate to `/graph`
+  - `/` → focus the search input within `/graph`
+  - `esc` → close the `GraphDetailPanel`
+  - `o` → toggle "show orphans only"
+
+Keyboard shortcuts are a nice-to-have for the MVP. Gate them behind the global command-palette work (not yet shipped) if that feels cleaner.
+
+**Empty state** (zero articles): friendly "Your graph is empty. Ingest a source to start building your wiki." with a link to `/inbox`.
+
+**Sparse state** (articles exist but no edges): the graph renders as a cloud of dots. Show a banner: "Your wiki has {N} articles but no backlinks yet. Backlinks are created when compiled articles cross-reference each other via `[[wikilinks]]`." This is the cold-start reality until #95 is live **and** the user has compiled enough articles for cross-references to emerge.
+
+### 5f. Performance thresholds
+
+Force-directed layout in a 2D canvas starts to feel sluggish past a certain node count. Measured rough thresholds for `react-force-graph-2d`:
+
+| Node count | Behavior | Mitigation |
+|---|---|---|
+| 0 – 500 | Smooth. No mitigation needed. | — |
+| 500 – 2,000 | Noticeable simulation lag on first render; interaction still OK | Pre-compute positions via `cooldownTicks`, render post-settle |
+| 2,000 – 5,000 | Canvas rendering becomes the bottleneck | Switch to `react-force-graph-webgl` (WebGL variant, same API) |
+| 5,000+ | WebGL also strained | Server-side sub-graph filtering (e.g. only return top 1000 most-connected nodes by default); virtualized rendering |
+
+**For WikiMind's target audience** — personal wikis of 10² to a few × 10³ articles — we are comfortably in the "no mitigation needed" band for the foreseeable future. The 500-node cutoff is the trigger to introduce auto-filtering: when the graph returns >500 nodes, the default view shows only the top-500 most-connected subgraph, with a "show all" escape hatch.
+
+**Backend cache strategy.** `GET /wiki/graph` is the single hot endpoint. Cache the computed response in-memory (LRU with TTL, or invalidate on article write) behind the service method:
+
+- **Invalidation:** on any `Article` insert/update/delete and on any `Backlink` insert/delete. Hook via SQLAlchemy events or explicit service-method bustling.
+- **TTL fallback:** 5 minutes. If events are missed for any reason, staleness is bounded.
+- **Cache key:** single global key (the graph is global). No per-user consideration — WikiMind is single-user.
+
+Implementation-wise, this is a plain Python `dict` with timestamps. Not Redis, not memcached. Fits in the existing process.
+
+## 6. Alternatives considered
+
+**Real graph database (neo4j, dgraph, Kuzu).** Rejected. At personal-wiki scale (O(10³) articles), SQLite + the existing `Backlink` table handles every query this spec envisions in <100ms with no special infrastructure. Adopting a graph database would:
+
+- violate ADR-001's zero-dependency-startup principle (now the user needs neo4j installed),
+- require a second storage layer with its own consistency story,
+- contribute nothing that a BFS/DFS over a few thousand rows in Python can't already do.
+
+Revisit only if the wiki scales by 10² and we can measure real pain. Not today.
+
+**3D graph visualization.** Rejected. `react-force-graph-3d` exists and looks cool. But it adds cognitive load (users rotate to see structure), it doesn't reveal more information than 2D at this scale, and it's novelty-driven rather than utility-driven. The payoff of the knowledge graph is "I can see my wiki's structure" — 2D delivers that cleanly.
+
+**Timeline view as the primary layout.** Rejected. Time is one axis the wiki has (via `Article.created_at`) but the graph's purpose is to expose *connections*, not chronology. A timeline layout flattens the connection structure into a line. Could be a separate view in a future epic; should not be the primary graph layout.
+
+**Server-side computed layout.** Rejected. Sending positions from the backend means:
+
+- re-running the simulation every time the viewer wants a different sub-view,
+- coupling the storage layer to a rendering concern,
+- losing the interactive dynamism of live physics (nodes that spring back when dragged, smooth transitions when filters apply).
+
+Client-side wins on every axis.
+
+**Make concepts first-class graph nodes.** Already discussed in 5a. Rejected because it complicates every downstream query and visually drowns article-to-article structure in concept hubs.
+
+## 7. Consequences
+
+### Enables
+
+- **The payoff of the wiki.** Everything shipped so far (ingest, compile, backlinks, concepts, Ask) has been building toward the moment the user sees their wiki *as a structure*. Epic 3 is that moment.
+- **Empirical gap analysis.** Concepts with sparse subgraphs are, by definition, areas where the user has knowledge fragments but few cross-connections. This is ground truth for the linter's "data gaps" feature — the graph surfaces them visually and the linter can report them in copy.
+- **Navigation at a new level.** The Wiki Explorer is list-oriented; the Graph is spatial. Some questions ("what's near article X in concept-space?") are natural to answer spatially and awkward to answer in a list.
+- **A natural home for future graph queries.** N-hop neighborhood, shortest path, most central article — all of these become new routes on the existing `/wiki/graph/*` namespace without touching the core model.
+
+### Constrains
+
+- **Backlink quality becomes user-visible.** Any regression in #95's wikilink resolution — a missed link, a false positive, a title-matching bug — shows up silently as a wrong edge (or a missing edge) in the graph. This creates a soft obligation to keep backlink quality high and to monitor the compiler's behavior on each release.
+- **`/wiki/graph` becomes a hot endpoint.** It's called on every `/graph` page load. Adding fields to the response costs every call. Adding heavy joins costs every call. The endpoint has to stay lean.
+- **Layout is ephemeral.** Users cannot "arrange" their graph. If a researcher expects Obsidian-style persistent node positions, they will be disappointed. This is an intentional trade-off (see 5c) but should be documented in the user-facing docs.
+
+### Risks
+
+- **Cold-start UX.** A new user's first compiled article is one node with zero edges. A user with five articles and no cross-references is five disconnected dots. Until the wiki grows, the graph view is *less* impressive than the list view. **Mitigate** with friendly empty-state copy (see 5e) and by gating the "Graph" nav link on `article_count >= 5` in the MVP — users don't see the link until their wiki is interesting enough for the graph to be meaningful. Decision flagged in §9.
+- **Graph can reveal sparseness.** Showing a user how sparsely connected their wiki is, is both motivating ("wow, so much room to grow") and discouraging ("wow, I thought I knew more"). Early users are more likely to land on the discouraging side. **Mitigate** with celebration patterns ("Your graph now has 10 connections!") — but **not in v1**. Ship the bare view first, see how it feels, iterate on morale.
+- **#95 quality directly bounds graph quality.** If #95 ships with a 60%-recall wikilink resolver, the graph shows 60% of the edges. Users will blame the graph, not the resolver. **Mitigate** by shipping #95 with an explicit recall benchmark and tracking it as a regression guard.
+- **Performance cliff at unexpected scale.** If a user imports an Obsidian vault (#92, future) with 10k articles, the force simulation will stutter. **Mitigate** by the auto-filter-to-top-500 rule in 5f, and by adding a "too many nodes to display — showing top 500 by connection count" banner.
+
+## 8. Hard dependencies
+
+| Dependency | Why | Status |
+|---|---|---|
+| **#95 — wikilink resolution** | Without it, the `Backlink` table stays empty and the graph renders as disconnected dots. The entire Epic is meaningless until #95 ships. | **Must merge before Epic 3 implementation PR 2 starts.** PR 1 (data model + API polish) can land before #95 because it doesn't render anything. |
+| **#24 — concept taxonomy populated** | Without this, `concept_cluster` is always `None` and the graph falls back to a single color. Still usable, less interesting. | **Nice-to-have.** Epic 3 does not block on #24; it degrades gracefully when the concept table is empty or flat. |
+| **Existing `/wiki/graph` endpoint** | Already exists (§2b). PR 1 extends it. | **Done.** |
+| **ADR-012** | Architectural decisions (SQLite storage, client-side layout, concept-as-color) deserve a tracked record. | Drafted as sibling to this spec. |
+
+## 9. Open decisions for the user
+
+These are the decisions this spec deliberately does **not** make. They are flagged for spec review and should be locked in before implementation starts.
+
+1. **Graph library lock-in.** This spec recommends `react-force-graph-2d`. The user should confirm before the frontend PR (PR 2) starts — changing libraries mid-implementation is painful. Alternatives on the table: cytoscape.js (more features, heavier), sigma.js (WebGL-first, smaller ecosystem).
+
+2. **Graph view placement relative to Wiki Explorer.** Does the graph view **replace** the Wiki Explorer as the primary browsing UI, or **live alongside it**? Recommendation: **alongside.** Different audiences (list-oriented vs spatial) want different affordances. The graph is additive.
+
+3. **Search / filter on launch, or v1.1?** The full set of filters (concept, confidence, orphan toggle, min connection count, search) is a non-trivial amount of frontend work. Could the MVP ship with *no filters at all* and add them in a follow-up? Recommendation: **ship MVP with basic filters only** (concept multi-select + orphan toggle + search). Defer the rest. The MVP is tested for "can a user find and navigate to a node from the graph"; that works without a min-connection-count slider.
+
+4. **Definition of done for Epic 3's first shipped PR.** Two readings:
+   - **View only:** PR 2 ships the view. Graph queries (neighbors / path) ship in a follow-up PR 4.
+   - **View + at least one graph query:** PR 2 ships the view plus `GET /wiki/graph/neighbors/{id}`, because without at least one graph-native query, the feature is *just* a visualization and fails goal 2.
+
+   Recommendation: **view only.** The visualization is the primary payoff. Graph queries are a follow-up that become trivial once the data model is locked in.
+
+5. **Cold-start gating.** Should the "Graph" nav link hide until the user has a minimum number of articles and edges (e.g. 5 articles + 3 edges)? Recommendation: **hide until 5 articles exist.** The edge requirement is too brittle (depends on #95 quality and the user's compilation history).
+
+6. **`Backlink.created_at` addition — in PR 1 or later?** The spec (5a) recommends PR 1, but it's a small lift. Could be its own tiny follow-up PR. Recommendation: **in PR 1**, bundle it with the other data model polish.
+
+7. **Caching strategy for `/wiki/graph`.** Do we need the cache at MVP? At <500 articles the raw query is fast. Recommendation: **defer cache to PR 5 (performance pass).** Ship MVP without it.
+
+## 10. Suggested PR decomposition
+
+This is a sketch, not a plan. A separate planning document will refine it when implementation actually begins.
+
+### PR 1 — backend polish (≈200 LOC)
+
+- Extend `Backlink` with `created_at` (or whichever fields the spec review settles on)
+- Populate `concept_cluster` in `GraphResponse` from `Article.concept_ids` + `Concept` table
+- Add `slug` and `updated_at` to `GraphNode`
+- Add `created_at` to `GraphEdge`
+- Unit tests on `WikiService.get_graph` for the new fields
+- `docs/openapi.yaml` auto-regenerates
+- `.env.example` updated if any settings are added (not currently planned)
+- **Depends on:** nothing. Can land before #95.
+
+### PR 2 — frontend graph view MVP (≈500 LOC)
+
+- New `apps/web/src/api/wiki.ts` `getGraph()` method and types
+- New `apps/web/src/components/graph/GraphView.tsx`, `GraphCanvas.tsx`, `GraphDetailPanel.tsx`
+- New `/graph` route in `App.tsx`
+- Nav link in `Layout.tsx` (optionally gated on article count per §9)
+- `react-force-graph-2d` added to `apps/web/package.json`
+- Basic click-to-preview, double-click-to-navigate
+- Loading state and empty state
+- **No filters in this PR.** Filters are PR 3.
+- **Depends on:** PR 1 merged + #95 merged (otherwise the graph is empty).
+
+### PR 3 — filters + orphan handling + keyboard nav (≈300 LOC)
+
+- `GraphFilters.tsx` with concept / confidence / orphan toggle / search
+- Filter state management (zustand or lifted state — decide at implementation time)
+- Keyboard shortcuts (`g` → graph, `/` → search, `esc` → close panel, `o` → orphans)
+- Orphan visual treatment (dimmer, smaller radius)
+- **Depends on:** PR 2 merged.
+
+### PR 4 — graph queries (≈400 LOC backend + ≈200 LOC frontend)
+
+- `GET /wiki/graph/neighbors/{article_id}?depth=N` — BFS subgraph
+- `GET /wiki/graph/path?from={a}&to={b}` — shortest path
+- `GET /wiki/graph/cluster/{concept}` — subgraph by concept
+- Frontend: "focus on neighborhood" action from the detail panel
+- Frontend: "show path to…" action
+- **Depends on:** PR 3 merged.
+
+### PR 5 — performance pass (≈200 LOC) — conditional
+
+- Only if measurements show real problems at expected scale.
+- Backend caching of `/wiki/graph` with event-based invalidation.
+- Frontend degradation strategy: auto-filter to top-N-most-connected when the graph is too large.
+- Optional: swap to `react-force-graph-webgl` if 2D canvas is the bottleneck.
+- **Depends on:** PR 4 merged + evidence that performance is actually a problem.
+
+## 11. Related work
+
+- [#3 — Epic 3: Knowledge Graph](https://github.com/manavgup/wikimind/issues/3) — the umbrella epic this spec fulfills.
+- [#23 — Backlink extraction + graph tables](https://github.com/manavgup/wikimind/issues/23) — the original Phase 3 placeholder; effectively subsumed by #95's more specific fix.
+- [#24 — Concept taxonomy auto-generation](https://github.com/manavgup/wikimind/issues/24) — feeds graph coloring. Not a hard blocker (graceful degradation), but materially improves the payoff.
+- [#25 — React UI: Graph view](https://github.com/manavgup/wikimind/issues/25) — the UI-side placeholder; PR 2 closes it.
+- [#95 — Wikilinks in compiled articles are unresolved](https://github.com/manavgup/wikimind/issues/95) — the hard blocker. Epic 3 PR 2 cannot ship meaningfully until #95 ships.
+- [ADR-001 — FastAPI + async SQLite](../../adr/adr-001-fastapi-async-sqlite.md) — the local-first principle that rejects adopting a real graph database.
+- [ADR-004 — Markdown files + SQLite metadata](../../adr/adr-004-markdown-files-sqlite-metadata.md) — the existing storage model the graph reads from.
+- [ADR-012 — Knowledge graph architecture](../../adr/adr-012-knowledge-graph-architecture.md) — the architectural decisions this spec is grounded in.

--- a/docs/superpowers/specs/2026-04-08-wiki-linter-design.md
+++ b/docs/superpowers/specs/2026-04-08-wiki-linter-design.md
@@ -1,0 +1,542 @@
+# Wiki Linter — Design
+
+**Date:** 2026-04-08
+**Status:** Draft (open decisions flagged in § Open decisions)
+**Author:** Spec session against the WikiMind / Karpathy LLM Wiki Pattern
+**Related issues:** [#4 Epic 4: Health + Linter](https://github.com/manavgup/wikimind/issues/4), [#26 Wiki linter — LLM-powered health audit](https://github.com/manavgup/wikimind/issues/26), [#27 React UI: Health Dashboard](https://github.com/manavgup/wikimind/issues/27), [#95 Wikilinks unresolved](https://github.com/manavgup/wikimind/issues/95)
+
+## Context
+
+The linter is the **third core operation of the Karpathy LLM Wiki Pattern** (gist: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f), alongside ingest and query. Karpathy frames it as a periodic health check that the LLM runs against the wiki to look for contradictions, stale claims, orphan pages, missing pages, and data gaps. Without a lint pass, "the wiki accumulates drift as sources and claims compound" — meaning ingest and query are not enough on their own to keep a compounding knowledge base honest.
+
+WikiMind has ingest and query shipped (the Ask vertical slice closed the Karpathy loop in PR #85/#92/#93). It does **not** yet have a real linter. What it does have is a **stub**: `src/wikimind/jobs/worker.py::lint_wiki` is a single LLM call that dumps the first 50 articles into one prompt, asks for contradictions + orphans + gaps + coverage scores in one pass, and writes the result to `wiki/_meta/health.json` as an opaque blob. There is an ARQ cron wired to run it weekly (`cron_jobs = [cron(lint_wiki, weekday=0, hour=2, minute=0)]`), a `POST /jobs/lint` trigger, a `GET /wiki/health` route that reads the JSON file, a `Job` table entry for each run, a WebSocket `emit_linter_alert` event, and an empty `apps/web/src/components/health/` directory earmarked for the UI. None of this produces structured, queryable, per-finding data; none of it is independently testable check-by-check; and the single-prompt design does not scale past the 50-article cap that already exists in code.
+
+This spec replaces the stub with a real, structured, check-per-function linter backed by two new tables (`LintReport`, `LintFinding`), while preserving the existing API surface (`POST /jobs/lint`, `GET /wiki/health`) as a thin compatibility shim on top of the new model so the frontend health dashboard can be built on structured data instead of an opaque JSON blob.
+
+## Current state — what the linter can build on
+
+The linter is not starting from zero. The relevant infrastructure already exists and should be reused:
+
+| Capability | Where | Used by the linter how |
+|---|---|---|
+| Multi-provider LLM router with cost tracking | `src/wikimind/engine/llm_router.py` (ADR-003) | All LLM calls go through `get_llm_router().complete()` with `task_type=TaskType.LINT`, which is already defined. Cost tracking and provider fallback are free. |
+| ARQ + fakeredis background jobs | `src/wikimind/jobs/worker.py`, `src/wikimind/jobs/background.py` (ADR-002) | The linter runs as a background job. `BackgroundCompiler.schedule_lint()` already exists — we reshape what it does, not whether it exists. The existing weekly cron trigger stays. |
+| `ConfidenceLevel` enum on claims | `src/wikimind/models.py::ConfidenceLevel` (ADR-005) | Input signal for contradiction detection: two `SOURCED` claims that contradict each other are a higher-severity finding than two `INFERRED` claims. |
+| Article retrieval + scoring | `src/wikimind/engine/qa_agent.py::QAAgent._retrieve_context` | Reusable for "find related articles by shared keywords" when batching article pairs for contradiction detection. The current naive token-overlap scoring is good enough for this — pair-finding doesn't need embeddings. |
+| `Backlink` table (schema only) | `src/wikimind/models.py::Backlink` | The ORM table and the `backlinks_in` / `backlinks_out` relationships already exist. **The table is empty in practice** because the compiler never writes rows to it — that's what #95 is about. Orphan detection is therefore blocked on #95 (see § Goals). |
+| `Concept` taxonomy | `src/wikimind/models.py::Concept`, `Article.concept_ids` (JSON array) | Used to batch articles that are about the same topic, keeping contradiction detection O(articles within a concept) instead of O(articles²). |
+| `Job` table + WS event bus | `src/wikimind/models.py::Job`, `src/wikimind/api/routes/ws.py::emit_linter_alert` | Lint runs get a `Job` row for progress tracking. Completion emits a WebSocket event so the health view can re-fetch without polling. |
+| Empty frontend placeholder | `apps/web/src/components/health/` | Target directory for the health view components. Nothing to migrate — the directory is genuinely empty. |
+| Stub `lint_wiki` ARQ function + `POST /jobs/lint` + `GET /wiki/health` + weekly cron | `src/wikimind/jobs/worker.py`, `src/wikimind/api/routes/jobs.py`, `src/wikimind/api/routes/wiki.py` | Gets replaced internally. External API surface is preserved as a compatibility shim. See § Migration from the stub. |
+
+**What does not yet exist**: structured per-finding storage, per-check function decomposition, a real `LintReport` / `LintFinding` data model, a dedicated health view, dismiss semantics, or any unit tests on the linter path.
+
+## Goals — v1 scope
+
+The linter v1 must:
+
+1. **Detect contradictions** between `key_claims` of different articles that share at least one concept. Contradiction detection is the single highest-value check — it is the one thing no amount of structural analysis can do without an LLM, and it is the one thing a non-linted wiki silently gets wrong.
+2. **Detect orphan articles** — articles with zero inbound backlinks AND zero outbound backlinks. **This check depends on #95 (wikilinks unresolved) being merged first.** Until #95 lands, the `Backlink` table is empty and every article looks orphaned, so the check is useless. Call this out in the plan and ship the linter without it if #95 is delayed.
+3. **Produce a structured health report** — a `LintReport` row plus N `LintFinding` rows, queryable from SQL, renderable as JSON for the UI. Not an opaque blob.
+4. **Persist reports so the user can see history** — every lint run creates a new `LintReport` row. Old reports are retained (no auto-delete in v1).
+5. **Run on demand via a manual trigger**, and on the existing weekly cron. The cron already exists; reshape what it does, keep the schedule.
+6. **Emit a WebSocket completion event** so the health dashboard re-fetches without polling. The existing `emit_linter_alert` event bus is reusable.
+
+### Explicit in-scope checks for v1
+
+| Check | Implementation | Depends on |
+|---|---|---|
+| Contradictions | LLM per concept-bucket | Concept taxonomy (exists) |
+| Orphans | Pure SQL on `Backlink` table | #95 (Backlink population at compile time) |
+| Missing pages | **DROPPED from v1** — see § Non-goals and § Open decisions | — |
+
+## Non-goals — v1
+
+Each of these is a real Karpathy lint category that v1 deliberately defers:
+
+- **Stale claims detection** — requires per-claim timestamps and a way to know when a source has been superseded. `Article.updated_at` exists but `CompiledClaim` has no timestamp of its own, and "superseded" needs cross-article reasoning that is expensive. Out of scope. File as follow-up if the user wants it.
+- **Data gaps detection** — requires a model of user interest (queries asked, queries left unanswered, topics the user has spent time on). This is a phase-5 signal that does not exist yet. Out of scope.
+- **Missing pages detection** — the algorithm is either "LLM-per-article" (expensive, redundant with contradiction detection's token budget) or "reuse #95's wikilink resolver" (blocked on #95 being merged and also on a decision about whether missing-page surfacing belongs in lint or in the compile-time resolver itself). Dropped from v1 by recommendation; see § Open decisions.
+- **Auto-fix / auto-rewrite** — the linter is strictly read-only in v1. It surfaces findings and lets the user decide what to do about them. Auto-fix is a massive blast-radius feature that requires a separate design.
+- **Compiler prompt engineering** — contradiction detection may reveal patterns that would be better prevented at compile time, but v1 does not touch the compiler. Lint is a separate pass, by design.
+- **Per-finding email / push notifications** — WebSocket events are in; external notifications are out.
+- **Linter cost dashboard** — cost tracking is already in `CostLog` (keyed by `task_type=LINT`). A dedicated view of lint cost history is a polish item and out of scope.
+
+## Design
+
+### Pipeline
+
+```text
+POST /lint/run                        (or weekly cron)
+    │
+    ▼
+BackgroundCompiler.schedule_lint()    (unchanged — ARQ in prod, asyncio.create_task in dev)
+    │
+    ▼
+worker.lint_wiki(ctx)                 (REWRITTEN — dispatch to run_lint)
+    │
+    ▼
+engine/linter/runner.py::run_lint(session)
+    │
+    ├─► create LintReport(status="in_progress")
+    ├─► detect_contradictions(session) → list[ContradictionFinding]
+    ├─► detect_orphans(session) → list[OrphanFinding]    # no-op if Backlink table empty
+    ├─► persist all findings as LintFinding rows, FK'd to the report
+    ├─► update LintReport(status="complete", counts populated)
+    └─► emit_linter_alert event over WebSocket
+```
+
+Each check is a **standalone async function** that takes a session and returns a list of typed findings. The top-level `run_lint(session)` is the only thing that knows about `LintReport`; the individual checks know nothing about persistence. This makes each check independently unit-testable, and it makes adding a fourth check in the future a one-line change to `run_lint`.
+
+### Check: `detect_contradictions`
+
+```python
+async def detect_contradictions(
+    session: AsyncSession,
+    router: LLMRouter,
+    settings: Settings,
+) -> list[ContradictionFinding]:
+    """For each concept, LLM-compare article pairs within that concept bucket."""
+```
+
+**Algorithm:**
+
+1. Load all `Concept` rows. For each concept, load all `Article` rows whose `concept_ids` JSON array contains that concept's id.
+2. Within each concept bucket, enumerate article pairs (up to a cap — see § Settings). Call the LLM once per pair with the two articles' `key_claims` (parsed from the `Article` body or a pre-stored structured field — see § Open decision on input shape).
+3. The LLM returns a JSON list of contradictions, each with `description`, `article_a_claim`, `article_b_claim`, `confidence` (high|medium|low). Non-contradictions return an empty list.
+4. Persist each returned contradiction as one `ContradictionFinding` (in-memory Pydantic model; `run_lint` converts them to `LintFinding` rows).
+5. Cap: `settings.linter.max_contradiction_pairs_per_concept` (default 10). If a concept bucket has more pairs than the cap, sample — do not scan all.
+6. Cap: `settings.linter.max_concepts_per_run` (default 25). If the wiki has more concepts than the cap, process the N most-recently-updated concepts first. This keeps a single lint pass bounded at roughly `25 × 10 = 250` LLM calls in the worst case. With caching by `(article_a.id, article_b.id, article_a.updated_at, article_b.updated_at)` across runs (see § Caching), steady-state cost is much lower.
+
+**Prompt sketch** (strict JSON, matching ADR-007 convention):
+
+```text
+System: You are a wiki health auditor. Given two short wiki articles about the same topic,
+identify any contradictory assertions between their key claims. Return strict JSON.
+
+User:
+Article A: "{article_a.title}"
+Key claims:
+- {claim 1}
+- {claim 2}
+...
+
+Article B: "{article_b.title}"
+Key claims:
+- {claim 1}
+- {claim 2}
+...
+
+Return JSON of this shape:
+{
+  "contradictions": [
+    {
+      "description": "one-sentence summary of the contradiction",
+      "article_a_claim": "the specific claim from A",
+      "article_b_claim": "the specific claim from B",
+      "confidence": "high" | "medium" | "low"
+    }
+  ]
+}
+If there are no contradictions, return {"contradictions": []}.
+```
+
+The LLM call uses `task_type=TaskType.LINT` so cost lands in the existing `CostLog` rows with a distinguishable task type. The provider / model selection is handled by the router per ADR-003 and can be overridden per-request if needed.
+
+### Check: `detect_orphans`
+
+```python
+async def detect_orphans(session: AsyncSession) -> list[OrphanFinding]:
+    """SQL-only: articles with zero inbound AND zero outbound backlinks."""
+```
+
+**Algorithm** (no LLM call):
+
+1. `SELECT article.id FROM article LEFT JOIN backlink bl_in ON bl_in.target_article_id = article.id LEFT JOIN backlink bl_out ON bl_out.source_article_id = article.id WHERE bl_in.target_article_id IS NULL AND bl_out.source_article_id IS NULL`.
+2. For each returned id, build an `OrphanFinding(article_id, title)`.
+
+**Dependency note:** This query only produces meaningful results once #95 ships and the `Backlink` table is actually populated by the compiler. Before #95, the table is empty and every article is "orphaned" — the check must be **disabled** in that state. See § Gating orphan detection below.
+
+### Gating orphan detection on #95
+
+Two options for handling the #95 dependency gracefully:
+
+**Option 1 (recommended):** A `settings.linter.enable_orphan_detection: bool = False` flag, default off. Once #95 lands, flip the default to `True` in the same PR that lands #95 (or the PR right after). This keeps the linter shippable without waiting for #95 and makes the dependency explicit.
+
+**Option 2:** Runtime check: `SELECT COUNT(*) FROM backlink` at the start of `detect_orphans`; if zero, return `[]` and log a warning. Simpler but silently hides the feature's absence.
+
+This spec recommends Option 1 because it is explicit in configuration and surfaces the dependency at review time instead of hiding it in a runtime branch.
+
+### Data model
+
+Two new tables. Both use the existing `utcnow_naive` datetime helper from `src/wikimind/_datetime.py` (the project's replacement for `datetime.utcnow()` — see PRs #60-#64).
+
+```python
+# src/wikimind/models.py
+
+class LintSeverity(StrEnum):
+    """Severity level for a lint finding."""
+
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+
+
+class LintFindingKind(StrEnum):
+    """Kind of lint finding — maps 1:1 to a detection function."""
+
+    CONTRADICTION = "contradiction"
+    ORPHAN = "orphan"
+    # Future: MISSING_PAGE, STALE_CLAIM, DATA_GAP
+
+
+class LintReportStatus(StrEnum):
+    """Lifecycle of a lint report."""
+
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+class LintReport(SQLModel, table=True):
+    """One run of the linter. All findings from a run FK back to this row."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    generated_at: datetime = Field(default_factory=utcnow_naive, index=True)
+    completed_at: datetime | None = None
+    status: LintReportStatus = LintReportStatus.IN_PROGRESS
+    article_count: int = 0  # snapshot of Article count at run time
+    total_findings: int = 0
+    contradictions_count: int = 0
+    orphans_count: int = 0
+    error_message: str | None = None
+    # Link back to the Job row so the existing jobs UI can point at the report
+    job_id: str | None = Field(default=None, foreign_key="job.id", index=True)
+
+
+class LintFinding(SQLModel, table=True):
+    """One finding from one lint run."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    report_id: str = Field(foreign_key="lintreport.id", index=True)
+    kind: LintFindingKind
+    severity: LintSeverity = LintSeverity.WARN
+    # The primary article involved in the finding.
+    article_id: str | None = Field(default=None, foreign_key="article.id", index=True)
+    # For contradictions, the "other" article. Null for orphans.
+    related_article_id: str | None = Field(default=None, foreign_key="article.id")
+    # Human-readable short description shown in the UI.
+    description: str
+    # Structured data specific to the finding kind, as a JSON string.
+    # For contradictions: {"article_a_claim": "...", "article_b_claim": "...", "llm_confidence": "high"}
+    # For orphans: {}
+    # The JSON shape is documented in the typed Pydantic models in engine/linter/findings.py;
+    # the raw string storage is a compromise to avoid a separate table per finding kind.
+    raw_json: str = "{}"
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    # Dismiss state is per-finding. Dismissed findings stay in the DB but are
+    # filtered out of default queries. See § Dismiss semantics for what "dismissed"
+    # means across runs (it is NOT just "hidden in this report").
+    dismissed: bool = False
+    dismissed_at: datetime | None = None
+    # Content hash — a stable hash of (kind, article_id, related_article_id, description)
+    # used for cross-run dedup of dismissed findings. See § Dismiss semantics.
+    content_hash: str = Field(index=True)
+```
+
+**Schema additions via the lightweight migration helper:** both tables are new, so `SQLModel.metadata.create_all()` in `init_db()` creates them on startup with no migration-helper changes. Matches the `Conversation` table approach from the Ask slice.
+
+### Typed in-memory finding models
+
+In `src/wikimind/engine/linter/findings.py`, the Pydantic models returned by each check function. These are the authoritative typed shape; `raw_json` storage on `LintFinding` is a compromise for storage density, but in code the linter always operates on these typed models.
+
+```python
+class ContradictionFinding(BaseModel):
+    kind: Literal[LintFindingKind.CONTRADICTION] = LintFindingKind.CONTRADICTION
+    article_a_id: str
+    article_b_id: str
+    description: str
+    article_a_claim: str
+    article_b_claim: str
+    llm_confidence: str  # "high" | "medium" | "low" (LLM's self-assessment)
+
+
+class OrphanFinding(BaseModel):
+    kind: Literal[LintFindingKind.ORPHAN] = LintFindingKind.ORPHAN
+    article_id: str
+    article_title: str  # for display — denormalized for convenience
+```
+
+### Settings (no magic numbers)
+
+Per `CLAUDE.md`: "Keep constants configurable via Settings, not hardcoded magic numbers." Add a `LinterConfig` Pydantic submodel to `src/wikimind/config.py` and wire it into `Settings` alongside `server` and `qa`.
+
+```python
+class LinterConfig(BaseModel):
+    """Wiki linter configuration."""
+
+    # Gating — #95 dependency, see spec § Gating orphan detection
+    enable_orphan_detection: bool = False
+
+    # Contradiction detection caps
+    max_concepts_per_run: int = 25
+    max_contradiction_pairs_per_concept: int = 10
+
+    # LLM behavior
+    contradiction_llm_max_tokens: int = 1024
+    contradiction_llm_temperature: float = 0.2
+
+    # Cost budget (see § Open decisions)
+    respect_monthly_budget: bool = True
+    max_cost_per_run_usd: float = 1.00
+
+    # Caching — skip re-evaluating an article pair whose (updated_at_a, updated_at_b)
+    # has not changed since the last time we lint-scored it
+    enable_pair_cache: bool = True
+```
+
+All defaults are conservative and tunable in `.env` via `WIKIMIND_LINTER__*` prefixes, matching the existing `WIKIMIND_SERVER__*` and `WIKIMIND_QA__*` conventions.
+
+### Caching
+
+To keep steady-state cost under control, the linter caches per-pair contradiction results keyed by `(article_a.id, article_b.id, article_a.updated_at, article_b.updated_at)`. A new helper table (or a column on `LintFinding` — implementation decision) stores these cache entries. When a run encounters a pair with unchanged `updated_at` on both sides and a cache hit, it reuses the previous finding state instead of re-calling the LLM.
+
+The exact cache storage is deferred to the plan step. The conceptual guarantee is: **a lint run over a wiki where nothing has changed since the last run is zero-LLM-cost**. This matters because the weekly cron will run on mostly-static wikis most weeks.
+
+### API surface
+
+Five new endpoints. The existing stub endpoints are reshaped as compatibility shims.
+
+```text
+POST /lint/run
+    body: {} (empty)
+    returns: { report_id: str, status: "in_progress" }
+    side effects: creates a LintReport row, schedules the ARQ job, returns immediately
+
+GET /lint/reports?limit=20
+    returns: list[LintReportSummary]  # ordered by generated_at DESC
+
+GET /lint/reports/latest
+    returns: LintReportDetail  # most recent report with all (non-dismissed) findings
+    404 if no reports exist yet
+
+GET /lint/reports/{report_id}
+    returns: LintReportDetail
+    query params: ?include_dismissed=false
+
+POST /lint/findings/{finding_id}/dismiss
+    returns: { dismissed: true, finding_id: str }
+    side effect: sets dismissed=true, dismissed_at=now, and records the content_hash
+                 in a Dismiss table (see § Dismiss semantics) so future runs suppress
+                 equivalent findings automatically.
+```
+
+**Compatibility shim endpoints** (preserved because they already exist and have one in-tree caller each):
+
+```text
+POST /jobs/lint
+    DEPRECATED alias for POST /lint/run. Returns the same payload.
+    Keep for one release then remove.
+
+GET /wiki/health
+    DEPRECATED. Reshaped to return a JSON-serialized version of the latest
+    LintReportDetail, matching the old HealthReport shape as closely as
+    possible so any existing frontend caller keeps working during migration.
+    Keep for one release then remove.
+```
+
+Both shims live in their current files (`api/routes/jobs.py`, `api/routes/wiki.py`) and delegate to the new `LinterService`. The new endpoints live in a new `api/routes/lint.py`.
+
+### Service layer
+
+New file `src/wikimind/services/linter.py`:
+
+```python
+class LinterService:
+    async def trigger_run(self) -> LintReport: ...
+    async def list_reports(self, session: AsyncSession, limit: int = 20) -> list[LintReport]: ...
+    async def get_report(self, session: AsyncSession, report_id: str, *, include_dismissed: bool = False) -> LintReportDetail: ...
+    async def get_latest(self, session: AsyncSession) -> LintReportDetail: ...
+    async def dismiss_finding(self, session: AsyncSession, finding_id: str) -> LintFinding: ...
+
+
+def get_linter_service() -> LinterService: ...   # DI provider
+```
+
+The service is thin — it persists/loads rows. All check logic lives in `engine/linter/`.
+
+### Engine layer
+
+New directory `src/wikimind/engine/linter/`:
+
+```text
+src/wikimind/engine/linter/
+├── __init__.py            # re-exports run_lint, detection functions
+├── runner.py              # run_lint(session) orchestrator
+├── findings.py            # ContradictionFinding, OrphanFinding Pydantic models
+├── contradictions.py      # detect_contradictions()
+├── orphans.py             # detect_orphans()
+├── pair_cache.py          # caching helpers (if non-trivial)
+└── prompts.py             # LLM prompt constants
+```
+
+### Frontend — new components in `apps/web/src/components/health/`
+
+The placeholder directory is empty today. Six new components:
+
+| Component | Responsibility |
+|---|---|
+| `HealthView.tsx` | Page container. Two-column layout similar to `WikiExplorerView`. Top: `LintReportSummary`. Bottom: `FindingsByKindTabs`. |
+| `LintReportSummary.tsx` | Top card: last-run timestamp, total findings, counts by kind, severity breakdown, "Run lint now" button (triggers `POST /lint/run`). Re-fetches via react-query on WS `linter.alert` event. |
+| `FindingsByKindTabs.tsx` | Tab view grouping findings by kind. Default tab: Contradictions. Each tab's count appears in the tab label. |
+| `FindingCard.tsx` | One finding. Shows severity badge, description, links to involved article(s) (via `/wiki/:id`), LLM confidence chip, dismiss button. Calls `POST /lint/findings/{id}/dismiss` on dismiss. |
+| `RunLintButton.tsx` | Embedded in summary. Shows "Run lint now" when idle; "Running…" with a spinner when a report is in progress; re-enables when complete. |
+| `LintHistoryList.tsx` | Optional v1.x: sidebar list of past runs. Omit from v1 if time is tight — a single "latest report" view is enough for the MVP. |
+
+**API client changes** in `apps/web/src/api/` (new file `lint.ts` matching the existing `query.ts` / `wiki.ts` pattern):
+
+```typescript
+export interface LintReport { ... }
+export interface LintFinding { ... }
+export interface LintReportDetail { report: LintReport; findings: LintFinding[] }
+
+export async function runLint(): Promise<{ report_id: string; status: string }>;
+export async function getLatestReport(): Promise<LintReportDetail>;
+export async function getReport(id: string): Promise<LintReportDetail>;
+export async function listReports(limit?: number): Promise<LintReport[]>;
+export async function dismissFinding(id: string): Promise<{ dismissed: boolean }>;
+```
+
+**Routing** in `App.tsx`: add `<Route path="/health" element={<HealthView />} />`. **Nav link** in `Layout.tsx`: add "Health" between "Wiki" and any future right-side items, in the same style as the existing Inbox / Ask / Wiki links.
+
+**State management:** react-query for all server state. Cache keys: `["lint", "reports"]`, `["lint", "report", id]`, `["lint", "latest"]`. The WebSocket `linter.alert` event handler invalidates `["lint", "latest"]`.
+
+### Dismiss semantics
+
+A dismissed finding must stay dismissed across runs, otherwise the user plays whack-a-mole with the same contradiction every Monday morning. The design:
+
+1. When a finding is dismissed, compute `content_hash = sha256(kind | article_id | related_article_id | description)`. Store the hash in a new `DismissedFinding` table (or as a `LintFinding.content_hash` column with a dedicated query).
+2. When a new lint run produces a finding, compute the same hash. If a dismissed entry with that hash exists, mark the new finding as `dismissed=true` at write time (and `dismissed_at` = now).
+3. The `LintFinding.content_hash` column is indexed so the suppression lookup is O(log n).
+
+**Recommended table approach** (cleaner than a column+dedicated query):
+
+```python
+class DismissedFinding(SQLModel, table=True):
+    """Cross-run dismiss record — keyed by content hash."""
+
+    content_hash: str = Field(primary_key=True)
+    dismissed_at: datetime = Field(default_factory=utcnow_naive)
+    reason: str | None = None  # optional user note, v1 leaves null
+```
+
+This is cleaner because dismiss state survives even if the original `LintFinding` row is eventually garbage-collected.
+
+### Hermetic testing
+
+All linter tests must be hermetic. The LLM router is mocked at the test fixture level (same pattern as the existing Q&A tests). No real network calls. SQLite is real. ARQ is mocked by the existing fakeredis fixtures.
+
+Key test shapes:
+
+| Test | Purpose |
+|---|---|
+| `test_detect_contradictions_single_concept_with_real_contradiction` | Inject two articles with genuinely contradictory claims into a fixture concept; mock the LLM to return a contradiction; assert the finding is produced. |
+| `test_detect_contradictions_respects_pair_cap` | Inject 30 articles in one concept; assert `max_contradiction_pairs_per_concept` caps LLM calls. |
+| `test_detect_contradictions_cache_hit_skips_llm` | Run the check twice with no article changes; assert the second run makes zero LLM calls. |
+| `test_detect_orphans_returns_empty_when_backlinks_disabled` | Assert the check is a no-op when `enable_orphan_detection=False`. |
+| `test_detect_orphans_finds_article_with_no_links_when_enabled` | Inject one linked article and one unlinked article; assert only the unlinked one is in the result. |
+| `test_run_lint_creates_report_with_correct_counts` | Integration-ish: run the full pipeline with mocked LLM; assert LintReport.contradictions_count matches. |
+| `test_run_lint_sets_status_failed_on_check_exception` | Inject a raising check; assert the report ends in `FAILED` and `error_message` is populated. |
+| `test_dismiss_finding_persists_and_suppresses_on_next_run` | Dismiss a finding; re-run the linter with the same inputs; assert the new finding is auto-dismissed. |
+| `test_lint_run_endpoint_returns_in_progress_immediately` | POST /lint/run; assert the response is a report_id and status=in_progress; assert the ARQ job was scheduled. |
+
+Coverage target: 90%+ on the new `engine/linter/*` modules, 80%+ on the service and routes. The existing `make verify` 80% floor is enforced and the new code must not regress it.
+
+### Migration from the stub
+
+The existing stub in `jobs/worker.py::lint_wiki` is rewritten rather than deleted so the existing cron and `POST /jobs/lint` entry point keep working:
+
+1. The body of `lint_wiki` is replaced with: open a session, call `run_lint(session)`, done. The existing `emit_linter_alert` call still happens (now from inside `run_lint`).
+2. The existing `wiki/_meta/health.json` file is **not written anymore**. The old `GET /wiki/health` endpoint is reshaped to query the new tables instead and produce a back-compat JSON shape.
+3. The weekly cron entry stays as-is — it already calls `lint_wiki`.
+4. Any existing `health.json` on disk is orphaned. The linter does not delete it; ops can clean it up manually. One release later it stops mattering entirely.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| **Pure-SQL linter (no LLM)** | Orphans are cheap in SQL, but contradictions and missing pages fundamentally need LLM reasoning. Shipping only SQL checks would ship only the easy one. |
+| **Synchronous linter (no job queue)** | A lint pass can take minutes with dozens of LLM calls. Blocking the API request on that is wrong. Use the existing ARQ path. |
+| **Store findings as markdown in `wiki/_meta/health.md`** | Can't be queried, can't be paginated, can't be dismissed on a per-finding basis. The current stub already stores as JSON and that is already too opaque. |
+| **One mega-prompt that asks the LLM to do all checks at once** (what the stub does) | Current behavior. Rejected because (a) it caps at 50 articles or token budget explodes, (b) it produces unstructured output, (c) it can't be incrementally cached, (d) each check can't be unit-tested in isolation, (e) adding a check requires rewriting the prompt. |
+| **Auto-fix mode** (linter rewrites articles) | Blast radius too large for a v1. The user must be in the loop. Read-only v1 is the safe default. |
+| **Per-check table** (one table per finding kind instead of `LintFinding.raw_json`) | Cleaner on paper; adds 2-N migrations every time a new check is added; the query shape for "give me all findings for this report" gets ugly with UNIONs. The `raw_json` compromise is pragmatic. |
+| **Make the compiler emit contradictions at compile time** | Compiler only sees one source; it cannot compare across articles. Contradiction detection is fundamentally a cross-article operation, which is what lint is for. |
+
+## Consequences
+
+**Enables:**
+
+- **Karpathy pattern completeness.** Ingest + query + lint are the three pillars of the pattern. Shipping the linter closes the structural gap. The wiki can now self-diagnose.
+- **User trust in wiki health over time.** The single most important signal from the linter to a user of a compounding knowledge base is "your wiki is not quietly contradicting itself". Without it, the user has to re-read every compiled article to be sure.
+- **Empirical signal for Epic 3 (Knowledge Graph).** Contradictions are graph edges with a `conflict` edge type. Missing pages are candidate nodes. Orphans are disconnected components. The linter's outputs are a data source for the graph view.
+- **Structured test fixture for compiler regressions.** When a compiler prompt change introduces a contradiction with an existing article, the next lint run will catch it. This is a long-term quality ratchet.
+- **Cost-tracked LLM usage visibility.** Every lint call lands in `CostLog` with `task_type=LINT`. Users can see how much the linter costs them per week.
+
+**Constrains:**
+
+- **Orphan detection depends on #95.** Until #95 merges, orphan detection cannot produce meaningful results and is shipped disabled by config flag. This is an architectural coupling that must be honored at review time.
+- **Concept taxonomy quality determines contradiction recall.** Two genuinely contradictory articles that don't share a concept will never be compared. Concept auto-generation quality (#24) becomes a linter-blocking dependency for good recall. v1 accepts this limitation; concept quality improvements are tracked separately.
+- **LLM reliability determines precision.** LLMs hallucinate contradictions sometimes. Mitigated by showing `llm_confidence` and letting users dismiss, but the linter will produce some false positives. v1 accepts this and makes dismissal easy.
+
+**Risks:**
+
+- **Combinatorial explosion.** A wiki with 100 articles all tagged "AI" would be `100 * 99 / 2 = 4950` pairs in one concept. Mitigated by `max_contradiction_pairs_per_concept=10` cap, but aggressive sampling means some real contradictions will be missed. The cap is tunable in Settings.
+- **Cost runaway.** A lint pass over a 100-article wiki could realistically be 20-50 LLM calls on the first run, much less on subsequent runs thanks to the pair cache. Mitigated by `max_cost_per_run_usd` budget, `respect_monthly_budget` flag, and pair caching. See § Open decisions for the budget-enforcement question.
+- **False positives eroding trust.** If the first run produces 15 contradictions and 12 of them are the LLM being confused by wording differences, the user dismisses them all and stops looking. Mitigated by showing confidence, letting users dismiss once (sticky), and by the `raw_json` storing the full LLM output so the user can evaluate each finding in context. First-run experience is the critical UX moment for this feature.
+- **Dismiss-table unbounded growth.** Every dismissed finding leaves a row in `DismissedFinding` forever. Low risk in practice (users dismiss dozens, not millions) but worth noting. Garbage collection deferred.
+- **The weekly cron runs against whatever provider is default at 2am Monday.** No provider pinning. A mid-week provider swap means the next lint run uses the new provider silently. Acceptable for v1; users who care can trigger manually after a provider swap.
+
+## Open decisions — flagged for user review
+
+These should be answered in spec review, not decided autonomously:
+
+1. **Schedule.** Keep the existing weekly Monday-2am cron? Also add a manual trigger (recommended)? Add "run after every N ingests"? **Recommendation: manual trigger + keep existing weekly cron. Defer "after N ingests" to v1.x.**
+
+2. **LLM cost budgeting.** Does the linter respect `LinterConfig.respect_monthly_budget`? If the monthly budget is already near cap, does the linter (a) refuse to run, (b) run in degraded mode (fewer pairs per concept), or (c) run anyway? **Recommendation: refuse with a clear error when `respect_monthly_budget=True` and budget would be exceeded; let the user manually override by flipping the flag.**
+
+3. **Missing-page detection.** Drop from v1 entirely (recommendation) or implement it as a cheap LLM-per-article check (expensive) or defer until #95 ships and reuse the resolver (preferred if kept)? **Recommendation: drop from v1. It is the lowest-value of the three Karpathy checks we could implement (contradictions are higher value, orphans are free once #95 ships). Track as follow-up.**
+
+4. **Contradiction confidence threshold.** Persist all LLM-returned contradictions regardless of confidence? Or only `high` and `medium`? **Recommendation: persist all but filter `low` out of the default UI view; let the user toggle a "show low-confidence" checkbox. Storing them is cheap; hiding them by default is the right first impression.**
+
+5. **Dismiss semantics.** Hide forever, keyed by content hash (recommendation)? Or only hide in the current report, so the user sees the same contradiction re-filed next week? **Recommendation: hide forever via the `DismissedFinding` table. Playing whack-a-mole weekly is a feature killer.**
+
+6. **Dependency on #95.** Acceptable to ship the linter WITHOUT orphan detection if #95 is not yet merged? **Recommendation: yes. Ship v1 with contradictions only. Orphan detection is one small PR (PR C in the implementation plan) that lands the moment #95 merges. This decouples the linter's ship date from #95's ship date.**
+
+7. **Concept taxonomy quality.** Concept auto-generation (#24) is still open. How should the linter behave when no concepts exist yet? **Recommendation: fall back to running contradiction detection across the top-N articles by `updated_at`, using a single synthetic "all articles" bucket capped at `max_contradiction_pairs_per_concept`. This keeps the feature working on a concept-free wiki; it does not replace real concept taxonomies.**
+
+8. **Retention.** Keep lint reports forever? Or auto-delete after N days? **Recommendation: keep forever in v1. Addition later as `linter.report_retention_days` config if the table grows unwieldy (it won't at a weekly cadence).**
+
+9. **`LintFinding.raw_json` shape evolution.** The `raw_json` column is a compromise. Is a per-finding-kind table worth the cost later? **Recommendation: revisit only if a new check kind needs fields incompatible with the current contract. Not in v1 scope.**
+
+## Related issues
+
+Found via `gh issue list --search "lint OR health" --repo manavgup/wikimind --state open`:
+
+- **[#4 Epic 4: Health + Linter](https://github.com/manavgup/wikimind/issues/4)** — the umbrella epic this spec implements. Close or amend when the plan lands.
+- **[#26 Wiki linter — LLM-powered health audit](https://github.com/manavgup/wikimind/issues/26)** — the direct backend issue. This spec is its design doc.
+- **[#27 React UI: Health Dashboard](https://github.com/manavgup/wikimind/issues/27)** — the direct frontend issue. Implemented in PR B of the plan.
+- **[#95 Wikilinks in compiled articles are unresolved](https://github.com/manavgup/wikimind/issues/95)** — hard dependency for orphan detection; see § Gating orphan detection.
+- **[#23 Backlink extraction + graph tables](https://github.com/manavgup/wikimind/issues/23)** — adjacent; overlaps with #95's scope for the backlink producer.
+- **[#24 Concept taxonomy auto-generation](https://github.com/manavgup/wikimind/issues/24)** — affects contradiction recall quality, not a hard blocker.
+
+## Definition of done
+
+- [ ] PR A (backend, data model + contradictions): new tables migrate cleanly, `detect_contradictions` unit-tested with mocked LLM, `run_lint` integration test passes, `POST /lint/run` + `GET /lint/reports/latest` live, stub `lint_wiki` rewritten to call `run_lint`, old `GET /wiki/health` reshaped to return new-model data.
+- [ ] PR B (frontend health view): `HealthView` reachable at `/health`, summary card and findings list render real data from PR A, "Run lint now" button works, dismiss button works, WS `linter.alert` triggers re-fetch.
+- [ ] PR C (orphan detection, gated on #95): `detect_orphans` added, `enable_orphan_detection` flag flipped to `True` in the same PR that lands #95.
+- [ ] PR D (scheduling polish, optional): richer cron config; currently the existing weekly cron is kept as-is.
+- [ ] `make verify` green on every PR. Coverage floor maintained.
+- [ ] All open decisions in § Open decisions answered in review and recorded in the PR descriptions.
+- [ ] `docs/openapi.yaml` regenerated by the doc-sync hook.
+- [ ] Epic #4 closed, #26 closed, #27 closed (PR B), #95 unblocks PR C.

--- a/docs/superpowers/specs/2026-04-08-wikilink-resolution-design.md
+++ b/docs/superpowers/specs/2026-04-08-wikilink-resolution-design.md
@@ -1,0 +1,288 @@
+# Wikilink Resolution — Design
+
+**Date:** 2026-04-08
+**Status:** Draft — pending user review
+**Author:** Design session against issues manavgup/wikimind#95 and #96
+**Related issues:** #95 (wikilinks 404), #96 (slug divergence), Epic 3 (knowledge graph)
+
+## Context
+
+Every `[[wikilink]]` in a compiled article currently 404s (issue #95). The compiler's JSON prompt contract asks the LLM for a `backlink_suggestions` list of "related concepts that likely exist in the wiki" (`src/wikimind/engine/compiler.py:52`) and the compiler writes those titles verbatim into the "Related" section as `[[Title]]` markdown (`src/wikimind/engine/compiler.py:333`). Nothing verifies that the target exists, no `Backlink` row is created, and the React `ArticleReader` then slugifies the link text client-side and fetches `/wiki/articles/{slug}`, which fails for two reasons: (a) the LLM hallucinates titles that were never compiled, and (b) even when a target exists, the frontend's homemade regex slugifier and the backend's `python-slugify` library disagree on unicode, underscores, and apostrophes — the slug divergence tracked as #96. The user-visible impact is that the "Related" section is entirely broken: every link is a dead link, there are no real backlinks anywhere in the knowledge base, and the primitive Epic 3 (knowledge graph view) depends on — real `Backlink` rows the compiler does not currently emit.
+
+## Current state
+
+| Concern | Location |
+|---|---|
+| LLM prompt asks for `backlink_suggestions` strings | `src/wikimind/engine/compiler.py:52` |
+| Compiler writes verbatim `[[title]]` to markdown "Related" section | `src/wikimind/engine/compiler.py:333` (inside `_write_article_file`) |
+| `Backlink` SQLModel table **already exists** (composite PK `source_article_id` + `target_article_id`, optional `context` snippet) | `src/wikimind/models.py:157` |
+| `Backlink` has NO `id` field — composite primary key is `(source_article_id, target_article_id)` | `src/wikimind/models.py:160-162` |
+| Compiler **never writes `Backlink` rows** — grep `session.add(Backlink(...))` returns nothing | codebase-wide |
+| Slug-based article lookup — the only way to resolve a link from the frontend today | `src/wikimind/services/wiki.py:177` (backed by route `src/wikimind/api/routes/wiki.py:26`) |
+| Frontend client-side slugifier (diverges from backend `python-slugify`) | `apps/web/src/components/wiki/ArticleReader.tsx:19-25` |
+| Frontend `data-wikilink` attribute hack + custom anchor renderer | `apps/web/src/components/wiki/ArticleReader.tsx:33-40`, `:77-101` |
+| `CompilationResult.backlink_suggestions: list[str]` Pydantic field | `src/wikimind/models.py:290` |
+
+Key finding: **the `Backlink` model already exists but is never populated**. The compiler-save path (`Compiler._create_article` and `Compiler._replace_article_in_place` in `compiler.py`) writes the markdown file and commits an `Article` row, and nothing else. The knowledge graph endpoint `WikiService.get_graph` (`services/wiki.py:222`) reads from the `Backlink` table — it has been returning an empty edge set since day one.
+
+## Goals
+
+1. Every `[[wikilink]]` rendered in an article body is either (a) a clickable link to an existing article or (b) visually marked as unresolved and non-clickable. No more silent 404s.
+2. Resolved links produce **real `Backlink` rows** in the database at compile time. The knowledge graph primitive that Epic 3 needs becomes populated on the very next compile.
+3. The frontend stops doing client-side slugification. Resolved links travel by article ID, not by slug — sidesteps issue #96 entirely.
+4. Both issue #95 (broken wikilinks) and issue #96 (slug divergence) are closed by this work. #96 becomes subsumed: if the frontend never slugifies, the two slugifiers can never drift.
+5. The compiler's prompt contract is **unchanged**. The LLM keeps asking for `backlink_suggestions` exactly as today. Only the post-processing of its output changes.
+6. The resolution algorithm is **deterministic**. Given the same set of articles and the same candidate list, resolution produces the same result every time. No fuzzy thresholds, no embedding lookups, no LLM-in-the-loop.
+
+## Non-goals
+
+- **Does NOT implement the knowledge graph visualization.** Epic 3 builds on top of the `Backlink` rows this work produces; it is not part of this PR.
+- **Does NOT implement Obsidian-style "create new note on dead-link click".** Dead links are visually marked and non-interactive. A future feature can make them clickable and open a "create new article" flow; this PR does not.
+- **Does NOT change the compiler's prompt contract fundamentally.** The LLM still returns `backlink_suggestions: list[str]`. We add post-processing of that output. We do not ask the LLM for richer candidates (entities + relation types, semantic embeddings, etc) — that is a separate brainstorming session if ever.
+- **Does NOT do fuzzy matching.** No Levenshtein, no trigrams, no edit distance. The false-positive risk in a knowledge base (where two articles can have near-identical titles and different meanings) is too high.
+- **Does NOT do embedding-based matching.** Scope creep into Epic 3/5 retrieval work.
+- **Does NOT retroactively fix every existing article's wikilinks on deploy.** See "Backfill strategy" below for the three options; one is picked in review.
+- **Does NOT introduce a new LLM call.** Resolution is a pure function of (candidate strings, existing article titles). Zero cost, zero latency, zero network.
+
+## Design
+
+### Compiler post-processing pipeline
+
+Today, `Compiler._create_article` and `Compiler._replace_article_in_place` each do: generate slug → write markdown file via `_write_article_file` → commit an `Article` row. We insert a resolution step between "compile" and "write markdown":
+
+```text
+LLM returns CompilationResult (unchanged)
+        ↓
+resolve_backlink_candidates(result.backlink_suggestions, session)
+        ↓
+(resolved: list[ResolvedBacklink], unresolved: list[str])
+        ↓
+_write_article_file(result, source, slug, resolved, unresolved)
+        ↓
+For each resolved ref: session.add(Backlink(source_article_id=new_article.id,
+                                           target_article_id=ref.target_id,
+                                           context=ref.candidate_text))
+        ↓
+commit
+```
+
+The new type:
+
+```python
+@dataclass(frozen=True)
+class ResolvedBacklink:
+    candidate_text: str  # What the LLM said — preserved verbatim for display
+    target_id: str       # The Article.id this resolved to
+    target_title: str    # The Article.title (canonical spelling, for rendering)
+```
+
+`ResolvedBacklink` is a plain dataclass in `src/wikimind/engine/wikilink_resolver.py` (new file), NOT a SQLModel and NOT stored — it is purely a resolution-pipeline carrier.
+
+### Resolution algorithm — two stages, no fuzzy
+
+**Stage 1: exact case-insensitive match.**
+
+For each candidate string, look up `Article` where `LOWER(title) == LOWER(candidate)`. If exactly one match: resolve to it. If zero matches: go to Stage 2. If multiple matches (shouldn't happen today because `Article.slug` is unique but `Article.title` is not): pick the one with the earliest `created_at` — deterministic tiebreak.
+
+**Stage 2: normalized match — the #96 fix.**
+
+Both the candidate and every existing `Article.title` are passed through a single shared normalizer function:
+
+```python
+def normalize_title(s: str) -> str:
+    """Canonicalize a title for wikilink resolution.
+
+    Lowercases, strips non-alphanumeric characters except hyphens,
+    collapses whitespace to single hyphens. Underscores become hyphens.
+    Unicode is NFKD-normalized and stripped to ASCII.
+    """
+```
+
+Match if `normalize_title(candidate) == normalize_title(article.title)`. Same tiebreak as Stage 1 (earliest `created_at`) if multiple articles share a normalized form.
+
+**No Stage 3.** If both stages fail, the candidate is unresolved. That is the final answer. No Levenshtein. No "did you mean". No LLM fallback.
+
+Rationale for no fuzzy matching: in a knowledge base, "Machine Learning" and "Machine Learning Ops" are different articles. "React" and "React Native" are different articles. Any similarity threshold tight enough to avoid false positives at that scale is tight enough to reject the same-article variants we actually want to catch, so fuzzy buys nothing over exact+normalized.
+
+### The single normalizer — drift prevention
+
+`normalize_title` lives in a new module `src/wikimind/engine/title_normalizer.py`. It is imported from **exactly one place**. The compiler imports it. Any future code that needs to compare titles (a runtime resolver, the knowledge graph builder, a search feature) imports it from the same module. There is no second normalizer anywhere in the codebase.
+
+This is the #96 fix. Issue #96 exists because the frontend had one slugifier and the backend had another. The solution is not "keep them in sync" — the solution is "delete one of them". The frontend's `slugify()` helper in `ArticleReader.tsx:19-25` gets deleted entirely; there is no second implementation to diverge from.
+
+### Storage — where do resolution results live?
+
+**Resolved candidates become `Backlink` rows.** The existing `Backlink` model is used as-is (composite PK `(source_article_id, target_article_id)`, optional `context`). For each `ResolvedBacklink` returned by the resolver, the save path creates one `Backlink` row with:
+- `source_article_id` = the new Article's ID
+- `target_article_id` = `resolved.target_id`
+- `context` = `resolved.candidate_text` (the raw string the LLM produced, kept for display and debugging)
+
+Because `Backlink` uses a composite PK, duplicate (source, target) pairs are rejected by SQLite automatically — useful if a future Stage 2 refactor would otherwise emit two `Backlink` rows for two candidate strings that both resolve to the same target. The save path must catch `IntegrityError` on the composite key and skip the duplicate.
+
+**Unresolved candidates: where do they go?** Three options considered:
+
+| Option | Storage | Pros | Cons |
+|---|---|---|---|
+| **A** | JSON column on `Article` row — `unresolved_backlinks TEXT` (JSON array) | Queryable, survives round trip from disk | New schema column, new migration, one more field to keep in sync with the disk markdown |
+| **B** | New `UnresolvedBacklink` table with `(article_id, candidate_text)` rows | Cleanest relational model, easy to query "what candidates never resolved across my wiki" | Whole new table for data that is essentially a TODO list, more surface for bugs, Epic 3 doesn't need it |
+| **C** | **Not persisted at all.** The markdown body contains the unresolved `[[Title]]` text, the frontend renders it as a dimmed span, done. | Zero schema change. Single source of truth (the .md file). Re-compiling an article re-derives unresolved state from the same .md output. Trivial to revisit later if we decide we DO want querying. | Can't write a SQL query like "show me all dead links in the wiki" without scanning markdown files |
+
+**Recommendation: Option C.** For a v1 that closes the loop, persisting unresolved candidates buys us nothing the markdown body doesn't already carry. The incremental-sweep backfill job (option B3 below) is the natural place to resolve old unresolved links over time — and it only needs the markdown text, not a separate table. Flagged as an open decision in case the user wants A or B for future flexibility.
+
+### Markdown generation — the "Related" section format
+
+Two options considered:
+
+**Option A — custom marker syntax.** Emit `[[Title|resolved]]` vs `[[Title|unresolved]]`. Requires a custom parser on the frontend (react-markdown doesn't understand the `|resolved` suffix). Keeps Obsidian-style brackets for both cases.
+
+**Option B — standard markdown link for resolved, Obsidian brackets for unresolved.** Emit `[Title](/wiki/<article_id>)` for resolved, `[[Title]]` for unresolved. react-markdown renders the former as a native `<a>` tag with zero custom code. The latter is picked up by a simple pre-processor on the frontend that converts unresolved `[[...]]` to a dimmed span before react-markdown ever sees it.
+
+**Recommendation: Option B.** Standard markdown links work natively with react-markdown and remark-gfm (both already in the deps). No custom parser. No `data-wikilink` attribute hack. The only frontend code is a one-line preprocessing regex that replaces `[[Foo]]` with `<span class="wikilink-unresolved" title="not yet in wiki">Foo</span>`.
+
+**The "Related" section is rebuilt from resolution output, not the raw LLM list.** In `_write_article_file`, the `backlinks` block becomes:
+
+```python
+# Inside _write_article_file, replacing the current line 333:
+related_lines: list[str] = []
+for rb in resolved_backlinks:
+    related_lines.append(f"- [{rb.candidate_text}](/wiki/{rb.target_id})")
+for text in unresolved_backlinks:
+    related_lines.append(f"- [[{text}]]")
+backlinks = "\n".join(related_lines)
+```
+
+The resolved-link URL uses the **article ID**, not the slug. This is the permanent sidestep of issue #96: the slug is no longer a public identifier that travels through markdown → frontend → backend. The ID is. Slugs remain the human-facing part of the URL bar (via the `/wiki/{id_or_slug}` route below), but they no longer appear in article bodies.
+
+### Backend: article lookup accepts ID or slug
+
+The existing `WikiService.get_article(slug)` at `services/wiki.py:177` is modified to try ID first, then fall back to slug:
+
+```python
+async def get_article(self, id_or_slug: str, session: AsyncSession) -> ArticleResponse:
+    # Try ID first (UUID format, set by default_factory in the model)
+    result = await session.execute(select(Article).where(Article.id == id_or_slug))
+    article = result.scalar_one_or_none()
+    if article is None:
+        # Fall back to slug — preserves backward compat with existing bookmarks
+        result = await session.execute(select(Article).where(Article.slug == id_or_slug))
+        article = result.scalar_one_or_none()
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+    # ... rest unchanged
+```
+
+The route path parameter is renamed from `slug` to `id_or_slug` for clarity; the URL pattern stays the same (`/wiki/articles/{id_or_slug}`). No new route is added. This is a pure superset — any existing slug-based URL continues to work, and any new ID-based URL from a resolved wikilink also works.
+
+### Frontend changes
+
+`apps/web/src/components/wiki/ArticleReader.tsx`:
+
+1. **Delete the local `slugify()` helper** (lines 19-25). No replacement. The frontend no longer slugifies anything.
+2. **Delete the `data-wikilink` attribute hack** in `preprocessMarkdown` (lines 36-39). Replace with a simpler preprocessor that only handles unresolved brackets:
+   ```typescript
+   function preprocessMarkdown(content: string): string {
+     return content
+       .replace(FRONTMATTER_REGEX, "")
+       .replace(WIKILINK_REGEX, (_, target: string) => {
+         const safe = escapeHtml(target.trim());
+         return `<span class="wikilink-unresolved" title="Article not yet in wiki">${safe}</span>`;
+       });
+   }
+   ```
+3. **Simplify the custom anchor renderer** (lines 77-101). The `wikilink` branch is deleted. Resolved wikilinks now arrive as ordinary `<a href="/wiki/{id}">` tags produced by react-markdown from `[text](/wiki/{id})`. The only custom logic left is the `target="_blank"` for external links, which is still needed for `http://` hrefs but NOT for `/wiki/…` hrefs — the renderer detects internal vs external by path prefix.
+4. **Internal links use React Router `<Link>`**, not raw `<a>`, so navigation is client-side. The check is `href?.startsWith("/wiki/")`.
+5. **Add a small CSS rule** for `.wikilink-unresolved`: dim color, dotted underline, `cursor: help` (or similar). Lives in the Tailwind class via an `@apply` directive, or inline via a Tailwind class string, matching the existing style conventions for `apps/web/src/index.css`.
+
+The result: `ArticleReader.tsx` shrinks. Fewer lines, fewer moving parts, and the resolved-link path runs through a standard react-markdown render with zero custom attribute plumbing.
+
+### Backfill strategy — the architectural decision flagged for the user
+
+This is the one design call I am explicitly NOT making in this spec. Three options, each with different PR-level impact:
+
+#### Option B1 — Re-compile every existing article on next deploy
+
+Walk every `Article` row, re-run the compiler on the original `Source`, let the normal save path produce resolved wikilinks and `Backlink` rows.
+
+- **Pro:** Clean knowledge graph on day one. Every link is either resolved or consciously unresolved.
+- **Con:** LLM cost (every article re-compiled). `updated_at` timestamps change on every row. `content_hash` / provider-based deduplication fingerprints may invalidate. Users see the entire wiki "refresh" with no visible benefit to most articles.
+- **PR-level impact:** +1 new job in `src/wikimind/jobs/`, +1 startup hook (or manual admin endpoint). Testing surface grows. Not small.
+
+#### Option B2 — Forward only
+
+New articles get real backlinks. Existing articles keep their unresolved `[[Title]]` text until they happen to be re-ingested for another reason.
+
+- **Pro:** Zero disruption. Zero LLM cost. Deterministic. Simplest possible rollout.
+- **Con:** The knowledge graph starts sparse (Epic 3's graph view shows near-empty edges for the first week or two). Existing articles' "Related" sections stay broken forever for users who never re-ingest.
+- **PR-level impact:** Zero. This is the "do nothing extra" option.
+
+#### Option B3 — Incremental resolution sweep (recommended long term)
+
+Add a background job `wikilink_resolution_sweep` (new file in `src/wikimind/jobs/`) that walks existing articles, reads each `.md` file, finds the `[[Title]]` tokens, runs them through the exact same `resolve_backlink_candidates()` function, and — if resolution succeeds now for a link that used to be unresolved — rewrites that one line in the .md file AND creates a `Backlink` row. No LLM call. Pure deterministic resolution against the current `Article` table.
+
+- **Pro:** Eventually-consistent knowledge graph. No LLM cost. Re-runnable on a timer (e.g. every ingestion, or nightly). When a user adds an article titled "Quantum Computing", every prior article that linked `[[Quantum Computing]]` as unresolved gets its link upgraded automatically on the next sweep.
+- **Con:** Most code of the three options. New job, new tests, new scheduling decision. May miss nuanced context the LLM had when it originally produced the candidate (but since we're only promoting EXACT and NORMALIZED matches, "nuance" shouldn't matter).
+- **PR-level impact:** Moderate. New job module, new tests, a small hook in the ingest-complete signal. But orthogonal to this spec's main work — the sweep job can be a separate follow-up PR.
+
+**Recommendation: B3 as the right long-term answer.** Best of both: no disruption at deploy time, no LLM cost, and the graph fills in as the wiki grows without any user action. But it is the most code, and it is reasonable to ship **B2 in this PR** and file B3 as a follow-up issue.
+
+**Flagged as user-facing decision** in the open-decisions section below.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| **Client-side resolution** — fetch the full article list once, do title matching in JS | Doesn't scale past a few hundred articles (pulls the entire article index on every article render). Keeps the render-time resolution bug — the fix needs to happen at compile time so that `Backlink` rows get created. |
+| **LLM-in-the-loop resolution** — ask the LLM "which of these existing articles does this link refer to" | Too expensive (one LLM call per wikilink per article), too slow (compile time doubles), and introduces non-determinism into a step that should be pure. |
+| **Fuzzy matching with Levenshtein or trigrams** | False-positive risk is too high for a knowledge base. "React" → "React Native" looks fuzzy-close and is semantically distinct. Any threshold tight enough to avoid that is equivalent to exact match. |
+| **Embedding-based matching** | Scope creep into Epic 3 (graph building) and Epic 5 (retrieval overhaul). Also introduces a dependency on the embedding model being stable across runs. Reconsider when embeddings land for retrieval anyway. |
+| **Change the prompt contract to ask the LLM for structured entities + relation types** | Much bigger change. Requires a Pydantic schema change, prompt validation updates, and retraining every downstream code path that consumes `CompilationResult`. Does not address the core bug (which is post-processing, not prompt quality). |
+| **Drop the `[[Title]]` syntax and stop producing wikilinks altogether** | Loses the entire "related concepts" affordance in the reader. The feature is user-valuable when it works. |
+
+## Consequences
+
+**Enables:**
+
+- Real `Backlink` rows in the database on every new compile. Epic 3's knowledge graph view becomes feasible; `WikiService.get_graph` stops returning an empty edge set.
+- Obsidian-style dead-link UX. Users can see what's missing from the wiki and know which concepts the LLM is waiting for them to document.
+- Deterministic, testable resolution. No flaky "sometimes it matches" behavior.
+- A clean slug-or-ID lookup on the backend. External bookmarks to slugs still work; new internal links use stable IDs.
+
+**Constrains:**
+
+- New articles with novel titles create temporary dead links until a future article fills the gap. Acceptable — the dead links are visually distinct, not silent 404s.
+- The normalizer is now a piece of critical infrastructure. Changing it changes which links resolve, which could cause spurious churn in `Backlink` rows. Mitigation: the normalizer's tests cover all edge cases (unicode, underscores, apostrophes, long titles), and any future change must preserve the contract or bump a version.
+
+**Risks:**
+
+- **Title normalizer drift** — if a second normalizer appears anywhere in the codebase, the bug from #96 comes back in a new disguise. Mitigation: single function in a single module, imported from exactly one place. A lint rule or a grep check in CI could enforce "only `title_normalizer.py` implements title normalization".
+- **Duplicate `Backlink` rows** — two candidates ("React" and "react") both resolve to the same target. The composite PK prevents inserting duplicates, but the save path must catch `IntegrityError` and skip. Covered by a test.
+- **Backfill strategy choice affects rollout** — B2 means existing wikis stay broken until the user decides to act. B3 ships the fix but needs more code. The user decides.
+- **A candidate that resolves to the CURRENT article** — e.g. the LLM suggests a backlink to the article it's currently compiling. The resolver must filter this out (a self-loop is not a meaningful backlink). Covered by a test. Note that at save time the article does not yet have an ID, so this is enforced by: (a) passing the new article's eventual ID/title into `resolve_backlink_candidates`, or (b) filtering `where Article.id != new_article.id` inside the resolver. Implementation detail for the plan.
+
+## Open decisions for the user
+
+1. **Backfill strategy: B1, B2, or B3?**
+   - B1 = re-compile all existing articles (LLM cost, disruption, cleanest graph)
+   - B2 = forward only, ship this PR as-is (no cost, graph fills in slowly as users re-ingest)
+   - **B3 = incremental sweep job (recommended long term; most code)**
+   - Suggestion: **ship B2 in this PR, file B3 as a follow-up issue.** Clean separation, no blocker.
+
+2. **Persist unresolved backlinks?**
+   - Option A: JSON column on Article — queryable but adds schema.
+   - Option B: New `UnresolvedBacklink` table — cleanest model, more surface.
+   - **Option C: not persisted — the markdown body IS the record. (Recommended.)**
+
+3. **Should the compiler prompt contract change to ask for richer candidates (entities + relation types)?**
+   - Probably no — the existing `backlink_suggestions` list is adequate for the resolution pipeline and the LLM doesn't need to know about article IDs or link types. But worth explicitly confirming.
+
+4. **Should the unresolved-link span style be purely visual, or should it trigger a "propose to add this article" affordance?**
+   - v1 should be visual only — dim, non-clickable, tooltip. A "propose new article" flow is a separate feature and expands scope.
+
+5. **Route parameter rename.** The existing route `GET /wiki/articles/{slug}` (and its service method) gets its path parameter renamed from `slug` to `id_or_slug`. This is a documentation change — no URL pattern change — but `docs/openapi.yaml` will be regenerated. Confirm that's acceptable; it is the intended meaning.
+
+## Related issues
+
+- **#95** — closed by this work (primary fix).
+- **#96** — subsumed and closed by this work (no more second slugifier to drift against).
+- **Epic 3 (knowledge graph view)** — unblocked by this work. The first compile after this PR ships produces real `Backlink` rows, and `WikiService.get_graph` will return a populated edge list for the first time.
+- **Follow-up issue (to be filed):** incremental `wikilink_resolution_sweep` job — option B3 from the backfill section. Scope-separated into its own PR so the main fix can ship immediately.

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -23,14 +23,14 @@ async def list_articles(
     return await service.list_articles(session, concept=concept, confidence=confidence, limit=limit, offset=offset)
 
 
-@router.get("/articles/{slug}", response_model=ArticleResponse)
+@router.get("/articles/{id_or_slug}", response_model=ArticleResponse)
 async def get_article(
-    slug: str,
+    id_or_slug: str,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
 ):
-    """Get full article with content, backlinks, and source provenance."""
-    return await service.get_article(slug, session)
+    """Get full article by ID or slug, with content, backlinks, and source provenance."""
+    return await service.get_article(id_or_slug, session)
 
 
 @router.get("/graph", response_model=GraphResponse)

--- a/src/wikimind/engine/title_normalizer.py
+++ b/src/wikimind/engine/title_normalizer.py
@@ -1,0 +1,58 @@
+"""Single source of truth for title normalization.
+
+This is the only title normalizer in the entire WikiMind codebase. Any
+code that needs to compare article titles — the wikilink resolver, the
+knowledge graph builder, future search features — MUST import
+``normalize_title`` from this module. Do NOT add a second normalizer
+anywhere else. Doing so will reintroduce the slug-divergence bug tracked
+in issue #96.
+
+The algorithm is intentionally simple:
+    1. Unicode NFKD decomposition + ASCII strip (so "Café" → "Cafe").
+    2. Lowercase.
+    3. Strip apostrophes entirely, so "it's" → "its" (not "it-s").
+       Both ASCII and Unicode right single quotation mark (U+2019).
+    4. Replace every run of non-alphanumeric characters (except hyphens)
+       with a single hyphen. Underscores count as non-alphanumeric.
+    5. Strip leading and trailing hyphens.
+    6. Collapse consecutive hyphens to one.
+
+The output is suitable for exact-match comparison: two strings produce
+the same output iff they normalize to the same canonical form.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+_NON_ALNUM_HYPHEN = re.compile(r"[^a-z0-9-]+")
+_MULTI_HYPHEN = re.compile(r"-{2,}")
+
+
+def normalize_title(s: str) -> str:
+    """Canonicalize a title for wikilink resolution.
+
+    Args:
+        s: Raw title string. May be empty, contain unicode, contain
+           punctuation, contain mixed whitespace.
+
+    Returns:
+        A lowercase ASCII string containing only ``[a-z0-9-]``. Empty
+        input yields an empty string.
+    """
+    # 1. Unicode → ASCII (NFKD normalizes U+2019 to ASCII "'" along with
+    #    other compatibility characters; the apostrophe strip in step 3
+    #    then removes it).
+    ascii_form = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    # 2. Lowercase
+    lower = ascii_form.lower()
+    # 3. Strip apostrophes before hyphenation so "Karpathy's" → "karpathys",
+    #    not "karpathy-s". Matches the documented contract in the unit tests.
+    no_apostrophes = lower.replace("'", "")
+    # 4. Replace runs of non-alnum-non-hyphen with a single hyphen
+    hyphenated = _NON_ALNUM_HYPHEN.sub("-", no_apostrophes)
+    # 5. Strip leading/trailing hyphens
+    stripped = hyphenated.strip("-")
+    # 6. Collapse consecutive hyphens
+    return _MULTI_HYPHEN.sub("-", stripped)

--- a/src/wikimind/engine/wikilink_resolver.py
+++ b/src/wikimind/engine/wikilink_resolver.py
@@ -1,0 +1,116 @@
+"""Resolve LLM-suggested wikilink candidates against the Article table.
+
+Given a list of candidate title strings (as produced by the compiler
+LLM in ``CompilationResult.backlink_suggestions``) and an async DB
+session, return two lists:
+
+    - ``resolved``: :class:`ResolvedBacklink` rows, each pointing at a
+      real :class:`Article` by ID.
+    - ``unresolved``: candidate strings that matched no article.
+
+The algorithm is deterministic and has exactly two stages:
+
+    1. Exact case-insensitive match against ``Article.title``.
+    2. Normalized match using :func:`normalize_title` on both sides.
+
+There is NO fuzzy matching. See the design spec for rationale
+(docs/superpowers/specs/2026-04-08-wikilink-resolution-design.md).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.engine.title_normalizer import normalize_title
+from wikimind.models import Article
+
+
+@dataclass(frozen=True)
+class ResolvedBacklink:
+    """A successfully resolved wikilink candidate.
+
+    Attributes:
+        candidate_text: The raw string the LLM produced. Preserved
+            verbatim so the rendered markdown can show the LLM's
+            wording if it differs from the canonical title.
+        target_id: The :class:`Article.id` this candidate resolved to.
+        target_title: The canonical :class:`Article.title` of the
+            resolved article. Used by the compiler's markdown writer.
+    """
+
+    candidate_text: str
+    target_id: str
+    target_title: str
+
+
+async def resolve_backlink_candidates(
+    candidates: list[str],
+    session: AsyncSession,
+    exclude_article_id: str | None = None,
+) -> tuple[list[ResolvedBacklink], list[str]]:
+    """Resolve wikilink candidates against the Article table.
+
+    Args:
+        candidates: Raw title strings from
+            :attr:`CompilationResult.backlink_suggestions`. Empty
+            strings and whitespace-only strings are silently dropped.
+        session: Async DB session.
+        exclude_article_id: If set, any candidate that would resolve
+            to this article ID is treated as unresolved. Used by the
+            compiler to prevent self-references when an article is
+            suggested to link to itself.
+
+    Returns:
+        A tuple ``(resolved, unresolved)``. Resolved contains one
+        :class:`ResolvedBacklink` per unique target article (so two
+        candidates pointing at the same article produce one row).
+        Unresolved is the list of candidate strings that matched no
+        article, in input order.
+    """
+    # Drop empty / whitespace-only candidates up front.
+    cleaned = [c.strip() for c in candidates if c and c.strip()]
+    if not cleaned:
+        return [], []
+
+    # Load every Article once. For a single-user personal wiki this is
+    # fine — we expect O(hundreds) of articles at most. If this ever
+    # becomes a bottleneck, narrow the SELECT to (id, title, created_at).
+    result = await session.execute(select(Article).order_by(Article.created_at))  # type: ignore[arg-type]
+    all_articles: list[Article] = list(result.scalars().all())
+    if exclude_article_id is not None:
+        all_articles = [a for a in all_articles if a.id != exclude_article_id]
+
+    # Build lookup dicts once per call. Both map canonical form → first article.
+    by_lower: dict[str, Article] = {}
+    by_normalized: dict[str, Article] = {}
+    for article in all_articles:
+        lower_key = article.title.lower()
+        if lower_key not in by_lower:
+            by_lower[lower_key] = article
+        norm_key = normalize_title(article.title)
+        if norm_key and norm_key not in by_normalized:
+            by_normalized[norm_key] = article
+
+    resolved_by_target: dict[str, ResolvedBacklink] = {}
+    unresolved: list[str] = []
+    for candidate in cleaned:
+        target = by_lower.get(candidate.lower())
+        if target is None:
+            norm = normalize_title(candidate)
+            if norm:
+                target = by_normalized.get(norm)
+        if target is None:
+            unresolved.append(candidate)
+            continue
+        # Dedup: two candidates resolving to the same target → one entry.
+        if target.id not in resolved_by_target:
+            resolved_by_target[target.id] = ResolvedBacklink(
+                candidate_text=candidate,
+                target_id=target.id,
+                target_title=target.title,
+            )
+
+    return list(resolved_by_target.values()), unresolved

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -174,8 +174,13 @@ class WikiService:
         articles = list(result.scalars().all())
         return [await _build_article_summary(a, session) for a in articles]
 
-    async def get_article(self, slug: str, session: AsyncSession) -> ArticleResponse:
-        """Retrieve a full article by slug, including content, backlinks, and sources.
+    async def get_article(self, id_or_slug: str, session: AsyncSession) -> ArticleResponse:
+        """Retrieve a full article by ID or slug.
+
+        Tries the article's UUID first (resolved wikilinks travel by ID
+        via the ``[text](/wiki/<id>)`` markdown format). Falls back to
+        slug lookup for backward compatibility with external bookmarks
+        and the human-facing URL bar.
 
         The returned response embeds full :class:`SourceResponse` records
         for every raw source the article was compiled from. Sources that
@@ -183,17 +188,22 @@ class WikiService:
         are silently omitted.
 
         Args:
-            slug: The article URL slug.
+            id_or_slug: Either an ``Article.id`` UUID or an ``Article.slug``.
             session: Async database session.
 
         Returns:
             :class:`ArticleResponse` with content, backlink, and source data.
 
         Raises:
-            HTTPException: If the article is not found.
+            HTTPException: If no article matches either lookup.
         """
-        result = await session.execute(select(Article).where(Article.slug == slug))
+        # Try ID first
+        result = await session.execute(select(Article).where(Article.id == id_or_slug))
         article = result.scalar_one_or_none()
+        if article is None:
+            # Fall back to slug
+            result = await session.execute(select(Article).where(Article.slug == id_or_slug))
+            article = result.scalar_one_or_none()
         if not article:
             raise HTTPException(status_code=404, detail="Article not found")
 

--- a/tests/unit/test_title_normalizer.py
+++ b/tests/unit/test_title_normalizer.py
@@ -1,0 +1,68 @@
+"""Tests for the single shared title normalizer."""
+
+import pytest
+
+from wikimind.engine.title_normalizer import normalize_title
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Baseline
+        ("Machine Learning", "machine-learning"),
+        ("machine learning", "machine-learning"),
+        ("MACHINE LEARNING", "machine-learning"),
+        # Whitespace variants collapse
+        ("Machine   Learning", "machine-learning"),
+        ("  Machine Learning  ", "machine-learning"),
+        ("Machine\tLearning", "machine-learning"),
+        ("Machine\nLearning", "machine-learning"),
+        # Underscores become hyphens
+        ("machine_learning", "machine-learning"),
+        ("Machine_Learning_Ops", "machine-learning-ops"),
+        # Punctuation stripped
+        ("Machine Learning!", "machine-learning"),
+        ("Machine Learning?", "machine-learning"),
+        ("Machine Learning.", "machine-learning"),
+        ("Machine, Learning", "machine-learning"),
+        # Apostrophes stripped, not preserved as hyphens
+        ("Karpathy's wiki pattern", "karpathys-wiki-pattern"),
+        ("it's", "its"),
+        # Unicode NFKD + ASCII strip
+        ("Café", "cafe"),
+        ("naïve", "naive"),
+        ("Zürich", "zurich"),
+        # Hyphens preserved
+        ("state-of-the-art", "state-of-the-art"),
+        # Multiple consecutive separators collapse
+        ("foo   ---   bar", "foo-bar"),
+        ("foo___bar", "foo-bar"),
+        # Long titles are not truncated (the resolver does not care about length)
+        ("a" * 200, "a" * 200),
+        # Numbers preserved
+        ("GPT-4o", "gpt-4o"),
+        ("Article 1", "article-1"),
+        # Empty and whitespace-only
+        ("", ""),
+        ("   ", ""),
+        # Symbols dropped
+        ("C++", "c"),
+        ("C#", "c"),
+    ],
+)
+def test_normalize_title(raw: str, expected: str) -> None:
+    assert normalize_title(raw) == expected
+
+
+def test_normalize_title_is_idempotent() -> None:
+    """Normalizing an already-normalized string is a no-op."""
+    once = normalize_title("Machine Learning Operations")
+    twice = normalize_title(once)
+    assert once == twice
+
+
+def test_normalize_title_deterministic() -> None:
+    """Two calls with the same input produce identical output."""
+    a = normalize_title("Karpathy's LLM Wiki Pattern")
+    b = normalize_title("Karpathy's LLM Wiki Pattern")
+    assert a == b

--- a/tests/unit/test_wiki_service.py
+++ b/tests/unit/test_wiki_service.py
@@ -124,3 +124,40 @@ class TestArticleProvenance:
         response = await service.get_article("no-source-article", db_session)
 
         assert response.sources == []
+
+    async def test_get_article_by_id_returns_article(self, db_session, tmp_path):
+        """Fetching an article by its UUID id returns it."""
+        file_path = tmp_path / "my-article.md"
+        file_path.write_text("# My Article", encoding="utf-8")
+        article = Article(
+            slug="my-article",
+            title="My Article",
+            file_path=str(file_path),
+        )
+        db_session.add(article)
+        await db_session.commit()
+        await db_session.refresh(article)
+
+        service = WikiService()
+        result = await service.get_article(article.id, db_session)
+
+        assert result.id == article.id
+        assert result.slug == "my-article"
+
+    async def test_get_article_by_slug_still_works(self, db_session, tmp_path):
+        """Backward compat: slug lookup continues to work after the ID-first rewrite."""
+        file_path = tmp_path / "legacy.md"
+        file_path.write_text("# Legacy Bookmark", encoding="utf-8")
+        article = Article(
+            slug="legacy-bookmark",
+            title="Legacy Bookmark",
+            file_path=str(file_path),
+        )
+        db_session.add(article)
+        await db_session.commit()
+        await db_session.refresh(article)
+
+        service = WikiService()
+        result = await service.get_article("legacy-bookmark", db_session)
+
+        assert result.slug == "legacy-bookmark"

--- a/tests/unit/test_wikilink_resolver.py
+++ b/tests/unit/test_wikilink_resolver.py
@@ -36,9 +36,7 @@ async def _make_article(
 @pytest.mark.asyncio
 async def test_exact_match_resolves(db_session: AsyncSession) -> None:
     existing = await _make_article(db_session, "Machine Learning")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["Machine Learning"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["Machine Learning"], db_session)
     assert len(resolved) == 1
     assert resolved[0].target_id == existing.id
     assert resolved[0].candidate_text == "Machine Learning"
@@ -49,9 +47,7 @@ async def test_exact_match_resolves(db_session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_case_insensitive_exact_match_resolves(db_session: AsyncSession) -> None:
     existing = await _make_article(db_session, "Machine Learning")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["machine learning"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["machine learning"], db_session)
     assert len(resolved) == 1
     assert resolved[0].target_id == existing.id
     assert unresolved == []
@@ -61,9 +57,7 @@ async def test_case_insensitive_exact_match_resolves(db_session: AsyncSession) -
 async def test_normalized_match_resolves(db_session: AsyncSession) -> None:
     """Stage 2: candidate differs from title by punctuation only."""
     existing = await _make_article(db_session, "Karpathy's Wiki Pattern")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["Karpathys Wiki Pattern"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["Karpathys Wiki Pattern"], db_session)
     assert len(resolved) == 1
     assert resolved[0].target_id == existing.id
     assert unresolved == []
@@ -72,9 +66,7 @@ async def test_normalized_match_resolves(db_session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_underscore_to_space_resolves_via_normalizer(db_session: AsyncSession) -> None:
     existing = await _make_article(db_session, "Machine Learning Ops")
-    resolved, _unresolved = await resolve_backlink_candidates(
-        ["machine_learning_ops"], db_session
-    )
+    resolved, _unresolved = await resolve_backlink_candidates(["machine_learning_ops"], db_session)
     assert len(resolved) == 1
     assert resolved[0].target_id == existing.id
 
@@ -82,20 +74,16 @@ async def test_underscore_to_space_resolves_via_normalizer(db_session: AsyncSess
 @pytest.mark.asyncio
 async def test_no_match_stays_unresolved(db_session: AsyncSession) -> None:
     await _make_article(db_session, "Machine Learning")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["Quantum Computing"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["Quantum Computing"], db_session)
     assert resolved == []
     assert unresolved == ["Quantum Computing"]
 
 
 @pytest.mark.asyncio
 async def test_similar_but_distinct_does_not_match(db_session: AsyncSession) -> None:
-    """"Machine Learning Ops" must NOT match "Machine Learning" — no fuzzy."""
+    """Reject 'Machine Learning Ops' as a match for 'Machine Learning' — no fuzzy."""
     await _make_article(db_session, "Machine Learning")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["Machine Learning Ops"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["Machine Learning Ops"], db_session)
     assert resolved == []
     assert unresolved == ["Machine Learning Ops"]
 
@@ -104,9 +92,7 @@ async def test_similar_but_distinct_does_not_match(db_session: AsyncSession) -> 
 async def test_mixed_resolved_and_unresolved(db_session: AsyncSession) -> None:
     await _make_article(db_session, "React")
     await _make_article(db_session, "TypeScript")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["React", "Redux", "TypeScript", "Zustand"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["React", "Redux", "TypeScript", "Zustand"], db_session)
     assert len(resolved) == 2
     assert sorted(unresolved) == ["Redux", "Zustand"]
     resolved_titles = sorted(r.target_title for r in resolved)
@@ -117,9 +103,7 @@ async def test_mixed_resolved_and_unresolved(db_session: AsyncSession) -> None:
 async def test_duplicate_candidates_deduped_in_resolved(db_session: AsyncSession) -> None:
     """Two candidates resolving to the same target produce ONE ResolvedBacklink."""
     await _make_article(db_session, "React")
-    resolved, unresolved = await resolve_backlink_candidates(
-        ["React", "react"], db_session
-    )
+    resolved, unresolved = await resolve_backlink_candidates(["React", "react"], db_session)
     assert len(resolved) == 1
     assert unresolved == []
 

--- a/tests/unit/test_wikilink_resolver.py
+++ b/tests/unit/test_wikilink_resolver.py
@@ -1,0 +1,174 @@
+"""Tests for the two-stage wikilink resolution algorithm."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.engine.wikilink_resolver import resolve_backlink_candidates
+from wikimind.models import Article, ConfidenceLevel
+
+
+async def _make_article(
+    session: AsyncSession,
+    title: str,
+    slug: str | None = None,
+    created_at: datetime | None = None,
+) -> Article:
+    article = Article(
+        id=str(uuid.uuid4()),
+        slug=slug or title.lower().replace(" ", "-"),
+        title=title,
+        file_path=f"/tmp/{slug or title}.md",
+        confidence=ConfidenceLevel.SOURCED,
+        created_at=created_at or utcnow_naive(),
+    )
+    session.add(article)
+    await session.commit()
+    await session.refresh(article)
+    return article
+
+
+@pytest.mark.asyncio
+async def test_exact_match_resolves(db_session: AsyncSession) -> None:
+    existing = await _make_article(db_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Machine Learning"], db_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+    assert resolved[0].candidate_text == "Machine Learning"
+    assert resolved[0].target_title == "Machine Learning"
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_case_insensitive_exact_match_resolves(db_session: AsyncSession) -> None:
+    existing = await _make_article(db_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["machine learning"], db_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_normalized_match_resolves(db_session: AsyncSession) -> None:
+    """Stage 2: candidate differs from title by punctuation only."""
+    existing = await _make_article(db_session, "Karpathy's Wiki Pattern")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Karpathys Wiki Pattern"], db_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_underscore_to_space_resolves_via_normalizer(db_session: AsyncSession) -> None:
+    existing = await _make_article(db_session, "Machine Learning Ops")
+    resolved, _unresolved = await resolve_backlink_candidates(
+        ["machine_learning_ops"], db_session
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == existing.id
+
+
+@pytest.mark.asyncio
+async def test_no_match_stays_unresolved(db_session: AsyncSession) -> None:
+    await _make_article(db_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Quantum Computing"], db_session
+    )
+    assert resolved == []
+    assert unresolved == ["Quantum Computing"]
+
+
+@pytest.mark.asyncio
+async def test_similar_but_distinct_does_not_match(db_session: AsyncSession) -> None:
+    """"Machine Learning Ops" must NOT match "Machine Learning" — no fuzzy."""
+    await _make_article(db_session, "Machine Learning")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Machine Learning Ops"], db_session
+    )
+    assert resolved == []
+    assert unresolved == ["Machine Learning Ops"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_resolved_and_unresolved(db_session: AsyncSession) -> None:
+    await _make_article(db_session, "React")
+    await _make_article(db_session, "TypeScript")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["React", "Redux", "TypeScript", "Zustand"], db_session
+    )
+    assert len(resolved) == 2
+    assert sorted(unresolved) == ["Redux", "Zustand"]
+    resolved_titles = sorted(r.target_title for r in resolved)
+    assert resolved_titles == ["React", "TypeScript"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_candidates_deduped_in_resolved(db_session: AsyncSession) -> None:
+    """Two candidates resolving to the same target produce ONE ResolvedBacklink."""
+    await _make_article(db_session, "React")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["React", "react"], db_session
+    )
+    assert len(resolved) == 1
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_normalized_match_picks_earliest(db_session: AsyncSession) -> None:
+    """Two articles with the same normalized form → pick the earliest created_at."""
+    older = await _make_article(
+        db_session,
+        "Machine Learning",
+        slug="machine-learning-older",
+        created_at=datetime(2026, 1, 1),
+    )
+    await _make_article(
+        db_session,
+        "machine-learning",
+        slug="machine-learning-newer",
+        created_at=datetime(2026, 2, 1),
+    )
+    resolved, _ = await resolve_backlink_candidates(["Machine Learning"], db_session)
+    assert len(resolved) == 1
+    assert resolved[0].target_id == older.id
+
+
+@pytest.mark.asyncio
+async def test_exclude_self_reference(db_session: AsyncSession) -> None:
+    """A candidate that matches the article currently being compiled is excluded."""
+    self_article = await _make_article(db_session, "Self Article")
+    other = await _make_article(db_session, "Other Article")
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Self Article", "Other Article"],
+        db_session,
+        exclude_article_id=self_article.id,
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == other.id
+    assert unresolved == ["Self Article"]
+
+
+@pytest.mark.asyncio
+async def test_empty_candidate_list(db_session: AsyncSession) -> None:
+    resolved, unresolved = await resolve_backlink_candidates([], db_session)
+    assert resolved == []
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_empty_string_candidate_is_unresolved(db_session: AsyncSession) -> None:
+    resolved, unresolved = await resolve_backlink_candidates(["", "   "], db_session)
+    assert resolved == []
+    # Empty strings are dropped, not passed through as unresolved
+    assert unresolved == []


### PR DESCRIPTION
## Summary

This PR contains two layers:

1. **Spec + plan documents** for three architectural initiatives (wikilink resolution, wiki linter, knowledge graph / Epic 3)
2. **Low-risk implementation** of the first three tasks of the wikilink resolution plan — purely additive, zero existing behavior changed

It is the first output of a long-running design + prototype session. The compiler surgery (Task 4), frontend slugify removal (Task 6), and integration test (Task 7) that close #95 end-to-end are **intentionally deferred** to a follow-up PR after this one is reviewed.

---

## Part 1 — Specs and plans (3 commits)

| Commit | What |
|---|---|
| \`412c4b8\` | Epic 3 knowledge graph design doc + ADR-012 |
| \`07f794e\` | Wikilink resolution design spec + 1690-line TDD implementation plan |
| \`c0394fa\` | Wiki linter design spec + phased implementation plan |

### \`docs/superpowers/specs/2026-04-08-knowledge-graph-design.md\` (429 lines)

Epic 3 design. Covers: graph data model, API surface (extending \`/wiki/graph\` with cluster / path / neighbors endpoints), layout algorithm, frontend architecture, library choice, interaction model, performance thresholds, PR decomposition.

### \`docs/adr/adr-012-knowledge-graph-architecture.md\` (223 lines, Status: Proposed)

Locks in three architectural choices for Epic 3:

- **Storage:** SQLite \`Backlink\` table, not a real graph database. Keeps ADR-001 (local-first) intact.
- **Layout:** client-side via a force-directed library, not backend-computed. Offloads CPU to the browser, enables real-time interactivity.
- **Concepts:** coloring / clustering layer, not a parallel node type. Keeps the graph simple.

### \`docs/superpowers/specs/2026-04-08-wikilink-resolution-design.md\` (288 lines)

The #95 and #96 spec. Covers:

- Current state (compiler at \`compiler.py:52\` asks LLM for \`backlink_suggestions\`, writes them verbatim as \`[[Title]]\` without resolution)
- Two-stage resolution algorithm (exact case-insensitive → normalized)
- \`Backlink\` row persistence (the \`Backlink\` model exists but is never populated in any deployment — this spec produces the first real rows)
- Frontend rendering for resolved (\`<Link to=\"/wiki/{id}\">\`) vs unresolved (dimmed \`<span>\`)
- **Backfill strategy decision**: B1 / B2 / B3 options with explicit trade-offs

### \`docs/superpowers/plans/2026-04-08-wikilink-resolution.md\` (1690 lines)

TDD-style implementation plan with 8 tasks, each with complete code in every step (no placeholders). Task 8 is an explicit STOP marker for the backfill decision.

### \`docs/superpowers/specs/2026-04-08-wiki-linter-design.md\` (542 lines)

Wiki linter spec. Notable finding: **a \`lint_wiki\` stub already exists** in \`jobs/worker.py\` (single mega-prompt writing to \`wiki/_meta/health.json\`, \`POST /jobs/lint\`, \`GET /wiki/health\`, weekly ARQ cron, \`emit_linter_alert\` WebSocket event, and the empty \`apps/web/src/components/health/\` placeholder). The spec reshapes this as a structured check-per-function linter backed by \`LintReport\` + \`LintFinding\` tables, preserving the existing API surface as compatibility shims.

### \`docs/superpowers/plans/2026-04-08-wiki-linter.md\` (2592 lines)

Phased multi-PR plan: PR A (backend + contradictions) → PR B (frontend health view) → PR C (orphan detection, gated on #95) → PR D (schedule polish) → PR E (missing-page detection, deferred indefinitely).

---

## Part 2 — Wikilink resolution implementation (3 commits, 4 of 8 tasks)

| Commit | Task | Tests added | Net test delta |
|---|---|---|---|
| \`82ec5eb\` | Task 2 — title normalizer | 30 | 254 → 284 |
| \`9223746\` | Task 3 — two-stage resolver | 12 | 284 → 296 |
| \`3c89ba6\` | Task 5 — \`get_article\` by ID or slug | 2 | 296 → 298 |

**Zero regressions. +44 new tests. Zero touches to existing code behavior.**

### \`82ec5eb\` — \`src/wikimind/engine/title_normalizer.py\`

Single-source-of-truth title normalizer. Closes #96 by construction. The module docstring explicitly forbids adding a parallel normalizer anywhere else in the codebase.

**Small deviation from the plan**: the plan's test table asserted apostrophes strip to nothing (\`\"it's\"\` → \`\"its\"\`), but the plan's regex would have produced \`\"it-s\"\`. Fixed the implementation to match the table (added an apostrophe-strip step before the regex, per the plan's own \"the table is the contract\" guidance).

### \`9223746\` — \`src/wikimind/engine/wikilink_resolver.py\`

Pure async function that takes a list of LLM-suggested title strings and an \`AsyncSession\`, returns \`(list[ResolvedBacklink], list[str])\`. Two-stage matching (exact case-insensitive → normalized via the Task 2 module). Dedupes candidates resolving to the same target. Supports \`exclude_article_id\` for self-reference prevention.

This is a pure function — no side effects, no DB writes, only reads. Task 4 (compiler rewrite, deferred) is what actually calls this and persists the results.

### \`3c89ba6\` — \`WikiService.get_article\` accepts ID or slug

Backend lookup now tries UUID match first, falls back to slug match, raises 404 only if both fail. Path parameter renamed from \`{slug}\` to \`{id_or_slug}\`. \`docs/openapi.yaml\` regenerated. Non-breaking: existing slug bookmarks still work.

This unblocks the frontend change in Task 6 (deferred) — resolved wikilinks will arrive with article IDs in their URLs, and the backend can now serve them.

---

## What's NOT in this PR (and why)

- **Task 4** (compiler rewrite) — changes the markdown format emitted by \`_write_article_file\` and starts creating \`Backlink\` rows. Load-bearing enough to deserve a focused follow-up PR.
- **Task 6** (frontend slugify removal) — coupled to Task 4's markdown format change. Ships with Task 4.
- **Task 7** (end-to-end integration test) — depends on Tasks 4 + 6 being live.
- **Task 8** (backfill strategy) — decision is B1 (one-time re-compile) per the review. A one-shot management command \`python -m wikimind.tools.recompile_all_articles\` will ship with the Task 4 PR.

---

## Review order suggestion

1. Skim the three spec / plan docs — they're the mental model for the next ~6 PRs
2. Review the three code commits (they're small: ~170 / ~290 / ~130 lines each including tests)
3. Verify the OpenAPI diff in \`docs/openapi.yaml\` shows only the \`slug\` → \`id_or_slug\` path parameter rename
4. Verify full test suite — 298/298 should pass locally (\`make verify\`)

---

## Test plan

- [ ] CI green (pytest, lint, typecheck, doc-sync)
- [ ] \`make verify\` passes locally
- [ ] OpenAPI diff reviewed and matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)