### PR TITLE
fix(ingest): add token-aware fallback to chunk_text for large headingless documents

### DIFF
--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -86,14 +86,157 @@ def estimate_tokens(text: str) -> int:
     return len(text) // 4
 
 
+def _split_by_paragraphs(
+    text: str,
+    doc_id: str,
+    heading_path: list[str],
+    max_chunk_tokens: int,
+    start_index: int,
+) -> list[DocumentChunk]:
+    """Split text on paragraph boundaries (double newlines).
+
+    If any resulting paragraph still exceeds *max_chunk_tokens*, it is
+    further split using :func:`_split_by_token_window`.
+
+    Args:
+        text: The text to split.
+        doc_id: Document ID for the chunks.
+        heading_path: Heading path to assign to each chunk.
+        max_chunk_tokens: Maximum tokens per chunk.
+        start_index: Starting chunk_index for numbering.
+
+    Returns:
+        A list of :class:`DocumentChunk` instances, each within the token limit.
+    """
+    paragraphs = re.split(r"\n\n+", text)
+    chunks: list[DocumentChunk] = []
+    current_parts: list[str] = []
+    chunk_index = start_index
+
+    for para in paragraphs:
+        candidate = "\n\n".join([*current_parts, para]).strip()
+        if estimate_tokens(candidate) > max_chunk_tokens and current_parts:
+            # Flush accumulated paragraphs
+            content = "\n\n".join(current_parts).strip()
+            if estimate_tokens(content) > max_chunk_tokens:
+                sub = _split_by_token_window(content, doc_id, heading_path, max_chunk_tokens, chunk_index)
+                chunks.extend(sub)
+                chunk_index += len(sub)
+            else:
+                chunks.append(
+                    DocumentChunk(
+                        document_id=doc_id,
+                        content=content,
+                        heading_path=list(heading_path),
+                        token_count=estimate_tokens(content),
+                        chunk_index=chunk_index,
+                    )
+                )
+                chunk_index += 1
+            current_parts = [para]
+        else:
+            current_parts.append(para)
+
+    # Flush remaining
+    if current_parts:
+        content = "\n\n".join(current_parts).strip()
+        if content:
+            if estimate_tokens(content) > max_chunk_tokens:
+                sub = _split_by_token_window(content, doc_id, heading_path, max_chunk_tokens, chunk_index)
+                chunks.extend(sub)
+            else:
+                chunks.append(
+                    DocumentChunk(
+                        document_id=doc_id,
+                        content=content,
+                        heading_path=list(heading_path),
+                        token_count=estimate_tokens(content),
+                        chunk_index=chunk_index,
+                    )
+                )
+
+    return chunks
+
+
+def _split_by_token_window(
+    text: str,
+    doc_id: str,
+    heading_path: list[str],
+    max_chunk_tokens: int,
+    start_index: int,
+) -> list[DocumentChunk]:
+    """Split text into fixed token-sized windows on the nearest whitespace.
+
+    This is the last-resort fallback when neither heading-based nor
+    paragraph-based splitting produces chunks within the token limit.
+
+    Args:
+        text: The text to split.
+        doc_id: Document ID for the chunks.
+        heading_path: Heading path to assign to each chunk.
+        max_chunk_tokens: Maximum tokens per chunk.
+        start_index: Starting chunk_index for numbering.
+
+    Returns:
+        A list of :class:`DocumentChunk` instances, each within the token limit.
+    """
+    # Convert token limit to an approximate character budget.
+    max_chars = max_chunk_tokens * 4
+    chunks: list[DocumentChunk] = []
+    chunk_index = start_index
+    pos = 0
+
+    while pos < len(text):
+        end = min(pos + max_chars, len(text))
+        if end < len(text):
+            # Walk back to nearest whitespace so we don't split mid-word.
+            split_at = text.rfind(" ", pos, end)
+            if split_at <= pos:
+                # No whitespace found — hard split at max_chars.
+                split_at = end
+            end = split_at
+
+        content = text[pos:end].strip()
+        if content:
+            chunks.append(
+                DocumentChunk(
+                    document_id=doc_id,
+                    content=content,
+                    heading_path=list(heading_path),
+                    token_count=estimate_tokens(content),
+                    chunk_index=chunk_index,
+                )
+            )
+            chunk_index += 1
+        pos = end
+        # Skip whitespace at the split point to avoid leading spaces in next chunk.
+        while pos < len(text) and text[pos] == " ":
+            pos += 1
+
+    return chunks
+
+
 def chunk_text(text: str, doc_id: str, max_chunk_tokens: int = 4000) -> list[DocumentChunk]:
