### PR TITLE
feat(qa): add conversation export — download Q&A threads as markdown without saving to wiki

### DIFF
--- a/apps/web/src/api/query.ts
+++ b/apps/web/src/api/query.ts
@@ -1,6 +1,6 @@
 // Endpoints in src/wikimind/api/routes/query.py.
 
-import { apiFetch } from "./client";
+import { apiFetch, getBaseUrl } from "./client";
 
 // ----- Types -----
 
@@ -71,4 +71,10 @@ export function getConversation(id: string): Promise<ConversationDetail> {
 
 export function fileBackConversation(id: string): Promise<FileBackResponse> {
   return apiFetch<FileBackResponse>(`/query/conversations/${id}/file-back`, { method: "POST" });
+}
+
+export async function exportConversation(id: string): Promise<string> {
+  const res = await fetch(`${getBaseUrl()}/query/conversations/${id}/export`);
+  if (!res.ok) throw new Error("Export failed");
+  return res.text();
 }

--- a/apps/web/src/components/ask/AskView.tsx
+++ b/apps/web/src/components/ask/AskView.tsx
@@ -102,8 +102,14 @@ export function AskView() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download =
-        (conversationDetail.data?.conversation.title ?? "conversation") + ".md";
+      const rawTitle =
+        conversationDetail.data?.conversation.title ?? "conversation";
+      const safeName = rawTitle
+        .replace(/[^a-zA-Z0-9_ -]/g, "")
+        .replace(/ +/g, " ")
+        .trim()
+        || "conversation";
+      a.download = safeName + ".md";
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/apps/web/src/components/ask/AskView.tsx
+++ b/apps/web/src/components/ask/AskView.tsx
@@ -6,6 +6,7 @@ import {
   getConversation,
   listConversations,
   fileBackConversation,
+  exportConversation,
   type AskRequest,
   type ConversationDetail,
 } from "../../api/query";
@@ -91,6 +92,33 @@ export function AskView() {
     if (conversationId) fileBack.mutate(conversationId);
   };
 
+  const [isExporting, setIsExporting] = useState(false);
+  const handleExport = async () => {
+    if (!conversationId) return;
+    setIsExporting(true);
+    try {
+      const markdown = await exportConversation(conversationId);
+      const blob = new Blob([markdown], { type: "text/markdown" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        (conversationDetail.data?.conversation.title ?? "conversation") + ".md";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      pushToast({
+        kind: "error",
+        title: "Failed to export conversation",
+        detail: "Could not download the markdown file.",
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   // Optimistic UI: while the ask mutation is in flight, show the user's
   // question in a "pending" turn card so they get immediate visual feedback
   // instead of staring at a frozen UI for 5-30 seconds.
@@ -112,6 +140,8 @@ export function AskView() {
             pendingQuestion={pendingQuestion}
             onSave={handleSave}
             isSaving={fileBack.isPending}
+            onExport={handleExport}
+            isExporting={isExporting}
           />
           {pendingError && (
             <div className="mt-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">

--- a/apps/web/src/components/ask/ConversationThread.tsx
+++ b/apps/web/src/components/ask/ConversationThread.tsx
@@ -8,6 +8,8 @@ interface Props {
   pendingQuestion: string | null;
   onSave: () => void;
   isSaving: boolean;
+  onExport: () => void;
+  isExporting: boolean;
 }
 
 export function ConversationThread({
@@ -16,6 +18,8 @@ export function ConversationThread({
   pendingQuestion,
   onSave,
   isSaving,
+  onExport,
+  isExporting,
 }: Props) {
   // Empty state: no existing conversation AND nothing in flight
   if (!detail && !pendingQuestion) {
@@ -41,12 +45,20 @@ export function ConversationThread({
         />
       )}
       {queries.length > 0 && !pendingQuestion && (
-        <div className="pt-4">
+        <div className="flex gap-2 pt-4">
           <SaveThreadButton
             isFiledBack={isFiledBack}
             isSaving={isSaving}
             onClick={onSave}
           />
+          <button
+            type="button"
+            onClick={onExport}
+            disabled={isExporting}
+            className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            {isExporting ? "Exporting…" : "Export markdown"}
+          </button>
         </div>
       )}
     </div>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -486,8 +486,9 @@ paths:
         '200':
           description: Successful Response
           content:
-            application/json:
-              schema: {}
+            text/markdown:
+              schema:
+                type: string
         '422':
           description: Validation Error
           content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -467,6 +467,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /query/conversations/{conversation_id}/export:
+    get:
+      tags:
+      - Query
+      summary: Export Conversation
+      description: Export a conversation as standalone markdown. Pure read, no DB
+        writes.
+      operationId: export_conversation_query_conversations__conversation_id__export_get
+      parameters:
+      - name: conversation_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Conversation Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /query/conversations/{conversation_id}/file-back:
     post:
       tags:

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -61,7 +61,11 @@ async def get_conversation(
     return await service.get_conversation(conversation_id, session)
 
 
-@router.get("/conversations/{conversation_id}/export")
+@router.get(
+    "/conversations/{conversation_id}/export",
+    response_class=Response,
+    responses={200: {"content": {"text/markdown": {"schema": {"type": "string"}}}}},
+)
 async def export_conversation(
     conversation_id: str,
     session: AsyncSession = Depends(get_session),

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -1,6 +1,7 @@
 """Endpoints for asking questions, browsing conversations, and filing answers back."""
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import Response
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
@@ -58,6 +59,16 @@ async def get_conversation(
 ):
     """Return a single conversation with all its turns."""
     return await service.get_conversation(conversation_id, session)
+
+
+@router.get("/conversations/{conversation_id}/export")
+async def export_conversation(
+    conversation_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: QueryService = Depends(get_query_service),
+) -> Response:
+    """Export a conversation as standalone markdown. Pure read, no DB writes."""
+    return await service.export_conversation(conversation_id, session)
 
 
 @router.post("/conversations/{conversation_id}/file-back")

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -8,12 +8,15 @@ from.
 """
 
 import json
+import re
 
 import structlog
 from fastapi import HTTPException
+from fastapi.responses import Response
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from wikimind.engine.conversation_serializer import serialize_conversation_to_markdown
 from wikimind.engine.qa_agent import QAAgent
 from wikimind.models import (
     Article,
@@ -318,6 +321,67 @@ class QueryService:
             "article": {"id": article.id, "slug": article.slug, "title": article.title},
             "was_update": was_update,
         }
+
+    async def export_conversation(
+        self,
+        conversation_id: str,
+        session: AsyncSession,
+    ) -> Response:
+        """Export conversation as markdown. Read-only, no DB writes.
+
+        Fetches the conversation and its queries, serializes them using the
+        same serializer as file-back, and returns the markdown as a
+        downloadable response.
+
+        Args:
+            conversation_id: The conversation UUID to export.
+            session: Async database session.
+
+        Returns:
+            :class:`Response` with ``text/markdown`` content and a
+            ``Content-Disposition`` header for download.
+
+        Raises:
+            HTTPException: 404 if the conversation is not found.
+        """
+        conversation = await session.get(Conversation, conversation_id)
+        if conversation is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+
+        result = await session.execute(
+            select(Query).where(Query.conversation_id == conversation_id).order_by(Query.turn_index.asc())  # type: ignore[attr-defined]
+        )
+        queries = list(result.scalars().all())
+
+        markdown = serialize_conversation_to_markdown(conversation, queries)
+
+        filename = _sanitize_filename(conversation.title) + ".md"
+        return Response(
+            content=markdown,
+            media_type="text/markdown",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+
+_FILENAME_UNSAFE_RE = re.compile(r"[^a-zA-Z0-9_\- ]")
+
+
+def _sanitize_filename(title: str) -> str:
+    """Sanitize a conversation title for use as a download filename.
+
+    Replaces non-alphanumeric characters (except hyphens, underscores, and
+    spaces) with hyphens, collapses runs of hyphens, and strips leading/
+    trailing hyphens.
+
+    Args:
+        title: Raw conversation title.
+
+    Returns:
+        A filesystem-safe filename (without extension).
+    """
+    sanitized = _FILENAME_UNSAFE_RE.sub("-", title)
+    sanitized = re.sub(r"-{2,}", "-", sanitized)
+    return sanitized.strip("- ") or "conversation"
 
 
 _query_service: QueryService | None = None

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -1,12 +1,15 @@
-"""Tests for the QueryService citation chain resolution."""
+"""Tests for the QueryService citation chain resolution and conversation export."""
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 
-from wikimind.models import Article, Query, Source, SourceType
-from wikimind.services.query import _build_citations
+from wikimind.engine.conversation_serializer import serialize_conversation_to_markdown
+from wikimind.models import Article, Conversation, Query, Source, SourceType
+from wikimind.services.query import QueryService, _build_citations, _sanitize_filename
 
 
 async def _seed(db_session, tmp_path: Path) -> tuple[Query, Article, Source]:
@@ -104,3 +107,132 @@ class TestQueryCitations:
         assert len(citations) == 1
         assert citations[0].article.title == article.title
         assert citations[0].sources == []
+
+
+async def _seed_conversation(db_session) -> tuple[Conversation, list[Query]]:
+    """Persist a Conversation with two Q&A turns for export tests."""
+    conv = Conversation(
+        id="conv-export-1",
+        title="Export Test Conversation",
+        created_at=datetime(2026, 4, 8, 12, 0, 0),
+        updated_at=datetime(2026, 4, 8, 12, 5, 0),
+    )
+    db_session.add(conv)
+    await db_session.flush()
+
+    q1 = Query(
+        id="q-export-1",
+        question="What is X?",
+        answer="X is a thing.",
+        confidence="high",
+        source_article_ids=json.dumps(["Article One"]),
+        related_article_ids=json.dumps([]),
+        conversation_id="conv-export-1",
+        turn_index=0,
+        created_at=datetime(2026, 4, 8, 12, 0, 0),
+    )
+    q2 = Query(
+        id="q-export-2",
+        question="How does X work?",
+        answer="X works by Y.",
+        confidence="medium",
+        source_article_ids=json.dumps([]),
+        related_article_ids=json.dumps([]),
+        conversation_id="conv-export-1",
+        turn_index=1,
+        created_at=datetime(2026, 4, 8, 12, 1, 0),
+    )
+    db_session.add_all([q1, q2])
+    await db_session.commit()
+    return conv, [q1, q2]
+
+
+@pytest.mark.asyncio
+class TestExportConversation:
+    async def test_export_returns_markdown_content(self, db_session):
+        """Export returns a Response with text/markdown content type."""
+        await _seed_conversation(db_session)
+        service = QueryService()
+
+        response = await service.export_conversation("conv-export-1", db_session)
+
+        assert response.media_type == "text/markdown"
+        body = response.body.decode()
+        assert "# Export Test Conversation" in body
+        assert "## Q1: What is X?" in body
+        assert "## Q2: How does X work?" in body
+
+    async def test_export_has_content_disposition_header(self, db_session):
+        """Export response includes a Content-Disposition header for download."""
+        await _seed_conversation(db_session)
+        service = QueryService()
+
+        response = await service.export_conversation("conv-export-1", db_session)
+
+        assert "content-disposition" in response.headers
+        assert "attachment" in response.headers["content-disposition"]
+        assert ".md" in response.headers["content-disposition"]
+
+    async def test_export_is_read_only(self, db_session):
+        """Export does not modify the conversation or query rows."""
+        conv, queries = await _seed_conversation(db_session)
+        service = QueryService()
+
+        # Capture state before export
+        conv_before_title = conv.title
+        conv_before_filed = conv.filed_article_id
+        q_before_filed = [q.filed_back for q in queries]
+
+        await service.export_conversation("conv-export-1", db_session)
+
+        # Refresh from DB to check no writes happened
+        await db_session.refresh(conv)
+        for q in queries:
+            await db_session.refresh(q)
+
+        assert conv.title == conv_before_title
+        assert conv.filed_article_id == conv_before_filed
+        assert [q.filed_back for q in queries] == q_before_filed
+
+    async def test_export_404_for_nonexistent_conversation(self, db_session):
+        """Export raises 404 for a conversation that doesn't exist."""
+        service = QueryService()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.export_conversation("nonexistent-id", db_session)
+
+        assert exc_info.value.status_code == 404
+
+    async def test_export_matches_serializer_output(self, db_session):
+        """Exported markdown is byte-identical to calling the serializer directly."""
+        conv, queries = await _seed_conversation(db_session)
+        service = QueryService()
+
+        response = await service.export_conversation("conv-export-1", db_session)
+        exported = response.body.decode()
+
+        expected = serialize_conversation_to_markdown(conv, queries)
+        assert exported == expected
+
+
+class TestSanitizeFilename:
+    def test_basic_title(self):
+        assert _sanitize_filename("Hello World") == "Hello World"
+
+    def test_special_characters_replaced(self):
+        assert _sanitize_filename('What is "AI"?') == "What is -AI"
+
+    def test_collapses_multiple_hyphens(self):
+        assert _sanitize_filename("a!!!b") == "a-b"
+
+    def test_strips_leading_trailing_hyphens(self):
+        assert _sanitize_filename("!!!Hello!!!") == "Hello"
+
+    def test_empty_title_returns_fallback(self):
+        assert _sanitize_filename("") == "conversation"
+
+    def test_all_special_returns_fallback(self):
+        assert _sanitize_filename("!@#$%") == "conversation"
+
+    def test_preserves_hyphens_and_underscores(self):
+        assert _sanitize_filename("my-conversation_v2") == "my-conversation_v2"


### PR DESCRIPTION
## Problem

WikiMind lets users file Q&A conversations back to the wiki via "Save to wiki", but sometimes you just want to grab the conversation as a `.md` file — to share with someone, paste into another tool, or archive externally — without creating a wiki article. There is no way to do that today.

## Solution

Add a read-only export endpoint and a frontend download button:

- **Backend:** `GET /query/conversations/{id}/export` returns the conversation serialized as markdown with `Content-Disposition: attachment` header
- **Frontend:** "Export markdown" button next to "Save to wiki" triggers a browser download
- **Guarantees:** zero database writes, idempotent, byte-identical to file-back output (same serializer)

Example output:
```markdown
---
title: "How does attention differ from convolution?"
type: qa-conversation
turn_count: 2
---

# How does attention differ from convolution?

## Q1: How does attention differ from convolution?

Attention computes pairwise relationships between all positions...

**Sources:** [[attention-mechanisms]], [[convolutional-networks]]
```

## Changes

| File | What |
|------|------|
| `src/wikimind/api/routes/query.py` | New `GET /conversations/{id}/export` endpoint |
| `src/wikimind/services/query.py` | `export_conversation()` method + `_sanitize_filename()` |
| `apps/web/src/api/query.ts` | `exportConversation()` fetch function |
| `apps/web/src/components/ask/AskView.tsx` | Export handler with download logic |
| `apps/web/src/components/ask/ConversationThread.tsx` | "Export markdown" button |
| `tests/unit/test_query_service.py` | 12 tests: content, headers, read-only, 404, byte-identical, filename sanitization |
| `docs/openapi.yaml` | Regenerated with correct `text/markdown` media type |

Closes #91

## Test plan

- [x] 12 new tests (5 export + 7 filename edge cases)
- [x] All 333 tests pass
- [x] `make verify` clean
- [x] OpenAPI spec correctly declares `text/markdown`
- [ ] Manual: ask questions, click "Export markdown", verify `.md` file downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)