### PR TITLE
feat(graph): force-directed knowledge graph visualization

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.59.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-force-graph-2d": "^1.29.1",
         "react-markdown": "^9.0.1",
         "react-router-dom": "^6.26.2",
         "rehype-raw": "^7.0.0",
@@ -1399,6 +1400,12 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1744,6 +1751,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1922,6 +1938,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2032,6 +2058,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2225,6 +2263,222 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2746,6 +3000,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.2",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.2.tgz",
+      "integrity": "sha512-zZNdMqx8qIQGurgnbgYIUsdXxSfvhfRSIdncsKGv/twUOZpwCsk9hPHmdjdcme1+epATgb41G0rkIGHJ0Wydng==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3119,6 +3413,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3143,6 +3446,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -3279,6 +3591,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3355,6 +3676,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3414,6 +3747,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4414,7 +4753,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4851,6 +5189,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4859,6 +5207,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/property-information": {
@@ -4925,6 +5284,44 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-markdown": {
@@ -5491,6 +5888,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.59.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.26.2",
     "rehype-raw": "^7.0.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from "./components/shared/Layout";
 import { InboxView } from "./components/inbox/InboxView";
 import { WikiExplorerView } from "./components/wiki/WikiExplorerView";
 import { AskView } from "./components/ask/AskView";
+import { GraphView } from "./components/graph/GraphView";
 import { useWebSocket } from "./hooks/useWebSocket";
 
 export function App() {
@@ -18,6 +19,7 @@ export function App() {
         <Route path="/ask/:conversationId" element={<AskView />} />
         <Route path="/wiki" element={<WikiExplorerView />} />
         <Route path="/wiki/:slug" element={<WikiExplorerView />} />
+        <Route path="/graph" element={<GraphView />} />
         <Route path="*" element={<Navigate to="/inbox" replace />} />
       </Routes>
     </Layout>

--- a/apps/web/src/api/wiki.ts
+++ b/apps/web/src/api/wiki.ts
@@ -6,6 +6,7 @@ import type {
   ArticleResponse,
   Concept,
   ConfidenceLevel,
+  GraphResponse,
 } from "../types/api";
 
 export interface ListArticlesParams {
@@ -31,4 +32,8 @@ export function listConcepts(): Promise<Concept[]> {
 
 export function searchWiki(q: string, limit = 20): Promise<Article[]> {
   return apiFetch<Article[]>("/wiki/search", { query: { q, limit } });
+}
+
+export function getGraph(): Promise<GraphResponse> {
+  return apiFetch<GraphResponse>("/wiki/graph");
 }

--- a/apps/web/src/components/graph/GraphCanvas.tsx
+++ b/apps/web/src/components/graph/GraphCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import ForceGraph from "react-force-graph-2d";
 import type { ForceGraphMethods } from "react-force-graph-2d";
 import type { GraphNode, GraphEdge } from "../../types/api";
@@ -93,13 +93,16 @@ export function GraphCanvas({ nodes, edges, width, height, onNodeClick }: GraphC
     [onNodeClick],
   );
 
-  // Zoom to fit once the engine settles
+  // Stable key for the current node set — triggers zoom on any filter change
+  const nodeKey = useMemo(() => nodes.map((n) => n.id).join(","), [nodes]);
+
+  // Zoom to fit whenever the visible node set changes
   useEffect(() => {
     const timer = setTimeout(() => {
       fgRef.current?.zoomToFit(400, 40);
-    }, 500);
+    }, 600);
     return () => clearTimeout(timer);
-  }, [nodes.length]);
+  }, [nodeKey]);
 
   return (
     <ForceGraph<GraphCanvasNode, GraphCanvasLink>

--- a/apps/web/src/components/graph/GraphCanvas.tsx
+++ b/apps/web/src/components/graph/GraphCanvas.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef } from "react";
+import ForceGraph from "react-force-graph-2d";
+import type { ForceGraphMethods } from "react-force-graph-2d";
+import type { GraphNode, GraphEdge } from "../../types/api";
+
+/** Simple palette for concept clusters. Cycles if more concepts than colors. */
+const CONCEPT_COLORS = [
+  "#6366f1", // indigo
+  "#f59e0b", // amber
+  "#10b981", // emerald
+  "#ef4444", // red
+  "#3b82f6", // blue
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#14b8a6", // teal
+  "#f97316", // orange
+  "#84cc16", // lime
+];
+
+const DEFAULT_NODE_COLOR = "#94a3b8"; // slate-400
+
+interface GraphCanvasNode {
+  id: string;
+  label: string;
+  concept_cluster: string | null;
+  connection_count: number;
+  confidence: string | null;
+  val: number;
+  color: string;
+}
+
+interface GraphCanvasLink {
+  source: string;
+  target: string;
+  context: string | null;
+}
+
+interface GraphCanvasData {
+  nodes: GraphCanvasNode[];
+  links: GraphCanvasLink[];
+}
+
+interface GraphCanvasProps {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  width: number;
+  height: number;
+  onNodeClick?: (node: GraphCanvasNode) => void;
+}
+
+function buildColorMap(nodes: GraphNode[]): Map<string, string> {
+  const concepts = new Set<string>();
+  for (const n of nodes) {
+    if (n.concept_cluster) {
+      concepts.add(n.concept_cluster);
+    }
+  }
+  const map = new Map<string, string>();
+  let i = 0;
+  for (const c of concepts) {
+    map.set(c, CONCEPT_COLORS[i % CONCEPT_COLORS.length]);
+    i++;
+  }
+  return map;
+}
+
+export function GraphCanvas({ nodes, edges, width, height, onNodeClick }: GraphCanvasProps) {
+  const fgRef = useRef<ForceGraphMethods<GraphCanvasNode, GraphCanvasLink>>();
+
+  const colorMap = buildColorMap(nodes);
+
+  const graphData: GraphCanvasData = {
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      label: n.label,
+      concept_cluster: n.concept_cluster,
+      connection_count: n.connection_count,
+      confidence: n.confidence,
+      val: Math.max(1, n.connection_count),
+      color: n.concept_cluster ? (colorMap.get(n.concept_cluster) ?? DEFAULT_NODE_COLOR) : DEFAULT_NODE_COLOR,
+    })),
+    links: edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      context: e.context,
+    })),
+  };
+
+  const handleNodeClick = useCallback(
+    (node: GraphCanvasNode) => {
+      onNodeClick?.(node);
+    },
+    [onNodeClick],
+  );
+
+  // Zoom to fit once the engine settles
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fgRef.current?.zoomToFit(400, 40);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [nodes.length]);
+
+  return (
+    <ForceGraph<GraphCanvasNode, GraphCanvasLink>
+      ref={fgRef}
+      graphData={graphData}
+      width={width}
+      height={height}
+      nodeLabel="label"
+      nodeColor="color"
+      nodeVal="val"
+      nodeRelSize={4}
+      linkColor={() => "#cbd5e1"}
+      linkWidth={1}
+      linkDirectionalArrowLength={3}
+      linkDirectionalArrowRelPos={1}
+      onNodeClick={handleNodeClick}
+      warmupTicks={50}
+      cooldownTicks={100}
+      d3AlphaDecay={0.02}
+      d3VelocityDecay={0.3}
+      enableNodeDrag={true}
+      backgroundColor="transparent"
+    />
+  );
+}

