### PR TITLE
feat(wiki): add index.md — Karpathy-style content catalog for Obsidian and agent navigation

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -34,6 +34,7 @@ from wikimind.models import (
     TaskType,
 )
 from wikimind.services.activity_log import append_log_entry
+from wikimind.services.wiki_index import regenerate_index_md
 
 log = structlog.get_logger()
 
@@ -283,6 +284,11 @@ Compile this into a wiki article following the JSON schema exactly."""
         except Exception:
             log.warning("activity log write failed", op="compile", article_id=article.id)
 
+        try:
+            await regenerate_index_md(session)
+        except Exception:
+            log.warning("index.md regeneration failed", article_id=article.id)
+
         log.info(
             "Article saved",
             slug=slug,
@@ -348,6 +354,11 @@ Compile this into a wiki article following the JSON schema exactly."""
             )
         except Exception:
             log.warning("activity log write failed", op="compile", article_id=existing.id)
+
+        try:
+            await regenerate_index_md(session)
+        except Exception:
+            log.warning("index.md regeneration failed", article_id=existing.id)
 
         log.info(
             "Article replaced in place",

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -70,18 +70,23 @@ async def regenerate_index_md(session: AsyncSession) -> Path:
     uncategorized: list[Article] = []
 
     for article in articles:
-        concept_ids: list[str] = []
+        raw_ids: list[str] = []
         if article.concept_ids:
             with contextlib.suppress(json.JSONDecodeError, TypeError):
-                concept_ids = json.loads(article.concept_ids)
+                parsed = json.loads(article.concept_ids)
+                if isinstance(parsed, list):
+                    raw_ids = [str(v) for v in parsed if v]
 
-        # Filter to concept IDs that actually resolve to a known concept
-        resolved = [cid for cid in concept_ids if cid in concept_map]
-        if resolved:
-            for cid in resolved:
-                concept_articles[concept_map[cid]].append(article)
-        else:
+        if not raw_ids:
             uncategorized.append(article)
+            continue
+
+        # The compiler stores concept *names* (not UUIDs) in concept_ids.
+        # Try the Concept table first (UUID → name); fall back to using
+        # the raw value directly as the heading (which is a name already).
+        for raw_id in raw_ids:
+            name = concept_map.get(raw_id, raw_id)
+            concept_articles[name].append(article)
 
     # Build the markdown content
     lines: list[str] = [_INDEX_HEADER]

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -1,0 +1,111 @@
+"""Regenerate ``{data_dir}/wiki/index.md`` content catalog from the database.
+
+The index is a derived Markdown export grouped by concept, aimed at Obsidian
+users and agent-first navigation. The DB remains the source of truth; this
+file is rewritten in place on every call (NOT append-only).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import structlog
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import get_settings
+from wikimind.models import Article, Concept
+
+log = structlog.get_logger()
+
+_INDEX_HEADER = "# Wiki Index\n\n"
+
+_SUMMARY_MAX_CHARS = 120
+
+
+def _first_sentence(text: str) -> str:
+    """Extract the first sentence from *text*, capped at 120 characters.
+
+    Splits on ``. `` (period-space) to avoid breaking on abbreviations like
+    ``e.g.`` or decimal numbers. Falls back to the full text when no sentence
+    boundary is found.
+    """
+    dot_pos = text.find(". ")
+    sentence = text[: dot_pos + 1] if dot_pos != -1 else text
+    if len(sentence) > _SUMMARY_MAX_CHARS:
+        return sentence[: _SUMMARY_MAX_CHARS - 1] + "\u2026"
+    return sentence
+
+
+async def regenerate_index_md(session: AsyncSession) -> Path:
+    """Regenerate the wiki/index.md content catalog from the database.
+
+    Reads all Articles + their concepts, groups by concept, writes a
+    markdown catalog. Rewritten in place on every call (NOT append-only).
+
+    Args:
+        session: Async database session.
+
+    Returns:
+        The Path to the written file.
+    """
+    settings = get_settings()
+    wiki_dir = Path(settings.data_dir) / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    index_path = wiki_dir / "index.md"
+
+    # Fetch all articles and concepts
+    articles_result = await session.execute(select(Article))
+    articles: list[Article] = list(articles_result.scalars().all())
+
+    concepts_result = await session.execute(select(Concept))
+    concepts: list[Concept] = list(concepts_result.scalars().all())
+    concept_map: dict[str, str] = {c.id: c.name for c in concepts}
+
+    # Group articles by concept name
+    concept_articles: dict[str, list[Article]] = defaultdict(list)
+    uncategorized: list[Article] = []
+
+    for article in articles:
+        concept_ids: list[str] = []
+        if article.concept_ids:
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                concept_ids = json.loads(article.concept_ids)
+
+        # Filter to concept IDs that actually resolve to a known concept
+        resolved = [cid for cid in concept_ids if cid in concept_map]
+        if resolved:
+            for cid in resolved:
+                concept_articles[concept_map[cid]].append(article)
+        else:
+            uncategorized.append(article)
+
+    # Build the markdown content
+    lines: list[str] = [_INDEX_HEADER]
+
+    # Concepts sorted alphabetically, articles sorted alphabetically within each
+    for concept_name in sorted(concept_articles):
+        lines.append(f"## {concept_name}\n\n")
+        for article in sorted(concept_articles[concept_name], key=lambda a: a.slug):
+            summary_part = ""
+            if article.summary:
+                summary_part = f" \u2014 {_first_sentence(article.summary)}"
+            lines.append(f"- [[{article.slug}]]{summary_part}\n")
+        lines.append("\n")
+
+    # Uncategorized section at the bottom
+    if uncategorized:
+        lines.append("## Uncategorized\n\n")
+        for article in sorted(uncategorized, key=lambda a: a.slug):
+            summary_part = ""
+            if article.summary:
+                summary_part = f" \u2014 {_first_sentence(article.summary)}"
+            lines.append(f"- [[{article.slug}]]{summary_part}\n")
+        lines.append("\n")
+
+    index_path.write_text("".join(lines), encoding="utf-8")
+    log.info("index.md regenerated", article_count=len(articles))
+    return index_path

--- a/tests/unit/test_wiki_index.py
+++ b/tests/unit/test_wiki_index.py
@@ -112,14 +112,14 @@ class TestRegenerateIndexMd:
         assert "- [[random-note]]" in content
 
     @pytest.mark.anyio
-    async def test_unresolved_concept_ids_go_to_uncategorized(self, db_session: AsyncSession) -> None:
-        """Articles whose concept_ids don't match any Concept go to Uncategorized."""
+    async def test_unresolved_concept_ids_used_as_raw_headings(self, db_session: AsyncSession) -> None:
+        """Concept names that don't match Concept table rows are used directly as headings."""
         a1 = Article(
             slug="orphan-article",
             title="Orphan Article",
             file_path="/wiki/orphan.md",
-            concept_ids=json.dumps(["nonexistent-id"]),
-            summary="This concept ID does not exist.",
+            concept_ids=json.dumps(["Machine Learning"]),
+            summary="This concept name is used directly.",
         )
         db_session.add(a1)
         await db_session.commit()
@@ -127,8 +127,9 @@ class TestRegenerateIndexMd:
         path = await regenerate_index_md(db_session)
         content = path.read_text(encoding="utf-8")
 
-        assert "## Uncategorized" in content
+        assert "## Machine Learning" in content
         assert "- [[orphan-article]]" in content
+        assert "## Uncategorized" not in content
 
     @pytest.mark.anyio
     async def test_entry_format(self, db_session: AsyncSession) -> None:

--- a/tests/unit/test_wiki_index.py
+++ b/tests/unit/test_wiki_index.py
@@ -1,0 +1,319 @@
+"""Tests for wiki/index.md content catalog generation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from wikimind.models import Article, Concept
+from wikimind.services.wiki_index import (
+    _INDEX_HEADER,
+    _SUMMARY_MAX_CHARS,
+    _first_sentence,
+    regenerate_index_md,
+)
+
+
+class TestFirstSentence:
+    """Unit tests for the _first_sentence helper."""
+
+    def test_extracts_first_sentence(self) -> None:
+        text = "This is the first sentence. This is the second."
+        assert _first_sentence(text) == "This is the first sentence."
+
+    def test_returns_full_text_when_no_period_space(self) -> None:
+        text = "No period at end"
+        assert _first_sentence(text) == "No period at end"
+
+    def test_truncates_long_sentence(self) -> None:
+        text = "A" * 200 + ". Second sentence."
+        result = _first_sentence(text)
+        assert len(result) <= _SUMMARY_MAX_CHARS
+        assert result.endswith("\u2026")
+
+    def test_does_not_truncate_short_sentence(self) -> None:
+        text = "Short sentence. Another one."
+        result = _first_sentence(text)
+        assert result == "Short sentence."
+        assert "\u2026" not in result
+
+
+class TestRegenerateIndexMd:
+    """Unit tests for regenerate_index_md."""
+
+    @pytest.mark.anyio
+    async def test_empty_database_produces_header_only(self, db_session: AsyncSession) -> None:
+        """An empty DB should produce a file with just the header."""
+        path = await regenerate_index_md(db_session)
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert content == _INDEX_HEADER
+
+    @pytest.mark.anyio
+    async def test_articles_grouped_by_concept(self, db_session: AsyncSession) -> None:
+        """Articles should appear under their concept headings."""
+        # Create concepts
+        c1 = Concept(id="c1", name="Databases")
+        c2 = Concept(id="c2", name="Algorithms")
+        db_session.add_all([c1, c2])
+        await db_session.commit()
+
+        # Create articles with concept_ids
+        a1 = Article(
+            slug="postgres-internals",
+            title="Postgres Internals",
+            file_path="/wiki/postgres-internals.md",
+            concept_ids=json.dumps(["c1"]),
+            summary="How Postgres works internally. Deep dive into storage.",
+        )
+        a2 = Article(
+            slug="sorting-algorithms",
+            title="Sorting Algorithms",
+            file_path="/wiki/sorting-algorithms.md",
+            concept_ids=json.dumps(["c2"]),
+            summary="Overview of sorting algorithms. Comparison based approaches.",
+        )
+        db_session.add_all([a1, a2])
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        # Both concept headings should appear
+        assert "## Algorithms" in content
+        assert "## Databases" in content
+
+        # Articles under correct headings
+        assert "- [[sorting-algorithms]]" in content
+        assert "- [[postgres-internals]]" in content
+
+        # Alphabetical order: Algorithms before Databases
+        assert content.index("## Algorithms") < content.index("## Databases")
+
+    @pytest.mark.anyio
+    async def test_uncategorized_section(self, db_session: AsyncSession) -> None:
+        """Articles without concepts should land in Uncategorized."""
+        a1 = Article(
+            slug="random-note",
+            title="Random Note",
+            file_path="/wiki/random-note.md",
+            concept_ids=None,
+            summary="A note with no concept.",
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        assert "## Uncategorized" in content
+        assert "- [[random-note]]" in content
+
+    @pytest.mark.anyio
+    async def test_unresolved_concept_ids_go_to_uncategorized(self, db_session: AsyncSession) -> None:
+        """Articles whose concept_ids don't match any Concept go to Uncategorized."""
+        a1 = Article(
+            slug="orphan-article",
+            title="Orphan Article",
+            file_path="/wiki/orphan.md",
+            concept_ids=json.dumps(["nonexistent-id"]),
+            summary="This concept ID does not exist.",
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        assert "## Uncategorized" in content
+        assert "- [[orphan-article]]" in content
+
+    @pytest.mark.anyio
+    async def test_entry_format(self, db_session: AsyncSession) -> None:
+        """Each entry should be: - [[slug]] -- summary first sentence."""
+        c1 = Concept(id="c1", name="Testing")
+        db_session.add(c1)
+        await db_session.commit()
+
+        a1 = Article(
+            slug="unit-testing-guide",
+            title="Unit Testing Guide",
+            file_path="/wiki/unit-testing-guide.md",
+            concept_ids=json.dumps(["c1"]),
+            summary="How to write effective unit tests. Covers mocking and fixtures.",
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        expected = "- [[unit-testing-guide]] \u2014 How to write effective unit tests."
+        assert expected in content
+
+    @pytest.mark.anyio
+    async def test_summary_truncation(self, db_session: AsyncSession) -> None:
+        """Summaries longer than 120 chars should be truncated with an ellipsis."""
+        c1 = Concept(id="c1", name="Long")
+        db_session.add(c1)
+        await db_session.commit()
+
+        long_sentence = "A" * 200 + ". Second."
+        a1 = Article(
+            slug="long-summary",
+            title="Long Summary",
+            file_path="/wiki/long-summary.md",
+            concept_ids=json.dumps(["c1"]),
+            summary=long_sentence,
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        # The entry line should contain a truncated summary
+        for line in content.splitlines():
+            if "[[long-summary]]" in line:
+                # Extract the summary part after the em dash
+                summary_part = line.split("\u2014 ", 1)[1]
+                assert len(summary_part) <= _SUMMARY_MAX_CHARS
+                assert summary_part.endswith("\u2026")
+                break
+        else:
+            pytest.fail("Entry for long-summary not found")
+
+    @pytest.mark.anyio
+    async def test_regeneration_overwrites(self, db_session: AsyncSession) -> None:
+        """Calling regenerate twice should overwrite, not append."""
+        a1 = Article(
+            slug="first-article",
+            title="First Article",
+            file_path="/wiki/first-article.md",
+            concept_ids=None,
+            summary="First.",
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        first_content = path.read_text(encoding="utf-8")
+        assert "[[first-article]]" in first_content
+
+        # Add a second article and regenerate
+        a2 = Article(
+            slug="second-article",
+            title="Second Article",
+            file_path="/wiki/second-article.md",
+            concept_ids=None,
+            summary="Second.",
+        )
+        db_session.add(a2)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        second_content = path.read_text(encoding="utf-8")
+
+        # Both should be present
+        assert "[[first-article]]" in second_content
+        assert "[[second-article]]" in second_content
+
+        # The header should appear exactly once (not duplicated by append)
+        assert second_content.count("# Wiki Index") == 1
+
+    @pytest.mark.anyio
+    async def test_article_with_no_summary(self, db_session: AsyncSession) -> None:
+        """Articles with no summary should have no em-dash suffix."""
+        a1 = Article(
+            slug="no-summary",
+            title="No Summary",
+            file_path="/wiki/no-summary.md",
+            concept_ids=None,
+            summary=None,
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        assert "- [[no-summary]]\n" in content
+        assert "\u2014" not in content.split("[[no-summary]]")[1].split("\n")[0]
+
+    @pytest.mark.anyio
+    async def test_article_in_multiple_concepts(self, db_session: AsyncSession) -> None:
+        """An article with multiple concepts should appear under each."""
+        c1 = Concept(id="c1", name="Alpha")
+        c2 = Concept(id="c2", name="Beta")
+        db_session.add_all([c1, c2])
+        await db_session.commit()
+
+        a1 = Article(
+            slug="multi-concept",
+            title="Multi Concept",
+            file_path="/wiki/multi-concept.md",
+            concept_ids=json.dumps(["c1", "c2"]),
+            summary="Belongs to two concepts.",
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        # Should appear under both headings
+        assert "## Alpha" in content
+        assert "## Beta" in content
+
+        # Count occurrences of the article slug
+        assert content.count("[[multi-concept]]") == 2
+
+    @pytest.mark.anyio
+    async def test_articles_sorted_within_concept(self, db_session: AsyncSession) -> None:
+        """Articles within a concept should be sorted alphabetically by slug."""
+        c1 = Concept(id="c1", name="Concept")
+        db_session.add(c1)
+        await db_session.commit()
+
+        a_zebra = Article(
+            slug="zebra",
+            title="Zebra",
+            file_path="/wiki/zebra.md",
+            concept_ids=json.dumps(["c1"]),
+            summary="Zebra summary.",
+        )
+        a_alpha = Article(
+            slug="alpha",
+            title="Alpha",
+            file_path="/wiki/alpha.md",
+            concept_ids=json.dumps(["c1"]),
+            summary="Alpha summary.",
+        )
+        db_session.add_all([a_zebra, a_alpha])
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        assert content.index("[[alpha]]") < content.index("[[zebra]]")
+
+    @pytest.mark.anyio
+    async def test_malformed_concept_ids_go_to_uncategorized(self, db_session: AsyncSession) -> None:
+        """Articles with malformed concept_ids JSON should go to Uncategorized."""
+        a1 = Article(
+            slug="bad-json",
+            title="Bad JSON",
+            file_path="/wiki/bad-json.md",
+            concept_ids="not-valid-json",
+            summary="Malformed concept IDs.",
+        )
+        db_session.add(a1)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+
+        assert "## Uncategorized" in content
+        assert "- [[bad-json]]" in content


### PR DESCRIPTION
## Problem

WikiMind's `wiki/` directory contains compiled articles but has no top-level table of contents. Users browsing the directory in Obsidian (or agents reading it directly) have to scan individual files to understand what the wiki covers. Karpathy's [LLM Wiki Pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) explicitly calls for an `index.md` that catalogs all pages — this is the second of two navigation primitives (the first, `log.md`, shipped in PR #106).

## Solution

Auto-generate `{data_dir}/wiki/index.md` after every compilation. The file groups articles by concept and shows a one-line summary for each:

```markdown
# Wiki Index

## Machine Learning
- [[attention-mechanisms]] — How transformers route information across sequence positions.
- [[prompt-caching-strategies]] — Techniques for reducing redundant LLM computation.

## Uncategorized
- [[my-reading-list]]
```

**Key design decisions:**
- **Regeneration trigger:** rewritten after every compile (simple, no debounce)
- **Concept grouping:** uses the concept names the compiler stores in `Article.concept_ids`. Falls back gracefully when the `Concept` table is empty (pre-Epic 3)
- **Summary:** first sentence of `article.summary`, capped at 120 chars
- **Error handling:** failures never block compilation (try/except with warning log)
- **Not append-only** — unlike `log.md`, this is a full rewrite every time

## Changes

| File | What |
|------|------|
| `src/wikimind/services/wiki_index.py` | New module: `regenerate_index_md(session)` |
| `src/wikimind/engine/compiler.py` | Calls regenerate after article create/replace |
| `tests/unit/test_wiki_index.py` | 15 tests: grouping, sorting, truncation, malformed JSON, overwrite, empty DB |

Closes #100

## Test plan

- [x] 15 unit tests (100% coverage on new module)
- [x] All 336 tests pass
- [x] `make verify` clean
- [x] Manual: ingest articles, open `~/.wikimind/wiki/index.md` in Obsidian or editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)