### PR TITLE
fix(compiler): use json.dumps for concept_ids and source_ids — fixes malformed JSON breaking index.md grouping

### DIFF
--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -13,6 +13,7 @@ exception — including connection errors — triggers a rollback so the
 session is always left in a clean state.
 """
 
+import json
 import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -93,6 +94,7 @@ async def init_db():
         await conn.run_sync(SQLModel.metadata.create_all)
     await _migrate_added_columns(engine)
     await _backfill_conversation_for_legacy_queries(engine)
+    await _repair_malformed_json_arrays(engine)
 
 
 async def _migrate_added_columns(engine) -> None:
@@ -182,6 +184,61 @@ async def _backfill_conversation_for_legacy_queries(engine) -> None:
                 "UPDATE query SET conversation_id = ?, turn_index = 0 WHERE id = ?",
                 (conv_id, query_id),
             )
+
+
+def _repair_json_array(raw: str) -> str | None:
+    """Attempt to repair a malformed JSON array string.
+
+    The old serialiser produced strings like ``["a"b"c"]`` (missing commas).
+    This function strips the outer ``[]``, splits on ``"``, filters empties,
+    and re-serialises with :func:`json.dumps`.
+
+    Returns the repaired JSON string, or ``None`` if *raw* is already valid.
+    """
+    try:
+        json.loads(raw)
+        return None  # already valid
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    inner = raw.strip()
+    if inner.startswith("["):
+        inner = inner[1:]
+    if inner.endswith("]"):
+        inner = inner[:-1]
+
+    items = [part for part in inner.split('"') if part.strip()]
+    return json.dumps(items)
+
+
+async def _repair_malformed_json_arrays(engine) -> None:
+    """Fix ``concept_ids`` and ``source_ids`` rows containing malformed JSON.
+
+    Idempotent: rows that already contain valid JSON are left untouched.
+    See issue #112.
+    """
+    async with engine.begin() as conn:
+
+        def _select_articles(sync_conn):
+            return sync_conn.exec_driver_sql(
+                "SELECT id, concept_ids, source_ids FROM article"
+                " WHERE concept_ids IS NOT NULL OR source_ids IS NOT NULL"
+            ).fetchall()
+
+        rows = await conn.run_sync(_select_articles)
+
+        for row in rows:
+            article_id, concept_ids, source_ids = row
+            repaired_concepts = _repair_json_array(concept_ids) if concept_ids else None
+            repaired_sources = _repair_json_array(source_ids) if source_ids else None
+
+            if repaired_concepts is not None or repaired_sources is not None:
+                new_concepts = repaired_concepts if repaired_concepts is not None else concept_ids
+                new_sources = repaired_sources if repaired_sources is not None else source_ids
+                await conn.exec_driver_sql(
+                    "UPDATE article SET concept_ids = ?, source_ids = ? WHERE id = ?",
+                    (new_concepts, new_sources, article_id),
+                )
 
 
 async def close_db():

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -6,6 +6,7 @@ This is the core value-creation step.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import structlog
@@ -260,8 +261,8 @@ Compile this into a wiki article following the JSON schema exactly."""
             file_path=str(file_path),
             confidence=self._overall_confidence(result),
             summary=result.summary,
-            source_ids=f'["{source.id}"]',
-            concept_ids=f'["{chr(34).join(result.concepts)}"]',
+            source_ids=json.dumps([source.id]),
+            concept_ids=json.dumps(result.concepts),
             provider=provider,
         )
         session.add(article)
@@ -328,7 +329,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         existing.summary = result.summary
         existing.confidence = self._overall_confidence(result)
         existing.file_path = str(new_path)
-        existing.concept_ids = f'["{chr(34).join(result.concepts)}"]'
+        existing.concept_ids = json.dumps(result.concepts)
         existing.updated_at = utcnow_naive()
         session.add(existing)
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,13 +1,15 @@
 """Tests for database session lifecycle — commit on success, rollback on error."""
 
 import contextlib
+import json
+import uuid
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
-from wikimind.database import get_session
-from wikimind.models import Source, SourceType
+from wikimind.database import _repair_json_array, _repair_malformed_json_arrays, get_session
+from wikimind.models import Article, ConfidenceLevel, Source, SourceType
 
 
 @pytest.fixture
@@ -62,3 +64,109 @@ class TestSessionLifecycle:
             result = await verify_session.execute(select(Source).where(Source.id == source_id))
             persisted = result.scalar_one_or_none()
             assert persisted is None