--- a/apps/web/src/components/graph/GraphDetailPanel.tsx
+++ b/apps/web/src/components/graph/GraphDetailPanel.tsx
@@ -28,9 +28,6 @@ export function GraphDetailPanel({ node, edges, allNodes, onClose }: GraphDetail
   }
   const neighbors = allNodes.filter((n) => connectedIds.has(n.id));
 
-  // Use the node label as slug (lowercase, spaces to hyphens)
-  const slug = node.label.toLowerCase().replace(/\s+/g, "-");
-
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-start justify-between">
@@ -62,7 +59,7 @@ export function GraphDetailPanel({ node, edges, allNodes, onClose }: GraphDetail
 
       <button
         type="button"
-        onClick={() => navigate(`/wiki/${encodeURIComponent(slug)}`)}
+        onClick={() => navigate(`/wiki/${encodeURIComponent(node.id)}`)}
         className="rounded-md bg-brand-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-700 transition"
       >
         Open article
@@ -76,7 +73,7 @@ export function GraphDetailPanel({ node, edges, allNodes, onClose }: GraphDetail
               <li key={n.id}>
                 <button
                   type="button"
-                  onClick={() => navigate(`/wiki/${encodeURIComponent(n.label.toLowerCase().replace(/\s+/g, "-"))}`)}
+                  onClick={() => navigate(`/wiki/${encodeURIComponent(n.id)}`)}
                   className="w-full truncate rounded px-2 py-1 text-left text-xs text-brand-600 hover:bg-slate-50"
                 >
                   {n.label}

--- a/apps/web/src/components/graph/GraphDetailPanel.tsx
+++ b/apps/web/src/components/graph/GraphDetailPanel.tsx
@@ -1,0 +1,91 @@
+import { useNavigate } from "react-router-dom";
+import { Badge } from "../shared/Badge";
+import type { BadgeTone } from "../shared/Badge";
+import type { GraphNode, GraphEdge, ConfidenceLevel } from "../../types/api";
+
+interface GraphDetailPanelProps {
+  node: GraphNode;
+  edges: GraphEdge[];
+  allNodes: GraphNode[];
+  onClose: () => void;
+}
+
+const CONFIDENCE_TONE: Record<ConfidenceLevel, BadgeTone> = {
+  sourced: "success",
+  mixed: "info",
+  inferred: "warning",
+  opinion: "danger",
+};
+
+export function GraphDetailPanel({ node, edges, allNodes, onClose }: GraphDetailPanelProps) {
+  const navigate = useNavigate();
+
+  // Find connected nodes
+  const connectedIds = new Set<string>();
+  for (const e of edges) {
+    if (e.source === node.id) connectedIds.add(e.target);
+    if (e.target === node.id) connectedIds.add(e.source);
+  }
+  const neighbors = allNodes.filter((n) => connectedIds.has(n.id));
+
+  // Use the node label as slug (lowercase, spaces to hyphens)
+  const slug = node.label.toLowerCase().replace(/\s+/g, "-");
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-between">
+        <h3 className="text-sm font-semibold text-slate-800">{node.label}</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-slate-400 hover:text-slate-600"
+          aria-label="Close detail panel"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {node.concept_cluster && (
+          <Badge tone="brand">{node.concept_cluster}</Badge>
+        )}
+        {node.confidence && (
+          <Badge tone={CONFIDENCE_TONE[node.confidence]}>
+            {node.confidence}
+          </Badge>
+        )}
+      </div>
+
+      <div className="text-xs text-slate-500">
+        {node.connection_count} connection{node.connection_count !== 1 ? "s" : ""}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => navigate(`/wiki/${encodeURIComponent(slug)}`)}
+        className="rounded-md bg-brand-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-700 transition"
+      >
+        Open article
+      </button>
+
+      {neighbors.length > 0 && (
+        <div>
+          <h4 className="mb-2 text-xs font-medium text-slate-600">Connected articles</h4>
+          <ul className="flex flex-col gap-1">
+            {neighbors.map((n) => (
+              <li key={n.id}>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/wiki/${encodeURIComponent(n.label.toLowerCase().replace(/\s+/g, "-"))}`)}
+                  className="w-full truncate rounded px-2 py-1 text-left text-xs text-brand-600 hover:bg-slate-50"
+                >
+                  {n.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/graph/GraphFilters.tsx
+++ b/apps/web/src/components/graph/GraphFilters.tsx
@@ -1,0 +1,117 @@
+import type { Concept, ConfidenceLevel } from "../../types/api";
+
+const CONFIDENCE_LEVELS: ConfidenceLevel[] = ["sourced", "mixed", "inferred", "opinion"];
+
+export interface GraphFilterState {
+  selectedConcepts: Set<string>;
+  selectedConfidence: Set<ConfidenceLevel>;
+  showOrphans: boolean;
+}
+
+interface GraphFiltersProps {
+  concepts: Concept[];
+  filters: GraphFilterState;
+  totalNodeCount: number;
+  visibleNodeCount: number;
+  onToggleConcept: (conceptName: string) => void;
+  onToggleConfidence: (level: ConfidenceLevel) => void;
+  onToggleOrphans: () => void;
+  onResetFilters: () => void;
+}
+
+export function GraphFilters({
+  concepts,
+  filters,
+  totalNodeCount,
+  visibleNodeCount,
+  onToggleConcept,
+  onToggleConfidence,
+  onToggleOrphans,
+  onResetFilters,
+}: GraphFiltersProps) {
+  const hasActiveFilters =
+    filters.selectedConcepts.size > 0 ||
+    filters.selectedConfidence.size > 0 ||
+    !filters.showOrphans;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-800">Filters</h3>
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={onResetFilters}
+            className="text-xs text-brand-600 hover:text-brand-700"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      <p className="text-xs text-slate-500">
+        Showing {visibleNodeCount} of {totalNodeCount} nodes
+      </p>
+
+      {/* Concept filters */}
+      <div>
+        <h4 className="mb-2 text-xs font-medium text-slate-600">Concepts</h4>
+        <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+          {concepts.length === 0 ? (
+            <p className="text-xs text-slate-400">No concepts</p>
+          ) : (
+            concepts.map((c) => (
+              <label
+                key={c.id}
+                className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-xs text-slate-700 hover:bg-slate-50"
+              >
+                <input
+                  type="checkbox"
+                  checked={filters.selectedConcepts.has(c.name)}
+                  onChange={() => onToggleConcept(c.name)}
+                  className="rounded border-slate-300 text-brand-600 focus:ring-brand-500"
+                />
+                <span className="truncate">{c.name}</span>
+                <span className="ml-auto text-slate-400">{c.article_count}</span>
+              </label>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Confidence filters */}
+      <div>
+        <h4 className="mb-2 text-xs font-medium text-slate-600">Confidence</h4>
+        <div className="flex flex-col gap-1">
+          {CONFIDENCE_LEVELS.map((level) => (
+            <label
+              key={level}
+              className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-xs text-slate-700 hover:bg-slate-50"
+            >
+              <input
+                type="checkbox"
+                checked={filters.selectedConfidence.has(level)}
+                onChange={() => onToggleConfidence(level)}
+                className="rounded border-slate-300 text-brand-600 focus:ring-brand-500"
+              />
+              <span className="capitalize">{level}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Orphan toggle */}
+      <div>
+        <label className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-xs text-slate-700 hover:bg-slate-50">
+          <input
+            type="checkbox"
+            checked={filters.showOrphans}
+            onChange={onToggleOrphans}
+            className="rounded border-slate-300 text-brand-600 focus:ring-brand-500"
+          />
+          <span>Show orphan nodes</span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/graph/GraphView.tsx
+++ b/apps/web/src/components/graph/GraphView.tsx
@@ -14,6 +14,10 @@ function useContainerSize() {
     const el = containerRef.current;
     if (!el) return;
 
+    // Measure immediately so the first render has dimensions
+    const rect = el.getBoundingClientRect();
+    setSize({ width: rect.width, height: rect.height });
+
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         setSize({

--- a/apps/web/src/components/graph/GraphView.tsx
+++ b/apps/web/src/components/graph/GraphView.tsx
@@ -106,9 +106,12 @@ export function GraphView() {
       // Orphan filter
       if (!filters.showOrphans && !connectedIds.has(n.id)) return false;
 
-      // Concept filter
+      // Concept filter — normalize concept_cluster to match Concept.name
+      // (slugified). Some older articles store raw names with spaces.
       if (filters.selectedConcepts.size > 0) {
-        if (!n.concept_cluster || !filters.selectedConcepts.has(n.concept_cluster)) {
+        const normalized = n.concept_cluster
+          ?.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+        if (!normalized || !filters.selectedConcepts.has(normalized)) {
           return false;
         }
       }

--- a/apps/web/src/components/graph/GraphView.tsx
+++ b/apps/web/src/components/graph/GraphView.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useGraph, useConcepts } from "../../hooks/useArticles";
+import { Spinner } from "../shared/Spinner";
+import { GraphCanvas } from "./GraphCanvas";
+import { GraphFilters, type GraphFilterState } from "./GraphFilters";
+import { GraphDetailPanel } from "./GraphDetailPanel";
+import type { ConfidenceLevel, GraphNode } from "../../types/api";
+
+function useContainerSize() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setSize({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return { containerRef, size };
+}
+
+const INITIAL_FILTERS: GraphFilterState = {
+  selectedConcepts: new Set<string>(),
+  selectedConfidence: new Set<ConfidenceLevel>(),
+  showOrphans: true,
+};
+
+export function GraphView() {
+  const graphQuery = useGraph();
+  const conceptsQuery = useConcepts();
+  const { containerRef, size } = useContainerSize();
+
+  const [filters, setFilters] = useState<GraphFilterState>(INITIAL_FILTERS);
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+
+  const handleToggleConcept = useCallback((name: string) => {
+    setFilters((prev) => {
+      const next = new Set(prev.selectedConcepts);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return { ...prev, selectedConcepts: next };
+    });
+  }, []);
+
+  const handleToggleConfidence = useCallback((level: ConfidenceLevel) => {
+    setFilters((prev) => {
+      const next = new Set(prev.selectedConfidence);
+      if (next.has(level)) {
+        next.delete(level);
+      } else {
+        next.add(level);
+      }
+      return { ...prev, selectedConfidence: next };
+    });
+  }, []);
+
+  const handleToggleOrphans = useCallback(() => {
+    setFilters((prev) => ({ ...prev, showOrphans: !prev.showOrphans }));
+  }, []);
+
+  const handleResetFilters = useCallback(() => {
+    setFilters(INITIAL_FILTERS);
+  }, []);
+
+  const handleNodeClick = useCallback(
+    (node: { id: string; label: string; concept_cluster: string | null; connection_count: number; confidence: string | null }) => {
+      const graphNode = graphQuery.data?.nodes.find((n) => n.id === node.id);
+      if (graphNode) {
+        setSelectedNode(graphNode);
+      }
+    },
+    [graphQuery.data],
+  );
+
+  // Filter graph data based on filter state
+  const filteredData = useMemo(() => {
+    if (!graphQuery.data) return { nodes: [], edges: [] };
+
+    const { nodes, edges } = graphQuery.data;
+
+    // Build a set of connected node IDs
+    const connectedIds = new Set<string>();
+    for (const e of edges) {
+      connectedIds.add(e.source);
+      connectedIds.add(e.target);
+    }
+
+    const filteredNodes = nodes.filter((n) => {
+      // Orphan filter
+      if (!filters.showOrphans && !connectedIds.has(n.id)) return false;
+
+      // Concept filter
+      if (filters.selectedConcepts.size > 0) {
+        if (!n.concept_cluster || !filters.selectedConcepts.has(n.concept_cluster)) {
+          return false;
+        }
+      }
+
+      // Confidence filter
+      if (filters.selectedConfidence.size > 0) {
+        if (!n.confidence || !filters.selectedConfidence.has(n.confidence)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    const nodeIds = new Set(filteredNodes.map((n) => n.id));
+    const filteredEdges = edges.filter(
+      (e) => nodeIds.has(e.source) && nodeIds.has(e.target),
+    );
+
+    return { nodes: filteredNodes, edges: filteredEdges };
+  }, [graphQuery.data, filters]);
+
+  if (graphQuery.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 text-sm text-slate-500">
+        <Spinner size={16} /> Loading graph...
+      </div>
+    );
+  }
+
+  if (graphQuery.isError) {
+    return (
+      <div className="m-8 rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+        Failed to load graph data.
+      </div>
+    );
+  }
+
+  const totalNodeCount = graphQuery.data?.nodes.length ?? 0;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="border-b border-slate-200 bg-white px-6 py-4">
+        <h1 className="text-lg font-semibold text-slate-900">Knowledge Graph</h1>
+      </header>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Canvas area */}
+        <div ref={containerRef} className="flex-1 bg-slate-50">
+          {size.width > 0 && size.height > 0 && (
+            <GraphCanvas
+              nodes={filteredData.nodes}
+              edges={filteredData.edges}
+              width={size.width}
+              height={size.height}
+              onNodeClick={handleNodeClick}
+            />
+          )}
+        </div>
+
+        {/* Right sidebar */}
+        <aside className="w-64 shrink-0 overflow-y-auto border-l border-slate-200 bg-white p-4">
+          {selectedNode ? (
+            <GraphDetailPanel
+              node={selectedNode}
+              edges={graphQuery.data?.edges ?? []}
+              allNodes={graphQuery.data?.nodes ?? []}
+              onClose={() => setSelectedNode(null)}
+            />
+          ) : (
+            <GraphFilters
+              concepts={conceptsQuery.data ?? []}
+              filters={filters}
+              totalNodeCount={totalNodeCount}
+              visibleNodeCount={filteredData.nodes.length}
+              onToggleConcept={handleToggleConcept}
+              onToggleConfidence={handleToggleConfidence}
+              onToggleOrphans={handleToggleOrphans}
+              onResetFilters={handleResetFilters}
+            />
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/graph/GraphView.tsx
+++ b/apps/web/src/components/graph/GraphView.tsx
@@ -131,23 +131,8 @@ export function GraphView() {
     return { nodes: filteredNodes, edges: filteredEdges };
   }, [graphQuery.data, filters]);
 
-  if (graphQuery.isLoading) {
-    return (
-      <div className="flex h-full items-center justify-center gap-2 text-sm text-slate-500">
-        <Spinner size={16} /> Loading graph...
-      </div>
-    );
-  }
-
-  if (graphQuery.isError) {
-    return (
-      <div className="m-8 rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
-        Failed to load graph data.
-      </div>
-    );
-  }
-
   const totalNodeCount = graphQuery.data?.nodes.length ?? 0;
+  const isReady = !graphQuery.isLoading && !graphQuery.isError && size.width > 0 && size.height > 0;
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -156,9 +141,17 @@ export function GraphView() {
       </header>
 
       <div className="flex flex-1 overflow-hidden">
-        {/* Canvas area */}
+        {/* Canvas area — always mounted so the ref is attached for ResizeObserver */}
         <div ref={containerRef} className="flex-1 bg-slate-50">
-          {size.width > 0 && size.height > 0 && (
+          {graphQuery.isLoading ? (
+            <div className="flex h-full items-center justify-center gap-2 text-sm text-slate-500">
+              <Spinner size={16} /> Loading graph...
+            </div>
+          ) : graphQuery.isError ? (
+            <div className="m-8 rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+              Failed to load graph data.
+            </div>
+          ) : isReady ? (
             <GraphCanvas
               nodes={filteredData.nodes}
               edges={filteredData.edges}
@@ -166,7 +159,7 @@ export function GraphView() {
               height={size.height}
               onNodeClick={handleNodeClick}
             />
-          )}
+          ) : null}
         </div>
 
         {/* Right sidebar */}

--- a/apps/web/src/components/shared/Layout.tsx
+++ b/apps/web/src/components/shared/Layout.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { to: "/inbox", label: "Inbox", icon: "📥" },
   { to: "/ask", label: "Ask", icon: "💬" },
   { to: "/wiki", label: "Wiki", icon: "📚" },
+  { to: "/graph", label: "Graph", icon: "🕸️" },
 ];
 
 export function Layout({ children }: LayoutProps) {

--- a/apps/web/src/hooks/useArticles.ts
+++ b/apps/web/src/hooks/useArticles.ts
@@ -1,6 +1,6 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { listArticles, listConcepts, searchWiki } from "../api/wiki";
-import type { Article, Concept, ConfidenceLevel } from "../types/api";
+import { getGraph, listArticles, listConcepts, searchWiki } from "../api/wiki";
+import type { Article, Concept, ConfidenceLevel, GraphResponse } from "../types/api";
 
 export interface UseArticlesParams {
   concept?: string;
@@ -29,5 +29,13 @@ export function useSearch(query: string): UseQueryResult<Article[]> {
     queryFn: () => searchWiki(query),
     enabled: query.trim().length >= 2,
     staleTime: 30_000,
+  });
+}
+
+export function useGraph(): UseQueryResult<GraphResponse> {
+  return useQuery({
+    queryKey: ["wiki-graph"],
+    queryFn: () => getGraph(),
+    staleTime: 60_000,
   });
 }

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -95,6 +95,25 @@ export interface TriggerCompileResponse {
   status: string;
 }
 
+export interface GraphNode {
+  id: string;
+  label: string;
+  concept_cluster: string | null;
+  connection_count: number;
+  confidence: ConfidenceLevel | null;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  context: string | null;
+}
+
+export interface GraphResponse {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
 // WebSocket event shapes (see src/wikimind/api/routes/ws.py)
 export type WSEvent =
   | { event: "connected"; message?: string }


### PR DESCRIPTION
## Problem

WikiMind compiles articles with backlinks and concept clusters but provides no way to visualize the knowledge graph (#25). Users can't see how their articles connect, identify orphaned content, or discover clusters of related knowledge.

## Solution

Build a full force-directed graph view using `react-force-graph-2d` (ADR-013). Nodes represent articles, sized by connection count and colored by concept cluster. Interactive filters for concept, confidence, and orphan visibility. Click-to-inspect detail panel with neighbor listing.

## Changes

- **`react-force-graph-2d`** — New npm dependency (per ADR-013)
- **`types/api.ts`** — Add `GraphResponse` interface
- **`api/wiki.ts`** — Add `getGraph()` function
- **`hooks/useArticles.ts`** — Add `useGraph()` TanStack Query hook
- **`GraphCanvas.tsx`** — Force-directed graph wrapping `react-force-graph-2d`. 10-color concept palette, connection-count sizing, directional arrows, auto zoom-to-fit, performance tuning (warmupTicks=50, cooldownTicks=100)
- **`GraphFilters.tsx`** — Sidebar with concept checkboxes, confidence filters, orphan toggle, node count display, reset button
- **`GraphDetailPanel.tsx`** — Node detail with title, concept badge, confidence badge, neighbor list, "Open article" navigation
- **`GraphView.tsx`** — Main container composing canvas + sidebar with `useMemo` filtering and `ResizeObserver` responsive sizing
- **`App.tsx`** — Add `/graph` route
- **`Layout.tsx`** — Add Graph nav item (🕸️)

## Test plan

- [x] Navigate to /graph → force-directed graph renders
- [x] Nodes colored by concept cluster (distinct colors per concept)
- [x] Larger nodes have more connections
- [x] Click node → detail panel shows with title, neighbors, confidence
- [x] "Open article" button navigates to /wiki/:slug
- [x] Concept filter checkboxes filter visible nodes
- [x] Confidence filter works
- [x] "Hide orphans" toggle removes 0-connection nodes
- [x] Graph handles 0 articles (empty state)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)