### PR TITLE
feat(wiki): emit log.md chronological append log

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -33,6 +33,7 @@ from wikimind.models import (
     Source,
     TaskType,
 )
+from wikimind.services.activity_log import append_log_entry
 
 log = structlog.get_logger()
 
@@ -273,6 +274,15 @@ Compile this into a wiki article following the JSON schema exactly."""
 
         await self._persist_resolved_backlinks(article.id, resolved, session)
 
+        try:
+            append_log_entry(
+                "compile",
+                article.title,
+                extra={"source_id": source.id, "article_slug": article.slug},
+            )
+        except Exception:
+            log.warning("activity log write failed", op="compile", article_id=article.id)
+
         log.info(
             "Article saved",
             slug=slug,
@@ -329,6 +339,15 @@ Compile this into a wiki article following the JSON schema exactly."""
         await session.refresh(existing)
 
         await self._persist_resolved_backlinks(existing.id, resolved, session)
+
+        try:
+            append_log_entry(
+                "compile",
+                existing.title,
+                extra={"source_id": source.id, "article_slug": existing.slug},
+            )
+        except Exception:
+            log.warning("activity log write failed", op="compile", article_id=existing.id)
 
         log.info(
             "Article replaced in place",

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -27,6 +27,7 @@ from wikimind.models import (
     QueryResult,
     TaskType,
 )
+from wikimind.services.activity_log import append_log_entry
 
 log = structlog.get_logger()
 
@@ -194,14 +195,27 @@ class QAAgent:
 
         # File back if requested — stage the changes and let the single
         # commit below persist everything atomically (no double commit).
+        filed_article: Article | None = None
         if request.file_back and result.confidence in ("high", "medium"):
             await session.flush()  # make the new Query visible to file_back's SELECT
             article, _ = await self._file_back_thread(conversation.id, session)
             query_record.filed_back = True
             query_record.filed_article_id = article.id
+            filed_article = article
             session.add(query_record)
 
         await session.commit()
+
+        try:
+            append_log_entry("query", request.question[:120])
+            if filed_article is not None:
+                append_log_entry(
+                    "filed",
+                    filed_article.title,
+                    extra={"conversation_id": conversation.id},
+                )
+        except Exception:
+            log.warning("activity log write failed", op="query")
 
         await session.refresh(query_record)
         await session.refresh(conversation)

--- a/src/wikimind/services/activity_log.py
+++ b/src/wikimind/services/activity_log.py
@@ -38,10 +38,6 @@ def append_log_entry(op: str, title: str, extra: dict | None = None) -> None:
     wiki_dir.mkdir(parents=True, exist_ok=True)
     log_path = wiki_dir / "log.md"
 
-    # Create the file with a header if it doesn't exist yet.
-    if not log_path.exists():
-        log_path.write_text(_LOG_HEADER, encoding="utf-8")
-
     datestamp = utcnow_naive().strftime("%Y-%m-%d")
     lines = [f"## [{datestamp}] {op} | {title}\n"]
     if extra:
@@ -49,5 +45,11 @@ def append_log_entry(op: str, title: str, extra: dict | None = None) -> None:
             lines.append(f"- {key}: {value}\n")
     lines.append("\n")
 
+    # Open in append mode and write the header atomically if the file is
+    # new.  Using fh.tell() == 0 inside the same open avoids the TOCTOU
+    # race between exists() and write_text() that could truncate a
+    # concurrent writer's header.
     with log_path.open("a", encoding="utf-8") as fh:
+        if fh.tell() == 0:
+            fh.write(_LOG_HEADER)
         fh.writelines(lines)

--- a/src/wikimind/services/activity_log.py
+++ b/src/wikimind/services/activity_log.py
@@ -1,0 +1,53 @@
+"""Append-only chronological activity log at ``{data_dir}/wiki/log.md``.
+
+Implements Karpathy's LLM Wiki ``log.md`` primitive -- a flat, append-only
+Markdown file that records ingest, compile, query, and file-back events.
+The DB remains the source of truth; this file is a navigational aid.
+"""
+
+from pathlib import Path
+
+import structlog
+
+from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
+
+log = structlog.get_logger()
+
+_LOG_HEADER = "# Activity Log\n\n"
+
+
+def append_log_entry(op: str, title: str, extra: dict | None = None) -> None:
+    """Append an entry to wiki/log.md.
+
+    Line format::
+
+        ## [YYYY-MM-DD] op | title
+
+    With optional indented detail lines for extra context::
+
+        - key: value
+
+    Args:
+        op: Short operation tag (e.g. ``ingest``, ``compile``, ``query``, ``filed``).
+        title: Human-readable subject of the entry.
+        extra: Optional dict of supplementary key/value pairs written as
+            indented detail lines beneath the heading.
+    """
+    wiki_dir = Path(get_settings().data_dir) / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    log_path = wiki_dir / "log.md"
+
+    # Create the file with a header if it doesn't exist yet.
+    if not log_path.exists():
+        log_path.write_text(_LOG_HEADER, encoding="utf-8")
+
+    datestamp = utcnow_naive().strftime("%Y-%m-%d")
+    lines = [f"## [{datestamp}] {op} | {title}\n"]
+    if extra:
+        for key, value in extra.items():
+            lines.append(f"- {key}: {value}\n")
+    lines.append("\n")
+
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.writelines(lines)

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -19,6 +19,7 @@ from wikimind.config import get_settings
 from wikimind.ingest.service import IngestService as IngestAdapter
 from wikimind.jobs.background import get_background_compiler
 from wikimind.models import Source
+from wikimind.services.activity_log import append_log_entry
 
 log = structlog.get_logger()
 
@@ -50,6 +51,15 @@ class IngestService:
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
+        try:
+            append_log_entry(
+                "ingest",
+                source.title or "untitled",
+                extra={"source_type": source.source_type, "source_url": source.source_url},
+            )
+        except Exception:
+            log.warning("activity log write failed", op="ingest", source_id=source.id)
+
         if auto_compile:
             await self._schedule_compile(source)
         return source
@@ -76,6 +86,16 @@ class IngestService:
             The persisted Source record.
         """
         source = await self._adapter.ingest_pdf(file_bytes, filename, session)
+
+        try:
+            append_log_entry(
+                "ingest",
+                source.title or "untitled",
+                extra={"source_type": source.source_type, "source_url": source.source_url},
+            )
+        except Exception:
+            log.warning("activity log write failed", op="ingest", source_id=source.id)
+
         if auto_compile:
             await self._schedule_compile(source)
         return source
@@ -102,6 +122,16 @@ class IngestService:
             The persisted Source record.
         """
         source = await self._adapter.ingest_text(content, title, session)
+
+        try:
+            append_log_entry(
+                "ingest",
+                source.title or "untitled",
+                extra={"source_type": source.source_type, "source_url": source.source_url},
+            )
+        except Exception:
+            log.warning("activity log write failed", op="ingest", source_id=source.id)
+
         if auto_compile:
             await self._schedule_compile(source)
         return source

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -51,14 +51,7 @@ class IngestService:
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
-        try:
-            append_log_entry(
-                "ingest",
-                source.title or "untitled",
-                extra={"source_type": source.source_type, "source_url": source.source_url},
-            )
-        except Exception:
-            log.warning("activity log write failed", op="ingest", source_id=source.id)
+        self._log_ingest(source)
 
         if auto_compile:
             await self._schedule_compile(source)
@@ -86,15 +79,7 @@ class IngestService:
             The persisted Source record.
         """
         source = await self._adapter.ingest_pdf(file_bytes, filename, session)
-
-        try:
-            append_log_entry(
-                "ingest",
-                source.title or "untitled",
-                extra={"source_type": source.source_type, "source_url": source.source_url},
-            )
-        except Exception:
-            log.warning("activity log write failed", op="ingest", source_id=source.id)
+        self._log_ingest(source)
 
         if auto_compile:
             await self._schedule_compile(source)
@@ -122,7 +107,15 @@ class IngestService:
             The persisted Source record.
         """
         source = await self._adapter.ingest_text(content, title, session)
+        self._log_ingest(source)
 
+        if auto_compile:
+            await self._schedule_compile(source)
+        return source
+
+    @staticmethod
+    def _log_ingest(source: Source) -> None:
+        """Write an ingest entry to the activity log, swallowing failures."""
         try:
             append_log_entry(
                 "ingest",
@@ -131,10 +124,6 @@ class IngestService:
             )
         except Exception:
             log.warning("activity log write failed", op="ingest", source_id=source.id)
-
-        if auto_compile:
-            await self._schedule_compile(source)
-        return source
 
     @staticmethod
     async def _schedule_compile(source: Source) -> None:

--- a/tests/unit/test_activity_log.py
+++ b/tests/unit/test_activity_log.py
@@ -1,0 +1,93 @@
+"""Tests for the append-only wiki/log.md activity log."""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from wikimind.services.activity_log import _LOG_HEADER, append_log_entry
+
+
+class TestAppendLogEntry:
+    """Unit tests for append_log_entry."""
+
+    def test_creates_log_file_with_header_if_missing(self, tmp_path: Path) -> None:
+        """First call should create log.md with the standard header."""
+        wiki_dir = tmp_path / "wiki"
+        # wiki_dir intentionally not pre-created — the function should mkdir.
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("ingest", "Test Source")
+
+        log_path = wiki_dir / "log.md"
+        assert log_path.exists()
+        content = log_path.read_text(encoding="utf-8")
+        assert content.startswith(_LOG_HEADER)
+
+    def test_entries_are_appended_not_overwritten(self, tmp_path: Path) -> None:
+        """Multiple calls should all appear in the file in order."""
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("ingest", "First")
+            append_log_entry("compile", "Second")
+            append_log_entry("query", "Third")
+
+        content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+        assert "ingest | First" in content
+        assert "compile | Second" in content
+        assert "query | Third" in content
+        # Verify ordering: First appears before Second appears before Third
+        assert content.index("First") < content.index("Second") < content.index("Third")
+
+    def test_line_format(self, tmp_path: Path) -> None:
+        """Entry should follow ## [YYYY-MM-DD] op | title format."""
+        with (
+            patch("wikimind.services.activity_log.get_settings") as mock_settings,
+            patch("wikimind.services.activity_log.utcnow_naive") as mock_now,
+        ):
+            mock_settings.return_value.data_dir = str(tmp_path)
+            mock_now.return_value = datetime(2026, 4, 9, 12, 0, 0)
+            append_log_entry("ingest", "My Article")
+
+        content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+        assert "## [2026-04-09] ingest | My Article\n" in content
+
+    def test_extra_dict_produces_detail_lines(self, tmp_path: Path) -> None:
+        """When extra is provided, indented key: value lines should follow the heading."""
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry(
+                "ingest",
+                "Test",
+                extra={"source_type": "url", "source_url": "https://example.com"},
+            )
+
+        content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+        assert "- source_type: url\n" in content
+        assert "- source_url: https://example.com\n" in content
+
+    def test_extra_none_produces_no_detail_lines(self, tmp_path: Path) -> None:
+        """When extra is None, no detail lines should appear."""
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("query", "What is X?")
+
+        content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+        lines = content.strip().split("\n")
+        # Only header line, blank, heading line, blank — no "- key:" lines
+        detail_lines = [ln for ln in lines if ln.startswith("- ")]
+        assert detail_lines == []
+
+    def test_preserves_existing_content(self, tmp_path: Path) -> None:
+        """Appending should preserve the header and all prior entries."""
+        wiki_dir = tmp_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        log_path = wiki_dir / "log.md"
+        log_path.write_text(_LOG_HEADER + "## [2026-01-01] old | entry\n\n", encoding="utf-8")
+
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("compile", "New Article")
+
+        content = log_path.read_text(encoding="utf-8")
+        assert "## [2026-01-01] old | entry" in content
+        assert "compile | New Article" in content


### PR DESCRIPTION
## Summary

- New `activity_log.py` service module with `append_log_entry(op, title, extra)` — append-only file at `{data_dir}/wiki/log.md`
- Integrated into 3 event sources: IngestService (all adapters), Compiler (create + replace), QAAgent (query + file-back)
- Race-safe file creation using `fh.tell() == 0` inside append-mode open
- Failures never block main flow (try/except with warning-level log at every call site)

Closes #99

## Test plan

- [x] 6 unit tests: file creation, append ordering, line format, extra dict, no-extra, content preservation
- [x] All 304 existing tests pass
- [x] `make verify` clean (lint + format + typecheck + test)
- [ ] Manual: ingest a source, verify `~/.wikimind/wiki/log.md` contains ingest + compile entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)