### PR TITLE
fix(ingest): extract meaningful PDF title from metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ Thumbs.db
 # ~/.wikimind/ is outside repo, but just in case:
 *.db
 
+# Git worktrees (parallel development)
+.worktrees/
+
 # Serena MCP tool — auto-generated per-worktree config + cache + memories
 .serena/

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import re
+from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 import fitz
@@ -468,6 +469,62 @@ class URLAdapter:
 
 
 # ---------------------------------------------------------------------------
+# PDF metadata helpers
+# ---------------------------------------------------------------------------
+
+
+class _PdfMetadata(NamedTuple):
+    """Metadata extracted from a PDF's info dictionary via fitz."""
+
+    title: str | None
+    author: str | None
+    published_date: date | None
+
+
+def _extract_pdf_metadata(file_bytes: bytes) -> _PdfMetadata:
+    """Read title, author, and creation date from a PDF's info dictionary.
+
+    Uses :mod:`fitz` (pymupdf) which reads the metadata dict instantly without
+    any ML processing.  Returns ``None`` for any field that is missing or empty.
+    """
+    doc = fitz.open(stream=file_bytes, filetype="pdf")
+    meta = doc.metadata or {}
+    doc.close()
+
+    title = (meta.get("title") or "").strip() or None
+    author = (meta.get("author") or "").strip() or None
+    published_date = _parse_pdf_date(meta.get("creationDate"))
+
+    return _PdfMetadata(title=title, author=author, published_date=published_date)
+
+
+def _parse_pdf_date(raw: str | None) -> date | None:
+    """Parse a PDF date string (``D:YYYYMMDDHHmmSS...``) into a date.
+
+    Returns ``None`` if the string is missing, empty, or unparseable.
+    """
+    if not raw:
+        return None
+    # Strip the ``D:`` prefix that PDF date strings use.
+    cleaned = raw.strip()
+    if cleaned.startswith("D:"):
+        cleaned = cleaned[2:]
+    # We only need YYYYMMDD — ignore time/timezone suffixes.
+    if len(cleaned) < 8:
+        return None
+    try:
+        return date(int(cleaned[:4]), int(cleaned[4:6]), int(cleaned[6:8]))
+    except (ValueError, IndexError):
+        return None
+
+
+def _first_markdown_heading(text: str) -> str | None:
+    """Return the text of the first top-level markdown heading, or ``None``."""
+    match = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+# ---------------------------------------------------------------------------
 # PDF Adapter
 # ---------------------------------------------------------------------------
 
@@ -516,10 +573,17 @@ class PDFAdapter:
             log.info("Source dedup hit (PDF)", source_id=existing.id, hash=content_hash[:16])
             return existing, reconstruct_normalized_doc(existing)
 
+        # Extract metadata (title, author, date) from the PDF info dictionary.
+        # This is an instant fitz dict lookup — no ML processing.
+        pdf_meta = _extract_pdf_metadata(file_bytes)
+        fallback_title = filename.replace(".pdf", "")
+
         # Create source record
         source = Source(
             source_type=SourceType.PDF,
-            title=filename.replace(".pdf", ""),
+            title=pdf_meta.title or fallback_title,
+            author=pdf_meta.author,
+            published_date=pdf_meta.published_date,
             status=IngestStatus.PROCESSING,
             content_hash=content_hash,
         )
@@ -545,6 +609,13 @@ class PDFAdapter:
             clean_text, page_count = await self._extract_via_docling_batched(raw_pdf_path, source.id)
         else:
             clean_text, page_count = self._extract_via_fitz(file_bytes)
+
+        # If the title is still the filename fallback (no PDF metadata title),
+        # try extracting the first markdown heading from the converted text.
+        if source.title == fallback_title:
+            heading = _first_markdown_heading(clean_text)
+            if heading:
+                source.title = heading
 
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(clean_text, encoding="utf-8")

--- a/tests/unit/test_ingest_service.py
+++ b/tests/unit/test_ingest_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +15,9 @@ from wikimind.ingest.service import (
     TextAdapter,
     URLAdapter,
     YouTubeAdapter,
+    _extract_pdf_metadata,
+    _first_markdown_heading,
+    _parse_pdf_date,
     chunk_text,
     estimate_tokens,
 )
@@ -78,12 +82,19 @@ async def test_url_adapter_no_content_raises(db_session) -> None:
 async def test_pdf_adapter_fitz_path(db_session, tmp_path) -> None:
     fake_page = MagicMock()
     fake_page.get_text = MagicMock(return_value="page text")
