### PR TITLE
fix(web): resolve BacklinkPanel showing raw UUIDs instead of titles

### DIFF
--- a/apps/web/src/components/wiki/BacklinkPanel.tsx
+++ b/apps/web/src/components/wiki/BacklinkPanel.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { ArticleResponse } from "../../types/api";
+import type { ArticleResponse, BacklinkEntry } from "../../types/api";
 
 interface BacklinkPanelProps {
   article: ArticleResponse | null;
@@ -45,7 +45,7 @@ export function BacklinkPanel({ article }: BacklinkPanelProps) {
 
 interface SectionProps {
   title: string;
-  links: string[];
+  links: BacklinkEntry[];
   emptyText: string;
 }
 
@@ -60,12 +60,12 @@ function Section({ title, links, emptyText }: SectionProps) {
       ) : (
         <ul className="space-y-1">
           {links.map((link) => (
-            <li key={link}>
+            <li key={link.id}>
               <Link
-                to={`/wiki/${encodeURIComponent(link)}`}
+                to={`/wiki/${encodeURIComponent(link.slug)}`}
                 className="block truncate rounded px-2 py-1 text-sm text-brand-700 hover:bg-brand-50"
               >
-                {link}
+                {link.title}
               </Link>
             </li>
           ))}

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -51,10 +51,16 @@ export interface Article {
   updated_at: string;
 }
 
+export interface BacklinkEntry {
+  id: string;
+  title: string;
+  slug: string;
+}
+
 export interface ArticleResponse extends Article {
   content: string;
-  backlinks_in: string[];
-  backlinks_out: string[];
+  backlinks_in: BacklinkEntry[];
+  backlinks_out: BacklinkEntry[];
   concepts: string[];
 }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -743,13 +743,13 @@ components:
           default: []
         backlinks_in:
           items:
-            type: string
+            $ref: '#/components/schemas/BacklinkEntry'
           type: array
           title: Backlinks In
           default: []
         backlinks_out:
           items:
-            type: string
+            $ref: '#/components/schemas/BacklinkEntry'
           type: array
           title: Backlinks Out
           default: []
@@ -878,6 +878,24 @@ components:
       title: AskResponse
       description: Response shape for POST /query — wraps both the new query and its
         parent conversation.
+    BacklinkEntry:
+      properties:
+        id:
+          type: string
+          title: Id
+        title:
+          type: string
+          title: Title
+        slug:
+          type: string
+          title: Slug
+      type: object
+      required:
+      - id
+      - title
+      - slug
+      title: BacklinkEntry
+      description: A backlink entry with human-readable metadata for the frontend.
     Body_ingest_pdf_ingest_pdf_post:
       properties:
         file:

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -377,6 +377,14 @@ class ArticleSourceSummary(BaseModel):
     title: str | None
 
 
+class BacklinkEntry(BaseModel):
+    """A backlink entry with human-readable metadata for the frontend."""
+
+    id: str
+    title: str
+    slug: str
+
+
 class ArticleResponse(BaseModel):
     """Full article response with content, backlinks, and source provenance."""
 
@@ -387,8 +395,8 @@ class ArticleResponse(BaseModel):
     confidence: ConfidenceLevel | None
     linter_score: float | None
     concepts: list[str] = []
-    backlinks_in: list[str] = []
-    backlinks_out: list[str] = []
+    backlinks_in: list[BacklinkEntry] = []
+    backlinks_out: list[BacklinkEntry] = []
     content: str  # Full .md content
     sources: list[SourceResponse] = []
     created_at: datetime

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -21,6 +21,7 @@ from wikimind.models import (
     ArticleSourceSummary,
     ArticleSummaryResponse,
     Backlink,
+    BacklinkEntry,
     Concept,
     GraphEdge,
     GraphNode,
@@ -207,8 +208,21 @@ class WikiService:
         if not article:
             raise HTTPException(status_code=404, detail="Article not found")
 
-        bl_in = await session.execute(select(Backlink).where(Backlink.target_article_id == article.id))
-        bl_out = await session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
+        # Resolve incoming backlinks (articles that link TO this one)
+        bl_in_result = await session.execute(
+            select(Backlink.source_article_id, Article.title, Article.slug)
+            .join(Article, Article.id == Backlink.source_article_id)  # type: ignore[arg-type]
+            .where(Backlink.target_article_id == article.id)
+        )
+        backlinks_in = [BacklinkEntry(id=row[0], title=row[1], slug=row[2]) for row in bl_in_result.all()]
+
+        # Resolve outgoing backlinks (articles this one links TO)
+        bl_out_result = await session.execute(
+            select(Backlink.target_article_id, Article.title, Article.slug)
+            .join(Article, Article.id == Backlink.target_article_id)  # type: ignore[arg-type]
+            .where(Backlink.source_article_id == article.id)
+        )
+        backlinks_out = [BacklinkEntry(id=row[0], title=row[1], slug=row[2]) for row in bl_out_result.all()]
 
         source_ids = _parse_source_ids(article.source_ids)
         sources = await _fetch_sources(session, source_ids)
@@ -221,8 +235,8 @@ class WikiService:
             confidence=article.confidence,
             linter_score=article.linter_score,
             concepts=[],
-            backlinks_in=[b.source_article_id for b in bl_in.scalars().all()],
-            backlinks_out=[b.target_article_id for b in bl_out.scalars().all()],
+            backlinks_in=backlinks_in,
+            backlinks_out=backlinks_out,
             content=_read_article_content(article.file_path),
             sources=[_to_source_response(s) for s in sources],
             created_at=article.created_at,

--- a/tests/unit/test_wiki_service.py
+++ b/tests/unit/test_wiki_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from wikimind.models import Article, Source, SourceType
+from wikimind.models import Article, Backlink, BacklinkEntry, Source, SourceType
 from wikimind.services.wiki import WikiService
 
 
@@ -161,3 +161,85 @@ class TestArticleProvenance:
         result = await service.get_article("legacy-bookmark", db_session)
 
         assert result.slug == "legacy-bookmark"
+
+
+@pytest.mark.asyncio
+class TestBacklinkEntries:
+    async def test_get_article_returns_backlink_entries_with_title_and_slug(self, db_session, tmp_path):
+        """backlinks_in and backlinks_out are BacklinkEntry objects with id, title, slug."""
+        # Create three articles: A links to B, C links to B
+        fp_a = tmp_path / "article-a.md"
+        fp_a.write_text("# Article A", encoding="utf-8")
+        fp_b = tmp_path / "article-b.md"
+        fp_b.write_text("# Article B", encoding="utf-8")
+        fp_c = tmp_path / "article-c.md"
+        fp_c.write_text("# Article C", encoding="utf-8")
+
+        article_a = Article(slug="article-a", title="Article A", file_path=str(fp_a))
+        article_b = Article(slug="article-b", title="Article B", file_path=str(fp_b))
+        article_c = Article(slug="article-c", title="Article C", file_path=str(fp_c))
+        db_session.add_all([article_a, article_b, article_c])
+        await db_session.flush()
+
+        # A -> B and C -> B
+        bl_ab = Backlink(source_article_id=article_a.id, target_article_id=article_b.id)
+        bl_cb = Backlink(source_article_id=article_c.id, target_article_id=article_b.id)
+        # B -> A
+        bl_ba = Backlink(source_article_id=article_b.id, target_article_id=article_a.id)
+        db_session.add_all([bl_ab, bl_cb, bl_ba])
+        await db_session.commit()
+
+        service = WikiService()
+        response = await service.get_article(article_b.id, db_session)
+
+        # backlinks_in: A and C link to B
+        assert len(response.backlinks_in) == 2
+        in_ids = {bl.id for bl in response.backlinks_in}
+        assert in_ids == {article_a.id, article_c.id}
+        for bl in response.backlinks_in:
+            assert isinstance(bl, BacklinkEntry)
+            assert bl.title in ("Article A", "Article C")
+            assert bl.slug in ("article-a", "article-c")
+
+        # backlinks_out: B links to A
+        assert len(response.backlinks_out) == 1
+        assert response.backlinks_out[0].id == article_a.id
+        assert response.backlinks_out[0].title == "Article A"
+        assert response.backlinks_out[0].slug == "article-a"
+
+    async def test_get_article_skips_deleted_backlink_targets(self, db_session, tmp_path):
+        """Backlinks referencing a deleted article are silently dropped."""
+        fp = tmp_path / "survivor.md"
+        fp.write_text("# Survivor", encoding="utf-8")
+
+        article = Article(slug="survivor", title="Survivor", file_path=str(fp))
+        db_session.add(article)
+        await db_session.flush()
+
+        # Insert a backlink whose source article does not exist.
+        # The JOIN will naturally exclude it because there's no matching Article row.
+        ghost_id = "00000000-0000-0000-0000-000000000000"
+        bl = Backlink(source_article_id=ghost_id, target_article_id=article.id)
+        db_session.add(bl)
+        await db_session.commit()
+
+        service = WikiService()
+        response = await service.get_article(article.id, db_session)
+
+        # The ghost backlink is dropped because the JOIN excludes missing articles
+        assert response.backlinks_in == []
+
+    async def test_get_article_empty_backlinks(self, db_session, tmp_path):
+        """An article with no backlinks returns empty BacklinkEntry lists."""
+        fp = tmp_path / "lonely.md"
+        fp.write_text("# Lonely", encoding="utf-8")
+
+        article = Article(slug="lonely", title="Lonely", file_path=str(fp))
+        db_session.add(article)
+        await db_session.commit()
+
+        service = WikiService()
+        response = await service.get_article(article.id, db_session)
+
+        assert response.backlinks_in == []
+        assert response.backlinks_out == []


### PR DESCRIPTION
## Summary

- Adds `BacklinkEntry` Pydantic model (`id`, `title`, `slug`) to replace raw `list[str]` in `ArticleResponse`
- Updates `WikiService.get_article` to JOIN through the Article table, resolving backlink IDs to human-readable titles and slugs
- Updates frontend `BacklinkPanel.tsx` to display article titles with slug-based URLs (consistent with ConceptTree, SearchBar, ArticleReader)
- Deleted articles are gracefully handled via INNER JOIN (silently dropped)

Closes #104

## Test plan

- [x] 3 new unit tests: happy path (multi-directional backlinks), deleted-article edge case, empty-backlinks baseline
- [x] All 301 existing tests pass
- [x] `make verify` clean (lint + format + typecheck + test)
- [x] OpenAPI spec regenerated
- [ ] Manual: ingest articles with cross-references, verify BacklinkPanel shows titles not UUIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)