+
+
+# ---------------------------------------------------------------------------
+# _repair_json_array unit tests (issue #112)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairJsonArray:
+    def test_valid_json_returns_none(self):
+        """Already-valid JSON is left untouched."""
+        assert _repair_json_array('["a", "b", "c"]') is None
+
+    def test_malformed_missing_commas(self):
+        """The old bug: ["a"b"c"] -> should repair to ["a","b","c"]."""
+        repaired = _repair_json_array('["data deduplication"data management"storage optimization"]')
+        assert repaired is not None
+        parsed = json.loads(repaired)
+        assert parsed == ["data deduplication", "data management", "storage optimization"]
+
+    def test_single_item_valid(self):
+        """Single-item arrays are already valid."""
+        assert _repair_json_array('["only-one"]') is None
+
+    def test_empty_array_valid(self):
+        """Empty array is valid JSON."""
+        assert _repair_json_array("[]") is None
+
+
+# ---------------------------------------------------------------------------
+# _repair_malformed_json_arrays migration tests (issue #112)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairMalformedJsonArraysMigration:
+    async def test_repairs_malformed_concept_ids(self, async_engine, db_session):
+        """Migration fixes malformed concept_ids in existing rows."""
+        article_id = str(uuid.uuid4())
+        malformed = '["data deduplication"data management"storage optimization"]'
+        article = Article(
+            id=article_id,
+            slug="test-malformed",
+            title="Test",
+            file_path="/tmp/test.md",
+            confidence=ConfidenceLevel.SOURCED,
+            concept_ids=malformed,
+            source_ids='["src-1"]',
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        await _repair_malformed_json_arrays(async_engine)
+
+        db_session.expire_all()
+        result = await db_session.execute(select(Article).where(Article.id == article_id))
+        fixed = result.scalar_one()
+        parsed = json.loads(fixed.concept_ids)
+        assert parsed == ["data deduplication", "data management", "storage optimization"]
+
+    async def test_leaves_valid_json_unchanged(self, async_engine, db_session):
+        """Migration does not alter rows with already-valid JSON."""
+        article_id = str(uuid.uuid4())
+        valid_concepts = '["alpha", "beta"]'
+        valid_sources = '["src-1"]'
+        article = Article(
+            id=article_id,
+            slug="test-valid",
+            title="Test Valid",
+            file_path="/tmp/test-valid.md",
+            confidence=ConfidenceLevel.SOURCED,
+            concept_ids=valid_concepts,
+            source_ids=valid_sources,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        await _repair_malformed_json_arrays(async_engine)
+
+        db_session.expire_all()
+        result = await db_session.execute(select(Article).where(Article.id == article_id))
+        fixed = result.scalar_one()
+        assert fixed.concept_ids == valid_concepts
+        assert fixed.source_ids == valid_sources
+
+    async def test_repairs_malformed_source_ids(self, async_engine, db_session):
+        """Migration also repairs malformed source_ids."""
+        article_id = str(uuid.uuid4())
+        malformed_sources = '["id1"id2"id3"]'
+        article = Article(
+            id=article_id,
+            slug="test-sources",
+            title="Test Sources",
+            file_path="/tmp/test-sources.md",
+            confidence=ConfidenceLevel.SOURCED,
+            concept_ids='["valid"]',
+            source_ids=malformed_sources,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        await _repair_malformed_json_arrays(async_engine)
+
+        db_session.expire_all()
+        result = await db_session.execute(select(Article).where(Article.id == article_id))
+        fixed = result.scalar_one()
+        parsed = json.loads(fixed.source_ids)
+        assert parsed == ["id1", "id2", "id3"]

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
@@ -247,6 +248,41 @@ async def test_save_article(db_session, tmp_path) -> None:
     assert article.slug
     assert Path(article.file_path).exists()
     assert src.status == IngestStatus.COMPILED
+
+
+async def test_save_article_stores_valid_json_in_concept_ids(db_session, tmp_path) -> None:
+    """concept_ids and source_ids must be valid JSON arrays (issue #112)."""
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+    concepts = ["data deduplication", "data management", "storage optimization"]
+    result = _result(concepts=concepts)
+    article = await compiler.save_article(result, source, db_session)
+
+    parsed_concepts = json.loads(article.concept_ids)
+    assert parsed_concepts == concepts
+
+    parsed_sources = json.loads(article.source_ids)
+    assert parsed_sources == [source.id]
+
+
+async def test_replace_article_stores_valid_json_in_concept_ids(db_session, tmp_path) -> None:
+    """Replacing an article in place also produces valid JSON (issue #112)."""
+    compiler = _compiler_for(tmp_path)
+    compiler._last_provider_used = Provider.ANTHROPIC
+    source = await _make_source(db_session)
+
+    # First save
+    result1 = _result(concepts=["alpha"])
+    article = await compiler.save_article(result1, source, db_session)
+
+    # Replace in place — same source & provider
+    concepts2 = ["beta", "gamma", "delta"]
+    result2 = _result(concepts=concepts2)
+    replaced = await compiler.save_article(result2, source, db_session)
+
+    assert replaced.id == article.id
+    parsed = json.loads(replaced.concept_ids)
+    assert parsed == concepts2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The compiler stores malformed JSON in `Article.concept_ids` — commas are missing between entries:

- **Expected:** `["data deduplication","data management","storage optimization"]`
- **Actual:** `["data deduplication"data management"storage optimization"]`

This breaks `json.loads()` everywhere that reads concept_ids, causing the index.md catalog (PR #107) to group everything under "Uncategorized" instead of by concept.

## Root cause

`compiler.py` line 264 uses `chr(34).join()` which produces `"` as the separator — but JSON arrays need `","` between elements. Same bug on line 331 (replace-in-place) and line 263 (source_ids, which only worked by coincidence with single-element arrays).

## Solution

1. **Replace string builder with `json.dumps()`** — produces correct JSON for any list content including special characters and unicode
2. **Database migration** — `_repair_malformed_json_arrays()` runs idempotently at startup, detects rows where `json.loads()` fails, and repairs them by splitting on `"` and filtering empties

## Changes

| File | What |
|------|------|
| `src/wikimind/engine/compiler.py` | Replace `chr(34).join` with `json.dumps()` on lines 263, 264, 331 |
| `src/wikimind/database.py` | Add `_repair_json_array()` helper + `_repair_malformed_json_arrays()` migration |
| `tests/unit/test_engine_compiler.py` | 2 new tests: valid JSON in create + replace paths |
| `tests/unit/test_database.py` | 7 new tests: repair helper (4) + migration integration (3) |

Closes #112

## Test plan

- [x] 9 new tests (2 compiler + 7 migration)
- [x] All 345 tests pass
- [x] `make verify` clean, 94.5% coverage
- [ ] Manual: recompile an article, verify `concept_ids` is valid JSON; restart server to trigger migration on existing rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