-    fake_doc = MagicMock()
-    fake_doc.__iter__ = lambda self: iter([fake_page, fake_page])
-    fake_doc.close = MagicMock()
+
+    # fitz.open is called twice: once for metadata, once for text extraction.
+    fake_meta_doc = MagicMock()
+    fake_meta_doc.metadata = {"title": "", "author": "", "creationDate": ""}
+    fake_meta_doc.close = MagicMock()
+
+    fake_text_doc = MagicMock()
+    fake_text_doc.__iter__ = lambda self: iter([fake_page, fake_page])
+    fake_text_doc.close = MagicMock()
+
     with (
         patch.object(ingest_mod, "_DOCLING_AVAILABLE", False),
-        patch.object(ingest_mod.fitz, "open", return_value=fake_doc),
+        patch.object(ingest_mod.fitz, "open", side_effect=[fake_meta_doc, fake_text_doc]),
     ):
         adapter = PDFAdapter()
         source, doc = await adapter.ingest(b"%PDF-1.4...", "test.pdf", db_session)
@@ -340,3 +351,166 @@ def test_get_docling_converter_unavailable() -> None:
         ingest_mod._docling_converter = None
         with pytest.raises(RuntimeError):
             ingest_mod._get_docling_converter()
+
+
+# ---------------------------------------------------------------------------
+# PDF metadata extraction tests (issue #124)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_pdf_metadata_with_title() -> None:
+    """Fitz metadata with a real title populates the result."""
+    fake_doc = MagicMock()
+    fake_doc.metadata = {
+        "title": "Attention Is All You Need",
+        "author": "Vaswani et al.",
+        "creationDate": "D:20170612120000",
+    }
+    fake_doc.close = MagicMock()
+    with patch.object(ingest_mod.fitz, "open", return_value=fake_doc):
+        meta = _extract_pdf_metadata(b"fake-pdf-bytes")
+    assert meta.title == "Attention Is All You Need"
+    assert meta.author == "Vaswani et al."
+    assert meta.published_date is not None
+    assert meta.published_date.year == 2017
+    assert meta.published_date.month == 6
+    assert meta.published_date.day == 12
+
+
+def test_extract_pdf_metadata_empty_title() -> None:
+    """Empty or whitespace-only title returns None."""
+    fake_doc = MagicMock()
+    fake_doc.metadata = {"title": "  ", "author": "", "creationDate": ""}
+    fake_doc.close = MagicMock()
+    with patch.object(ingest_mod.fitz, "open", return_value=fake_doc):
+        meta = _extract_pdf_metadata(b"fake-pdf-bytes")
+    assert meta.title is None
+    assert meta.author is None
+    assert meta.published_date is None
+
+
+def test_extract_pdf_metadata_no_metadata_dict() -> None:
+    """PDF with no metadata dict at all doesn't crash."""
+    fake_doc = MagicMock()
+    fake_doc.metadata = None
+    fake_doc.close = MagicMock()
+    with patch.object(ingest_mod.fitz, "open", return_value=fake_doc):
+        meta = _extract_pdf_metadata(b"fake-pdf-bytes")
+    assert meta.title is None
+    assert meta.author is None
+    assert meta.published_date is None
+
+
+def test_parse_pdf_date_valid() -> None:
+    assert _parse_pdf_date("D:20230115093000") == date(2023, 1, 15)
+
+
+def test_parse_pdf_date_no_prefix() -> None:
+    assert _parse_pdf_date("20230115") == date(2023, 1, 15)
+
+
+def test_parse_pdf_date_too_short() -> None:
+    assert _parse_pdf_date("D:2023") is None
+
+
+def test_parse_pdf_date_garbage() -> None:
+    assert _parse_pdf_date("not-a-date") is None
+
+
+def test_parse_pdf_date_none() -> None:
+    assert _parse_pdf_date(None) is None
+
+
+def test_parse_pdf_date_empty() -> None:
+    assert _parse_pdf_date("") is None
+
+
+def test_first_markdown_heading_found() -> None:
+    text = "Some intro text\n\n# My Great Title\n\nBody content here."
+    assert _first_markdown_heading(text) == "My Great Title"
+
+
+def test_first_markdown_heading_first_line() -> None:
+    text = "# First Heading\n\n## Sub heading\n\nContent."
+    assert _first_markdown_heading(text) == "First Heading"
+
+
+def test_first_markdown_heading_none() -> None:
+    text = "No headings at all.\n\nJust plain text."
+    assert _first_markdown_heading(text) is None
+
+
+def test_first_markdown_heading_skips_h2() -> None:
+    """Only top-level (h1) headings should be returned."""
+    text = "## Sub Heading\n\n### Another\n\nContent."
+    assert _first_markdown_heading(text) is None
+
+
+async def test_pdf_adapter_metadata_title(db_session) -> None:
+    """PDF with metadata title uses it instead of filename."""
+    fake_meta_doc = MagicMock()
+    fake_meta_doc.metadata = {
+        "title": "Attention Is All You Need",
+        "author": "Vaswani et al.",
+        "creationDate": "D:20170612120000",
+    }
+    fake_meta_doc.close = MagicMock()
+
+    fake_page = MagicMock()
+    fake_page.get_text = MagicMock(return_value="page text")
+    fake_text_doc = MagicMock()
+    fake_text_doc.__iter__ = lambda self: iter([fake_page])
+    fake_text_doc.close = MagicMock()
+
+    with (
+        patch.object(ingest_mod, "_DOCLING_AVAILABLE", False),
+        patch.object(ingest_mod.fitz, "open", side_effect=[fake_meta_doc, fake_text_doc]),
+    ):
+        adapter = PDFAdapter()
+        source, _ = await adapter.ingest(b"%PDF-1.4...", "2604.08016.pdf", db_session)
+    assert source.title == "Attention Is All You Need"
+    assert source.author == "Vaswani et al."
+    assert source.published_date is not None
+    assert source.published_date.year == 2017
+
+
+async def test_pdf_adapter_heading_fallback(db_session) -> None:
+    """When PDF has no metadata title, falls back to first markdown heading."""
+    fake_meta_doc = MagicMock()
+    fake_meta_doc.metadata = {"title": "", "author": "", "creationDate": ""}
+    fake_meta_doc.close = MagicMock()
+
+    fake_page = MagicMock()
+    fake_page.get_text = MagicMock(return_value="# A Great Paper\n\nContent here.")
+    fake_text_doc = MagicMock()
+    fake_text_doc.__iter__ = lambda self: iter([fake_page])
+    fake_text_doc.close = MagicMock()
+
+    with (
+        patch.object(ingest_mod, "_DOCLING_AVAILABLE", False),
+        patch.object(ingest_mod.fitz, "open", side_effect=[fake_meta_doc, fake_text_doc]),
+    ):
+        adapter = PDFAdapter()
+        source, _ = await adapter.ingest(b"%PDF-1.4...", "2604.08016.pdf", db_session)
+    assert source.title == "A Great Paper"
+
+
+async def test_pdf_adapter_filename_fallback(db_session) -> None:
+    """When no metadata title and no heading, falls back to filename."""
+    fake_meta_doc = MagicMock()
+    fake_meta_doc.metadata = {"title": "", "author": "", "creationDate": ""}
+    fake_meta_doc.close = MagicMock()
+
+    fake_page = MagicMock()
+    fake_page.get_text = MagicMock(return_value="Plain text with no headings.")
+    fake_text_doc = MagicMock()
+    fake_text_doc.__iter__ = lambda self: iter([fake_page])
+    fake_text_doc.close = MagicMock()
+
+    with (
+        patch.object(ingest_mod, "_DOCLING_AVAILABLE", False),
+        patch.object(ingest_mod.fitz, "open", side_effect=[fake_meta_doc, fake_text_doc]),
+    ):
+        adapter = PDFAdapter()
+        source, _ = await adapter.ingest(b"%PDF-1.4...", "report.pdf", db_session)
+    assert source.title == "report"


### PR DESCRIPTION
## Problem

PDF URLs like arxiv papers show bare filenames as the source title (e.g., `2604.08016` instead of the paper's actual name). The `PDFAdapter` unconditionally used `filename.replace(".pdf", "")` even though the PDF's internal metadata contains the real title, author, and creation date.

## Solution

Read the PDF info dictionary via `fitz` (already a hard dependency) before creating the Source row. Three-tier title fallback:

1. **PDF metadata title** — `fitz.open().metadata["title"]` (instant dict lookup, no ML)
2. **First markdown heading** — regex scan of extracted text after Docling/fitz conversion
3. **Filename** — current behavior, last resort

Also populates `Source.author` and `Source.published_date` from PDF metadata when available.

## Changes

- `src/wikimind/ingest/service.py` — Added `_extract_pdf_metadata()`, `_parse_pdf_date()`, `_first_markdown_heading()` helpers; wired into `PDFAdapter.ingest()`
- `tests/unit/test_ingest_service.py` — 14 new tests covering all fallback tiers, date parsing edge cases, and metadata extraction

## Test plan

- [x] `make verify` passes (466 tests, 89% coverage)
- [x] Manual test: ingest arxiv PDF → title shows paper name, not filename

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)