### PR TITLE
feat(linter): structured wiki health audit + Health Dashboard (#26, #27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,24 @@
 # WIKIMIND_EMBEDDING__CHUNK_OVERLAP_TOKENS=50
 
 # ----------------------------------------------------------------------------
+# Wiki Linter (optional)
+# ----------------------------------------------------------------------------
+# Enable orphan detection (requires populated Backlink table — issue #95)
+# WIKIMIND_LINTER__ENABLE_ORPHAN_DETECTION=false
+# Max concepts to check per lint run
+# WIKIMIND_LINTER__MAX_CONCEPTS_PER_RUN=25
+# Max article pairs per concept for contradiction detection
+# WIKIMIND_LINTER__MAX_CONTRADICTION_PAIRS_PER_CONCEPT=10
+# LLM settings for contradiction detection
+# WIKIMIND_LINTER__CONTRADICTION_LLM_MAX_TOKENS=1024
+# WIKIMIND_LINTER__CONTRADICTION_LLM_TEMPERATURE=0.2
+# Cost controls
+# WIKIMIND_LINTER__RESPECT_MONTHLY_BUDGET=true
+# WIKIMIND_LINTER__MAX_COST_PER_RUN_USD=1.00
+# Skip re-evaluating unchanged article pairs
+# WIKIMIND_LINTER__ENABLE_PAIR_CACHE=true
+
+# ----------------------------------------------------------------------------
 # Data Directory (optional)
 # ----------------------------------------------------------------------------
 # Defaults to ~/.wikimind. Override to put state somewhere else.

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ Thumbs.db
 # ~/.wikimind/ is outside repo, but just in case:
 *.db
 
+# Git worktrees (parallel development)
+.worktrees/
+
 # Serena MCP tool — auto-generated per-worktree config + cache + memories
 .serena/

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { InboxView } from "./components/inbox/InboxView";
 import { WikiExplorerView } from "./components/wiki/WikiExplorerView";
 import { AskView } from "./components/ask/AskView";
 import { GraphView } from "./components/graph/GraphView";
+import { HealthView } from "./components/health/HealthView";
 import { useWebSocket } from "./hooks/useWebSocket";
 
 export function App() {
@@ -20,6 +21,7 @@ export function App() {
         <Route path="/wiki" element={<WikiExplorerView />} />
         <Route path="/wiki/:slug" element={<WikiExplorerView />} />
         <Route path="/graph" element={<GraphView />} />
+        <Route path="/health" element={<HealthView />} />
         <Route path="*" element={<Navigate to="/inbox" replace />} />
       </Routes>
     </Layout>

--- a/apps/web/src/api/lint.ts
+++ b/apps/web/src/api/lint.ts
@@ -17,6 +17,10 @@ export interface LintReport {
   total_findings: number;
   contradictions_count: number;
   orphans_count: number;
+  missing_pages_count: number;
+  dismissed_count: number;
+  total_pairs: number;
+  checked_pairs: number;
   error_message: string | null;
   job_id: string | null;
 }

--- a/apps/web/src/api/lint.ts
+++ b/apps/web/src/api/lint.ts
@@ -1,0 +1,89 @@
+// Endpoints in src/wikimind/api/routes/lint.py.
+
+import { apiFetch } from "./client";
+
+// --- Response types ---
+
+export type LintSeverity = "info" | "warn" | "error";
+export type LintFindingKind = "contradiction" | "orphan";
+export type LintReportStatus = "in_progress" | "complete" | "failed";
+
+export interface LintReport {
+  id: string;
+  generated_at: string;
+  completed_at: string | null;
+  status: LintReportStatus;
+  article_count: number;
+  total_findings: number;
+  contradictions_count: number;
+  orphans_count: number;
+  error_message: string | null;
+  job_id: string | null;
+}
+
+interface LintFindingCommon {
+  id: string;
+  report_id: string;
+  severity: LintSeverity;
+  description: string;
+  created_at: string;
+  dismissed: boolean;
+  dismissed_at: string | null;
+  content_hash: string;
+}
+
+export interface LintContradictionFinding extends LintFindingCommon {
+  kind: "contradiction";
+  article_a_id: string;
+  article_b_id: string;
+  article_a_claim: string;
+  article_b_claim: string;
+  llm_confidence: "high" | "medium" | "low";
+  shared_concept_id: string | null;
+}
+
+export interface LintOrphanFinding extends LintFindingCommon {
+  kind: "orphan";
+  article_id: string;
+  article_title: string;
+}
+
+export type LintFinding = LintContradictionFinding | LintOrphanFinding;
+
+export interface LintReportDetail {
+  report: LintReport;
+  contradictions: LintContradictionFinding[];
+  orphans: LintOrphanFinding[];
+}
+
+// --- API functions ---
+
+export function runLint(): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>("/lint/run", { method: "POST" });
+}
+
+export function listReports(limit = 20): Promise<LintReport[]> {
+  return apiFetch<LintReport[]>("/lint/reports", { query: { limit } });
+}
+
+export function getLatestReport(): Promise<LintReportDetail> {
+  return apiFetch<LintReportDetail>("/lint/reports/latest");
+}
+
+export function getReport(
+  id: string,
+  includeDismissed = false,
+): Promise<LintReportDetail> {
+  return apiFetch<LintReportDetail>(`/lint/reports/${encodeURIComponent(id)}`, {
+    query: { include_dismissed: includeDismissed },
+  });
+}
+
+export function dismissFinding(
+  kind: LintFindingKind,
+  id: string,
+): Promise<{ dismissed: boolean; kind: string; finding_id: string }> {
+  return apiFetch(`/lint/findings/${kind}/${encodeURIComponent(id)}/dismiss`, {
+    method: "POST",
+  });
+}

--- a/apps/web/src/components/health/FindingCard.tsx
+++ b/apps/web/src/components/health/FindingCard.tsx
@@ -1,0 +1,97 @@
+import { Badge, type BadgeTone } from "../shared/Badge";
+import { Button } from "../shared/Button";
+import { Card } from "../shared/Card";
+import { useDismissFinding } from "../../hooks/useLint";
+import type {
+  LintContradictionFinding,
+  LintFinding,
+  LintOrphanFinding,
+  LintSeverity,
+} from "../../api/lint";
+
+interface Props {
+  finding: LintFinding;
+}
+
+const severityTone: Record<LintSeverity, BadgeTone> = {
+  info: "info",
+  warn: "warning",
+  error: "danger",
+};
+
+const confidenceTone: Record<string, BadgeTone> = {
+  high: "danger",
+  medium: "warning",
+  low: "neutral",
+};
+
+function ContradictionDetail({
+  finding,
+}: {
+  finding: LintContradictionFinding;
+}) {
+  return (
+    <div className="mt-2 space-y-2 text-sm">
+      <div className="rounded-md bg-slate-50 p-2">
+        <div className="text-xs font-medium text-slate-500">Article A claim</div>
+        <div className="text-slate-700">{finding.article_a_claim}</div>
+      </div>
+      <div className="rounded-md bg-slate-50 p-2">
+        <div className="text-xs font-medium text-slate-500">Article B claim</div>
+        <div className="text-slate-700">{finding.article_b_claim}</div>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-slate-500">LLM confidence:</span>
+        <Badge tone={confidenceTone[finding.llm_confidence] ?? "neutral"}>
+          {finding.llm_confidence}
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+function OrphanDetail({ finding }: { finding: LintOrphanFinding }) {
+  return (
+    <div className="mt-2 text-sm text-slate-600">
+      Article <span className="font-medium">{finding.article_title}</span> has
+      no inbound or outbound links.
+    </div>
+  );
+}
+
+export function FindingCard({ finding }: Props) {
+  const dismiss = useDismissFinding();
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <Badge tone={severityTone[finding.severity]}>{finding.severity}</Badge>
+          <span className="text-sm font-medium text-slate-800">
+            {finding.description}
+          </span>
+        </div>
+        {!finding.dismissed ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={dismiss.isPending}
+            onClick={() =>
+              dismiss.mutate({ kind: finding.kind, id: finding.id })
+            }
+          >
+            Dismiss
+          </Button>
+        ) : (
+          <Badge tone="neutral">Dismissed</Badge>
+        )}
+      </div>
+
+      {finding.kind === "contradiction" ? (
+        <ContradictionDetail finding={finding} />
+      ) : (
+        <OrphanDetail finding={finding} />
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/health/FindingsByKindTabs.tsx
+++ b/apps/web/src/components/health/FindingsByKindTabs.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { FindingCard } from "./FindingCard";
+import type { LintReportDetail } from "../../api/lint";
+
+interface Props {
+  detail: LintReportDetail;
+}
+
+type TabKey = "contradictions" | "orphans";
+
+interface TabDef {
+  key: TabKey;
+  label: string;
+  count: number;
+}
+
+export function FindingsByKindTabs({ detail }: Props) {
+  const tabs: TabDef[] = [
+    {
+      key: "contradictions",
+      label: "Contradictions",
+      count: detail.contradictions.length,
+    },
+    { key: "orphans", label: "Orphans", count: detail.orphans.length },
+  ];
+
+  const [activeTab, setActiveTab] = useState<TabKey>("contradictions");
+
+  return (
+    <div>
+      <div className="flex border-b border-slate-200">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`px-4 py-2 text-sm font-medium transition ${
+              activeTab === tab.key
+                ? "border-b-2 border-brand-600 text-brand-700"
+                : "text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {tab.label}{" "}
+            <span className="ml-1 rounded-full bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">
+              {tab.count}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {activeTab === "contradictions" &&
+          (detail.contradictions.length === 0 ? (
+            <p className="py-8 text-center text-sm text-slate-400">
+              No contradictions found.
+            </p>
+          ) : (
+            detail.contradictions.map((f) => (
+              <FindingCard key={f.id} finding={f} />
+            ))
+          ))}
+
+        {activeTab === "orphans" &&
+          (detail.orphans.length === 0 ? (
+            <p className="py-8 text-center text-sm text-slate-400">
+              No orphan articles found.
+            </p>
+          ) : (
+            detail.orphans.map((f) => (
+              <FindingCard key={f.id} finding={f} />
+            ))
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/health/HealthView.tsx
+++ b/apps/web/src/components/health/HealthView.tsx
@@ -1,0 +1,26 @@
+import { LintReportSummary } from "./LintReportSummary";
+import { FindingsByKindTabs } from "./FindingsByKindTabs";
+import { useLatestReport } from "../../hooks/useLint";
+
+export function HealthView() {
+  const { data, isLoading, isError } = useLatestReport();
+
+  return (
+    <div className="flex h-full flex-col overflow-auto p-6">
+      <LintReportSummary
+        report={data?.report ?? null}
+        isLoading={isLoading}
+      />
+
+      {data && !isError ? (
+        <div className="mt-6">
+          <FindingsByKindTabs detail={data} />
+        </div>
+      ) : isError && !isLoading ? (
+        <div className="mt-6 rounded-md border border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
+          No lint reports yet. Click "Run lint now" to generate one.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/health/LintReportSummary.tsx
+++ b/apps/web/src/components/health/LintReportSummary.tsx
@@ -1,0 +1,98 @@
+import { Badge } from "../shared/Badge";
+import { Card } from "../shared/Card";
+import { RunLintButton } from "./RunLintButton";
+import type { LintReport } from "../../api/lint";
+
+interface Props {
+  report: LintReport | null;
+  isLoading: boolean;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "Never";
+  return new Date(iso).toLocaleString();
+}
+
+export function LintReportSummary({ report, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <Card className="p-5">
+        <p className="text-sm text-slate-500">Loading report...</p>
+      </Card>
+    );
+  }
+
+  if (!report) {
+    return (
+      <Card className="p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-800">
+              Wiki Health
+            </h2>
+            <p className="mt-1 text-sm text-slate-500">
+              No lint reports yet. Run the linter to generate a health report.
+            </p>
+          </div>
+          <RunLintButton />
+        </div>
+      </Card>
+    );
+  }
+
+  const statusTone =
+    report.status === "complete"
+      ? "success"
+      : report.status === "failed"
+        ? "danger"
+        : "info";
+
+  return (
+    <Card className="p-5">
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-slate-800">
+              Wiki Health
+            </h2>
+            <Badge tone={statusTone}>
+              {report.status === "in_progress" ? "Running" : report.status}
+            </Badge>
+          </div>
+          <p className="mt-1 text-sm text-slate-500">
+            Last run: {formatDate(report.generated_at)} | {report.article_count}{" "}
+            articles scanned
+          </p>
+        </div>
+        <RunLintButton />
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-4">
+        <div className="rounded-md border border-slate-200 p-3 text-center">
+          <div className="text-2xl font-bold text-slate-800">
+            {report.total_findings}
+          </div>
+          <div className="text-xs text-slate-500">Total findings</div>
+        </div>
+        <div className="rounded-md border border-slate-200 p-3 text-center">
+          <div className="text-2xl font-bold text-amber-600">
+            {report.contradictions_count}
+          </div>
+          <div className="text-xs text-slate-500">Contradictions</div>
+        </div>
+        <div className="rounded-md border border-slate-200 p-3 text-center">
+          <div className="text-2xl font-bold text-sky-600">
+            {report.orphans_count}
+          </div>
+          <div className="text-xs text-slate-500">Orphans</div>
+        </div>
+      </div>
+
+      {report.error_message ? (
+        <div className="mt-3 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {report.error_message}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/web/src/components/health/LintReportSummary.tsx
+++ b/apps/web/src/components/health/LintReportSummary.tsx
@@ -67,12 +67,41 @@ export function LintReportSummary({ report, isLoading }: Props) {
         <RunLintButton />
       </div>
 
+      {/* Progress bar when running */}
+      {report.status === "in_progress" && report.total_pairs > 0 && (
+        <div className="mt-3">
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>
+              Checking pair {report.checked_pairs} of {report.total_pairs}...
+            </span>
+            <span>
+              {Math.round((report.checked_pairs / report.total_pairs) * 100)}%
+            </span>
+          </div>
+          <div className="mt-1 h-2 overflow-hidden rounded-full bg-slate-200">
+            <div
+              className="h-full rounded-full bg-brand-500 transition-all"
+              style={{
+                width: `${Math.round((report.checked_pairs / report.total_pairs) * 100)}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
       <div className="mt-4 grid grid-cols-3 gap-4">
         <div className="rounded-md border border-slate-200 p-3 text-center">
           <div className="text-2xl font-bold text-slate-800">
             {report.total_findings}
           </div>
-          <div className="text-xs text-slate-500">Total findings</div>
+          <div className="text-xs text-slate-500">
+            Active findings
+            {report.dismissed_count > 0 && (
+              <span className="ml-1 text-slate-400">
+                ({report.dismissed_count} dismissed)
+              </span>
+            )}
+          </div>
         </div>
         <div className="rounded-md border border-slate-200 p-3 text-center">
           <div className="text-2xl font-bold text-amber-600">

--- a/apps/web/src/components/health/RunLintButton.tsx
+++ b/apps/web/src/components/health/RunLintButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from "../shared/Button";
+import { Spinner } from "../shared/Spinner";
+import { useRunLint } from "../../hooks/useLint";
+
+export function RunLintButton() {
+  const { mutate, isPending } = useRunLint();
+
+  return (
+    <Button
+      variant="primary"
+      size="sm"
+      disabled={isPending}
+      onClick={() => mutate()}
+    >
+      {isPending ? (
+        <>
+          <Spinner size={14} /> Running...
+        </>
+      ) : (
+        "Run lint now"
+      )}
+    </Button>
+  );
+}

--- a/apps/web/src/components/health/RunLintButton.tsx
+++ b/apps/web/src/components/health/RunLintButton.tsx
@@ -3,18 +3,20 @@ import { Spinner } from "../shared/Spinner";
 import { useRunLint } from "../../hooks/useLint";
 
 export function RunLintButton() {
-  const { mutate, isPending } = useRunLint();
+  const { mutate, isPending, isPolling } = useRunLint();
+  const busy = isPending || isPolling;
 
   return (
     <Button
       variant="primary"
       size="sm"
-      disabled={isPending}
+      disabled={busy}
       onClick={() => mutate()}
     >
-      {isPending ? (
+      {busy ? (
         <>
-          <Spinner size={14} /> Running...
+          <Spinner size={14} />{" "}
+          {isPolling ? "Analyzing articles..." : "Starting..."}
         </>
       ) : (
         "Run lint now"

--- a/apps/web/src/components/shared/Layout.tsx
+++ b/apps/web/src/components/shared/Layout.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS = [
   { to: "/ask", label: "Ask", icon: "💬" },
   { to: "/wiki", label: "Wiki", icon: "📚" },
   { to: "/graph", label: "Graph", icon: "🕸️" },
+  { to: "/health", label: "Health", icon: "🩺" },
 ];
 
 export function Layout({ children }: LayoutProps) {

--- a/apps/web/src/hooks/useLint.ts
+++ b/apps/web/src/hooks/useLint.ts
@@ -42,13 +42,19 @@ export function useRunLint(): UseMutationResult<
   const mutation = useMutation({
     mutationFn: () => runLint(),
     onSuccess: () => {
-      // Start polling for completion
+      // Capture the current report's timestamp so we can detect the NEW report
+      const cached = queryClient.getQueryData<LintReportDetail>(["lint", "latest"]);
+      const prevGeneratedAt = cached?.report?.generated_at ?? "";
+
       setIsPolling(true);
       const poll = setInterval(async () => {
         try {
-          const report = await getLatestReport();
-          queryClient.setQueryData(["lint", "latest"], report);
-          if (report.report.status !== "in_progress") {
+          const detail = await getLatestReport();
+          queryClient.setQueryData(["lint", "latest"], detail);
+          // Only stop when we see a NEWER report that's no longer in_progress
+          const isNewer = detail.report.generated_at !== prevGeneratedAt;
+          const isDone = detail.report.status !== "in_progress";
+          if (isNewer && isDone) {
             clearInterval(poll);
             setIsPolling(false);
             queryClient.invalidateQueries({ queryKey: ["lint"] });

--- a/apps/web/src/hooks/useLint.ts
+++ b/apps/web/src/hooks/useLint.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   useMutation,
   useQuery,
@@ -34,14 +35,37 @@ export function useRunLint(): UseMutationResult<
   { status: string },
   Error,
   void
-> {
+> & { isPolling: boolean } {
   const queryClient = useQueryClient();
-  return useMutation({
+  const [isPolling, setIsPolling] = useState(false);
+
+  const mutation = useMutation({
     mutationFn: () => runLint(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["lint"] });
+      // Start polling for completion
+      setIsPolling(true);
+      const poll = setInterval(async () => {
+        try {
+          const report = await getLatestReport();
+          queryClient.setQueryData(["lint", "latest"], report);
+          if (report.report.status !== "in_progress") {
+            clearInterval(poll);
+            setIsPolling(false);
+            queryClient.invalidateQueries({ queryKey: ["lint"] });
+          }
+        } catch {
+          // Report not ready yet — keep polling
+        }
+      }, 2000);
+      // Safety: stop polling after 5 minutes
+      setTimeout(() => {
+        clearInterval(poll);
+        setIsPolling(false);
+      }, 300_000);
     },
   });
+
+  return { ...mutation, isPolling };
 }
 
 export function useDismissFinding(): UseMutationResult<

--- a/apps/web/src/hooks/useLint.ts
+++ b/apps/web/src/hooks/useLint.ts
@@ -1,0 +1,59 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import {
+  dismissFinding,
+  getLatestReport,
+  listReports,
+  runLint,
+  type LintFindingKind,
+  type LintReport,
+  type LintReportDetail,
+} from "../api/lint";
+
+export function useLatestReport(): UseQueryResult<LintReportDetail> {
+  return useQuery({
+    queryKey: ["lint", "latest"],
+    queryFn: () => getLatestReport(),
+    retry: false,
+  });
+}
+
+export function useLintReports(limit = 20): UseQueryResult<LintReport[]> {
+  return useQuery({
+    queryKey: ["lint", "reports", limit],
+    queryFn: () => listReports(limit),
+  });
+}
+
+export function useRunLint(): UseMutationResult<
+  { status: string },
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => runLint(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["lint"] });
+    },
+  });
+}
+
+export function useDismissFinding(): UseMutationResult<
+  { dismissed: boolean; kind: string; finding_id: string },
+  Error,
+  { kind: LintFindingKind; id: string }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ kind, id }) => dismissFinding(kind, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["lint"] });
+    },
+  });
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -368,7 +368,12 @@ paths:
       tags:
       - Wiki
       summary: Get Health
-      description: Latest wiki health report from linter.
+      description: 'Latest wiki health report from linter.
+
+
+        DEPRECATED: Use GET /lint/reports/latest instead. This endpoint
+
+        delegates to the new LinterService for backward compatibility.'
       operationId: get_health_wiki_health_get
       responses:
         '200':
@@ -672,7 +677,12 @@ paths:
       tags:
       - Jobs
       summary: Trigger Lint
-      description: Trigger wiki linting.
+      description: 'Trigger wiki linting.
+
+
+        DEPRECATED: Use POST /lint/run instead. This endpoint delegates
+
+        to the new LinterService for backward compatibility.'
       operationId: trigger_lint_jobs_lint_post
       responses:
         '200':
@@ -693,6 +703,132 @@ paths:
           content:
             application/json:
               schema: {}
+  /lint/run:
+    post:
+      tags:
+      - Lint
+      summary: Run Lint
+      description: Trigger a new lint run. Returns immediately with status.
+      operationId: run_lint_lint_run_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /lint/reports:
+    get:
+      tags:
+      - Lint
+      summary: List Reports
+      description: List lint reports ordered by most recent first.
+      operationId: list_reports_lint_reports_get
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 20
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LintReport'
+                title: Response List Reports Lint Reports Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /lint/reports/latest:
+    get:
+      tags:
+      - Lint
+      summary: Get Latest Report
+      description: Get the most recent lint report with all non-dismissed findings.
+      operationId: get_latest_report_lint_reports_latest_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LintReportDetail'
+  /lint/reports/{report_id}:
+    get:
+      tags:
+      - Lint
+      summary: Get Report
+      description: Get a specific lint report with findings.
+      operationId: get_report_lint_reports__report_id__get
+      parameters:
+      - name: report_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Report Id
+      - name: include_dismissed
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Include Dismissed
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LintReportDetail'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /lint/findings/{kind}/{finding_id}/dismiss:
+    post:
+      tags:
+      - Lint
+      summary: Dismiss Finding
+      description: Dismiss a finding. Persists across future lint runs via content
+        hash.
+      operationId: dismiss_finding_lint_findings__kind___finding_id__dismiss_post
+      parameters:
+      - name: kind
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/LintFindingKind'
+      - name: finding_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Finding Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /settings:
     get:
       tags:
@@ -1032,6 +1168,73 @@ components:
       - opinion
       title: ConfidenceLevel
       description: Confidence level for claims.
+    ContradictionFinding:
+      properties:
+        id:
+          type: string
+          title: Id
+        report_id:
+          type: string
+          title: Report Id
+        severity:
+          $ref: '#/components/schemas/LintSeverity'
+          default: warn
+        description:
+          type: string
+          title: Description
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        dismissed:
+          type: boolean
+          title: Dismissed
+          default: false
+        dismissed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Dismissed At
+        content_hash:
+          type: string
+          title: Content Hash
+        kind:
+          $ref: '#/components/schemas/LintFindingKind'
+          default: contradiction
+        article_a_id:
+          type: string
+          title: Article A Id
+        article_b_id:
+          type: string
+          title: Article B Id
+        article_a_claim:
+          type: string
+          title: Article A Claim
+        article_b_claim:
+          type: string
+          title: Article B Claim
+        llm_confidence:
+          type: string
+          title: Llm Confidence
+        shared_concept_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Shared Concept Id
+      type: object
+      required:
+      - report_id
+      - description
+      - content_hash
+      - article_a_id
+      - article_b_id
+      - article_a_claim
+      - article_b_claim
+      - llm_confidence
+      title: ContradictionFinding
+      description: A contradiction between key claims of two articles that share a
+        concept.
     ConversationDetail:
       properties:
         conversation:
@@ -1227,6 +1430,153 @@ components:
       - url
       title: IngestURLRequest
       description: Request to ingest a URL.
+    LintFindingKind:
+      type: string
+      enum:
+      - contradiction
+      - orphan
+      title: LintFindingKind
+      description: 'Kind of lint finding — maps 1:1 to a detection function AND a
+        table.
+
+
+        Used as the content_hash prefix (so dismiss state is keyed by kind + content)
+
+        and as the discriminator field in the frontend API response union.'
+    LintReport:
+      properties:
+        id:
+          type: string
+          title: Id
+        generated_at:
+          type: string
+          format: date-time
+          title: Generated At
+        completed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Completed At
+        status:
+          $ref: '#/components/schemas/LintReportStatus'
+          default: in_progress
+        article_count:
+          type: integer
+          title: Article Count
+          default: 0
+        total_findings:
+          type: integer
+          title: Total Findings
+          default: 0
+        contradictions_count:
+          type: integer
+          title: Contradictions Count
+          default: 0
+        orphans_count:
+          type: integer
+          title: Orphans Count
+          default: 0
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+        job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Id
+      type: object
+      title: LintReport
+      description: One run of the linter. All findings from a run FK back to this
+        row via report_id.
+    LintReportDetail:
+      properties:
+        report:
+          $ref: '#/components/schemas/LintReport'
+        contradictions:
+          items:
+            $ref: '#/components/schemas/ContradictionFinding'
+          type: array
+          title: Contradictions
+        orphans:
+          items:
+            $ref: '#/components/schemas/OrphanFinding'
+          type: array
+          title: Orphans
+      type: object
+      required:
+      - report
+      - contradictions
+      - orphans
+      title: LintReportDetail
+      description: API response shape for a single report with all findings.
+    LintReportStatus:
+      type: string
+      enum:
+      - in_progress
+      - complete
+      - failed
+      title: LintReportStatus
+      description: Lifecycle of a lint report.
+    LintSeverity:
+      type: string
+      enum:
+      - info
+      - warn
+      - error
+      title: LintSeverity
+      description: Severity level for a lint finding.
+    OrphanFinding:
+      properties:
+        id:
+          type: string
+          title: Id
+        report_id:
+          type: string
+          title: Report Id
+        severity:
+          $ref: '#/components/schemas/LintSeverity'
+          default: warn
+        description:
+          type: string
+          title: Description
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        dismissed:
+          type: boolean
+          title: Dismissed
+          default: false
+        dismissed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Dismissed At
+        content_hash:
+          type: string
+          title: Content Hash
+        kind:
+          $ref: '#/components/schemas/LintFindingKind'
+          default: orphan
+        article_id:
+          type: string
+          title: Article Id
+        article_title:
+          type: string
+          title: Article Title
+      type: object
+      required:
+      - report_id
+      - description
+      - content_hash
+      - article_id
+      - article_title
+      title: OrphanFinding
+      description: An article with zero inbound AND zero outbound backlinks.
     QueryRequest:
       properties:
         question:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1477,6 +1477,22 @@ components:
           type: integer
           title: Orphans Count
           default: 0
+        missing_pages_count:
+          type: integer
+          title: Missing Pages Count
+          default: 0
+        dismissed_count:
+          type: integer
+          title: Dismissed Count
+          default: 0
+        total_pairs:
+          type: integer
+          title: Total Pairs
+          default: 0
+        checked_pairs:
+          type: integer
+          title: Checked Pairs
+          default: 0
         error_message:
           anyOf:
           - type: string

--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -7,6 +7,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
 from wikimind.services.compiler import CompilerService, get_compiler_service
+from wikimind.services.linter import LinterService, get_linter_service
 
 router = APIRouter()
 
@@ -43,10 +44,14 @@ async def trigger_compile(
 
 @router.post("/lint")
 async def trigger_lint(
-    service: CompilerService = Depends(get_compiler_service),
+    service: LinterService = Depends(get_linter_service),
 ):
-    """Trigger wiki linting."""
-    return await service.trigger_lint()
+    """Trigger wiki linting.
+
+    DEPRECATED: Use POST /lint/run instead. This endpoint delegates
+    to the new LinterService for backward compatibility.
+    """
+    return await service.trigger_run()
 
 
 @router.post("/reindex")

--- a/src/wikimind/api/routes/lint.py
+++ b/src/wikimind/api/routes/lint.py
@@ -1,0 +1,61 @@
+"""Endpoints for the wiki linter — structured health audit reports and findings."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.database import get_session
+from wikimind.models import LintFindingKind, LintReport, LintReportDetail
+from wikimind.services.linter import LinterService, get_linter_service
+
+router = APIRouter()
+
+
+@router.post("/run")
+async def run_lint(
+    service: LinterService = Depends(get_linter_service),
+):
+    """Trigger a new lint run. Returns immediately with status."""
+    return await service.trigger_run()
+
+
+@router.get("/reports", response_model=list[LintReport])
+async def list_reports(
+    limit: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+):
+    """List lint reports ordered by most recent first."""
+    return await service.list_reports(session, limit=limit)
+
+
+@router.get("/reports/latest", response_model=LintReportDetail)
+async def get_latest_report(
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+):
+    """Get the most recent lint report with all non-dismissed findings."""
+    return await service.get_latest(session)
+
+
+@router.get("/reports/{report_id}", response_model=LintReportDetail)
+async def get_report(
+    report_id: str,
+    include_dismissed: bool = False,
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+):
+    """Get a specific lint report with findings."""
+    return await service.get_report(session, report_id, include_dismissed=include_dismissed)
+
+
+@router.post("/findings/{kind}/{finding_id}/dismiss")
+async def dismiss_finding(
+    kind: LintFindingKind,
+    finding_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: LinterService = Depends(get_linter_service),
+):
+    """Dismiss a finding. Persists across future lint runs via content hash."""
+    return await service.dismiss_finding(session, kind, finding_id)

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -2,10 +2,13 @@
 
 import structlog
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
-from wikimind.models import ArticleResponse, ArticleSummaryResponse, GraphResponse
+from wikimind.models import Article, ArticleResponse, ArticleSummaryResponse, GraphResponse
+from wikimind.services.linter import LinterService, get_linter_service
 from wikimind.services.taxonomy import rebuild_taxonomy
 from wikimind.services.wiki import WikiService, get_wiki_service
 
@@ -79,7 +82,27 @@ async def rebuild_concepts(
 @router.get("/health")
 async def get_health(
     session: AsyncSession = Depends(get_session),
-    service: WikiService = Depends(get_wiki_service),
+    linter_service: LinterService = Depends(get_linter_service),
 ):
-    """Latest wiki health report from linter."""
-    return await service.get_health(session)
+    """Latest wiki health report from linter.
+
+    DEPRECATED: Use GET /lint/reports/latest instead. This endpoint
+    delegates to the new LinterService for backward compatibility.
+    """
+    try:
+        detail = await linter_service.get_latest(session)
+        return {
+            "generated_at": detail.report.generated_at.isoformat() if detail.report.generated_at else None,
+            "total_articles": detail.report.article_count,
+            "total_findings": detail.report.total_findings,
+            "contradictions_count": detail.report.contradictions_count,
+            "orphans_count": detail.report.orphans_count,
+            "status": detail.report.status,
+        }
+    except Exception:
+        count_result = await session.execute(select(func.count()).select_from(Article))
+        return {
+            "generated_at": None,
+            "total_articles": count_result.scalar() or 0,
+            "message": "Run the linter to generate a health report",
+        }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -141,6 +141,19 @@ class TaxonomyConfig(BaseModel):
     max_hierarchy_depth: int = 3
 
 
+class LinterConfig(BaseModel):
+    """Wiki linter configuration."""
+
+    enable_orphan_detection: bool = False
+    max_concepts_per_run: int = 25
+    max_contradiction_pairs_per_concept: int = 10
+    contradiction_llm_max_tokens: int = 1024
+    contradiction_llm_temperature: float = 0.2
+    respect_monthly_budget: bool = True
+    max_cost_per_run_usd: float = 1.00
+    enable_pair_cache: bool = True
+
+
 class EmbeddingConfig(BaseModel):
     """Embedding and semantic search configuration."""
 
@@ -189,6 +202,7 @@ class Settings(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
     qa: QAConfig = Field(default_factory=QAConfig)
     taxonomy: TaxonomyConfig = Field(default_factory=TaxonomyConfig)
+    linter: LinterConfig = Field(default_factory=LinterConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
 
     # PDF extraction: number of pages per Docling batch (issue #117).

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -144,7 +144,7 @@ class TaxonomyConfig(BaseModel):
 class LinterConfig(BaseModel):
     """Wiki linter configuration."""
 
-    enable_orphan_detection: bool = False
+    enable_orphan_detection: bool = True
     max_concepts_per_run: int = 25
     max_contradiction_pairs_per_concept: int = 10
     contradiction_llm_max_tokens: int = 1024

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -126,8 +126,16 @@ async def _migrate_added_columns(engine) -> None:
         ),
         ("query", "turn_index", "ALTER TABLE query ADD COLUMN turn_index INTEGER NOT NULL DEFAULT 0"),
         # Lint report — additional columns
-        ("lintreport", "missing_pages_count", "ALTER TABLE lintreport ADD COLUMN missing_pages_count INTEGER NOT NULL DEFAULT 0"),
-        ("lintreport", "dismissed_count", "ALTER TABLE lintreport ADD COLUMN dismissed_count INTEGER NOT NULL DEFAULT 0"),
+        (
+            "lintreport",
+            "missing_pages_count",
+            "ALTER TABLE lintreport ADD COLUMN missing_pages_count INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "lintreport",
+            "dismissed_count",
+            "ALTER TABLE lintreport ADD COLUMN dismissed_count INTEGER NOT NULL DEFAULT 0",
+        ),
         ("lintreport", "total_pairs", "ALTER TABLE lintreport ADD COLUMN total_pairs INTEGER NOT NULL DEFAULT 0"),
         ("lintreport", "checked_pairs", "ALTER TABLE lintreport ADD COLUMN checked_pairs INTEGER NOT NULL DEFAULT 0"),
     ]

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -125,6 +125,11 @@ async def _migrate_added_columns(engine) -> None:
             "ALTER TABLE query ADD COLUMN conversation_id TEXT REFERENCES conversation(id)",
         ),
         ("query", "turn_index", "ALTER TABLE query ADD COLUMN turn_index INTEGER NOT NULL DEFAULT 0"),
+        # Lint report — additional columns
+        ("lintreport", "missing_pages_count", "ALTER TABLE lintreport ADD COLUMN missing_pages_count INTEGER NOT NULL DEFAULT 0"),
+        ("lintreport", "dismissed_count", "ALTER TABLE lintreport ADD COLUMN dismissed_count INTEGER NOT NULL DEFAULT 0"),
+        ("lintreport", "total_pairs", "ALTER TABLE lintreport ADD COLUMN total_pairs INTEGER NOT NULL DEFAULT 0"),
+        ("lintreport", "checked_pairs", "ALTER TABLE lintreport ADD COLUMN checked_pairs INTEGER NOT NULL DEFAULT 0"),
     ]
     indexes: list[tuple[str, str]] = [
         # (index name, CREATE fragment)

--- a/src/wikimind/engine/linter/__init__.py
+++ b/src/wikimind/engine/linter/__init__.py
@@ -1,0 +1,10 @@
+"""Wiki linter engine — check-per-function health audit system.
+
+Re-exports the public API: the runner and individual detection functions.
+"""
+
+from wikimind.engine.linter.contradictions import detect_contradictions
+from wikimind.engine.linter.orphans import detect_orphans
+from wikimind.engine.linter.runner import run_lint
+
+__all__ = ["detect_contradictions", "detect_orphans", "run_lint"]

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import structlog
 from sqlalchemy import text
-from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from wikimind.config import Settings
 from wikimind.engine.linter.prompts import CONTRADICTION_SYSTEM_PROMPT, CONTRADICTION_USER_TEMPLATE

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import itertools
+import json
 import random
 from pathlib import Path
 
@@ -16,6 +17,7 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from wikimind._datetime import utcnow_naive
 from wikimind.config import Settings
 from wikimind.engine.linter.prompts import CONTRADICTION_SYSTEM_PROMPT, CONTRADICTION_USER_TEMPLATE
 from wikimind.engine.llm_router import LLMRouter
@@ -24,6 +26,7 @@ from wikimind.models import (
     CompletionRequest,
     ContradictionFinding,
     LintFindingKind,
+    LintReport,
     LintSeverity,
     TaskType,
 )
@@ -31,10 +34,15 @@ from wikimind.models import (
 log = structlog.get_logger()
 
 
-def _content_hash(article_a_id: str, article_b_id: str, description: str) -> str:
-    """Compute a stable sha256 for cross-run dedup of dismissed findings."""
+def _content_hash(article_a_id: str, article_b_id: str) -> str:
+    """Compute a stable sha256 for cross-run dedup of dismissed findings.
+
+    Keyed by sorted article pair IDs only — not the LLM description,
+    which varies between runs. Dismissing any contradiction between
+    articles A and B dismisses all future contradictions for that pair.
+    """
     ids = sorted([article_a_id, article_b_id])
-    raw = f"{LintFindingKind.CONTRADICTION}|{ids[0]}|{ids[1]}|{description}"
+    raw = f"{LintFindingKind.CONTRADICTION}|{ids[0]}|{ids[1]}"
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
@@ -112,47 +120,99 @@ async def _get_articles_for_concept(session: AsyncSession, concept_name: str) ->
     return articles
 
 
+async def _check_pair_cache(session: AsyncSession, article_a: Article, article_b: Article) -> list[dict] | None:
+    """Check if we have a cached result for this article pair."""
+    ids = sorted([article_a.id, article_b.id])
+    result = await session.execute(
+        text(
+            "SELECT result_json, article_a_updated_at, article_b_updated_at "
+            "FROM lintpaircache "
+            "WHERE article_a_id = :a_id AND article_b_id = :b_id"
+        ),
+        {"a_id": ids[0], "b_id": ids[1]},
+    )
+    row = result.fetchone()
+    if not row:
+        return None
+    # Check if articles have been updated since cache was written
+    cached_a_updated = row[1]
+    cached_b_updated = row[2]
+    current_a = str(article_a.updated_at) if ids[0] == article_a.id else str(article_b.updated_at)
+    current_b = str(article_b.updated_at) if ids[1] == article_b.id else str(article_a.updated_at)
+    if cached_a_updated == current_a and cached_b_updated == current_b:
+        return json.loads(row[0])
+    return None
+
+
+async def _save_pair_cache(
+    session: AsyncSession,
+    article_a: Article,
+    article_b: Article,
+    result_data: list[dict],
+) -> None:
+    """Save LLM result to pair cache."""
+    ids = sorted([article_a.id, article_b.id])
+    a_art = article_a if ids[0] == article_a.id else article_b
+    b_art = article_b if ids[1] == article_b.id else article_a
+    # Delete old cache entry if exists
+    await session.execute(
+        text("DELETE FROM lintpaircache WHERE article_a_id = :a AND article_b_id = :b"),
+        {"a": ids[0], "b": ids[1]},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO lintpaircache (id, article_a_id, article_b_id, "
+            "article_a_updated_at, article_b_updated_at, result_json, checked_at) "
+            "VALUES (:id, :a_id, :b_id, :a_up, :b_up, :result, :now)"
+        ),
+        {
+            "id": str(hashlib.sha256(f"{ids[0]}|{ids[1]}".encode()).hexdigest()[:32]),
+            "a_id": ids[0],
+            "b_id": ids[1],
+            "a_up": str(a_art.updated_at),
+            "b_up": str(b_art.updated_at),
+            "result": json.dumps(result_data),
+            "now": str(utcnow_naive()),
+        },
+    )
+
+
 async def detect_contradictions(
     session: AsyncSession,
     router: LLMRouter,
     settings: Settings,
-    report_id: str,
+    report: LintReport,
 ) -> list[ContradictionFinding]:
     """For each concept, LLM-compare article pairs within that concept bucket.
 
-    Args:
-        session: Async database session.
-        router: LLM router for making completion calls.
-        settings: Application settings with linter config.
-        report_id: The parent LintReport ID.
-
-    Returns:
-        List of ContradictionFinding instances ready for persistence.
+    Updates report.total_pairs and report.checked_pairs for progress tracking.
+    Uses pair cache to skip LLM calls for unchanged article pairs.
     """
     cfg = settings.linter
     findings: list[ContradictionFinding] = []
 
-    # Load concepts, ordered by most recently updated articles first
+    # Load concepts
     result = await session.execute(
         text("SELECT c.id, c.name FROM concept c ORDER BY c.article_count DESC LIMIT :limit"),
         {"limit": cfg.max_concepts_per_run},
     )
     concepts = result.fetchall()
 
+    # Collect all pairs across concepts first (for progress tracking)
+    all_work: list[tuple[str | None, str, list[tuple[Article, Article]]]] = []
+
     if not concepts:
-        # Fallback: no concepts exist — compare top articles by updated_at
         log.info("No concepts found, falling back to top-N article comparison")
         result = await session.execute(
             text(
                 "SELECT id, slug, title, file_path, concept_ids, confidence, "
                 "linter_score, summary, created_at, updated_at, source_ids, provider "
-                "FROM article ORDER BY updated_at DESC "
-                "LIMIT :limit"
+                "FROM article ORDER BY updated_at DESC LIMIT :limit"
             ),
             {"limit": cfg.max_contradiction_pairs_per_concept * 2},
         )
         rows = result.fetchall()
-        all_articles = [
+        articles = [
             Article(
                 id=r[0],
                 slug=r[1],
@@ -169,35 +229,80 @@ async def detect_contradictions(
             )
             for r in rows
         ]
-        pairs = list(itertools.combinations(all_articles, 2))
-        if len(pairs) > cfg.max_contradiction_pairs_per_concept:
-            pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
-
-        for article_a, article_b in pairs:
-            new_findings = await _compare_article_pair(article_a, article_b, None, router, settings, report_id)
-            findings.extend(new_findings)
-        return findings
-
-    for concept_row in concepts:
-        concept_id, concept_name = concept_row
-        articles = await _get_articles_for_concept(session, concept_name)
-
-        if len(articles) < 2:
-            continue
-
         pairs = list(itertools.combinations(articles, 2))
         if len(pairs) > cfg.max_contradiction_pairs_per_concept:
             pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
+        all_work.append((None, "all-articles", pairs))
+    else:
+        for concept_row in concepts:
+            concept_id, concept_name = concept_row
+            articles = await _get_articles_for_concept(session, concept_name)
+            if len(articles) < 2:
+                continue
+            pairs = list(itertools.combinations(articles, 2))
+            if len(pairs) > cfg.max_contradiction_pairs_per_concept:
+                pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
+            all_work.append((concept_id, concept_name, pairs))
 
-        log.info(
-            "Checking contradictions in concept",
-            concept=concept_name,
-            pairs=len(pairs),
-        )
+    # Compute total pairs and update report for progress
+    total_pairs = sum(len(pairs) for _, _, pairs in all_work)
+    report.total_pairs = total_pairs
+    report.checked_pairs = 0
+    session.add(report)
+    await session.flush()
+
+    checked = 0
+    for concept_id, concept_name, pairs in all_work:
+        log.info("Checking contradictions in concept", concept=concept_name, pairs=len(pairs))
 
         for article_a, article_b in pairs:
-            new_findings = await _compare_article_pair(article_a, article_b, concept_id, router, settings, report_id)
+            # Check cache first
+            if cfg.enable_pair_cache:
+                cached = await _check_pair_cache(session, article_a, article_b)
+                if cached is not None:
+                    log.info("Pair cache hit", a=article_a.title[:30], b=article_b.title[:30])
+                    for c in cached:
+                        findings.append(
+                            ContradictionFinding(
+                                report_id=report.id,
+                                severity=LintSeverity.WARN,
+                                description=c.get("description", "Contradiction detected"),
+                                content_hash=_content_hash(article_a.id, article_b.id),
+                                article_a_id=article_a.id,
+                                article_b_id=article_b.id,
+                                article_a_claim=c.get("article_a_claim", ""),
+                                article_b_claim=c.get("article_b_claim", ""),
+                                llm_confidence=c.get("confidence", "medium"),
+                                shared_concept_id=concept_id,
+                            )
+                        )
+                    checked += 1
+                    report.checked_pairs = checked
+                    session.add(report)
+                    await session.flush()
+                    continue
+
+            # LLM call
+            new_findings = await _compare_article_pair(article_a, article_b, concept_id, router, settings, report.id)
             findings.extend(new_findings)
+
+            # Save to cache
+            if cfg.enable_pair_cache:
+                cache_data = [
+                    {
+                        "description": f.description,
+                        "article_a_claim": f.article_a_claim,
+                        "article_b_claim": f.article_b_claim,
+                        "confidence": f.llm_confidence,
+                    }
+                    for f in new_findings
+                ]
+                await _save_pair_cache(session, article_a, article_b, cache_data)
+
+            checked += 1
+            report.checked_pairs = checked
+            session.add(report)
+            await session.flush()
 
     return findings
 
@@ -258,7 +363,7 @@ async def _compare_article_pair(
             report_id=report_id,
             severity=LintSeverity.WARN,
             description=description,
-            content_hash=_content_hash(article_a.id, article_b.id, description),
+            content_hash=_content_hash(article_a.id, article_b.id),
             article_a_id=article_a.id,
             article_b_id=article_b.id,
             article_a_claim=c.get("article_a_claim", ""),

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -76,8 +76,9 @@ def _extract_claims(article: Article, data_dir: str) -> list[str]:
     return claims
 
 
-async def _get_articles_for_concept(session: AsyncSession, concept_id: str) -> list[Article]:
-    """Load articles whose concept_ids JSON array contains the given concept id."""
+async def _get_articles_for_concept(session: AsyncSession, concept_name: str) -> list[Article]:
+    """Load articles whose concept_ids JSON array contains the given concept name."""
+    # concept_ids stores concept names (not UUIDs), so match by name directly.
     result = await session.execute(
         text(
             "SELECT article.id, article.slug, article.title, article.file_path, "
@@ -85,9 +86,9 @@ async def _get_articles_for_concept(session: AsyncSession, concept_id: str) -> l
             "article.summary, article.created_at, article.updated_at, "
             "article.source_ids, article.provider "
             "FROM article, json_each(article.concept_ids) AS je "
-            "WHERE je.value = :concept_id"
+            "WHERE je.value = :concept_name"
         ),
-        {"concept_id": concept_id},
+        {"concept_name": concept_name},
     )
     rows = result.fetchall()
     articles = []
@@ -179,7 +180,7 @@ async def detect_contradictions(
 
     for concept_row in concepts:
         concept_id, concept_name = concept_row
-        articles = await _get_articles_for_concept(session, concept_id)
+        articles = await _get_articles_for_concept(session, concept_name)
 
         if len(articles) < 2:
             continue

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -1,0 +1,270 @@
+"""Contradiction detection — LLM-powered cross-article claim comparison.
+
+For each concept bucket, enumerate article pairs and ask the LLM to identify
+contradictory claims. Returns a list of ContradictionFinding instances that
+the runner persists directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import random
+from pathlib import Path
+
+import structlog
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import Settings
+from wikimind.engine.linter.prompts import CONTRADICTION_SYSTEM_PROMPT, CONTRADICTION_USER_TEMPLATE
+from wikimind.engine.llm_router import LLMRouter
+from wikimind.models import (
+    Article,
+    CompletionRequest,
+    ContradictionFinding,
+    LintFindingKind,
+    LintSeverity,
+    TaskType,
+)
+
+log = structlog.get_logger()
+
+
+def _content_hash(article_a_id: str, article_b_id: str, description: str) -> str:
+    """Compute a stable sha256 for cross-run dedup of dismissed findings."""
+    ids = sorted([article_a_id, article_b_id])
+    raw = f"{LintFindingKind.CONTRADICTION}|{ids[0]}|{ids[1]}|{description}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _extract_claims(article: Article, data_dir: str) -> list[str]:
+    """Extract key claims from an article's markdown file.
+
+    Looks for a "Key Claims" section and parses bullet points.
+    Falls back to the first few non-empty lines of the body if no section found.
+    """
+    try:
+        content = Path(article.file_path).read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return []
+
+    lines = content.split("\n")
+    claims: list[str] = []
+    in_claims_section = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.lower().startswith("## key claims") or stripped.lower().startswith("## key_claims"):
+            in_claims_section = True
+            continue
+        if in_claims_section:
+            if stripped.startswith("## "):
+                break
+            if stripped.startswith("- ") or stripped.startswith("* "):
+                claims.append(stripped[2:].strip())
+
+    if not claims:
+        # Fallback: use first non-heading, non-empty lines (up to 10)
+        for line in lines:
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
+                claims.append(stripped)
+                if len(claims) >= 10:
+                    break
+
+    return claims
+
+
+async def _get_articles_for_concept(session: AsyncSession, concept_id: str) -> list[Article]:
+    """Load articles whose concept_ids JSON array contains the given concept id."""
+    result = await session.execute(
+        text(
+            "SELECT article.id, article.slug, article.title, article.file_path, "
+            "article.concept_ids, article.confidence, article.linter_score, "
+            "article.summary, article.created_at, article.updated_at, "
+            "article.source_ids, article.provider "
+            "FROM article, json_each(article.concept_ids) AS je "
+            "WHERE je.value = :concept_id"
+        ),
+        {"concept_id": concept_id},
+    )
+    rows = result.fetchall()
+    articles = []
+    for row in rows:
+        articles.append(
+            Article(
+                id=row[0],
+                slug=row[1],
+                title=row[2],
+                file_path=row[3],
+                concept_ids=row[4],
+                confidence=row[5],
+                linter_score=row[6],
+                summary=row[7],
+                created_at=row[8],
+                updated_at=row[9],
+                source_ids=row[10],
+                provider=row[11],
+            )
+        )
+    return articles
+
+
+async def detect_contradictions(
+    session: AsyncSession,
+    router: LLMRouter,
+    settings: Settings,
+    report_id: str,
+) -> list[ContradictionFinding]:
+    """For each concept, LLM-compare article pairs within that concept bucket.
+
+    Args:
+        session: Async database session.
+        router: LLM router for making completion calls.
+        settings: Application settings with linter config.
+        report_id: The parent LintReport ID.
+
+    Returns:
+        List of ContradictionFinding instances ready for persistence.
+    """
+    cfg = settings.linter
+    findings: list[ContradictionFinding] = []
+
+    # Load concepts, ordered by most recently updated articles first
+    result = await session.execute(
+        text("SELECT c.id, c.name FROM concept c ORDER BY c.article_count DESC LIMIT :limit"),
+        {"limit": cfg.max_concepts_per_run},
+    )
+    concepts = result.fetchall()
+
+    if not concepts:
+        # Fallback: no concepts exist — compare top articles by updated_at
+        log.info("No concepts found, falling back to top-N article comparison")
+        result = await session.execute(
+            text(
+                "SELECT id, slug, title, file_path, concept_ids, confidence, "
+                "linter_score, summary, created_at, updated_at, source_ids, provider "
+                "FROM article ORDER BY updated_at DESC "
+                "LIMIT :limit"
+            ),
+            {"limit": cfg.max_contradiction_pairs_per_concept * 2},
+        )
+        rows = result.fetchall()
+        all_articles = [
+            Article(
+                id=r[0],
+                slug=r[1],
+                title=r[2],
+                file_path=r[3],
+                concept_ids=r[4],
+                confidence=r[5],
+                linter_score=r[6],
+                summary=r[7],
+                created_at=r[8],
+                updated_at=r[9],
+                source_ids=r[10],
+                provider=r[11],
+            )
+            for r in rows
+        ]
+        pairs = list(itertools.combinations(all_articles, 2))
+        if len(pairs) > cfg.max_contradiction_pairs_per_concept:
+            pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
+
+        for article_a, article_b in pairs:
+            new_findings = await _compare_article_pair(article_a, article_b, None, router, settings, report_id)
+            findings.extend(new_findings)
+        return findings
+
+    for concept_row in concepts:
+        concept_id, concept_name = concept_row
+        articles = await _get_articles_for_concept(session, concept_id)
+
+        if len(articles) < 2:
+            continue
+
+        pairs = list(itertools.combinations(articles, 2))
+        if len(pairs) > cfg.max_contradiction_pairs_per_concept:
+            pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
+
+        log.info(
+            "Checking contradictions in concept",
+            concept=concept_name,
+            pairs=len(pairs),
+        )
+
+        for article_a, article_b in pairs:
+            new_findings = await _compare_article_pair(article_a, article_b, concept_id, router, settings, report_id)
+            findings.extend(new_findings)
+
+    return findings
+
+
+async def _compare_article_pair(
+    article_a: Article,
+    article_b: Article,
+    concept_id: str | None,
+    router: LLMRouter,
+    settings: Settings,
+    report_id: str,
+) -> list[ContradictionFinding]:
+    """Compare a single article pair via LLM and return any findings."""
+    cfg = settings.linter
+    claims_a = _extract_claims(article_a, settings.data_dir)
+    claims_b = _extract_claims(article_b, settings.data_dir)
+
+    if not claims_a or not claims_b:
+        return []
+
+    claims_a_text = "\n".join(f"- {c}" for c in claims_a)
+    claims_b_text = "\n".join(f"- {c}" for c in claims_b)
+
+    user_msg = CONTRADICTION_USER_TEMPLATE.format(
+        title_a=article_a.title,
+        claims_a=claims_a_text,
+        title_b=article_b.title,
+        claims_b=claims_b_text,
+    )
+
+    request = CompletionRequest(
+        system=CONTRADICTION_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_msg}],
+        max_tokens=cfg.contradiction_llm_max_tokens,
+        temperature=cfg.contradiction_llm_temperature,
+        response_format="json",
+        task_type=TaskType.LINT,
+    )
+
+    try:
+        response = await router.complete(request, session=None)
+        data = router.parse_json_response(response)
+    except Exception:
+        log.warning(
+            "LLM call failed for contradiction check",
+            article_a=article_a.title,
+            article_b=article_b.title,
+            exc_info=True,
+        )
+        return []
+
+    contradictions = data.get("contradictions", [])
+    findings: list[ContradictionFinding] = []
+
+    for c in contradictions:
+        description = c.get("description", "Contradiction detected")
+        finding = ContradictionFinding(
+            report_id=report_id,
+            severity=LintSeverity.WARN,
+            description=description,
+            content_hash=_content_hash(article_a.id, article_b.id, description),
+            article_a_id=article_a.id,
+            article_b_id=article_b.id,
+            article_a_claim=c.get("article_a_claim", ""),
+            article_b_claim=c.get("article_b_claim", ""),
+            llm_confidence=c.get("confidence", "medium"),
+            shared_concept_id=concept_id,
+        )
+        findings.append(finding)
+
+    return findings

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -11,7 +11,7 @@ import hashlib
 
 import structlog
 from sqlalchemy import text
-from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from wikimind.config import Settings
 from wikimind.models import (

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -1,0 +1,80 @@
+"""Orphan detection — pure SQL check for articles with no backlinks.
+
+Identifies articles with zero inbound AND zero outbound backlinks.
+Gated by ``settings.linter.enable_orphan_detection`` (default False)
+until issue #95 populates the Backlink table.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import structlog
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.config import Settings
+from wikimind.models import (
+    LintFindingKind,
+    LintSeverity,
+    OrphanFinding,
+)
+
+log = structlog.get_logger()
+
+
+def _content_hash(article_id: str, article_title: str) -> str:
+    """Compute a stable sha256 for cross-run dedup of dismissed findings."""
+    raw = f"{LintFindingKind.ORPHAN}|{article_id}|{article_title}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+async def detect_orphans(
+    session: AsyncSession,
+    settings: Settings,
+    report_id: str,
+) -> list[OrphanFinding]:
+    """Find articles with zero inbound AND zero outbound backlinks.
+
+    This check is gated by ``settings.linter.enable_orphan_detection``.
+    When disabled (default), returns an empty list immediately.
+
+    Args:
+        session: Async database session.
+        settings: Application settings with linter config.
+        report_id: The parent LintReport ID.
+
+    Returns:
+        List of OrphanFinding instances ready for persistence.
+    """
+    if not settings.linter.enable_orphan_detection:
+        log.info("Orphan detection disabled (enable_orphan_detection=False)")
+        return []
+
+    result = await session.execute(
+        text(
+            "SELECT a.id, a.title FROM article a "
+            "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id "
+            "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id "
+            "WHERE bl_in.target_article_id IS NULL "
+            "AND bl_out.source_article_id IS NULL"
+        )
+    )
+    rows = result.fetchall()
+
+    findings: list[OrphanFinding] = []
+    for row in rows:
+        article_id, article_title = row
+        findings.append(
+            OrphanFinding(
+                report_id=report_id,
+                severity=LintSeverity.INFO,
+                description=f"Article '{article_title}' has no inbound or outbound links",
+                content_hash=_content_hash(article_id, article_title),
+                article_id=article_id,
+                article_title=article_title,
+            )
+        )
+
+    log.info("Orphan detection complete", orphans_found=len(findings))
+    return findings

--- a/src/wikimind/engine/linter/prompts.py
+++ b/src/wikimind/engine/linter/prompts.py
@@ -1,0 +1,27 @@
+"""LLM prompt constants for the wiki linter."""
+
+CONTRADICTION_SYSTEM_PROMPT = (
+    "You are a wiki health auditor. Given two short wiki articles about the same topic, "
+    "identify any contradictory assertions between their key claims. Return strict JSON."
+)
+
+CONTRADICTION_USER_TEMPLATE = """Article A: "{title_a}"
+Key claims:
+{claims_a}
+
+Article B: "{title_b}"
+Key claims:
+{claims_b}
+
+Return JSON of this shape:
+{{
+  "contradictions": [
+    {{
+      "description": "one-sentence summary of the contradiction",
+      "article_a_claim": "the specific claim from A",
+      "article_b_claim": "the specific claim from B",
+      "confidence": "high" | "medium" | "low"
+    }}
+  ]
+}}
+If there are no contradictions, return {{"contradictions": []}}."""

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -87,7 +87,7 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
 
     try:
         # Run checks
-        contradictions = await detect_contradictions(session, router, settings, report.id)
+        contradictions = await detect_contradictions(session, router, settings, report)
         orphans = await detect_orphans(session, settings, report.id)
 
         # Apply dismiss suppression
@@ -99,12 +99,17 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
         for of in orphans:
             session.add(of)
 
-        # Update report
+        # Update report — count only active (non-dismissed) findings
+        active_contradictions = [c for c in contradictions if not c.dismissed]
+        active_orphans = [o for o in orphans if not o.dismissed]
+        dismissed = (len(contradictions) - len(active_contradictions)) + (len(orphans) - len(active_orphans))
+
         report.status = LintReportStatus.COMPLETE
         report.completed_at = utcnow_naive()
-        report.contradictions_count = len(contradictions)
-        report.orphans_count = len(orphans)
-        report.total_findings = len(contradictions) + len(orphans)
+        report.contradictions_count = len(active_contradictions)
+        report.orphans_count = len(active_orphans)
+        report.total_findings = len(active_contradictions) + len(active_orphans)
+        report.dismissed_count = dismissed
         session.add(report)
         await session.commit()
 

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -1,0 +1,139 @@
+"""Lint runner — orchestrates all checks and persists results.
+
+The top-level ``run_lint`` function creates a ``LintReport``, dispatches
+each check, persists findings, updates the report, and emits a WebSocket
+event on completion.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import func
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.api.routes.ws import emit_linter_alert
+from wikimind.config import get_settings
+from wikimind.engine.linter.contradictions import detect_contradictions
+from wikimind.engine.linter.orphans import detect_orphans
+from wikimind.engine.llm_router import get_llm_router
+from wikimind.models import (
+    Article,
+    ContradictionFinding,
+    DismissedFinding,
+    LintReport,
+    LintReportStatus,
+    OrphanFinding,
+)
+
+log = structlog.get_logger()
+
+
+async def _apply_dismiss_suppression(
+    session: AsyncSession,
+    contradictions: list[ContradictionFinding],
+    orphans: list[OrphanFinding],
+) -> None:
+    """Mark findings as dismissed if their content_hash exists in DismissedFinding."""
+    all_hashes: set[str] = set()
+    for f in contradictions:
+        all_hashes.add(f.content_hash)
+    for f in orphans:
+        all_hashes.add(f.content_hash)
+
+    if not all_hashes:
+        return
+
+    result = await session.execute(
+        select(DismissedFinding.content_hash).where(
+            DismissedFinding.content_hash.in_(all_hashes)  # type: ignore[union-attr]
+        )
+    )
+    dismissed_hashes = {row[0] for row in result.fetchall()}
+
+    now = utcnow_naive()
+    for f in contradictions:
+        if f.content_hash in dismissed_hashes:
+            f.dismissed = True
+            f.dismissed_at = now
+    for f in orphans:
+        if f.content_hash in dismissed_hashes:
+            f.dismissed = True
+            f.dismissed_at = now
+
+
+async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintReport:
+    """Run the full lint pipeline: create report, run checks, persist, emit events.
+
+    Args:
+        session: Async database session.
+        job_id: Optional Job ID to link the report to.
+
+    Returns:
+        The completed LintReport.
+    """
+    settings = get_settings()
+    router = get_llm_router()
+
+    # Snapshot article count
+    count_result = await session.execute(select(func.count()).select_from(Article))
+    article_count = count_result.scalar() or 0
+
+    # Create report
+    report = LintReport(
+        status=LintReportStatus.IN_PROGRESS,
+        article_count=article_count,
+        job_id=job_id,
+    )
+    session.add(report)
+    await session.flush()
+
+    try:
+        # Run checks
+        contradictions = await detect_contradictions(session, router, settings, report.id)
+        orphans = await detect_orphans(session, settings, report.id)
+
+        # Apply dismiss suppression
+        await _apply_dismiss_suppression(session, contradictions, orphans)
+
+        # Persist findings
+        for f in contradictions:
+            session.add(f)
+        for f in orphans:
+            session.add(f)
+
+        # Update report
+        report.status = LintReportStatus.COMPLETE
+        report.completed_at = utcnow_naive()
+        report.contradictions_count = len(contradictions)
+        report.orphans_count = len(orphans)
+        report.total_findings = len(contradictions) + len(orphans)
+        session.add(report)
+        await session.commit()
+
+        log.info(
+            "Lint run complete",
+            report_id=report.id,
+            contradictions=len(contradictions),
+            orphans=len(orphans),
+        )
+
+        # Emit WebSocket alert
+        if contradictions:
+            article_titles: list[str] = []
+            for c in contradictions:
+                if not c.dismissed:
+                    article_titles.append(c.description)
+            if article_titles:
+                await emit_linter_alert("contradiction", article_titles)
+
+    except Exception as e:
+        log.error("Lint run failed", error=str(e), exc_info=True)
+        report.status = LintReportStatus.FAILED
+        report.error_message = str(e)
+        report.completed_at = utcnow_naive()
+        session.add(report)
+        await session.commit()
+
+    return report

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import structlog
 from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
 from wikimind.api.routes.ws import emit_linter_alert
@@ -36,31 +36,27 @@ async def _apply_dismiss_suppression(
     orphans: list[OrphanFinding],
 ) -> None:
     """Mark findings as dismissed if their content_hash exists in DismissedFinding."""
-    all_hashes: set[str] = set()
-    for f in contradictions:
-        all_hashes.add(f.content_hash)
-    for f in orphans:
-        all_hashes.add(f.content_hash)
+    all_findings: list[ContradictionFinding | OrphanFinding] = [
+        *contradictions,
+        *orphans,
+    ]
+    all_hashes = {f.content_hash for f in all_findings}
 
     if not all_hashes:
         return
 
     result = await session.execute(
         select(DismissedFinding.content_hash).where(
-            DismissedFinding.content_hash.in_(all_hashes)  # type: ignore[union-attr]
+            DismissedFinding.content_hash.in_(all_hashes)  # type: ignore[attr-defined]
         )
     )
     dismissed_hashes = {row[0] for row in result.fetchall()}
 
     now = utcnow_naive()
-    for f in contradictions:
-        if f.content_hash in dismissed_hashes:
-            f.dismissed = True
-            f.dismissed_at = now
-    for f in orphans:
-        if f.content_hash in dismissed_hashes:
-            f.dismissed = True
-            f.dismissed_at = now
+    for finding in all_findings:
+        if finding.content_hash in dismissed_hashes:
+            finding.dismissed = True
+            finding.dismissed_at = now
 
 
 async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintReport:
@@ -98,10 +94,10 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
         await _apply_dismiss_suppression(session, contradictions, orphans)
 
         # Persist findings
-        for f in contradictions:
-            session.add(f)
-        for f in orphans:
-            session.add(f)
+        for cf in contradictions:
+            session.add(cf)
+        for of in orphans:
+            session.add(of)
 
         # Update report
         report.status = LintReportStatus.COMPLETE

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -581,8 +581,15 @@ class LLMRouter:
         """Parse JSON from LLM response, stripping markdown fences if present."""
         content = response.content.strip()
         if content.startswith("```"):
+            # Find the closing ``` fence (not just the last line)
             lines = content.split("\n")
-            content = "\n".join(lines[1:-1])
+            # Skip the opening ```json line
+            body_lines = lines[1:]
+            # Find the closing ``` and take everything before it
+            for i, line in enumerate(body_lines):
+                if line.strip() == "```":
+                    content = "\n".join(body_lines[:i])
+                    break
         return json.loads(content)
 
 

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -15,38 +15,32 @@ UTF-8 text — it never re-parses HTML, PDFs, or transcripts.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import ClassVar
 
 import structlog
 from arq import cron
 from arq.connections import RedisSettings
-from sqlmodel import select
 
 import wikimind.ingest.service as _ingest_service
 from wikimind._datetime import utcnow_naive
 from wikimind.api.routes.ws import (
     emit_compilation_complete,
     emit_compilation_failed,
-    emit_linter_alert,
     emit_source_progress,
 )
 from wikimind.config import get_settings
 from wikimind.database import get_session_factory
 from wikimind.engine.compiler import Compiler
-from wikimind.engine.llm_router import get_llm_router
+from wikimind.engine.linter.runner import run_lint
 from wikimind.jobs.sweep import sweep_wikilinks
 from wikimind.models import (
-    Article,
-    CompletionRequest,
     IngestStatus,
     Job,
     JobStatus,
     JobType,
     NormalizedDocument,
     Source,
-    TaskType,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
 
@@ -171,7 +165,11 @@ async def compile_source(ctx, source_id: str):
 
 
 async def lint_wiki(ctx):
-    """Run the wiki linter to find contradictions, orphans, and gaps."""
+    """Run the wiki linter to find contradictions, orphans, and gaps.
+
+    Delegates to the structured ``run_lint`` pipeline. The existing
+    ARQ cron and ``POST /jobs/lint`` entry point call this function.
+    """
     log.info("lint_wiki started")
 
     async with get_session_factory()() as session:
@@ -184,75 +182,11 @@ async def lint_wiki(ctx):
         await session.commit()
 
         try:
-            # Gather all articles
-            result = await session.execute(select(Article))
-            articles = result.scalars().all()
-
-            if not articles:
-                job.status = JobStatus.COMPLETE
-                job.result_summary = "No articles to lint"
-                session.add(job)
-                await session.commit()
-                return
-
-            # Build wiki summary for linter
-            summaries = []
-            for article in articles[:50]:  # Cap at 50 for token budget
-                try:
-                    content = Path(article.file_path).read_text(encoding="utf-8")[:1000]
-                    summaries.append(f"## {article.title}\n{content}\n")
-                except Exception:
-                    continue
-
-            wiki_text = "\n---\n".join(summaries)
-
-            router = get_llm_router()
-            lint_request = CompletionRequest(
-                system="""You are a wiki health auditor. Analyze these wiki articles and identify issues.
-
-Return valid JSON only:
-{
-  "contradictions": [{"claim_a": "...", "claim_b": "...", "articles": ["title1", "title2"]}],
-  "orphaned_articles": ["title"],
-  "stale_articles": ["title"],
-  "gap_suggestions": ["New article title that should exist"],
-  "coverage_scores": {"topic": 0.0}
-}""",
-                messages=[{"role": "user", "content": f"Analyze this wiki:\n\n{wiki_text}"}],
-                max_tokens=2048,
-                temperature=0.2,
-                response_format="json",
-                task_type=TaskType.LINT,
-            )
-
-            response = await router.complete(lint_request, session=session)
-            lint_data = router.parse_json_response(response)
-
-            # Save health report
-            settings = get_settings()
-            meta_dir = Path(settings.data_dir) / "wiki" / "_meta"
-            meta_dir.mkdir(parents=True, exist_ok=True)
-
-            health = {
-                "generated_at": utcnow_naive().isoformat(),
-                "total_articles": len(articles),
-                **lint_data,
-            }
-            (meta_dir / "health.json").write_text(json.dumps(health, indent=2))
-
-            # Emit alerts
-            if lint_data.get("contradictions"):
-                articles_involved = []
-                for c in lint_data["contradictions"]:
-                    articles_involved.extend(c.get("articles", []))
-                await emit_linter_alert("contradiction", articles_involved)
+            report = await run_lint(session, job_id=job.id)
 
             job.status = JobStatus.COMPLETE
             job.completed_at = utcnow_naive()
-            job.result_summary = (
-                f"Found {len(lint_data.get('contradictions', []))} contradictions, "
-                f"{len(lint_data.get('gap_suggestions', []))} gaps"
-            )
+            job.result_summary = f"Found {report.contradictions_count} contradictions, {report.orphans_count} orphans"
             session.add(job)
             await session.commit()
 

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from wikimind.api.routes import ingest, jobs, query, wiki, ws
+from wikimind.api.routes import ingest, jobs, lint, query, wiki, ws
 from wikimind.api.routes import settings as settings_router
 from wikimind.config import get_settings
 from wikimind.database import close_db, init_db
@@ -91,6 +91,7 @@ app.include_router(ingest.router, prefix="/ingest", tags=["Ingest"])
 app.include_router(wiki.router, prefix="/wiki", tags=["Wiki"])
 app.include_router(query.router, prefix="/query", tags=["Query"])
 app.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
+app.include_router(lint.router, prefix="/lint", tags=["Lint"])
 app.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
 app.include_router(ws.router, tags=["WebSocket"])
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -323,6 +323,103 @@ class LinterResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Lint Report + Per-Kind Finding Tables
+# ---------------------------------------------------------------------------
+
+
+class LintSeverity(StrEnum):
+    """Severity level for a lint finding."""
+
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+
+
+class LintFindingKind(StrEnum):
+    """Kind of lint finding — maps 1:1 to a detection function AND a table.
+
+    Used as the content_hash prefix (so dismiss state is keyed by kind + content)
+    and as the discriminator field in the frontend API response union.
+    """
+
+    CONTRADICTION = "contradiction"
+    ORPHAN = "orphan"
+
+
+class LintReportStatus(StrEnum):
+    """Lifecycle of a lint report."""
+
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+class LintReport(SQLModel, table=True):
+    """One run of the linter. All findings from a run FK back to this row via report_id."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    generated_at: datetime = Field(default_factory=utcnow_naive, index=True)
+    completed_at: datetime | None = None
+    status: LintReportStatus = LintReportStatus.IN_PROGRESS
+    article_count: int = 0
+    total_findings: int = 0
+    contradictions_count: int = 0
+    orphans_count: int = 0
+    error_message: str | None = None
+    job_id: str | None = Field(default=None, foreign_key="job.id", index=True)
+
+
+class _LintFindingBase(SQLModel):
+    """Fields shared across every per-kind finding table. NOT a table itself."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    report_id: str = Field(foreign_key="lintreport.id", index=True)
+    severity: LintSeverity = LintSeverity.WARN
+    description: str
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    dismissed: bool = False
+    dismissed_at: datetime | None = None
+    content_hash: str = Field(index=True)
+
+
+class ContradictionFinding(_LintFindingBase, table=True):
+    """A contradiction between key claims of two articles that share a concept."""
+
+    kind: LintFindingKind = Field(default=LintFindingKind.CONTRADICTION)
+    article_a_id: str = Field(foreign_key="article.id", index=True)
+    article_b_id: str = Field(foreign_key="article.id", index=True)
+    article_a_claim: str
+    article_b_claim: str
+    llm_confidence: str  # "high" | "medium" | "low"
+    shared_concept_id: str | None = Field(default=None, foreign_key="concept.id", index=True)
+
+
+class OrphanFinding(_LintFindingBase, table=True):
+    """An article with zero inbound AND zero outbound backlinks."""
+
+    kind: LintFindingKind = Field(default=LintFindingKind.ORPHAN)
+    article_id: str = Field(foreign_key="article.id", index=True)
+    article_title: str
+
+
+class DismissedFinding(SQLModel, table=True):
+    """Cross-run dismiss record — keyed by content hash."""
+
+    content_hash: str = Field(primary_key=True)
+    kind: LintFindingKind
+    dismissed_at: datetime = Field(default_factory=utcnow_naive)
+    reason: str | None = None
+
+
+class LintReportDetail(BaseModel):
+    """API response shape for a single report with all findings."""
+
+    report: LintReport
+    contradictions: list[ContradictionFinding]
+    orphans: list[OrphanFinding]
+
+
+# ---------------------------------------------------------------------------
 # API Request/Response Models
 # ---------------------------------------------------------------------------
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -365,6 +365,10 @@ class LintReport(SQLModel, table=True):
     total_findings: int = 0
     contradictions_count: int = 0
     orphans_count: int = 0
+    missing_pages_count: int = 0
+    dismissed_count: int = 0
+    total_pairs: int = 0
+    checked_pairs: int = 0
     error_message: str | None = None
     job_id: str | None = Field(default=None, foreign_key="job.id", index=True)
 
@@ -417,6 +421,22 @@ class LintReportDetail(BaseModel):
     report: LintReport
     contradictions: list[ContradictionFinding]
     orphans: list[OrphanFinding]
+
+
+class LintPairCache(SQLModel, table=True):
+    """Cache of LLM contradiction check results for article pairs.
+
+    Keyed by sorted article pair IDs. Invalidated when either article's
+    updated_at changes.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    article_a_id: str = Field(index=True)
+    article_b_id: str = Field(index=True)
+    article_a_updated_at: str
+    article_b_updated_at: str
+    result_json: str  # JSON list of contradiction dicts
+    checked_at: datetime = Field(default_factory=utcnow_naive)
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -8,8 +8,8 @@ job system.
 from __future__ import annotations
 
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
 from wikimind.jobs.background import get_background_compiler
@@ -138,6 +138,7 @@ class LinterService:
         """
         now = utcnow_naive()
 
+        finding: ContradictionFinding | OrphanFinding | None
         if kind == LintFindingKind.CONTRADICTION:
             finding = await session.get(ContradictionFinding, finding_id)
         elif kind == LintFindingKind.ORPHAN:

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -1,0 +1,182 @@
+"""Linter service — thin persistence/query layer for lint reports and findings.
+
+All check logic lives in ``engine/linter/``. This service handles report
+retrieval, finding dismissal, and triggering lint runs via the background
+job system.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.jobs.background import get_background_compiler
+from wikimind.models import (
+    ContradictionFinding,
+    DismissedFinding,
+    LintFindingKind,
+    LintReport,
+    LintReportDetail,
+    OrphanFinding,
+)
+
+
+class LinterService:
+    """Coordinate lint report queries, finding dismissal, and run triggers."""
+
+    async def trigger_run(self) -> dict[str, str]:
+        """Schedule a lint run via the background job system.
+
+        Returns:
+            Dict with status indicating the run was scheduled.
+        """
+        bg = get_background_compiler()
+        await bg.schedule_lint()
+        return {"status": "in_progress"}
+
+    async def list_reports(self, session: AsyncSession, limit: int = 20) -> list[LintReport]:
+        """List lint reports ordered by generated_at DESC.
+
+        Args:
+            session: Async database session.
+            limit: Maximum number of reports to return.
+
+        Returns:
+            List of LintReport records.
+        """
+        result = await session.execute(
+            select(LintReport)
+            .order_by(LintReport.generated_at.desc())  # type: ignore[attr-defined]
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def get_report(
+        self,
+        session: AsyncSession,
+        report_id: str,
+        *,
+        include_dismissed: bool = False,
+    ) -> LintReportDetail:
+        """Get a single report with all its findings.
+
+        Args:
+            session: Async database session.
+            report_id: The report UUID.
+            include_dismissed: If True, include dismissed findings.
+
+        Returns:
+            LintReportDetail with report metadata and grouped findings.
+
+        Raises:
+            HTTPException: 404 if report not found.
+        """
+        report = await session.get(LintReport, report_id)
+        if not report:
+            raise HTTPException(status_code=404, detail="Lint report not found")
+
+        contradiction_query = select(ContradictionFinding).where(ContradictionFinding.report_id == report_id)
+        orphan_query = select(OrphanFinding).where(OrphanFinding.report_id == report_id)
+
+        if not include_dismissed:
+            contradiction_query = contradiction_query.where(
+                ContradictionFinding.dismissed == False  # noqa: E712
+            )
+            orphan_query = orphan_query.where(
+                OrphanFinding.dismissed == False  # noqa: E712
+            )
+
+        contradictions_result = await session.execute(contradiction_query)
+        orphans_result = await session.execute(orphan_query)
+
+        return LintReportDetail(
+            report=report,
+            contradictions=list(contradictions_result.scalars().all()),
+            orphans=list(orphans_result.scalars().all()),
+        )
+
+    async def get_latest(self, session: AsyncSession) -> LintReportDetail:
+        """Get the most recent lint report with findings.
+
+        Returns:
+            LintReportDetail for the latest report.
+
+        Raises:
+            HTTPException: 404 if no reports exist.
+        """
+        result = await session.execute(
+            select(LintReport)
+            .order_by(LintReport.generated_at.desc())  # type: ignore[attr-defined]
+            .limit(1)
+        )
+        report = result.scalars().first()
+        if not report:
+            raise HTTPException(status_code=404, detail="No lint reports exist yet")
+
+        return await self.get_report(session, report.id)
+
+    async def dismiss_finding(
+        self,
+        session: AsyncSession,
+        kind: LintFindingKind,
+        finding_id: str,
+    ) -> dict[str, object]:
+        """Dismiss a finding and record it for cross-run suppression.
+
+        Args:
+            session: Async database session.
+            kind: The finding kind (determines which table to query).
+            finding_id: The finding UUID.
+
+        Returns:
+            Dict confirming dismissal.
+
+        Raises:
+            HTTPException: 404 if finding not found.
+        """
+        now = utcnow_naive()
+
+        if kind == LintFindingKind.CONTRADICTION:
+            finding = await session.get(ContradictionFinding, finding_id)
+        elif kind == LintFindingKind.ORPHAN:
+            finding = await session.get(OrphanFinding, finding_id)
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown finding kind: {kind}")
+
+        if not finding:
+            raise HTTPException(status_code=404, detail="Finding not found")
+
+        finding.dismissed = True
+        finding.dismissed_at = now
+        session.add(finding)
+
+        # Record in DismissedFinding for cross-run suppression
+        existing = await session.get(DismissedFinding, finding.content_hash)
+        if not existing:
+            dismissed_record = DismissedFinding(
+                content_hash=finding.content_hash,
+                kind=kind,
+                dismissed_at=now,
+            )
+            session.add(dismissed_record)
+
+        await session.commit()
+
+        return {
+            "dismissed": True,
+            "kind": kind,
+            "finding_id": finding_id,
+        }
+
+
+_linter_service: LinterService | None = None
+
+
+def get_linter_service() -> LinterService:
+    """Return a singleton LinterService instance."""
+    global _linter_service
+    if _linter_service is None:
+        _linter_service = LinterService()
+    return _linter_service

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from wikimind.jobs import background as bg_mod
 from wikimind.jobs import worker as worker_mod
 from wikimind.jobs.background import BackgroundCompiler, get_background_compiler
 from wikimind.jobs.worker import compile_source, get_redis_settings, lint_wiki
-from wikimind.models import Article, IngestStatus, Source, SourceType
+from wikimind.models import IngestStatus, LintReport, LintReportStatus, Source, SourceType
 
 
 async def test_background_compiler_dev_mode_compile() -> None:
@@ -275,44 +274,23 @@ async def test_lint_wiki_no_articles(db_session) -> None:
 
 
 async def test_lint_wiki_with_articles(db_session, tmp_path) -> None:
-    f = tmp_path / "a.md"
-    f.write_text("body", encoding="utf-8")
-    art = Article(slug="a", title="A", file_path=str(f))
-    db_session.add(art)
-    await db_session.commit()
-
-    fake_router = MagicMock()
-    fake_router.complete = AsyncMock(return_value=MagicMock(content="{}"))
-    fake_router.parse_json_response = MagicMock(
-        return_value={
-            "contradictions": [{"claim_a": "x", "claim_b": "y", "articles": ["A"]}],
-            "orphaned_articles": [],
-            "stale_articles": [],
-            "gap_suggestions": ["new"],
-            "coverage_scores": {},
-        }
+    """Lint runs the structured pipeline via run_lint."""
+    fake_report = LintReport(
+        status=LintReportStatus.COMPLETE,
+        contradictions_count=1,
+        orphans_count=0,
     )
     with (
         _patch_session_factory(db_session),
-        patch.object(worker_mod, "get_llm_router", return_value=fake_router),
-        patch.object(worker_mod, "emit_linter_alert", AsyncMock()),
-        patch.object(worker_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
+        patch("wikimind.jobs.worker.run_lint", AsyncMock(return_value=fake_report)),
     ):
         await lint_wiki({})
 
 
 async def test_lint_wiki_failure(db_session, tmp_path) -> None:
-    f = tmp_path / "a.md"
-    f.write_text("body", encoding="utf-8")
-    art = Article(slug="a", title="A", file_path=str(f))
-    db_session.add(art)
-    await db_session.commit()
-
-    fake_router = MagicMock()
-    fake_router.complete = AsyncMock(side_effect=RuntimeError("boom"))
+    """Lint handles run_lint exceptions gracefully."""
     with (
         _patch_session_factory(db_session),
-        patch.object(worker_mod, "get_llm_router", return_value=fake_router),
-        patch.object(worker_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
+        patch("wikimind.jobs.worker.run_lint", AsyncMock(side_effect=RuntimeError("boom"))),
     ):
         await lint_wiki({})

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -110,7 +110,10 @@ async def test_detect_contradictions_single_concept(db_session, _isolated_data_d
     )
 
     settings = get_settings()
-    findings = await detect_contradictions(db_session, mock_router, settings, report_id="r1")
+    report = LintReport(id="r1")
+    db_session.add(report)
+    await db_session.flush()
+    findings = await detect_contradictions(db_session, mock_router, settings, report)
 
     assert len(findings) == 1
     assert findings[0].description == "Sky color contradiction"
@@ -152,7 +155,10 @@ async def test_detect_contradictions_no_contradictions(db_session, _isolated_dat
     mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
 
     settings = get_settings()
-    findings = await detect_contradictions(db_session, mock_router, settings, report_id="r1")
+    report = LintReport(id="r1")
+    db_session.add(report)
+    await db_session.flush()
+    findings = await detect_contradictions(db_session, mock_router, settings, report)
 
     assert len(findings) == 0
 
@@ -183,7 +189,10 @@ async def test_detect_contradictions_respects_pair_cap(db_session, _isolated_dat
     # Set cap very low
     settings.linter.max_contradiction_pairs_per_concept = 2
 
-    await detect_contradictions(db_session, mock_router, settings, report_id="r1")
+    report = LintReport(id="r1")
+    db_session.add(report)
+    await db_session.flush()
+    await detect_contradictions(db_session, mock_router, settings, report)
 
     # 5 articles = 10 pairs, capped at 2
     assert mock_router.complete.call_count <= 2

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -77,7 +77,7 @@ async def test_detect_contradictions_single_concept(db_session, _isolated_data_d
         article_id="a1",
         slug="article-a",
         title="Article A",
-        concept_ids=["c1"],
+        concept_ids=["testing"],
         claims=["The sky is blue"],
     )
     art_b = _make_article(
@@ -85,7 +85,7 @@ async def test_detect_contradictions_single_concept(db_session, _isolated_data_d
         article_id="a2",
         slug="article-b",
         title="Article B",
-        concept_ids=["c1"],
+        concept_ids=["testing"],
         claims=["The sky is green"],
     )
     db_session.add(art_a)
@@ -132,7 +132,7 @@ async def test_detect_contradictions_no_contradictions(db_session, _isolated_dat
         article_id="a1",
         slug="article-a",
         title="Article A",
-        concept_ids=["c1"],
+        concept_ids=["testing"],
         claims=["The sky is blue"],
     )
     art_b = _make_article(
@@ -140,7 +140,7 @@ async def test_detect_contradictions_no_contradictions(db_session, _isolated_dat
         article_id="a2",
         slug="article-b",
         title="Article B",
-        concept_ids=["c1"],
+        concept_ids=["testing"],
         claims=["Water is wet"],
     )
     db_session.add(art_a)
@@ -169,7 +169,7 @@ async def test_detect_contradictions_respects_pair_cap(db_session, _isolated_dat
             article_id=f"a{i}",
             slug=f"article-{i}",
             title=f"Article {i}",
-            concept_ids=["c1"],
+            concept_ids=["testing"],
             claims=[f"Claim {i}"],
         )
         db_session.add(art)
@@ -249,7 +249,7 @@ async def test_run_lint_creates_report_with_correct_counts(db_session, _isolated
         article_id="a1",
         slug="article-a",
         title="Article A",
-        concept_ids=["c1"],
+        concept_ids=["testing"],
         claims=["Claim A"],
     )
     art_b = _make_article(
@@ -257,7 +257,7 @@ async def test_run_lint_creates_report_with_correct_counts(db_session, _isolated
         article_id="a2",
         slug="article-b",
         title="Article B",
-        concept_ids=["c1"],
+        concept_ids=["testing"],
         claims=["Claim B"],
     )
     db_session.add(art_a)

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -1,0 +1,484 @@
+"""Tests for the wiki linter engine, service, and API routes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
+from wikimind.engine.linter.contradictions import detect_contradictions
+from wikimind.engine.linter.orphans import detect_orphans
+from wikimind.engine.linter.runner import run_lint
+from wikimind.models import (
+    Article,
+    Backlink,
+    Concept,
+    ContradictionFinding,
+    DismissedFinding,
+    LintFindingKind,
+    LintReport,
+    LintReportStatus,
+    LintSeverity,
+)
+from wikimind.services.linter import LinterService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_article(
+    tmp_path: Path,
+    *,
+    article_id: str = "a1",
+    slug: str = "test-article",
+    title: str = "Test Article",
+    concept_ids: list[str] | None = None,
+    claims: list[str] | None = None,
+) -> Article:
+    """Create an Article with a real .md file containing claims."""
+    file_path = tmp_path / f"{slug}.md"
+    body_lines = [f"# {title}", ""]
+    if claims:
+        body_lines.append("## Key Claims")
+        for c in claims:
+            body_lines.append(f"- {c}")
+    else:
+        body_lines.append("Some body content here.")
+    file_path.write_text("\n".join(body_lines), encoding="utf-8")
+
+    return Article(
+        id=article_id,
+        slug=slug,
+        title=title,
+        file_path=str(file_path),
+        concept_ids=json.dumps(concept_ids) if concept_ids else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# detect_contradictions tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_single_concept(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Two articles with contradictory claims produce a ContradictionFinding."""
+    concept = Concept(id="c1", name="testing", article_count=2)
+    db_session.add(concept)
+
+    art_a = _make_article(
+        tmp_path,
+        article_id="a1",
+        slug="article-a",
+        title="Article A",
+        concept_ids=["c1"],
+        claims=["The sky is blue"],
+    )
+    art_b = _make_article(
+        tmp_path,
+        article_id="a2",
+        slug="article-b",
+        title="Article B",
+        concept_ids=["c1"],
+        claims=["The sky is green"],
+    )
+    db_session.add(art_a)
+    db_session.add(art_b)
+    await db_session.commit()
+
+    # Mock the LLM router
+    mock_response = MagicMock()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    mock_router.parse_json_response = MagicMock(
+        return_value={
+            "contradictions": [
+                {
+                    "description": "Sky color contradiction",
+                    "article_a_claim": "The sky is blue",
+                    "article_b_claim": "The sky is green",
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+
+    settings = get_settings()
+    findings = await detect_contradictions(db_session, mock_router, settings, report_id="r1")
+
+    assert len(findings) == 1
+    assert findings[0].description == "Sky color contradiction"
+    assert findings[0].article_a_id == "a1"
+    assert findings[0].article_b_id == "a2"
+    assert findings[0].llm_confidence == "high"
+    assert findings[0].report_id == "r1"
+    assert findings[0].content_hash  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_no_contradictions(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Two articles with no contradictions produce zero findings."""
+    concept = Concept(id="c1", name="testing", article_count=2)
+    db_session.add(concept)
+
+    art_a = _make_article(
+        tmp_path,
+        article_id="a1",
+        slug="article-a",
+        title="Article A",
+        concept_ids=["c1"],
+        claims=["The sky is blue"],
+    )
+    art_b = _make_article(
+        tmp_path,
+        article_id="a2",
+        slug="article-b",
+        title="Article B",
+        concept_ids=["c1"],
+        claims=["Water is wet"],
+    )
+    db_session.add(art_a)
+    db_session.add(art_b)
+    await db_session.commit()
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+
+    settings = get_settings()
+    findings = await detect_contradictions(db_session, mock_router, settings, report_id="r1")
+
+    assert len(findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_respects_pair_cap(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Pair cap limits the number of LLM calls."""
+    concept = Concept(id="c1", name="testing", article_count=5)
+    db_session.add(concept)
+
+    for i in range(5):
+        art = _make_article(
+            tmp_path,
+            article_id=f"a{i}",
+            slug=f"article-{i}",
+            title=f"Article {i}",
+            concept_ids=["c1"],
+            claims=[f"Claim {i}"],
+        )
+        db_session.add(art)
+    await db_session.commit()
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+
+    settings = get_settings()
+    # Set cap very low
+    settings.linter.max_contradiction_pairs_per_concept = 2
+
+    await detect_contradictions(db_session, mock_router, settings, report_id="r1")
+
+    # 5 articles = 10 pairs, capped at 2
+    assert mock_router.complete.call_count <= 2
+
+
+# ---------------------------------------------------------------------------
+# detect_orphans tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_orphans_returns_empty_when_disabled(db_session, _isolated_data_dir) -> None:
+    """Orphan detection returns empty when enable_orphan_detection=False."""
+    settings = get_settings()
+    settings.linter.enable_orphan_detection = False
+
+    findings = await detect_orphans(db_session, settings, report_id="r1")
+
+    assert len(findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_orphans_finds_unlinked_article(db_session, _isolated_data_dir, tmp_path) -> None:
+    """An article with no backlinks is detected as an orphan."""
+    # Create one linked article and one orphan
+    art_linked = _make_article(tmp_path, article_id="linked", slug="linked", title="Linked")
+    art_orphan = _make_article(tmp_path, article_id="orphan", slug="orphan", title="Orphan")
+    db_session.add(art_linked)
+    db_session.add(art_orphan)
+
+    # Create a backlink for the linked article
+    backlink = Backlink(
+        source_article_id="linked",
+        target_article_id="linked",
+        context="self-link",
+    )
+    db_session.add(backlink)
+    await db_session.commit()
+
+    settings = get_settings()
+    settings.linter.enable_orphan_detection = True
+
+    findings = await detect_orphans(db_session, settings, report_id="r1")
+
+    assert len(findings) == 1
+    assert findings[0].article_id == "orphan"
+    assert findings[0].article_title == "Orphan"
+
+
+# ---------------------------------------------------------------------------
+# run_lint integration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_lint_creates_report_with_correct_counts(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Full lint run creates a report with correct finding counts."""
+    concept = Concept(id="c1", name="testing", article_count=2)
+    db_session.add(concept)
+
+    art_a = _make_article(
+        tmp_path,
+        article_id="a1",
+        slug="article-a",
+        title="Article A",
+        concept_ids=["c1"],
+        claims=["Claim A"],
+    )
+    art_b = _make_article(
+        tmp_path,
+        article_id="a2",
+        slug="article-b",
+        title="Article B",
+        concept_ids=["c1"],
+        claims=["Claim B"],
+    )
+    db_session.add(art_a)
+    db_session.add(art_b)
+    await db_session.commit()
+
+    mock_response = MagicMock()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    mock_router.parse_json_response = MagicMock(
+        return_value={
+            "contradictions": [
+                {
+                    "description": "A vs B",
+                    "article_a_claim": "Claim A",
+                    "article_b_claim": "Claim B",
+                    "confidence": "medium",
+                }
+            ]
+        }
+    )
+
+    with (
+        patch(
+            "wikimind.engine.linter.runner.get_llm_router",
+            return_value=mock_router,
+        ),
+        patch(
+            "wikimind.engine.linter.runner.emit_linter_alert",
+            new_callable=AsyncMock,
+        ),
+    ):
+        report = await run_lint(db_session)
+
+    assert report.status == LintReportStatus.COMPLETE
+    assert report.contradictions_count == 1
+    assert report.orphans_count == 0
+    assert report.total_findings == 1
+    assert report.article_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_lint_sets_status_failed_on_exception(db_session, _isolated_data_dir) -> None:
+    """A failing check sets the report to FAILED with error_message."""
+    with (
+        patch(
+            "wikimind.engine.linter.runner.get_llm_router",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "wikimind.engine.linter.runner.detect_contradictions",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("LLM exploded"),
+        ),
+        patch(
+            "wikimind.engine.linter.runner.emit_linter_alert",
+            new_callable=AsyncMock,
+        ),
+    ):
+        report = await run_lint(db_session)
+
+    assert report.status == LintReportStatus.FAILED
+    assert "LLM exploded" in (report.error_message or "")
+
+
+# ---------------------------------------------------------------------------
+# Dismiss semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_persists_and_suppresses_on_next_run(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Dismissing a finding records a DismissedFinding that suppresses it on the next run."""
+    # Create a report and a contradiction finding
+    report = LintReport(
+        id="r1",
+        status=LintReportStatus.COMPLETE,
+        article_count=2,
+    )
+    db_session.add(report)
+
+    art_a = _make_article(tmp_path, article_id="a1", slug="art-a", title="Art A")
+    art_b = _make_article(tmp_path, article_id="a2", slug="art-b", title="Art B")
+    db_session.add(art_a)
+    db_session.add(art_b)
+
+    finding = ContradictionFinding(
+        id="f1",
+        report_id="r1",
+        severity=LintSeverity.WARN,
+        description="Test contradiction",
+        content_hash="hash123",
+        article_a_id="a1",
+        article_b_id="a2",
+        article_a_claim="claim a",
+        article_b_claim="claim b",
+        llm_confidence="high",
+    )
+    db_session.add(finding)
+    await db_session.commit()
+
+    # Dismiss the finding
+    svc = LinterService()
+    result = await svc.dismiss_finding(db_session, LintFindingKind.CONTRADICTION, "f1")
+
+    assert result["dismissed"] is True
+
+    # Check DismissedFinding was created
+    dismissed = await db_session.get(DismissedFinding, "hash123")
+    assert dismissed is not None
+    assert dismissed.kind == LintFindingKind.CONTRADICTION
+
+
+# ---------------------------------------------------------------------------
+# LinterService tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_linter_service_list_reports(db_session, _isolated_data_dir) -> None:
+    """list_reports returns reports ordered by generated_at DESC."""
+    r1 = LintReport(id="r1", status=LintReportStatus.COMPLETE, article_count=5)
+    r2 = LintReport(id="r2", status=LintReportStatus.COMPLETE, article_count=10)
+    db_session.add(r1)
+    db_session.add(r2)
+    await db_session.commit()
+
+    svc = LinterService()
+    reports = await svc.list_reports(db_session, limit=10)
+
+    assert len(reports) == 2
+
+
+@pytest.mark.asyncio
+async def test_linter_service_get_latest_returns_404_when_empty(db_session, _isolated_data_dir) -> None:
+    """get_latest raises 404 when no reports exist."""
+    svc = LinterService()
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_latest(db_session)
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_linter_service_get_report_filters_dismissed(db_session, _isolated_data_dir, tmp_path) -> None:
+    """get_report with include_dismissed=False filters out dismissed findings."""
+    report = LintReport(id="r1", status=LintReportStatus.COMPLETE, article_count=2)
+    db_session.add(report)
+
+    art_a = _make_article(tmp_path, article_id="a1", slug="art-a", title="Art A")
+    art_b = _make_article(tmp_path, article_id="a2", slug="art-b", title="Art B")
+    db_session.add(art_a)
+    db_session.add(art_b)
+
+    f1 = ContradictionFinding(
+        id="f1",
+        report_id="r1",
+        description="Active finding",
+        content_hash="h1",
+        article_a_id="a1",
+        article_b_id="a2",
+        article_a_claim="c1",
+        article_b_claim="c2",
+        llm_confidence="high",
+        dismissed=False,
+    )
+    f2 = ContradictionFinding(
+        id="f2",
+        report_id="r1",
+        description="Dismissed finding",
+        content_hash="h2",
+        article_a_id="a1",
+        article_b_id="a2",
+        article_a_claim="c3",
+        article_b_claim="c4",
+        llm_confidence="low",
+        dismissed=True,
+        dismissed_at=utcnow_naive(),
+    )
+    db_session.add(f1)
+    db_session.add(f2)
+    await db_session.commit()
+
+    svc = LinterService()
+
+    # Default: exclude dismissed
+    detail = await svc.get_report(db_session, "r1")
+    assert len(detail.contradictions) == 1
+    assert detail.contradictions[0].id == "f1"
+
+    # Include dismissed
+    detail_all = await svc.get_report(db_session, "r1", include_dismissed=True)
+    assert len(detail_all.contradictions) == 2
+
+
+# ---------------------------------------------------------------------------
+# API route tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lint_run_endpoint_returns_in_progress(client) -> None:
+    """POST /lint/run returns status in_progress."""
+    with patch("wikimind.services.linter.get_background_compiler") as mock_bg:
+        mock_bg.return_value.schedule_lint = AsyncMock(return_value="job-1")
+        response = await client.post("/lint/run")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_lint_reports_endpoint(client) -> None:
+    """GET /lint/reports returns an empty list when no reports exist."""
+    response = await client.get("/lint/reports")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_lint_latest_endpoint_returns_404_when_empty(client) -> None:
+    """GET /lint/reports/latest returns 404 when no reports exist."""
+    response = await client.get("/lint/reports/latest")
+    assert response.status_code == 404

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -294,8 +294,8 @@ async def test_run_lint_creates_report_with_correct_counts(db_session, _isolated
 
     assert report.status == LintReportStatus.COMPLETE
     assert report.contradictions_count == 1
-    assert report.orphans_count == 0
-    assert report.total_findings == 1
+    assert report.orphans_count == 2  # both articles have no backlinks
+    assert report.total_findings == 3  # 1 contradiction + 2 orphans
     assert report.article_count == 2
 
 


### PR DESCRIPTION
## Problem

The wiki linter is an opaque stub — a single LLM call that dumps 50 articles into one prompt and writes an unstructured JSON blob. Findings aren't queryable, dismissible, or independently testable.

## Solution

Replace with a structured, check-per-function health audit system:
- **3 checks:** contradiction detection (LLM per concept bucket), orphan detection (pure SQL), missing page detection (regex scan for `[[brackets]]`)
- **Per-kind finding tables:** `ContradictionFinding`, `OrphanFinding`, `MissingPageFinding` — queryable, dismissible, analytics-friendly
- **Dismiss semantics:** content hash persists across runs so dismissed findings stay hidden
- **Health Dashboard UI:** tabbed findings view, dismiss buttons, "Run lint now" trigger

## Changes

**Backend (13 files):**
- Data model: `LintReport`, 3 finding tables, `DismissedFinding`, enums
- Engine: `engine/linter/` — `runner.py`, `contradictions.py`, `orphans.py`, `missing_pages.py`, `prompts.py`
- Service: `services/linter.py` — trigger, list, get, dismiss
- API: `api/routes/lint.py` — 5 new endpoints
- Worker: `lint_wiki` rewritten to call `run_lint`

**Frontend (9 files):**
- `api/lint.ts`, `hooks/useLint.ts`
- `components/health/` — HealthView, LintReportSummary, FindingsByKindTabs, FindingCard, RunLintButton
- Route + nav item added

**Tests:** 12 new tests

## Test plan

- [x] `make verify` passes
- [x] Navigate to /health → empty state shows
- [x] Click "Run lint now" → findings appear after WS event
- [x] Contradictions/Orphans/Missing Pages tabs show correct counts
- [x] Dismiss a finding → disappears, stays hidden on re-run
- [x] `GET /lint/reports/latest` returns structured data

Closes #26, closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)