-    """Split text into semantic chunks preserving heading structure."""
+    """Split text into semantic chunks preserving heading structure.
+
+    Strategy (in order of preference):
+
+    1. **Heading-based** — split on markdown headings (``# ``, ``## ``, ``### ``).
+    2. **Paragraph-based** — if any heading-based chunk exceeds
+       *max_chunk_tokens*, split it further on paragraph boundaries
+       (double newlines).
+    3. **Token-window** — if a single paragraph still exceeds the limit,
+       hard-split on the nearest whitespace at *max_chunk_tokens* boundaries.
+
+    This ensures no chunk ever exceeds the token limit regardless of input
+    format (e.g. PDF-extracted text with no markdown headings).
+    """
     chunks: list[DocumentChunk] = []
     current_headings: list[str] = []
 
     # Split on headings
     sections = re.split(r"(#{1,3} .+)", text)
-    current_content = []
+    current_content: list[str] = []
     chunk_index = 0
 
     for section in sections:
@@ -134,10 +277,8 @@ def chunk_text(text: str, doc_id: str, max_chunk_tokens: int = 4000) -> list[Doc
             )
         )
 
-    return (
-        chunks
-        if chunks
-        else [
+    if not chunks:
+        chunks = [
             DocumentChunk(
                 document_id=doc_id,
                 content=text,
@@ -146,7 +287,25 @@ def chunk_text(text: str, doc_id: str, max_chunk_tokens: int = 4000) -> list[Doc
                 chunk_index=0,
             )
         ]
-    )
+
+    # --- Token-aware fallback: re-split oversized chunks ---
+    needs_resplit = any(c.token_count > max_chunk_tokens for c in chunks)
+    if not needs_resplit:
+        return chunks
+
+    result: list[DocumentChunk] = []
+    idx = 0
+    for chunk in chunks:
+        if chunk.token_count > max_chunk_tokens:
+            sub = _split_by_paragraphs(chunk.content, doc_id, chunk.heading_path, max_chunk_tokens, idx)
+            result.extend(sub)
+            idx += len(sub)
+        else:
+            chunk.chunk_index = idx
+            result.append(chunk)
+            idx += 1
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_chunk_text.py
+++ b/tests/unit/test_chunk_text.py
@@ -1,0 +1,200 @@
+"""Tests for chunk_text token-aware fallback (issue #110).
+
+Verifies that chunk_text correctly splits text that exceeds max_chunk_tokens
+regardless of whether the input has markdown headings, paragraph boundaries,
+or neither.
+"""
+
+from __future__ import annotations
+
+import re
+
+from wikimind.ingest.service import chunk_text, estimate_tokens
+
+
+def _join_chunk_content(chunks: list) -> str:
+    """Concatenate chunk contents, stripping whitespace for comparison."""
+    return "".join(c.content for c in chunks)
+
+
+# -----------------------------------------------------------------------
+# Heading-based splitting still works as before
+# -----------------------------------------------------------------------
+
+
+def test_heading_based_splitting_unchanged() -> None:
+    """Documents with headings and small sections should produce heading-based chunks."""
+    text = "# Intro\n\nSome intro text.\n\n## Details\n\nSome details."
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=100)
+    assert len(chunks) >= 1
+    # All chunks should be within the limit
+    for c in chunks:
+        assert c.token_count <= 100
+
+
+def test_small_document_single_chunk() -> None:
+    """A small document should remain a single chunk."""
+    text = "Hello, this is a small document."
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=4000)
+    assert len(chunks) == 1
+    assert chunks[0].content == text
+
+
+# -----------------------------------------------------------------------
+# No-headings fallback: paragraph splitting
+# -----------------------------------------------------------------------
+
+
+def test_no_headings_large_doc_splits_into_multiple_chunks() -> None:
+    """A large document with no headings and >max_chunk_tokens must be split."""
+    # Create ~8000 tokens of text (32000 chars at 4 chars/token) with paragraphs
+    paragraphs = [f"Paragraph {i}. " + ("word " * 200) for i in range(40)]
+    text = "\n\n".join(paragraphs)
+    assert estimate_tokens(text) > 4000
+
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=4000)
+    assert len(chunks) > 1
+
+
+def test_no_headings_all_chunks_under_limit() -> None:
+    """Every chunk must be under max_chunk_tokens, even without headings."""
+    paragraphs = [f"Para {i}. " + ("word " * 200) for i in range(40)]
+    text = "\n\n".join(paragraphs)
+    max_tokens = 2000
+
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=max_tokens)
+    for i, c in enumerate(chunks):
+        assert c.token_count <= max_tokens, f"Chunk {i} has {c.token_count} tokens, exceeds limit {max_tokens}"
+
+
+def test_paragraph_boundary_splitting() -> None:
+    """When headings produce oversized chunks, paragraph boundaries are used."""
+    # Two paragraphs, each ~600 tokens, no headings.  With max=500,
+    # heading split yields one big chunk; paragraph split should yield two.
+    para_a = "Alpha. " + ("aaa " * 600)
+    para_b = "Beta. " + ("bbb " * 600)
+    text = para_a + "\n\n" + para_b
+
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=500)
+    assert len(chunks) >= 2
+    for c in chunks:
+        assert c.token_count <= 500
+
+
+# -----------------------------------------------------------------------
+# Fixed-window fallback when paragraphs are also huge
+# -----------------------------------------------------------------------
+
+
+def test_single_huge_paragraph_uses_token_window() -> None:
+    r"""A single giant paragraph (no \n\n) must still be split via token window."""
+    # ~5000 tokens in one paragraph (no double-newline breaks)
+    text = "word " * 5000
+    max_tokens = 1000
+
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=max_tokens)
+    assert len(chunks) >= 5
+    for i, c in enumerate(chunks):
+        assert c.token_count <= max_tokens, f"Chunk {i} has {c.token_count} tokens, exceeds limit {max_tokens}"
+
+
+def test_token_window_splits_on_whitespace() -> None:
+    """Token-window fallback should not split mid-word."""
+    # Create text with long words separated by single spaces
+    text = "abcdefghij " * 2000  # 11 chars per unit, ~5500 tokens
+    max_tokens = 1000
+
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=max_tokens)
+    for c in chunks:
+        # No chunk content should start or end with a partial word fragment
+        # that was cut mid-character. Since we split on spaces, content
+        # should be clean.
+        assert not c.content.startswith(" ")
+        assert c.token_count <= max_tokens
+
+
+# -----------------------------------------------------------------------
+# Content preservation
+# -----------------------------------------------------------------------
+
+
+def test_all_text_preserved_no_headings() -> None:
+    """Concatenated chunk content should equal the original text (modulo whitespace)."""
+    paragraphs = [f"Paragraph {i}. " + ("content " * 200) for i in range(20)]
+    text = "\n\n".join(paragraphs)
+
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=1000)
+    # Reconstruct: join with the same separator and compare stripped versions
+    reconstructed = "".join(c.content for c in chunks)
+    # Remove all whitespace for comparison since splitting may alter spacing
+    original_no_ws = "".join(text.split())
+    reconstructed_no_ws = "".join(reconstructed.split())
+    assert original_no_ws == reconstructed_no_ws
+
+
+def test_all_text_preserved_with_headings() -> None:
+    """Body text (non-heading lines) is preserved when heading-based splitting is used.
+
+    Headings are stored in ``heading_path`` rather than chunk content, so
+    only the body text needs to match.
+    """
+    text = "# Title\n\nSome intro.\n\n## Section\n\nMore content here."
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=4000)
+    reconstructed = "".join(c.content for c in chunks)
+    # Strip heading lines from the original for comparison — headings go
+    # into heading_path, not content.
+    body_only = re.sub(r"#{1,3} .+", "", text)
+    original_no_ws = "".join(body_only.split())
+    reconstructed_no_ws = "".join(reconstructed.split())
+    assert original_no_ws == reconstructed_no_ws
+
+
+def test_all_text_preserved_token_window() -> None:
+    """Text is preserved even when the token-window fallback is used."""
+    text = "word " * 5000
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=500)
+    reconstructed = "".join(c.content for c in chunks)
+    original_no_ws = "".join(text.split())
+    reconstructed_no_ws = "".join(reconstructed.split())
+    assert original_no_ws == reconstructed_no_ws
+
+
+# -----------------------------------------------------------------------
+# Chunk metadata
+# -----------------------------------------------------------------------
+
+
+def test_chunk_indices_are_sequential() -> None:
+    """Chunk indices should be 0, 1, 2, ... with no gaps."""
+    text = "word " * 5000
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=500)
+    indices = [c.chunk_index for c in chunks]
+    assert indices == list(range(len(chunks)))
+
+
+def test_chunk_document_id() -> None:
+    """All chunks should carry the correct document_id."""
+    text = "word " * 5000
+    chunks = chunk_text(text, "my-doc-42", max_chunk_tokens=500)
+    for c in chunks:
+        assert c.document_id == "my-doc-42"
+
+
+# -----------------------------------------------------------------------
+# Edge cases
+# -----------------------------------------------------------------------
+
+
+def test_empty_text() -> None:
+    """Empty text should return one chunk with the original text."""
+    chunks = chunk_text("", "doc-1")
+    assert len(chunks) == 1
+
+
+def test_text_exactly_at_limit() -> None:
+    """Text exactly at the token limit should not be split further."""
+    # 4000 tokens = 16000 chars
+    text = "a" * 16000
+    chunks = chunk_text(text, "doc-1", max_chunk_tokens=4000)
+    assert len(chunks) == 1
+    assert chunks[0].token_count == 4000


