### PR TITLE
feat(qa): partial-thread and multi-thread file-back (#90)

### DIFF
--- a/apps/web/src/api/query.ts
+++ b/apps/web/src/api/query.ts
@@ -73,6 +73,20 @@ export interface ForkRequest {
   new_question: string;
 }
 
+export interface TurnSelection {
+  conversation_id: string;
+  turn_indices: number[];
+}
+
+export interface FileBackSelectionRequest {
+  selections: TurnSelection[];
+  title?: string;
+}
+
+export interface FileBackSelectionResponse {
+  article: { id: string; slug: string; title: string };
+}
+
 // ----- Functions -----
 
 export function askQuestion(req: AskRequest): Promise<AskResponse> {
@@ -93,6 +107,13 @@ export function getConversation(id: string): Promise<ConversationDetail> {
 
 export function fileBackConversation(id: string): Promise<FileBackResponse> {
   return apiFetch<FileBackResponse>(`/query/conversations/${id}/file-back`, { method: "POST" });
+}
+
+export function fileBackSelection(req: FileBackSelectionRequest): Promise<FileBackSelectionResponse> {
+  return apiFetch<FileBackSelectionResponse>("/query/conversations/file-back", {
+    method: "POST",
+    body: req,
+  });
 }
 
 export async function exportConversation(id: string): Promise<string> {

--- a/apps/web/src/components/ask/AskView.tsx
+++ b/apps/web/src/components/ask/AskView.tsx
@@ -7,17 +7,28 @@ import {
   getConversation,
   listConversations,
   fileBackConversation,
+  fileBackSelection,
   exportConversation,
   forkConversation,
   type AskRequest,
   type ConversationDetail,
+  type TurnSelection,
 } from "../../api/query";
 import { useWebSocketStore } from "../../store/websocket";
+import { SelectionProvider, useSelection } from "../../store/selection";
 import { ConversationHistory } from "./ConversationHistory";
 import { ConversationThread } from "./ConversationThread";
 import { QueryInput } from "./QueryInput";
 
 export function AskView() {
+  return (
+    <SelectionProvider>
+      <AskViewInner />
+    </SelectionProvider>
+  );
+}
+
+function AskViewInner() {
   const { conversationId } = useParams<{ conversationId?: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -109,7 +120,9 @@ export function AskView() {
     [conversationId, fork],
   );
 
-  // File-back mutation
+  const selection = useSelection();
+
+  // File-back mutation (whole conversation)
   const fileBack = useMutation({
     mutationFn: (id: string) => fileBackConversation(id),
     onSuccess: (response) => {
@@ -125,6 +138,29 @@ export function AskView() {
       pushToast({
         kind: "error",
         title: "Failed to save thread",
+        detail: err.message,
+      });
+    },
+  });
+
+  // File-back selection mutation (partial / multi-thread)
+  const fileBackSel = useMutation({
+    mutationFn: (selections: TurnSelection[]) =>
+      fileBackSelection({ selections }),
+    onSuccess: (response) => {
+      selection.clear();
+      queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      pushToast({
+        kind: "success",
+        title: "Saved selected turns to wiki",
+        detail: response.article.title,
+      });
+    },
+    onError: (err: Error) => {
+      pushToast({
+        kind: "error",
+        title: "Failed to save selection",
         detail: err.message,
       });
     },
@@ -183,6 +219,24 @@ export function AskView() {
     if (conversationId) fileBack.mutate(conversationId);
   };
 
+  const handleSaveSelection = () => {
+    if (selection.count === 0) return;
+    // Group selections by conversation_id
+    const byConv = new Map<string, number[]>();
+    for (const item of selection.items) {
+      const indices = byConv.get(item.conversationId) ?? [];
+      indices.push(item.turnIndex);
+      byConv.set(item.conversationId, indices);
+    }
+    const selections: TurnSelection[] = Array.from(byConv.entries()).map(
+      ([conversation_id, turn_indices]) => ({
+        conversation_id,
+        turn_indices: turn_indices.sort((a, b) => a - b),
+      }),
+    );
+    fileBackSel.mutate(selections);
+  };
+
   const [isExporting, setIsExporting] = useState(false);
   const handleExport = async () => {
     if (!conversationId) return;
@@ -238,6 +292,8 @@ export function AskView() {
             onExport={handleExport}
             isExporting={isExporting}
             onFork={handleFork}
+            onSaveSelection={handleSaveSelection}
+            isSavingSelection={fileBackSel.isPending}
           />
           {pendingError && (
             <div className="mt-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">

--- a/apps/web/src/components/ask/ConversationThread.tsx
+++ b/apps/web/src/components/ask/ConversationThread.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ConversationDetail } from "../../api/query";
+import { useSelection } from "../../store/selection";
 import { TurnCard } from "./TurnCard";
 import { SaveThreadButton } from "./SaveThreadButton";
 
@@ -13,6 +14,8 @@ interface Props {
   onExport: () => void;
   isExporting: boolean;
   onFork?: (turnIndex: number, newQuestion: string) => void;
+  onSaveSelection: () => void;
+  isSavingSelection: boolean;
 }
 
 export function ConversationThread({
@@ -25,8 +28,13 @@ export function ConversationThread({
   onExport,
   isExporting,
   onFork,
+  onSaveSelection,
+  isSavingSelection,
 }: Props) {
   const pendingRef = useRef<HTMLDivElement>(null);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const selection = useSelection();
+  const conversationId = detail?.conversation.id;
 
   useEffect(() => {
     if (pendingQuestion && pendingRef.current) {
@@ -46,6 +54,20 @@ export function ConversationThread({
   const queries = detail?.queries ?? [];
   const isFiledBack = !!detail?.conversation.filed_article_id;
 
+  const handleToggleSelectionMode = () => {
+    if (selectionMode) {
+      // Exiting selection mode — clear selections for this conversation
+      if (conversationId) {
+        for (const q of queries) {
+          if (selection.isSelected(conversationId, q.turn_index)) {
+            selection.removeTurn(conversationId, q.turn_index);
+          }
+        }
+      }
+    }
+    setSelectionMode((v) => !v);
+  };
+
   return (
     <div className="space-y-6">
       {queries.map((q) => (
@@ -54,6 +76,17 @@ export function ConversationThread({
           query={q}
           onEdit={onFork}
           forkCount={detail?.conversation.fork_count}
+          selectionMode={selectionMode}
+          isSelected={
+            selectionMode && conversationId
+              ? selection.isSelected(conversationId, q.turn_index)
+              : undefined
+          }
+          onToggleSelect={
+            selectionMode && conversationId
+              ? () => selection.toggleTurn(conversationId, q.turn_index)
+              : undefined
+          }
         />
       ))}
       {pendingQuestion && (
@@ -66,7 +99,7 @@ export function ConversationThread({
         </div>
       )}
       {queries.length > 0 && !pendingQuestion && (
-        <div className="flex gap-2 pt-4">
+        <div className="flex flex-wrap gap-2 pt-4">
           <SaveThreadButton
             isFiledBack={isFiledBack}
             isSaving={isSaving}
@@ -80,6 +113,29 @@ export function ConversationThread({
           >
             {isExporting ? "Exporting..." : "Export markdown"}
           </button>
+          <button
+            type="button"
+            onClick={handleToggleSelectionMode}
+            className={`rounded-lg border px-4 py-2 text-sm font-medium ${
+              selectionMode
+                ? "border-blue-400 bg-blue-50 text-blue-700"
+                : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+            }`}
+          >
+            {selectionMode ? "Cancel selection" : "Select turns"}
+          </button>
+          {selectionMode && selection.count > 0 && (
+            <button
+              type="button"
+              onClick={onSaveSelection}
+              disabled={isSavingSelection}
+              className="rounded-lg border border-blue-500 bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 disabled:opacity-50"
+            >
+              {isSavingSelection
+                ? "Saving..."
+                : `Save ${selection.count} turn${selection.count !== 1 ? "s" : ""} to wiki`}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/ask/TurnCard.tsx
+++ b/apps/web/src/components/ask/TurnCard.tsx
@@ -10,6 +10,9 @@ interface Props {
   query: QueryRecord;
   onEdit?: (turnIndex: number, newQuestion: string) => void;
   forkCount?: number;
+  selectionMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
 }
 
 /**
@@ -21,7 +24,7 @@ interface Props {
  * mount — swapping the `query` prop on a live instance would
  * leak stale expand/collapse state.
  */
-export function TurnCard({ query, onEdit, forkCount }: Props) {
+export function TurnCard({ query, onEdit, forkCount, selectionMode, isSelected, onToggleSelect }: Props) {
   const sources = useMemo(() => parseSources(query.source_article_ids), [query.source_article_ids]);
   const slugByTitle = useMemo(() => buildSlugMap(query.citations), [query.citations]);
   const relatedArticles = useMemo(
@@ -60,80 +63,97 @@ export function TurnCard({ query, onEdit, forkCount }: Props) {
     : truncateOnParagraphBoundary(query.answer, COLLAPSE_THRESHOLD_CHARS);
 
   return (
-    <article className="group rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
-      <header className="mb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
-              Q{query.turn_index + 1}
-            </span>
-            {forkCount !== undefined && forkCount > 0 && (
-              <span
-                className="inline-flex items-center gap-0.5 rounded bg-purple-50 px-1.5 py-0.5 text-xs font-medium text-purple-600"
-                title={`${forkCount} branch${forkCount === 1 ? "" : "es"}`}
-              >
-                <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM5 12.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM4.25 4.5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5a.75.75 0 0 1 .75-.75ZM11 4.5a.75.75 0 0 1 .75.75v1a2.25 2.25 0 0 1-2.25 2.25H6.56l1.22-1.22a.75.75 0 0 0-1.06-1.06l-2.5 2.5a.75.75 0 0 0 0 1.06l2.5 2.5a.75.75 0 1 0 1.06-1.06L6.56 10h2.94A3.75 3.75 0 0 0 13.25 6.25v-1A.75.75 0 0 0 12.5 4.5Z"/>
-                </svg>
-                {forkCount}
+    <article
+      className={`group rounded-lg border p-5 shadow-sm ${
+        selectionMode && isSelected
+          ? "border-blue-400 bg-blue-50"
+          : "border-slate-200 bg-white"
+      }`}
+    >
+      <header className="mb-3 flex items-start gap-3">
+        {selectionMode && (
+          <input
+            type="checkbox"
+            checked={isSelected ?? false}
+            onChange={onToggleSelect}
+            className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            aria-label={`Select turn Q${query.turn_index + 1}`}
+          />
+        )}
+        <div className="flex-1">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                Q{query.turn_index + 1}
               </span>
-            )}
-          </div>
-          {onEdit && !isEditing && (
-            <button
-              type="button"
-              onClick={() => {
-                setIsEditing(true);
-                setEditText(query.question);
-                setTimeout(() => textareaRef.current?.focus(), 0);
-              }}
-              className="rounded p-1 text-slate-300 opacity-0 transition-opacity hover:bg-slate-100 hover:text-slate-600 group-hover:opacity-100"
-              title="Edit question (creates a branch)"
-              aria-label="Edit question"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z"/>
-              </svg>
-            </button>
-          )}
-        </div>
-        {isEditing ? (
-          <div className="mt-1">
-            <textarea
-              ref={textareaRef}
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              onKeyDown={handleEditKeyDown}
-              rows={2}
-              className="w-full resize-none rounded border border-blue-300 bg-blue-50 p-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-            />
-            <div className="mt-1 flex items-center gap-2">
-              <button
-                type="button"
-                onClick={handleEditSubmit}
-                disabled={!editText.trim() || editText.trim() === query.question}
-                className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-              >
-                Fork
-              </button>
+              {forkCount !== undefined && forkCount > 0 && (
+                <span
+                  className="inline-flex items-center gap-0.5 rounded bg-purple-50 px-1.5 py-0.5 text-xs font-medium text-purple-600"
+                  title={`${forkCount} branch${forkCount === 1 ? "" : "es"}`}
+                >
+                  <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM5 12.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM4.25 4.5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5a.75.75 0 0 1 .75-.75ZM11 4.5a.75.75 0 0 1 .75.75v1a2.25 2.25 0 0 1-2.25 2.25H6.56l1.22-1.22a.75.75 0 0 0-1.06-1.06l-2.5 2.5a.75.75 0 0 0 0 1.06l2.5 2.5a.75.75 0 1 0 1.06-1.06L6.56 10h2.94A3.75 3.75 0 0 0 13.25 6.25v-1A.75.75 0 0 0 12.5 4.5Z"/>
+                  </svg>
+                  {forkCount}
+                </span>
+              )}
+            </div>
+            {onEdit && !isEditing && !selectionMode && (
               <button
                 type="button"
                 onClick={() => {
-                  setIsEditing(false);
+                  setIsEditing(true);
                   setEditText(query.question);
+                  setTimeout(() => textareaRef.current?.focus(), 0);
                 }}
-                className="rounded px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100"
+                className="rounded p-1 text-slate-300 opacity-0 transition-opacity hover:bg-slate-100 hover:text-slate-600 group-hover:opacity-100"
+                title="Edit question (creates a branch)"
+                aria-label="Edit question"
               >
-                Cancel
+                <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z"/>
+                </svg>
               </button>
-              <span className="text-xs text-slate-400">
-                This creates a new branch
-              </span>
-            </div>
+            )}
           </div>
-        ) : (
-          <h3 className="mt-1 text-base font-semibold text-slate-900">{query.question}</h3>
-        )}
+          {isEditing ? (
+            <div className="mt-1">
+              <textarea
+                ref={textareaRef}
+                value={editText}
+                onChange={(e) => setEditText(e.target.value)}
+                onKeyDown={handleEditKeyDown}
+                rows={2}
+                className="w-full resize-none rounded border border-blue-300 bg-blue-50 p-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+              <div className="mt-1 flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleEditSubmit}
+                  disabled={!editText.trim() || editText.trim() === query.question}
+                  className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  Fork
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsEditing(false);
+                    setEditText(query.question);
+                  }}
+                  className="rounded px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100"
+                >
+                  Cancel
+                </button>
+                <span className="text-xs text-slate-400">
+                  This creates a new branch
+                </span>
+              </div>
+            </div>
+          ) : (
+            <h3 className="mt-1 text-base font-semibold text-slate-900">{query.question}</h3>
+          )}
+        </div>
       </header>
 
       <div className="prose prose-sm max-w-none text-slate-700">

--- a/apps/web/src/store/selection.tsx
+++ b/apps/web/src/store/selection.tsx
@@ -1,0 +1,107 @@
+/**
+ * Selection cart context for partial/multi-thread file-back.
+ *
+ * Persists turn selections across conversation navigation so users can
+ * pick turns from multiple threads before filing them as one article.
+ */
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+export interface SelectionItem {
+  conversationId: string;
+  turnIndex: number;
+}
+
+interface SelectionContextValue {
+  /** All currently selected turns. */
+  items: SelectionItem[];
+  /** Add one or more turns from a conversation. */
+  addTurns: (conversationId: string, turnIndices: number[]) => void;
+  /** Remove a single turn. */
+  removeTurn: (conversationId: string, turnIndex: number) => void;
+  /** Toggle a single turn on/off. */
+  toggleTurn: (conversationId: string, turnIndex: number) => void;
+  /** Check if a turn is selected. */
+  isSelected: (conversationId: string, turnIndex: number) => boolean;
+  /** Clear all selections. */
+  clear: () => void;
+  /** Total number of selected turns. */
+  count: number;
+}
+
+const SelectionContext = createContext<SelectionContextValue | null>(null);
+
+export function SelectionProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<SelectionItem[]>([]);
+
+  const addTurns = useCallback((conversationId: string, turnIndices: number[]) => {
+    setItems((prev) => {
+      const existing = new Set(
+        prev
+          .filter((i) => i.conversationId === conversationId)
+          .map((i) => i.turnIndex),
+      );
+      const newItems = turnIndices
+        .filter((idx) => !existing.has(idx))
+        .map((idx) => ({ conversationId, turnIndex: idx }));
+      return [...prev, ...newItems];
+    });
+  }, []);
+
+  const removeTurn = useCallback((conversationId: string, turnIndex: number) => {
+    setItems((prev) =>
+      prev.filter(
+        (i) => !(i.conversationId === conversationId && i.turnIndex === turnIndex),
+      ),
+    );
+  }, []);
+
+  const toggleTurn = useCallback((conversationId: string, turnIndex: number) => {
+    setItems((prev) => {
+      const exists = prev.some(
+        (i) => i.conversationId === conversationId && i.turnIndex === turnIndex,
+      );
+      if (exists) {
+        return prev.filter(
+          (i) => !(i.conversationId === conversationId && i.turnIndex === turnIndex),
+        );
+      }
+      return [...prev, { conversationId, turnIndex }];
+    });
+  }, []);
+
+  const isSelected = useCallback(
+    (conversationId: string, turnIndex: number) =>
+      items.some(
+        (i) => i.conversationId === conversationId && i.turnIndex === turnIndex,
+      ),
+    [items],
+  );
+
+  const clear = useCallback(() => setItems([]), []);
+
+  const value = useMemo<SelectionContextValue>(
+    () => ({
+      items,
+      addTurns,
+      removeTurn,
+      toggleTurn,
+      isSelected,
+      clear,
+      count: items.length,
+    }),
+    [items, addTurns, removeTurn, toggleTurn, isSelected, clear],
+  );
+
+  return (
+    <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>
+  );
+}
+
+export function useSelection(): SelectionContextValue {
+  const ctx = useContext(SelectionContext);
+  if (!ctx) {
+    throw new Error("useSelection must be used within a SelectionProvider");
+  }
+  return ctx;
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -559,6 +559,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /query/conversations/file-back:
+    post:
+      tags:
+      - Query
+      summary: File Back Selection
+      description: File selected turns from one or more conversations back to the
+        wiki as a single article.
+      operationId: file_back_selection_query_conversations_file_back_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileBackSelectionRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /query/conversations/{conversation_id}/file-back:
     post:
       tags:
@@ -1386,6 +1412,23 @@ components:
       - turn_count
       title: ConversationSummary
       description: Conversation summary for the history sidebar — adds turn count.
+    FileBackSelectionRequest:
+      properties:
+        selections:
+          items:
+            $ref: '#/components/schemas/TurnSelection'
+          type: array
+          title: Selections
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+      type: object
+      required:
+      - selections
+      title: FileBackSelectionRequest
+      description: Request to file back selected turns from one or more conversations.
     ForkRequest:
       properties:
         turn_index:
@@ -1890,6 +1933,22 @@ components:
       - obsidian
       title: SourceType
       description: Type of ingested source.
+    TurnSelection:
+      properties:
+        conversation_id:
+          type: string
+          title: Conversation Id
+        turn_indices:
+          items:
+            type: integer
+          type: array
+          title: Turn Indices
+      type: object
+      required:
+      - conversation_id
+      - turn_indices
+      title: TurnSelection
+      description: A selection of specific turns from a single conversation.
     ValidationError:
       properties:
         loc:

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -14,6 +14,7 @@ from wikimind.models import (
     AskResponse,
     ConversationDetail,
     ConversationSummary,
+    FileBackSelectionRequest,
     ForkRequest,
     QueryRequest,
 )
@@ -117,6 +118,16 @@ async def export_conversation(
 ) -> Response:
     """Export a conversation as standalone markdown. Pure read, no DB writes."""
     return await service.export_conversation(conversation_id, session)
+
+
+@router.post("/conversations/file-back")
+async def file_back_selection(
+    request: FileBackSelectionRequest,
+    session: AsyncSession = Depends(get_session),
+    service: QueryService = Depends(get_query_service),
+):
+    """File selected turns from one or more conversations back to the wiki as a single article."""
+    return await service.file_back_selection(request, session)
 
 
 @router.post("/conversations/{conversation_id}/file-back")

--- a/src/wikimind/engine/conversation_serializer.py
+++ b/src/wikimind/engine/conversation_serializer.py
@@ -124,14 +124,7 @@ def serialize_selected_turns_to_markdown(
     """
     if not turns:
         effective_title = title or "Untitled"
-        return (
-            "---\n"
-            f'title: "{effective_title}"\n'
-            "type: qa-selection\n"
-            "turn_count: 0\n"
-            "---\n"
-            f"\n# {effective_title}\n"
-        )
+        return f'---\ntitle: "{effective_title}"\ntype: qa-selection\nturn_count: 0\n---\n\n# {effective_title}\n'
 
     effective_title = title or turns[0].conversation.title
     turn_count = len(turns)

--- a/src/wikimind/engine/conversation_serializer.py
+++ b/src/wikimind/engine/conversation_serializer.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 
 from wikimind.models import Conversation, Query
 
@@ -83,6 +84,102 @@ def serialize_conversation_to_markdown(
         if sources:
             lines.append("**Sources:** " + ", ".join(f"[[{s}]]" for s in sources))
             lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+@dataclass
+class SelectedTurn:
+    """A turn selected for partial/multi-thread file-back.
+
+    Groups a Query with the conversation it belongs to, preserving the
+    original turn_index for gap detection.
+    """
+
+    conversation: Conversation
+    query: Query
+
+
+def serialize_selected_turns_to_markdown(
+    turns: list[SelectedTurn],
+    title: str | None = None,
+) -> str:
+    """Serialize selected turns from one or more conversations into wiki markdown.
+
+    Supports partial-thread saves (subset of turns from one conversation) and
+    multi-thread merges (turns from multiple conversations combined into one
+    article). Output turns are numbered Q1, Q2, Q3... continuously regardless
+    of original turn indices.
+
+    Gap separators (``---``) are inserted:
+    - Between non-contiguous turns within the same conversation
+    - At conversation boundaries when merging multiple threads
+
+    Args:
+        turns: Ordered list of selected turns. Caller determines the order.
+        title: Custom article title. Defaults to the first conversation's title.
+
+    Returns:
+        Markdown string with frontmatter and one section per selected turn.
+    """
+    if not turns:
+        effective_title = title or "Untitled"
+        return (
+            "---\n"
+            f'title: "{effective_title}"\n'
+            "type: qa-selection\n"
+            "turn_count: 0\n"
+            "---\n"
+            f"\n# {effective_title}\n"
+        )
+
+    effective_title = title or turns[0].conversation.title
+    turn_count = len(turns)
+
+    lines: list[str] = []
+    lines.append("---")
+    escaped_title = effective_title.replace('"', '\\"')
+    lines.append(f'title: "{escaped_title}"')
+    lines.append("type: qa-selection")
+    lines.append(f"turn_count: {turn_count}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {effective_title}")
+    lines.append("")
+
+    prev_conv_id: str | None = None
+    prev_turn_index: int | None = None
+
+    for output_num, selected in enumerate(turns, start=1):
+        conv_id = selected.conversation.id
+        query = selected.query
+
+        # Insert gap separator when needed
+        need_separator = False
+        if prev_conv_id is not None:
+            if conv_id != prev_conv_id:
+                # Cross-conversation boundary
+                need_separator = True
+            elif prev_turn_index is not None and query.turn_index != prev_turn_index + 1:
+                # Non-contiguous turns within the same conversation
+                need_separator = True
+
+        if need_separator:
+            lines.append("---")
+            lines.append("")
+
+        lines.append(f"## Q{output_num}: {query.question}")
+        lines.append("")
+        lines.append(_downshift_answer_headings(query.answer))
+        lines.append("")
+
+        sources = _parse_sources(query.source_article_ids)
+        if sources:
+            lines.append("**Sources:** " + ", ".join(f"[[{s}]]" for s in sources))
+            lines.append("")
+
+        prev_conv_id = conv_id
+        prev_turn_index = query.turn_index
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -480,6 +480,20 @@ class ForkRequest(BaseModel):
     new_question: str
 
 
+class TurnSelection(BaseModel):
+    """A selection of specific turns from a single conversation."""
+
+    conversation_id: str
+    turn_indices: list[int]
+
+
+class FileBackSelectionRequest(BaseModel):
+    """Request to file back selected turns from one or more conversations."""
+
+    selections: list[TurnSelection]
+    title: str | None = None
+
+
 class SourceResponse(BaseModel):
     """Provenance view of a raw ingested source exposed via the API.
 

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -543,7 +543,7 @@ class QueryService:
             result = await session.execute(
                 select(Query)
                 .where(Query.conversation_id == selection.conversation_id)
-                .where(Query.turn_index.in_(selection.turn_indices))  # type: ignore[union-attr]
+                .where(Query.turn_index.in_(selection.turn_indices))  # type: ignore[attr-defined]
                 .order_by(Query.turn_index.asc())  # type: ignore[attr-defined]
             )
             queries = list(result.scalars().all())
@@ -553,10 +553,7 @@ class QueryService:
             if missing:
                 raise HTTPException(
                     status_code=400,
-                    detail=(
-                        f"Turn indices {sorted(missing)} not found "
-                        f"in conversation {selection.conversation_id}"
-                    ),
+                    detail=(f"Turn indices {sorted(missing)} not found in conversation {selection.conversation_id}"),
                 )
 
             for query in queries:

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -9,7 +9,9 @@ from.
 
 import json
 import re
+import uuid
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import structlog
 from fastapi import HTTPException
@@ -17,7 +19,13 @@ from fastapi.responses import Response
 from sqlmodel import func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from wikimind.engine.conversation_serializer import serialize_conversation_to_markdown
+from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
+from wikimind.engine.conversation_serializer import (
+    SelectedTurn,
+    serialize_conversation_to_markdown,
+    serialize_selected_turns_to_markdown,
+)
 from wikimind.engine.qa_agent import QAAgent
 from wikimind.models import (
     Article,
@@ -28,6 +36,7 @@ from wikimind.models import (
     ConversationDetail,
     ConversationResponse,
     ConversationSummary,
+    FileBackSelectionRequest,
     ForkRequest,
     Query,
     QueryRequest,
@@ -492,6 +501,106 @@ class QueryService:
             query=_to_query_response(query, citations),
             conversation=_to_conversation_response(conversation, fork_count),
         )
+
+    async def file_back_selection(
+        self,
+        request: FileBackSelectionRequest,
+        session: AsyncSession,
+    ) -> dict[str, object]:
+        """File selected turns from one or more conversations back to the wiki.
+
+        Validates that all referenced conversations and turns exist, builds
+        the selected-turn list, serializes to markdown, writes to disk, and
+        creates an Article row.
+
+        Args:
+            request: The file-back selection request with turn selections and optional title.
+            session: Async database session.
+
+        Returns:
+            Dict with article metadata (id, slug, title).
+
+        Raises:
+            HTTPException: 400 if selections are empty or invalid.
+            HTTPException: 404 if a conversation is not found.
+        """
+        if not request.selections:
+            raise HTTPException(status_code=400, detail="No selections provided")
+
+        selected_turns: list[SelectedTurn] = []
+
+        for selection in request.selections:
+            conversation = await session.get(Conversation, selection.conversation_id)
+            if conversation is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Conversation not found: {selection.conversation_id}",
+                )
+
+            if not selection.turn_indices:
+                continue
+
+            result = await session.execute(
+                select(Query)
+                .where(Query.conversation_id == selection.conversation_id)
+                .where(Query.turn_index.in_(selection.turn_indices))  # type: ignore[union-attr]
+                .order_by(Query.turn_index.asc())  # type: ignore[attr-defined]
+            )
+            queries = list(result.scalars().all())
+
+            found_indices = {q.turn_index for q in queries}
+            missing = set(selection.turn_indices) - found_indices
+            if missing:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Turn indices {sorted(missing)} not found "
+                        f"in conversation {selection.conversation_id}"
+                    ),
+                )
+
+            for query in queries:
+                selected_turns.append(SelectedTurn(conversation=conversation, query=query))
+
+        if not selected_turns:
+            raise HTTPException(status_code=400, detail="No turns selected")
+
+        markdown = serialize_selected_turns_to_markdown(selected_turns, title=request.title)
+
+        settings = get_settings()
+        wiki_dir = Path(settings.data_dir) / "wiki" / "qa-answers"
+        wiki_dir.mkdir(parents=True, exist_ok=True)
+
+        now = utcnow_naive()
+        effective_title = request.title or selected_turns[0].conversation.title
+
+        slug = str(uuid.uuid4())
+        file_path = wiki_dir / f"{slug}.md"
+        file_path.write_text(markdown, encoding="utf-8")
+
+        article = Article(
+            slug=slug,
+            title=effective_title,
+            file_path=str(file_path),
+            summary=(selected_turns[0].query.answer[:200] if selected_turns else None),
+            confidence=None,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(article)
+
+        # Mark selected turns as filed back
+        for selected in selected_turns:
+            selected.query.filed_back = True
+            selected.query.filed_article_id = article.id
+            session.add(selected.query)
+
+        await session.commit()
+        await session.refresh(article)
+
+        return {
+            "article": {"id": article.id, "slug": article.slug, "title": article.title},
+        }
 
     async def export_conversation(
         self,

--- a/tests/unit/test_conversation_serializer.py
+++ b/tests/unit/test_conversation_serializer.py
@@ -2,7 +2,11 @@
 
 from datetime import datetime
 
-from wikimind.engine.conversation_serializer import serialize_conversation_to_markdown
+from wikimind.engine.conversation_serializer import (
+    SelectedTurn,
+    serialize_conversation_to_markdown,
+    serialize_selected_turns_to_markdown,
+)
 from wikimind.models import Conversation, Query
 
 
@@ -197,3 +201,191 @@ def test_serializer_does_not_touch_non_heading_hashes():
         pass
     else:
         assert "# This is a Python comment, not a heading" in md
+
+
+# ---------------------------------------------------------------------------
+# Selected turns serializer (partial / multi-thread file-back)
+# ---------------------------------------------------------------------------
+
+
+def _conv2(conv_id: str = "conv-2", title: str = "Second thread") -> Conversation:
+    return Conversation(
+        id=conv_id,
+        title=title,
+        created_at=datetime(2026, 4, 9, 10, 0, 0),
+        updated_at=datetime(2026, 4, 9, 10, 5, 0),
+    )
+
+
+def _selected(conv: Conversation, question: str, answer: str, turn_index: int) -> SelectedTurn:
+    query = Query(
+        id=f"q-{conv.id}-{turn_index}",
+        question=question,
+        answer=answer,
+        confidence="high",
+        source_article_ids="[]",
+        conversation_id=conv.id,
+        turn_index=turn_index,
+        created_at=datetime(2026, 4, 8, 12, 0, turn_index),
+    )
+    return SelectedTurn(conversation=conv, query=query)
+
+
+def test_selected_turns_empty_list():
+    """Empty selections produce valid markdown with zero turns."""
+    md = serialize_selected_turns_to_markdown([], title="Empty")
+    assert "turn_count: 0" in md
+    assert "# Empty" in md
+    assert "type: qa-selection" in md
+
+
+def test_selected_turns_single_turn():
+    """A single selected turn renders as Q1."""
+    conv = _conv()
+    turns = [_selected(conv, "What is X?", "X is a thing.", turn_index=2)]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    assert "## Q1: What is X?" in md
+    assert "X is a thing." in md
+    # Uses first conversation's title by default
+    assert "# What is X?" in md
+    assert "type: qa-selection" in md
+    assert "turn_count: 1" in md
+
+
+def test_selected_turns_custom_title():
+    """Custom title overrides default conversation title."""
+    conv = _conv()
+    turns = [_selected(conv, "Q?", "A.", turn_index=0)]
+    md = serialize_selected_turns_to_markdown(turns, title="My Custom Title")
+
+    assert "# My Custom Title" in md
+    assert 'title: "My Custom Title"' in md
+
+
+def test_selected_turns_continuous_numbering():
+    """Output turns are numbered Q1, Q2, Q3 regardless of original turn indices."""
+    conv = _conv()
+    turns = [
+        _selected(conv, "Second question", "Answer 2.", turn_index=1),
+        _selected(conv, "Fifth question", "Answer 5.", turn_index=4),
+    ]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    assert "## Q1: Second question" in md
+    assert "## Q2: Fifth question" in md
+    # Should NOT use original turn indices
+    assert "## Q2: Second question" not in md
+    assert "## Q5:" not in md
+
+
+def test_selected_turns_contiguous_no_separator():
+    """Contiguous turns from the same conversation have NO gap separator."""
+    conv = _conv()
+    turns = [
+        _selected(conv, "Q1", "A1.", turn_index=0),
+        _selected(conv, "Q2", "A2.", turn_index=1),
+        _selected(conv, "Q3", "A3.", turn_index=2),
+    ]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    # Count --- occurrences (frontmatter has one closing ---)
+    # The body should have NO --- separators for contiguous turns
+    body = md.split("---\n", 2)[-1]  # after frontmatter
+    assert "\n---\n" not in body
+
+
+def test_selected_turns_gap_separator_for_non_contiguous():
+    """Non-contiguous turns within the same conversation get a --- separator."""
+    conv = _conv()
+    turns = [
+        _selected(conv, "First", "A1.", turn_index=0),
+        _selected(conv, "Third", "A3.", turn_index=2),  # gap: turn 1 is missing
+    ]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    # The body should have a --- separator between the two turns
+    body = md.split("---\n", 2)[-1]  # after frontmatter
+    assert "\n---\n" in body
+
+
+def test_selected_turns_cross_conversation_separator():
+    """Turns from different conversations get a --- separator at the boundary."""
+    conv1 = _conv()
+    conv2 = _conv2()
+    turns = [
+        _selected(conv1, "From thread 1", "Answer 1.", turn_index=0),
+        _selected(conv2, "From thread 2", "Answer 2.", turn_index=0),
+    ]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    body = md.split("---\n", 2)[-1]  # after frontmatter
+    assert "\n---\n" in body
+    assert "## Q1: From thread 1" in md
+    assert "## Q2: From thread 2" in md
+
+
+def test_selected_turns_multi_thread_merge():
+    """Full multi-thread merge: turns from two conversations combined."""
+    conv1 = _conv()
+    conv2 = _conv2()
+    turns = [
+        _selected(conv1, "Q from conv1 turn 0", "A1.", turn_index=0),
+        _selected(conv1, "Q from conv1 turn 1", "A2.", turn_index=1),
+        _selected(conv2, "Q from conv2 turn 0", "B1.", turn_index=0),
+        _selected(conv2, "Q from conv2 turn 2", "B3.", turn_index=2),
+    ]
+    md = serialize_selected_turns_to_markdown(turns, title="Merged research")
+
+    assert "# Merged research" in md
+    assert "## Q1: Q from conv1 turn 0" in md
+    assert "## Q2: Q from conv1 turn 1" in md
+    assert "## Q3: Q from conv2 turn 0" in md
+    assert "## Q4: Q from conv2 turn 2" in md
+
+    # Should have separator between conv1 and conv2 (cross-conversation)
+    # and between conv2 turn 0 and conv2 turn 2 (non-contiguous)
+    body = md.split("---\n", 2)[-1]
+    separator_count = body.count("\n---\n")
+    assert separator_count == 2
+
+
+def test_selected_turns_downshifts_headings():
+    """Answer headings are downshifted just like the full-conversation serializer."""
+    conv = _conv()
+    turns = [_selected(conv, "Q?", "# My Heading\n\nContent.", turn_index=0)]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    assert "### My Heading" in md
+
+
+def test_selected_turns_renders_sources():
+    """Sources from selected turns are rendered as wikilinks."""
+    conv = _conv()
+    query = Query(
+        id="q-src",
+        question="Q?",
+        answer="A.",
+        confidence="high",
+        source_article_ids='["Article One", "Article Two"]',
+        conversation_id=conv.id,
+        turn_index=0,
+        created_at=datetime(2026, 4, 8, 12, 0, 0),
+    )
+    turns = [SelectedTurn(conversation=conv, query=query)]
+    md = serialize_selected_turns_to_markdown(turns)
+
+    assert "[[Article One]]" in md
+    assert "[[Article Two]]" in md
+
+
+def test_selected_turns_byte_identical():
+    """Two calls with the same input produce byte-identical output."""
+    conv = _conv()
+    turns = [
+        _selected(conv, "Q1", "A1.", turn_index=0),
+        _selected(conv, "Q2", "A2.", turn_index=2),
+    ]
+    a = serialize_selected_turns_to_markdown(turns, title="Test")
+    b = serialize_selected_turns_to_markdown(turns, title="Test")
+    assert a == b

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -12,10 +12,12 @@ from wikimind.engine.conversation_serializer import serialize_conversation_to_ma
 from wikimind.models import (
     Article,
     Conversation,
+    FileBackSelectionRequest,
     Query,
     QueryRequest,
     Source,
     SourceType,
+    TurnSelection,
 )
 from wikimind.services.query import QueryService, _build_citations, _sanitize_filename
 
@@ -316,3 +318,217 @@ class TestAskStream:
         assert len(error_events) == 1
         error_data = json.loads(error_events[0].split("data: ", 1)[1].strip())
         assert error_data["code"] == "stream_failed"
+
+
+# ---------------------------------------------------------------------------
+# file_back_selection tests
+# ---------------------------------------------------------------------------
+
+
+async def _seed_two_conversations(db_session) -> tuple[Conversation, Conversation, list[Query]]:
+    """Seed two conversations with multiple turns each for file-back selection tests."""
+    conv1 = Conversation(
+        id="conv-sel-1",
+        title="First Thread",
+        created_at=datetime(2026, 4, 8, 12, 0, 0),
+        updated_at=datetime(2026, 4, 8, 12, 5, 0),
+    )
+    conv2 = Conversation(
+        id="conv-sel-2",
+        title="Second Thread",
+        created_at=datetime(2026, 4, 9, 10, 0, 0),
+        updated_at=datetime(2026, 4, 9, 10, 5, 0),
+    )
+    db_session.add_all([conv1, conv2])
+    await db_session.flush()
+
+    queries = [
+        Query(
+            id="q-sel-1-0",
+            question="Q1 from thread 1",
+            answer="Answer 1-0.",
+            confidence="high",
+            source_article_ids=json.dumps([]),
+            related_article_ids=json.dumps([]),
+            conversation_id="conv-sel-1",
+            turn_index=0,
+        ),
+        Query(
+            id="q-sel-1-1",
+            question="Q2 from thread 1",
+            answer="Answer 1-1.",
+            confidence="medium",
+            source_article_ids=json.dumps([]),
+            related_article_ids=json.dumps([]),
+            conversation_id="conv-sel-1",
+            turn_index=1,
+        ),
+        Query(
+            id="q-sel-1-2",
+            question="Q3 from thread 1",
+            answer="Answer 1-2.",
+            confidence="high",
+            source_article_ids=json.dumps([]),
+            related_article_ids=json.dumps([]),
+            conversation_id="conv-sel-1",
+            turn_index=2,
+        ),
+        Query(
+            id="q-sel-2-0",
+            question="Q1 from thread 2",
+            answer="Answer 2-0.",
+            confidence="high",
+            source_article_ids=json.dumps([]),
+            related_article_ids=json.dumps([]),
+            conversation_id="conv-sel-2",
+            turn_index=0,
+        ),
+        Query(
+            id="q-sel-2-1",
+            question="Q2 from thread 2",
+            answer="Answer 2-1.",
+            confidence="medium",
+            source_article_ids=json.dumps([]),
+            related_article_ids=json.dumps([]),
+            conversation_id="conv-sel-2",
+            turn_index=1,
+        ),
+    ]
+    db_session.add_all(queries)
+    await db_session.commit()
+    return conv1, conv2, queries
+
+
+@pytest.mark.asyncio
+class TestFileBackSelection:
+    async def test_partial_save_selected_turns(self, db_session):
+        """Partial save: only selected turns from one conversation are filed."""
+        await _seed_two_conversations(db_session)
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="conv-sel-1", turn_indices=[0, 2]),
+            ],
+        )
+        result = await service.file_back_selection(request, db_session)
+
+        assert "article" in result
+        article_data = result["article"]
+        assert article_data["title"] == "First Thread"  # defaults to first conv title
+
+        # Verify the article was created on disk
+        article = await db_session.get(Article, article_data["id"])
+        assert article is not None
+        content = Path(article.file_path).read_text(encoding="utf-8")
+        assert "## Q1: Q1 from thread 1" in content
+        assert "## Q2: Q3 from thread 1" in content
+        # Q2 from thread 1 (turn_index=1) should NOT be present
+        assert "Q2 from thread 1" not in content
+
+    async def test_multi_thread_merge(self, db_session):
+        """Multi-thread merge: turns from two conversations combined into one article."""
+        await _seed_two_conversations(db_session)
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="conv-sel-1", turn_indices=[0]),
+                TurnSelection(conversation_id="conv-sel-2", turn_indices=[0, 1]),
+            ],
+            title="Merged Research",
+        )
+        result = await service.file_back_selection(request, db_session)
+
+        article_data = result["article"]
+        assert article_data["title"] == "Merged Research"
+
+        article = await db_session.get(Article, article_data["id"])
+        content = Path(article.file_path).read_text(encoding="utf-8")
+        assert "# Merged Research" in content
+        assert "## Q1: Q1 from thread 1" in content
+        assert "## Q2: Q1 from thread 2" in content
+        assert "## Q3: Q2 from thread 2" in content
+
+    async def test_marks_turns_as_filed_back(self, db_session):
+        """Selected turns are marked filed_back=True with the article's id."""
+        await _seed_two_conversations(db_session)
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="conv-sel-1", turn_indices=[0, 1]),
+            ],
+        )
+        result = await service.file_back_selection(request, db_session)
+        article_id = result["article"]["id"]
+
+        # Refresh the selected queries
+        from sqlmodel import select
+
+        res = await db_session.execute(
+            select(Query).where(Query.conversation_id == "conv-sel-1")
+        )
+        queries = {q.turn_index: q for q in res.scalars().all()}
+
+        assert queries[0].filed_back is True
+        assert queries[0].filed_article_id == article_id
+        assert queries[1].filed_back is True
+        assert queries[1].filed_article_id == article_id
+        # Turn 2 was not selected — should remain unfiled
+        assert queries[2].filed_back is False
+
+    async def test_404_for_nonexistent_conversation(self, db_session):
+        """Raises 404 when a selection references a nonexistent conversation."""
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="nonexistent", turn_indices=[0]),
+            ],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await service.file_back_selection(request, db_session)
+        assert exc_info.value.status_code == 404
+
+    async def test_400_for_empty_selections(self, db_session):
+        """Raises 400 when the selections list is empty."""
+        service = QueryService()
+
+        request = FileBackSelectionRequest(selections=[])
+        with pytest.raises(HTTPException) as exc_info:
+            await service.file_back_selection(request, db_session)
+        assert exc_info.value.status_code == 400
+
+    async def test_400_for_missing_turn_indices(self, db_session):
+        """Raises 400 when requested turn indices don't exist."""
+        await _seed_two_conversations(db_session)
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="conv-sel-1", turn_indices=[0, 99]),
+            ],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await service.file_back_selection(request, db_session)
+        assert exc_info.value.status_code == 400
+        assert "99" in str(exc_info.value.detail)
+
+    async def test_custom_title_overrides_default(self, db_session):
+        """Custom title appears in the article and file content."""
+        await _seed_two_conversations(db_session)
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="conv-sel-1", turn_indices=[0]),
+            ],
+            title="My Custom Title",
+        )
+        result = await service.file_back_selection(request, db_session)
+
+        assert result["article"]["title"] == "My Custom Title"
+        article = await db_session.get(Article, result["article"]["id"])
+        content = Path(article.file_path).read_text(encoding="utf-8")
+        assert "# My Custom Title" in content

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
+from sqlmodel import select
 
 from wikimind.engine.conversation_serializer import serialize_conversation_to_markdown
 from wikimind.models import (
@@ -464,11 +465,7 @@ class TestFileBackSelection:
         article_id = result["article"]["id"]
 
         # Refresh the selected queries
-        from sqlmodel import select
-
-        res = await db_session.execute(
-            select(Query).where(Query.conversation_id == "conv-sel-1")
-        )
+        res = await db_session.execute(select(Query).where(Query.conversation_id == "conv-sel-1"))
         queries = {q.turn_index: q for q in res.scalars().all()}
 
         assert queries[0].filed_back is True


### PR DESCRIPTION
## Problem

File-back saves the entire conversation as one article. Users need to save only selected turns (skip dead ends) or merge turns from multiple conversations into one article.

## Solution

New `POST /conversations/file-back` endpoint accepting a list of `(conversation_id, turn_indices)` selections. The serializer handles non-contiguous turns with `---` separators and continuous Q1/Q2/Q3 numbering. Frontend adds turn selection mode with checkboxes and a cross-conversation selection cart.

## Changes

**Backend:**
- `conversation_serializer.py` — `serialize_selected_turns_to_markdown()` with gap separators
- `models.py` — `TurnSelection`, `FileBackSelectionRequest`
- `services/query.py` — `file_back_selection()` with validation
- `api/routes/query.py` — new endpoint (existing endpoint unchanged)

**Frontend:**
- `store/selection.tsx` — `SelectionProvider` context
- `TurnCard.tsx` — checkbox in selection mode
- `ConversationThread.tsx` — "Select turns" toggle + save button
- `AskView.tsx` — selection cart + file-back mutation

**Tests:** 18 new tests (serializer + service)

## Test plan

- [x] `make verify` passes
- [x] "Select turns" mode shows checkboxes on each turn
- [x] Check turns 2-3 of a 5-turn thread → save → article has only those turns
- [x] Non-contiguous selection → `---` separators in output
- [x] Existing "Save to wiki" (full conversation) still works

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)