### PR TITLE
feat(engine): complete wikilink resolution pipeline (#95, #96)

### DIFF
--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -16,26 +16,28 @@ const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
 // Match a YAML frontmatter block at the very start of the document.
 const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 
-function slugify(title: string): string {
-  return title
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-");
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 // Pre-process the markdown to:
 //   1. Strip the YAML frontmatter block emitted by the compiler (it leaks into
 //      the visible article body otherwise — react-markdown doesn't parse YAML).
-//   2. Convert [[wikilinks]] into a token react-markdown passes through.
-//      We use an HTML <a> tag with a data-wikilink attribute so the custom
-//      anchor renderer below can intercept it and emit a React Router <Link>.
+//   2. Convert any remaining [[wikilinks]] (which are by definition unresolved —
+//      the compiler rewrites resolved ones into standard [text](/wiki/<id>)
+//      markdown links at save time) into a dimmed <span> so the reader can see
+//      the reference exists but knows there's no article to click through to.
 function preprocessMarkdown(content: string): string {
   return content
     .replace(FRONTMATTER_REGEX, "")
     .replace(WIKILINK_REGEX, (_, target: string) => {
-      const safe = target.trim();
-      return `<a data-wikilink="${slugify(safe)}" href="#">${safe}</a>`;
+      const safe = escapeHtml(target.trim());
+      return `<span class="wikilink-unresolved" title="Article not yet in wiki">${safe}</span>`;
     });
 }
 
@@ -74,14 +76,11 @@ export function ArticleReader({ article }: ArticleReaderProps) {
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeRaw]}
           components={{
-            a: ({ node: _node, href, children, ...props }) => {
-              const wikilink = (props as { "data-wikilink"?: string })[
-                "data-wikilink"
-              ];
-              if (wikilink) {
+            a: ({ node: _node, href, children }) => {
+              if (href && href.startsWith("/wiki/")) {
                 return (
                   <Link
-                    to={`/wiki/${encodeURIComponent(wikilink)}`}
+                    to={href}
                     className="text-brand-700 underline decoration-dotted underline-offset-2 hover:text-brand-900"
                   >
                     {children}

--- a/apps/web/src/components/wiki/BacklinkPanel.tsx
+++ b/apps/web/src/components/wiki/BacklinkPanel.tsx
@@ -5,14 +5,6 @@ interface BacklinkPanelProps {
   article: ArticleResponse | null;
 }
 
-function slugify(title: string): string {
-  return title
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-");
-}
-
 export function BacklinkPanel({ article }: BacklinkPanelProps) {
   if (!article) {
     return (
@@ -70,7 +62,7 @@ function Section({ title, links, emptyText }: SectionProps) {
           {links.map((link) => (
             <li key={link}>
               <Link
-                to={`/wiki/${encodeURIComponent(slugify(link))}`}
+                to={`/wiki/${encodeURIComponent(link)}`}
                 className="block truncate rounded px-2 py-1 text-sm text-brand-700 hover:bg-brand-50"
               >
                 {link}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19,3 +19,10 @@ body {
     Arial,
     sans-serif;
 }
+
+.wikilink-unresolved {
+  color: rgb(148 163 184); /* slate-400 */
+  text-decoration: underline dotted rgb(148 163 184);
+  text-underline-offset: 2px;
+  cursor: help;
+}

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -271,7 +271,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         await session.commit()
         await session.refresh(article)
 
-        await self._persist_backlinks(article.id, resolved, session)
+        await self._persist_resolved_backlinks(article.id, resolved, session)
 
         log.info(
             "Article saved",
@@ -328,7 +328,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         await session.commit()
         await session.refresh(existing)
 
-        await self._persist_backlinks(existing.id, resolved, session)
+        await self._persist_resolved_backlinks(existing.id, resolved, session)
 
         log.info(
             "Article replaced in place",
@@ -340,17 +340,29 @@ Compile this into a wiki article following the JSON schema exactly."""
         )
         return existing
 
-    async def _persist_backlinks(
+    async def _persist_resolved_backlinks(
         self,
         source_article_id: str,
         resolved: list[ResolvedBacklink],
         session: AsyncSession,
     ) -> None:
-        """Insert one Backlink row per resolved candidate.
+        """Insert one :class:`Backlink` row per resolved candidate.
 
         The composite primary key ``(source_article_id, target_article_id)``
         on :class:`Backlink` rejects duplicates automatically. We catch
-        IntegrityError per-row so one duplicate does not abort the batch.
+        :class:`IntegrityError` per-row so one duplicate does not abort the
+        batch. In normal use the resolver upstream already dedupes candidates
+        by ``target_id`` (see :mod:`wikimind.engine.wikilink_resolver`), so
+        this except branch is cold — it exists as a defense against contract
+        drift between the resolver and this writer.
+
+        Committed per-row AFTER the parent article has already been committed
+        by the caller. This means the ``Article`` row and its backlinks are
+        NOT transactionally coupled: if the process dies mid-loop, the
+        article exists in the DB with a partially-populated backlink set.
+        The next re-compile (which clears stale rows and re-inserts) will
+        heal the state. The markdown file on disk is the other record of
+        the resolved links and is written before any DB work.
         """
         for rb in resolved:
             bl = Backlink(

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -10,14 +10,20 @@ from pathlib import Path
 
 import structlog
 from slugify import slugify
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
 from wikimind.engine.llm_router import get_llm_router
+from wikimind.engine.wikilink_resolver import (
+    ResolvedBacklink,
+    resolve_backlink_candidates,
+)
 from wikimind.models import (
     Article,
+    Backlink,
     CompilationResult,
     CompletionRequest,
     ConfidenceLevel,
@@ -241,7 +247,10 @@ Compile this into a wiki article following the JSON schema exactly."""
     ) -> Article:
         """Create a brand-new article (no existing same-provider article)."""
         slug = self._generate_unique_slug(result.title)
-        file_path = self._write_article_file(result, source, slug)
+
+        resolved, unresolved = await resolve_backlink_candidates(result.backlink_suggestions, session)
+
+        file_path = self._write_article_file(result, source, slug, resolved, unresolved)
 
         article = Article(
             slug=slug,
@@ -262,7 +271,16 @@ Compile this into a wiki article following the JSON schema exactly."""
         await session.commit()
         await session.refresh(article)
 
-        log.info("Article saved", slug=slug, title=result.title, provider=provider)
+        await self._persist_backlinks(article.id, resolved, session)
+
+        log.info(
+            "Article saved",
+            slug=slug,
+            title=result.title,
+            provider=provider,
+            resolved_backlinks=len(resolved),
+            unresolved_backlinks=len(unresolved),
+        )
         return article
 
     async def _replace_article_in_place(
@@ -284,7 +302,11 @@ Compile this into a wiki article following the JSON schema exactly."""
         old_path = Path(existing.file_path)
         old_path.unlink(missing_ok=True)
 
-        new_path = self._write_article_file(result, source, existing.slug)
+        resolved, unresolved = await resolve_backlink_candidates(
+            result.backlink_suggestions, session, exclude_article_id=existing.id
+        )
+
+        new_path = self._write_article_file(result, source, existing.slug, resolved, unresolved)
 
         existing.title = result.title
         existing.summary = result.summary
@@ -298,16 +320,54 @@ Compile this into a wiki article following the JSON schema exactly."""
         source.compiled_at = utcnow_naive()
         session.add(source)
 
+        # Clear stale Backlink rows from the previous compile (source side only)
+        old_bl = await session.execute(select(Backlink).where(Backlink.source_article_id == existing.id))
+        for row in old_bl.scalars().all():
+            await session.delete(row)
+
         await session.commit()
         await session.refresh(existing)
+
+        await self._persist_backlinks(existing.id, resolved, session)
 
         log.info(
             "Article replaced in place",
             slug=existing.slug,
             title=result.title,
             provider=existing.provider,
+            resolved_backlinks=len(resolved),
+            unresolved_backlinks=len(unresolved),
         )
         return existing
+
+    async def _persist_backlinks(
+        self,
+        source_article_id: str,
+        resolved: list[ResolvedBacklink],
+        session: AsyncSession,
+    ) -> None:
+        """Insert one Backlink row per resolved candidate.
+
+        The composite primary key ``(source_article_id, target_article_id)``
+        on :class:`Backlink` rejects duplicates automatically. We catch
+        IntegrityError per-row so one duplicate does not abort the batch.
+        """
+        for rb in resolved:
+            bl = Backlink(
+                source_article_id=source_article_id,
+                target_article_id=rb.target_id,
+                context=rb.candidate_text,
+            )
+            session.add(bl)
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()
+                log.debug(
+                    "Skipped duplicate backlink",
+                    source=source_article_id,
+                    target=rb.target_id,
+                )
 
     def _generate_unique_slug(self, title: str) -> str:
         base = slugify(title, max_length=80)
@@ -318,8 +378,17 @@ Compile this into a wiki article following the JSON schema exactly."""
         result: CompilationResult,
         source: Source,
         slug: str,
+        resolved: list[ResolvedBacklink],
+        unresolved: list[str],
     ) -> Path:
-        """Write .md file to wiki directory."""
+        """Write .md file to wiki directory.
+
+        The "Related" section emits standard markdown links for resolved
+        wikilinks (``[Text](/wiki/<article_id>)``) and Obsidian-style
+        brackets only for unresolved candidates (``[[Text]]``). The
+        frontend's ArticleReader distinguishes the two at render time:
+        resolved become React Router links, unresolved become dimmed spans.
+        """
         wiki_dir = Path(self.settings.data_dir) / "wiki"
 
         # Determine subdirectory from first concept
@@ -329,8 +398,14 @@ Compile this into a wiki article following the JSON schema exactly."""
 
         file_path = concept_dir / f"{slug}.md"
 
-        # Build backlinks section
-        backlinks = "\n".join([f"- [[{b}]]" for b in result.backlink_suggestions])
+        # Build backlinks section — resolved become real markdown links,
+        # unresolved remain as [[Title]] brackets for the frontend to style.
+        related_lines: list[str] = []
+        for rb in resolved:
+            related_lines.append(f"- [{rb.candidate_text}](/wiki/{rb.target_id})")
+        for text in unresolved:
+            related_lines.append(f"- [[{text}]]")
+        backlinks = "\n".join(related_lines)
 
         # Build claims section
         claims = "\n".join(

--- a/src/wikimind/jobs/background.py
+++ b/src/wikimind/jobs/background.py
@@ -20,7 +20,7 @@ from arq import create_pool
 from arq.connections import RedisSettings
 
 from wikimind.config import get_settings
-from wikimind.jobs.worker import compile_source, lint_wiki
+from wikimind.jobs.worker import compile_source, lint_wiki, sweep_wikilinks
 
 log = structlog.get_logger()
 
@@ -71,6 +71,22 @@ class BackgroundCompiler:
         log.info("lint scheduled", mode="arq" if self.is_prod else "in-process")
         return job_id
 
+    async def schedule_sweep(self) -> str:
+        """Schedule a wikilink resolution sweep job.
+
+        Returns:
+            A placeholder job ID string.
+        """
+        job_id = str(uuid.uuid4())
+
+        if self.is_prod:
+            await self._enqueue_arq("sweep_wikilinks")
+        else:
+            asyncio.create_task(self._run_sweep_in_process())  # noqa: RUF006
+
+        log.info("sweep scheduled", mode="arq" if self.is_prod else "in-process")
+        return job_id
+
     async def _enqueue_arq(self, func_name: str, *args: object) -> None:
         """Enqueue a job via ARQ Redis pool."""
         settings = RedisSettings.from_dsn(self._redis_url)  # type: ignore[arg-type]
@@ -95,6 +111,14 @@ class BackgroundCompiler:
             await lint_wiki({})
         except Exception:
             log.exception("in-process lint failed")
+
+    @staticmethod
+    async def _run_sweep_in_process() -> None:
+        """Run sweep_wikilinks directly in the current event loop."""
+        try:
+            await sweep_wikilinks({})
+        except Exception:
+            log.exception("in-process sweep failed")
 
 
 _background_compiler: BackgroundCompiler | None = None

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -27,9 +27,9 @@ from wikimind.models import Article, Backlink, Job, JobStatus, JobType
 
 log = structlog.get_logger()
 
-# Matches [[Title]] but NOT inside an already-resolved markdown link
-# like [Title](/wiki/id). The negative lookbehind rejects a leading `[`
-# so `[[Title]]` matches but `[Title](/wiki/...)` does not.
+# Matches [[Title]] — the double-bracket syntax for unresolved wikilinks.
+# Resolved links use single-bracket markdown syntax [Title](/wiki/id),
+# which this pattern does not match because it requires `[[` to open.
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -153,7 +153,7 @@ async def sweep_wikilinks(ctx) -> None:
 
             updated_count = 0
             for article in articles:
-                changed = await _sweep_single_article(article, session)
+                changed = await _sweep_single_article(article, session)  # type: ignore[arg-type]
                 if changed:
                     updated_count += 1
 

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -1,0 +1,178 @@
+"""Incremental wikilink resolution sweep (B3 backfill).
+
+Walks every article's .md file, finds unresolved ``[[brackets]]``, runs
+them through :func:`resolve_backlink_candidates`, and promotes matches
+to real ``[text](/wiki/<id>)`` markdown links with corresponding
+:class:`Backlink` rows.
+
+No LLM calls -- pure deterministic resolution against the current
+Article table. Idempotent: re-running on a wiki with nothing to
+promote is a no-op.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import structlog
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.database import get_session_factory
+from wikimind.engine.wikilink_resolver import resolve_backlink_candidates
+from wikimind.models import Article, Backlink, Job, JobStatus, JobType
+
+log = structlog.get_logger()
+
+# Matches [[Title]] but NOT inside an already-resolved markdown link
+# like [Title](/wiki/id). The negative lookbehind rejects a leading `[`
+# so `[[Title]]` matches but `[Title](/wiki/...)` does not.
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+async def _sweep_single_article(
+    article: Article,
+    session: AsyncSession,
+) -> bool:
+    """Resolve unresolved brackets in a single article's .md file.
+
+    Returns True if any replacement was made (file rewritten + backlinks
+    persisted), False if the file was unchanged.
+    """
+    file_path = Path(article.file_path)
+    if not file_path.exists():
+        log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
+        return False
+
+    content = file_path.read_text(encoding="utf-8")
+
+    # Collect all unique bracket texts
+    matches = _WIKILINK_RE.findall(content)
+    if not matches:
+        return False
+
+    # Deduplicate while preserving order
+    unique_candidates = list(dict.fromkeys(matches))
+
+    resolved, _unresolved = await resolve_backlink_candidates(unique_candidates, session, exclude_article_id=article.id)
+
+    if not resolved:
+        return False
+
+    # Build a lookup: candidate_text (case-insensitive) -> resolved backlink
+    resolved_map: dict[str, tuple[str, str]] = {}
+    for rb in resolved:
+        resolved_map[rb.candidate_text.lower()] = (rb.target_id, rb.candidate_text)
+
+    # Replace [[Title]] -> [Title](/wiki/{target_id}) using a replacement function
+    def _replace_match(m: re.Match) -> str:
+        bracket_text = m.group(1)
+        entry = resolved_map.get(bracket_text.lower())
+        if entry is not None:
+            target_id, _candidate = entry
+            return f"[{bracket_text}](/wiki/{target_id})"
+        return m.group(0)  # Leave unresolved brackets as-is
+
+    new_content = _WIKILINK_RE.sub(_replace_match, content)
+
+    if new_content == content:
+        return False  # pragma: no cover — defensive; resolved non-empty implies change
+
+    # Write the updated file
+    file_path.write_text(new_content, encoding="utf-8")
+
+    # Persist Backlink rows (per-row commit + IntegrityError catch)
+    for rb in resolved:
+        bl = Backlink(
+            source_article_id=article.id,
+            target_article_id=rb.target_id,
+            context=rb.candidate_text,
+        )
+        session.add(bl)
+        try:
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            log.debug(
+                "sweep: skipped duplicate backlink",
+                source=article.id,
+                target=rb.target_id,
+            )
+
+    log.info(
+        "sweep: article updated",
+        article_id=article.id,
+        resolved_count=len(resolved),
+    )
+    return True
+
+
+async def sweep_wikilinks(ctx) -> None:
+    """Walk every article's .md file, promote unresolved [[brackets]] to real links.
+
+    For each article:
+    1. Read the file from disk.
+    2. Find all [[Title]] tokens via regex.
+    3. Run them through resolve_backlink_candidates() against the current
+       Article table (excluding self).
+    4. For each newly-resolved link:
+       a. Replace the [[Title]] in the file with [Title](/wiki/{target_id}).
+       b. Create a Backlink row (skip on IntegrityError -- it means the
+          row already exists from a prior sweep or fresh compile).
+    5. If any replacements were made, write the file back to disk.
+
+    Idempotent: running the sweep on a wiki with no unresolved brackets
+    is a no-op (no file writes, no DB changes).
+    """
+    log.info("sweep_wikilinks started")
+
+    async with get_session_factory()() as session:
+        # Create job record
+        job = Job(
+            job_type=JobType.SWEEP_WIKILINKS,
+            status=JobStatus.RUNNING,
+            started_at=utcnow_naive(),
+        )
+        session.add(job)
+        await session.commit()
+
+        try:
+            result = await session.execute(select(Article))
+            articles = list(result.scalars().all())
+
+            if not articles:
+                job.status = JobStatus.COMPLETE
+                job.result_summary = "No articles to sweep"
+                session.add(job)
+                await session.commit()
+                log.info("sweep_wikilinks complete: no articles")
+                return
+
+            updated_count = 0
+            for article in articles:
+                changed = await _sweep_single_article(article, session)
+                if changed:
+                    updated_count += 1
+
+            job.status = JobStatus.COMPLETE
+            job.completed_at = utcnow_naive()
+            job.result_summary = f"Swept {len(articles)} articles, updated {updated_count}"
+            session.add(job)
+            await session.commit()
+
+            log.info(
+                "sweep_wikilinks complete",
+                total=len(articles),
+                updated=updated_count,
+            )
+
+        except Exception as e:
+            log.error("sweep_wikilinks failed", error=str(e))
+            job.status = JobStatus.FAILED
+            job.error = str(e)
+            job.completed_at = utcnow_naive()
+            session.add(job)
+            await session.commit()

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -36,6 +36,7 @@ from wikimind.config import get_settings
 from wikimind.database import get_session_factory
 from wikimind.engine.compiler import Compiler
 from wikimind.engine.llm_router import get_llm_router
+from wikimind.jobs.sweep import sweep_wikilinks
 from wikimind.models import (
     Article,
     CompletionRequest,
@@ -265,13 +266,14 @@ def get_redis_settings() -> RedisSettings:
 class WorkerSettings:
     """ARQ worker configuration for production (requires Redis)."""
 
-    functions: ClassVar[list] = [compile_source, lint_wiki]
+    functions: ClassVar[list] = [compile_source, lint_wiki, sweep_wikilinks]
     redis_settings = get_redis_settings()
     max_jobs = 4
     job_timeout = 300  # 5 min max per job
     keep_result = 3600  # Keep results for 1 hour
 
-    # Weekly linter
+    # Weekly linter + daily wikilink sweep
     cron_jobs: ClassVar[list] = [
-        cron(lint_wiki, weekday=0, hour=2, minute=0)  # Monday 2am
+        cron(lint_wiki, weekday=0, hour=2, minute=0),  # Monday 2am
+        cron(sweep_wikilinks, hour=3, minute=0),  # Daily 3am
     ]

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -125,6 +125,11 @@ async def compile_source(ctx, source_id: str):
 
             log.info("compile_source complete", source_id=source_id, slug=article.slug)
 
+            # Sweep existing articles — a newly compiled article may resolve
+            # brackets that were previously unresolvable. Fast (no LLM),
+            # idempotent, and safe to fire on every compile.
+            await sweep_wikilinks(ctx)
+
         except Exception as e:
             log.error("compile_source failed", source_id=source_id, error=str(e))
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -55,6 +55,7 @@ class JobType(StrEnum):
 
     COMPILE_SOURCE = "compile_source"
     LINT_WIKI = "lint_wiki"
+    SWEEP_WIKILINKS = "sweep_wikilinks"
     REINDEX = "reindex"
     EMBED_CHUNKS = "embed_chunks"
     SYNC_PUSH = "sync_push"

--- a/tests/integration/test_sweep_integration.py
+++ b/tests/integration/test_sweep_integration.py
@@ -1,0 +1,132 @@
+"""Integration test for the incremental wikilink resolution sweep (B3 backfill).
+
+Scenario:
+    1. Seed articles A and B where A's .md has [[B's Title]] as unresolved.
+    2. Run the sweep. Assert B's bracket resolved + Backlink row exists.
+    3. Add article C whose title matches another bracket in A's .md.
+    4. Re-run the sweep. Assert the second bracket is now also resolved.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
+
+from wikimind._datetime import utcnow_naive
+from wikimind.jobs.sweep import sweep_wikilinks
+from wikimind.models import Article, Backlink, ConfidenceLevel, Job, JobStatus, JobType
+
+
+async def _make_article(
+    session: AsyncSession,
+    title: str,
+    file_path: str,
+    slug: str | None = None,
+) -> Article:
+    """Create and persist a test article."""
+    article = Article(
+        id=str(uuid.uuid4()),
+        slug=slug or title.lower().replace(" ", "-"),
+        title=title,
+        file_path=file_path,
+        confidence=ConfidenceLevel.SOURCED,
+        created_at=utcnow_naive(),
+    )
+    session.add(article)
+    await session.commit()
+    await session.refresh(article)
+    return article
+
+
+@pytest.mark.asyncio
+async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engine, tmp_path: Path) -> None:
+    """Full sweep resolves brackets as target articles appear over time."""
+    # --- Setup: article B exists, article C does not yet exist ---
+    article_b = await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"), slug="machine-learning")
+
+    # Article A has brackets for both B and C (C does not exist yet)
+    a_md = tmp_path / "overview.md"
+    a_md.write_text(
+        "# AI Overview\n\n"
+        "See [[Machine Learning]] for the basics.\n\n"
+        "Also check [[Deep Learning]] for advanced topics.\n"
+    )
+    article_a = await _make_article(db_session, "AI Overview", str(a_md), slug="ai-overview")
+
+    # Build a real session factory backed by the same in-memory engine
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    # --- Phase 1: run sweep --- only Machine Learning should resolve ---
+    with patch("wikimind.jobs.sweep.get_session_factory", return_value=factory):
+        await sweep_wikilinks({})
+
+    # Assert: Machine Learning bracket resolved
+    content_after_phase1 = a_md.read_text()
+    assert f"[Machine Learning](/wiki/{article_b.id})" in content_after_phase1
+    assert "[[Machine Learning]]" not in content_after_phase1
+
+    # Assert: Deep Learning bracket still unresolved
+    assert "[[Deep Learning]]" in content_after_phase1
+
+    # Assert: Backlink A -> B exists (use a fresh session from factory to see committed data)
+    async with factory() as check_session:
+        bl_result = await check_session.execute(
+            select(Backlink).where(
+                Backlink.source_article_id == article_a.id,
+                Backlink.target_article_id == article_b.id,
+            )
+        )
+        assert bl_result.scalar_one_or_none() is not None
+
+        # Assert: Job row was created
+        job_result = await check_session.execute(select(Job).where(Job.job_type == JobType.SWEEP_WIKILINKS))
+        jobs = list(job_result.scalars().all())
+        assert len(jobs) >= 1
+        assert jobs[0].status == JobStatus.COMPLETE
+
+    # --- Phase 2: add article C, re-run sweep ---
+    async with factory() as seed_session:
+        article_c = Article(
+            id=str(uuid.uuid4()),
+            slug="deep-learning",
+            title="Deep Learning",
+            file_path=str(tmp_path / "dl.md"),
+            confidence=ConfidenceLevel.SOURCED,
+            created_at=utcnow_naive(),
+        )
+        seed_session.add(article_c)
+        await seed_session.commit()
+        await seed_session.refresh(article_c)
+
+    with patch("wikimind.jobs.sweep.get_session_factory", return_value=factory):
+        await sweep_wikilinks({})
+
+    # Assert: Deep Learning bracket now resolved
+    content_after_phase2 = a_md.read_text()
+    assert f"[Deep Learning](/wiki/{article_c.id})" in content_after_phase2
+    assert "[[Deep Learning]]" not in content_after_phase2
+
+    # Assert: Machine Learning link still intact
+    assert f"[Machine Learning](/wiki/{article_b.id})" in content_after_phase2
+
+    # Assert: Backlink A -> C exists
+    async with factory() as check_session2:
+        bl_result2 = await check_session2.execute(
+            select(Backlink).where(
+                Backlink.source_article_id == article_a.id,
+                Backlink.target_article_id == article_c.id,
+            )
+        )
+        assert bl_result2.scalar_one_or_none() is not None
+
+    # --- Phase 3: re-run again --- should be a complete no-op ---
+    with patch("wikimind.jobs.sweep.get_session_factory", return_value=factory):
+        await sweep_wikilinks({})
+
+    # Content unchanged
+    assert a_md.read_text() == content_after_phase2

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -78,9 +78,7 @@ async def test_wikilink_resolution_end_to_end(
     article = await compiler.save_article(result, source, db_session)
 
     # 3. Backlink row exists
-    bl_result = await db_session.execute(
-        select(Backlink).where(Backlink.source_article_id == article.id)
-    )
+    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
     backlinks = list(bl_result.scalars().all())
     assert len(backlinks) == 1
     assert backlinks[0].target_article_id == target.id

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -1,0 +1,104 @@
+"""End-to-end wikilink resolution proof (issue #95).
+
+Steps:
+    1. Seed an existing article "Existing Target".
+    2. Drive the compiler's save path with a mock CompilationResult
+       whose backlink_suggestions includes "Existing Target" (should
+       resolve) and "Nonexistent Topic" (should stay unresolved).
+    3. Assert a Backlink row exists pointing new -> target.
+    4. Assert the rendered markdown has [Existing Target](/wiki/<id>).
+    5. Assert the /wiki/articles/{id} route returns the new article
+       (verifies the ID-first lookup works end-to-end).
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.engine.compiler import Compiler
+from wikimind.models import (
+    Article,
+    Backlink,
+    CompilationResult,
+    CompiledClaim,
+    ConfidenceLevel,
+    IngestStatus,
+    Source,
+    SourceType,
+)
+
+
+@pytest.mark.asyncio
+async def test_wikilink_resolution_end_to_end(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    tmp_path: Path,
+) -> None:
+    # 1. Seed an existing target article
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="existing-target",
+        title="Existing Target",
+        file_path=str(tmp_path / "existing-target.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    db_session.add(target)
+
+    # Seed a Source the compiler will mark as COMPILED
+    source = Source(
+        id=str(uuid.uuid4()),
+        source_type=SourceType.TEXT,
+        title="Test Source",
+        status=IngestStatus.PROCESSING,
+        ingested_at=utcnow_naive(),
+    )
+    db_session.add(source)
+    await db_session.commit()
+
+    # 2. Drive the save path
+    compiler = Compiler()
+    result = CompilationResult(
+        title="New Compiled Article",
+        summary="Two sentence summary. For integration test.",
+        key_claims=[
+            CompiledClaim(claim="test claim", confidence=ConfidenceLevel.SOURCED),
+        ],
+        concepts=["test"],
+        backlink_suggestions=["Existing Target", "Nonexistent Topic"],
+        open_questions=["test?"],
+        article_body="## Body\n\nTest body content with enough text.",
+    )
+    article = await compiler.save_article(result, source, db_session)
+
+    # 3. Backlink row exists
+    bl_result = await db_session.execute(
+        select(Backlink).where(Backlink.source_article_id == article.id)
+    )
+    backlinks = list(bl_result.scalars().all())
+    assert len(backlinks) == 1
+    assert backlinks[0].target_article_id == target.id
+
+    # 4. Markdown has the resolved link by ID and the unresolved bracket
+    content = Path(article.file_path).read_text()
+    assert f"[Existing Target](/wiki/{target.id})" in content
+    assert "[[Nonexistent Topic]]" in content
+
+    # 5. ID-first lookup via the HTTP route
+    response = await client.get(f"/wiki/articles/{article.id}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == article.id
+    assert payload["title"] == "New Compiled Article"
+    assert f"[Existing Target](/wiki/{target.id})" in payload["content"]
+
+    # Slug-based lookup still works (backward compat)
+    response_by_slug = await client.get(f"/wiki/articles/{article.slug}")
+    assert response_by_slug.status_code == 200
+    assert response_by_slug.json()["id"] == article.id

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -345,8 +345,16 @@ async def test_save_markdown_has_resolved_link_and_unresolved_bracket(db_session
     assert "- [[Existing Article]]" not in content
 
 
-async def test_save_handles_duplicate_candidates_without_integrity_error(db_session, tmp_path) -> None:
-    """Two candidates resolving to the same target → one Backlink row, no IntegrityError."""
+async def test_save_dedupes_candidates_resolving_to_same_target(db_session, tmp_path) -> None:
+    """Two candidates resolving to the same target → one Backlink row.
+
+    The resolver dedupes by ``target_id`` upstream, so both ``"React"`` and
+    ``"react"`` collapse into a single :class:`ResolvedBacklink` before
+    ``_persist_resolved_backlinks`` ever runs. This test pins the end-to-end
+    behavior: the composite PK + per-row ``IntegrityError`` catch is a
+    defensive belt over the resolver's suspenders, and this test verifies
+    they work together (not that the catch branch is exercised — it isn't).
+    """
     target = Article(
         id=str(uuid.uuid4()),
         slug="react",

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from sqlmodel import select
+
+from wikimind._datetime import utcnow_naive
 from wikimind.engine import compiler as compiler_mod
 from wikimind.engine.compiler import Compiler
 from wikimind.models import (
+    Article,
+    Backlink,
     CompilationResult,
     CompiledClaim,
     CompletionResponse,
@@ -199,7 +205,7 @@ def test_write_article_file(tmp_path) -> None:
     ):
         c = Compiler()
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
-    path = c._write_article_file(_result(), src, "test-slug")
+    path = c._write_article_file(_result(), src, "test-slug", [], [])
     assert path.exists()
     text = path.read_text()
     assert "Test Article" in text
@@ -222,7 +228,7 @@ def test_write_article_file_no_concepts(tmp_path) -> None:
         article_body="x",
     )
     src = Source(source_type=SourceType.TEXT, title=None)
-    path = c._write_article_file(r, src, "no-concept")
+    path = c._write_article_file(r, src, "no-concept", [], [])
     assert path.exists()
     assert "general" in str(path)
 
@@ -241,3 +247,131 @@ async def test_save_article(db_session, tmp_path) -> None:
     assert article.slug
     assert Path(article.file_path).exists()
     assert src.status == IngestStatus.COMPILED
+
+
+# ---------------------------------------------------------------------------
+# Resolution-aware save path (Task 4)
+# ---------------------------------------------------------------------------
+
+
+def _result_with_backlinks(
+    title: str,
+    backlink_suggestions: list[str] | None = None,
+) -> CompilationResult:
+    return CompilationResult(
+        title=title,
+        summary="A two-sentence summary. For testing.",
+        key_claims=[
+            CompiledClaim(claim="test claim", confidence=ConfidenceLevel.SOURCED),
+        ],
+        concepts=["test-concept"],
+        backlink_suggestions=backlink_suggestions or [],
+        open_questions=["test question?"],
+        article_body="## Body\n\nTest body content sufficient length.",
+    )
+
+
+async def _make_source(session) -> Source:
+    source = Source(
+        id=str(uuid.uuid4()),
+        source_type=SourceType.TEXT,
+        title="Test Source",
+        status=IngestStatus.PROCESSING,
+        ingested_at=utcnow_naive(),
+    )
+    session.add(source)
+    await session.commit()
+    await session.refresh(source)
+    return source
+
+
+def _compiler_for(tmp_path: Path) -> Compiler:
+    with (
+        patch.object(compiler_mod, "get_llm_router"),
+        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
+    ):
+        return Compiler()
+
+
+async def test_save_creates_backlink_rows_for_resolved_candidates(db_session, tmp_path) -> None:
+    # Seed an existing article that a future candidate will resolve to.
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="existing-article",
+        title="Existing Article",
+        file_path=str(tmp_path / "existing.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    db_session.add(target)
+    await db_session.commit()
+
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+    result = _result_with_backlinks(
+        "New Article",
+        backlink_suggestions=["Existing Article", "Nonexistent Topic"],
+    )
+    article = await compiler.save_article(result, source, db_session)
+
+    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.scalars().all())
+    assert len(backlinks) == 1
+    assert backlinks[0].target_article_id == target.id
+    assert backlinks[0].context == "Existing Article"
+
+
+async def test_save_markdown_has_resolved_link_and_unresolved_bracket(db_session, tmp_path) -> None:
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="existing-article",
+        title="Existing Article",
+        file_path=str(tmp_path / "existing.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    db_session.add(target)
+    await db_session.commit()
+
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+    result = _result_with_backlinks(
+        "New Article",
+        backlink_suggestions=["Existing Article", "Nonexistent Topic"],
+    )
+    article = await compiler.save_article(result, source, db_session)
+
+    content = Path(article.file_path).read_text()
+    assert f"[Existing Article](/wiki/{target.id})" in content
+    assert "[[Nonexistent Topic]]" in content
+    assert "- [[Existing Article]]" not in content
+
+
+async def test_save_handles_duplicate_candidates_without_integrity_error(db_session, tmp_path) -> None:
+    """Two candidates resolving to the same target → one Backlink row, no IntegrityError."""
+    target = Article(
+        id=str(uuid.uuid4()),
+        slug="react",
+        title="React",
+        file_path=str(tmp_path / "react.md"),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    db_session.add(target)
+    await db_session.commit()
+
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+    result = _result_with_backlinks("New Article", backlink_suggestions=["React", "react"])
+    article = await compiler.save_article(result, source, db_session)
+
+    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.scalars().all())
+    assert len(backlinks) == 1
+
+
+async def test_save_skips_backlinks_when_no_candidates(db_session, tmp_path) -> None:
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+    result = _result_with_backlinks("Solo Article", backlink_suggestions=[])
+    article = await compiler.save_article(result, source, db_session)
+
+    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+    assert list(bl_result.scalars().all()) == []

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -1,0 +1,163 @@
+"""Tests for the incremental wikilink resolution sweep job (B3 backfill)."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.jobs.sweep import _sweep_single_article
+from wikimind.models import Article, Backlink, ConfidenceLevel
+
+
+async def _make_article(
+    session: AsyncSession,
+    title: str,
+    file_path: str,
+    slug: str | None = None,
+) -> Article:
+    """Create and persist a test article."""
+    article = Article(
+        id=str(uuid.uuid4()),
+        slug=slug or title.lower().replace(" ", "-"),
+        title=title,
+        file_path=file_path,
+        confidence=ConfidenceLevel.SOURCED,
+        created_at=utcnow_naive(),
+    )
+    session.add(article)
+    await session.commit()
+    await session.refresh(article)
+    return article
+
+
+@pytest.mark.asyncio
+async def test_resolves_bracket_and_creates_backlink(db_session: AsyncSession, tmp_path: Path) -> None:
+    """An article with [[Existing Title]] -> file rewritten + Backlink row created."""
+    target = await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"))
+
+    md_path = tmp_path / "source.md"
+    md_path.write_text("Some text about [[Machine Learning]] in the body.\n")
+    source = await _make_article(db_session, "AI Overview", str(md_path), slug="ai-overview")
+
+    changed = await _sweep_single_article(source, db_session)
+
+    assert changed is True
+    content = md_path.read_text()
+    assert f"[Machine Learning](/wiki/{target.id})" in content
+    assert "[[Machine Learning]]" not in content
+
+    result = await db_session.execute(
+        select(Backlink).where(
+            Backlink.source_article_id == source.id,
+            Backlink.target_article_id == target.id,
+        )
+    )
+    bl = result.scalar_one_or_none()
+    assert bl is not None
+
+
+@pytest.mark.asyncio
+async def test_no_brackets_no_write(db_session: AsyncSession, tmp_path: Path) -> None:
+    """An article with no [[brackets]] -> NOT rewritten (idempotency)."""
+    md_path = tmp_path / "clean.md"
+    original = "This article has no brackets at all.\n"
+    md_path.write_text(original)
+    article = await _make_article(db_session, "Clean Article", str(md_path))
+
+    changed = await _sweep_single_article(article, db_session)
+
+    assert changed is False
+    assert md_path.read_text() == original
+
+
+@pytest.mark.asyncio
+async def test_unknown_bracket_stays(db_session: AsyncSession, tmp_path: Path) -> None:
+    """An article with [[Unknown Title]] -> bracket stays, no Backlink row."""
+    md_path = tmp_path / "unknown.md"
+    md_path.write_text("See also [[Nonexistent Topic]] for more.\n")
+    article = await _make_article(db_session, "Some Article", str(md_path))
+
+    changed = await _sweep_single_article(article, db_session)
+
+    assert changed is False
+    content = md_path.read_text()
+    assert "[[Nonexistent Topic]]" in content
+
+    result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_already_resolved_link_not_rewritten(db_session: AsyncSession, tmp_path: Path) -> None:
+    """An article with [Title](/wiki/{id}) from a fresh compile -> NOT rewritten."""
+    target = await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"))
+    md_path = tmp_path / "resolved.md"
+    original = f"Read about [Machine Learning](/wiki/{target.id}) here.\n"
+    md_path.write_text(original)
+    article = await _make_article(db_session, "Resolved Article", str(md_path))
+
+    changed = await _sweep_single_article(article, db_session)
+
+    assert changed is False
+    assert md_path.read_text() == original
+
+
+@pytest.mark.asyncio
+async def test_idempotent_rerun_after_sweep(db_session: AsyncSession, tmp_path: Path) -> None:
+    """Re-running the sweep after a previous sweep -> no changes."""
+    await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"))
+    md_path = tmp_path / "source.md"
+    md_path.write_text("Text about [[Machine Learning]] here.\n")
+    source = await _make_article(db_session, "AI Overview", str(md_path), slug="ai-overview")
+
+    # First run: should make changes
+    changed1 = await _sweep_single_article(source, db_session)
+    assert changed1 is True
+
+    # Second run: no changes (bracket already resolved, Backlink already exists)
+    changed2 = await _sweep_single_article(source, db_session)
+    assert changed2 is False
+
+
+@pytest.mark.asyncio
+async def test_multiple_brackets_partial_resolution(db_session: AsyncSession, tmp_path: Path) -> None:
+    """Multiple brackets: some resolve, some stay. Only resolved ones are replaced."""
+    target = await _make_article(db_session, "React", str(tmp_path / "react.md"))
+    md_path = tmp_path / "multi.md"
+    md_path.write_text("Uses [[React]] and [[Unknown Framework]] for UI.\n")
+    source = await _make_article(db_session, "Frontend Guide", str(md_path))
+
+    changed = await _sweep_single_article(source, db_session)
+
+    assert changed is True
+    content = md_path.read_text()
+    assert f"[React](/wiki/{target.id})" in content
+    assert "[[Unknown Framework]]" in content
+
+
+@pytest.mark.asyncio
+async def test_self_link_excluded(db_session: AsyncSession, tmp_path: Path) -> None:
+    """A bracket matching the article's own title is not resolved (no self-link)."""
+    md_path = tmp_path / "self.md"
+    md_path.write_text("This article about [[Self Referencing]] itself.\n")
+    article = await _make_article(db_session, "Self Referencing", str(md_path), slug="self-referencing")
+
+    changed = await _sweep_single_article(article, db_session)
+
+    assert changed is False
+    content = md_path.read_text()
+    assert "[[Self Referencing]]" in content
+
+
+@pytest.mark.asyncio
+async def test_missing_file_handled_gracefully(db_session: AsyncSession, tmp_path: Path) -> None:
+    """Article whose file_path doesn't exist -> skip gracefully."""
+    article = await _make_article(db_session, "Missing File", str(tmp_path / "does-not-exist.md"))
+
+    changed = await _sweep_single_article(article, db_session)
+    assert changed is False


### PR DESCRIPTION
## Summary

- **Compiler emits Backlink rows** at save time — resolved wikilinks become `[text](/wiki/<id>)` markdown links, unresolved stay as `[[brackets]]`
- **Frontend slugifiers deleted** (both `ArticleReader.tsx` and `BacklinkPanel.tsx`) — closes the root cause of #96 architecturally; no second normalizer to drift against
- **Incremental sweep job (B3 backfill)** — walks existing articles, promotes unresolved brackets to real links as the wiki grows, zero LLM cost, idempotent
- **End-to-end integration test** — compile → DB Backlink row → markdown content → HTTP route lookup

## What shipped in PR #101 (already merged, included in this branch)

- `title_normalizer.py` — single-source-of-truth normalizer (Tasks 2)
- `wikilink_resolver.py` — two-stage deterministic resolution (Task 3)
- `get_article(id_or_slug)` — ID-first lookup with slug fallback (Task 5)

## What this PR adds (Tasks 4, 6, 7, 8)

- `compiler.py` — `_create_article` and `_replace_article_in_place` now call `resolve_backlink_candidates()` before writing the file, then emit `Backlink` rows after commit
- `ArticleReader.tsx` — deleted `slugify()`, deleted `data-wikilink` hack, added `escapeHtml` + dimmed-span preprocessor for unresolved brackets
- `BacklinkPanel.tsx` — deleted `slugify()`, passes article IDs verbatim
- `index.css` — `.wikilink-unresolved` style rule
- `jobs/sweep.py` — `sweep_wikilinks` background job (B3 strategy), registered as daily cron in ARQ
- `jobs/background.py` — `BackgroundCompiler.schedule_sweep()` for dev/prod dispatch
- `models.py` — `JobType.SWEEP_WIKILINKS` enum member

## Test coverage

- 4 unit tests for compiler Backlink emission
- 8 unit tests for sweep logic (bracket resolution, idempotency, self-link exclusion, missing file handling)
- 1 integration test for end-to-end resolution (compile → DB → markdown → HTTP)
- 1 integration test for sweep (incremental resolution across multiple sweep runs)
- **312 total tests passing**, `make verify` green

## Test plan

- [x] `make verify` passes (lint + format + mypy + pyright + 312 tests + coverage ≥ 80%)
- [x] `cd apps/web && npm run lint && npm run typecheck && npm run build` clean
- [x] `grep -rn 'function slugify' apps/web/src` returns zero hits
- [x] `grep -rn 'data-wikilink' apps/web/src` returns zero hits
- [x] Manual smoke: open an article with resolved + unresolved wikilinks, verify resolved are clickable links and unresolved are dimmed spans with tooltip

Closes #95, closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)