### PR DESCRIPTION
## Problem

When a large document (e.g. a 193K token PDF textbook) has no markdown headings, `chunk_text()` produces one giant chunk. The compiler's `_compile_chunked` then recurses infinitely between `compile()` and `_compile_chunked` — the sub-document has no `.chunks`, so it returns `None` and the compilation fails silently with "Compiler returned no result".

This affects any PDF or plain-text source extracted without markdown formatting (most PDFs via Docling produce heading-less text).

## Solution

Three-tier chunking strategy in `chunk_text()`:

1. **Heading-based** (existing, unchanged) — split on `# `, `## `, `### `
2. **Paragraph-based** (new) — when a chunk exceeds `max_chunk_tokens`, re-split on double newlines (`\n\n`)
3. **Token-window** (new) — when a single paragraph is still too large, hard-split at `max_chunk_tokens` boundaries on the nearest whitespace

This guarantees no chunk ever exceeds the token limit, regardless of input format.

## Changes

| File | What |
|------|------|
| `src/wikimind/ingest/service.py` | Added `_split_by_paragraphs()` and `_split_by_token_window()` helpers; updated `chunk_text()` to re-split oversized chunks |
| `tests/unit/test_chunk_text.py` | 14 new tests: heading split, no-heading split, paragraph boundaries, token window, content preservation, edge cases |

Closes #110

## Test plan

- [x] 14 new tests covering all three splitting tiers
- [x] Content preservation verified (concatenated chunks == original text)
- [x] All 350 tests pass
- [x] `make verify` clean, 95% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)