### PR TITLE
fix(linter): address code review findings from #131

### DIFF
--- a/apps/web/src/components/health/HealthView.tsx
+++ b/apps/web/src/components/health/HealthView.tsx
@@ -8,7 +8,7 @@ export function HealthView() {
   return (
     <div className="flex h-full flex-col overflow-auto p-6">
       <LintReportSummary
-        report={data?.report ?? null}
+        detail={data ?? null}
         isLoading={isLoading}
       />
 

--- a/apps/web/src/components/health/LintReportSummary.tsx
+++ b/apps/web/src/components/health/LintReportSummary.tsx
@@ -1,10 +1,10 @@
 import { Badge } from "../shared/Badge";
 import { Card } from "../shared/Card";
 import { RunLintButton } from "./RunLintButton";
-import type { LintReport } from "../../api/lint";
+import type { LintReportDetail } from "../../api/lint";
 
 interface Props {
-  report: LintReport | null;
+  detail: LintReportDetail | null;
   isLoading: boolean;
 }
 
@@ -13,7 +13,8 @@ function formatDate(iso: string | null): string {
   return new Date(iso).toLocaleString();
 }
 
-export function LintReportSummary({ report, isLoading }: Props) {
+export function LintReportSummary({ detail, isLoading }: Props) {
+  const report = detail?.report ?? null;
   if (isLoading) {
     return (
       <Card className="p-5">
@@ -92,7 +93,7 @@ export function LintReportSummary({ report, isLoading }: Props) {
       <div className="mt-4 grid grid-cols-3 gap-4">
         <div className="rounded-md border border-slate-200 p-3 text-center">
           <div className="text-2xl font-bold text-slate-800">
-            {report.total_findings}
+            {(detail?.contradictions.length ?? 0) + (detail?.orphans.length ?? 0)}
           </div>
           <div className="text-xs text-slate-500">
             Active findings
@@ -105,13 +106,13 @@ export function LintReportSummary({ report, isLoading }: Props) {
         </div>
         <div className="rounded-md border border-slate-200 p-3 text-center">
           <div className="text-2xl font-bold text-amber-600">
-            {report.contradictions_count}
+            {detail?.contradictions.length ?? 0}
           </div>
           <div className="text-xs text-slate-500">Contradictions</div>
         </div>
         <div className="rounded-md border border-slate-200 p-3 text-center">
           <div className="text-2xl font-bold text-sky-600">
-            {report.orphans_count}
+            {detail?.orphans.length ?? 0}
           </div>
           <div className="text-xs text-slate-500">Orphans</div>
         </div>

--- a/apps/web/src/hooks/useLint.ts
+++ b/apps/web/src/hooks/useLint.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   useMutation,
   useQuery,
@@ -38,6 +38,16 @@ export function useRunLint(): UseMutationResult<
 > & { isPolling: boolean } {
   const queryClient = useQueryClient();
   const [isPolling, setIsPolling] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
 
   const mutation = useMutation({
     mutationFn: () => runLint(),
@@ -47,7 +57,7 @@ export function useRunLint(): UseMutationResult<
       const prevGeneratedAt = cached?.report?.generated_at ?? "";
 
       setIsPolling(true);
-      const poll = setInterval(async () => {
+      pollRef.current = setInterval(async () => {
         try {
           const detail = await getLatestReport();
           queryClient.setQueryData(["lint", "latest"], detail);
@@ -55,7 +65,8 @@ export function useRunLint(): UseMutationResult<
           const isNewer = detail.report.generated_at !== prevGeneratedAt;
           const isDone = detail.report.status !== "in_progress";
           if (isNewer && isDone) {
-            clearInterval(poll);
+            if (pollRef.current) clearInterval(pollRef.current);
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
             setIsPolling(false);
             queryClient.invalidateQueries({ queryKey: ["lint"] });
           }
@@ -64,8 +75,8 @@ export function useRunLint(): UseMutationResult<
         }
       }, 2000);
       // Safety: stop polling after 5 minutes
-      setTimeout(() => {
-        clearInterval(poll);
+      timeoutRef.current = setTimeout(() => {
+        if (pollRef.current) clearInterval(pollRef.current);
         setIsPolling(false);
       }, 300_000);
     },

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -149,8 +149,6 @@ class LinterConfig(BaseModel):
     max_contradiction_pairs_per_concept: int = 10
     contradiction_llm_max_tokens: int = 1024
     contradiction_llm_temperature: float = 0.2
-    respect_monthly_budget: bool = True
-    max_cost_per_run_usd: float = 1.00
     enable_pair_cache: bool = True
 
 

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -130,8 +130,8 @@ async def _save_pair_cache(
     # Delete old cache entry if exists
     await session.execute(
         delete(LintPairCache).where(
-            LintPairCache.article_a_id == ids[0],
-            LintPairCache.article_b_id == ids[1],
+            LintPairCache.article_a_id == ids[0],  # type: ignore[arg-type]
+            LintPairCache.article_b_id == ids[1],  # type: ignore[arg-type]
         )
     )
     session.add(
@@ -161,24 +161,24 @@ async def detect_contradictions(
     findings: list[ContradictionFinding] = []
 
     # Load concepts
-    result = await session.execute(
+    concept_result = await session.execute(
         select(Concept)
         .order_by(Concept.article_count.desc())  # type: ignore[attr-defined]
         .limit(cfg.max_concepts_per_run)
     )
-    concepts = list(result.scalars().all())
+    concepts = list(concept_result.scalars().all())
 
     # Collect all pairs across concepts first (for progress tracking)
     all_work: list[tuple[str | None, str, list[tuple[Article, Article]]]] = []
 
     if not concepts:
         log.info("No concepts found, falling back to top-N article comparison")
-        result = await session.execute(
+        article_result = await session.execute(
             select(Article)
             .order_by(Article.updated_at.desc())  # type: ignore[attr-defined]
             .limit(cfg.max_contradiction_pairs_per_concept * 2)
         )
-        articles = list(result.scalars().all())
+        articles = list(article_result.scalars().all())
         pairs = list(itertools.combinations(articles, 2))
         if len(pairs) > cfg.max_contradiction_pairs_per_concept:
             pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
@@ -202,7 +202,7 @@ async def detect_contradictions(
     await session.flush()
 
     checked = 0
-    for concept_id, concept_name, pairs in all_work:
+    for concept_id, concept_name, pairs in all_work:  # type: ignore[assignment]
         log.info("Checking contradictions in concept", concept=concept_name, pairs=len(pairs))
 
         for article_a, article_b in pairs:

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -14,8 +14,9 @@ import random
 from pathlib import Path
 
 import structlog
-from sqlalchemy import text
+from sqlalchemy import delete, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import Settings
@@ -24,8 +25,10 @@ from wikimind.engine.llm_router import LLMRouter
 from wikimind.models import (
     Article,
     CompletionRequest,
+    Concept,
     ContradictionFinding,
     LintFindingKind,
+    LintPairCache,
     LintReport,
     LintSeverity,
     TaskType,
@@ -46,7 +49,7 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-def _extract_claims(article: Article, data_dir: str) -> list[str]:
+def _extract_claims(article: Article) -> list[str]:
     """Extract key claims from an article's markdown file.
 
     Looks for a "Key Claims" section and parses bullet points.
@@ -85,62 +88,33 @@ def _extract_claims(article: Article, data_dir: str) -> list[str]:
 
 
 async def _get_articles_for_concept(session: AsyncSession, concept_name: str) -> list[Article]:
-    """Load articles whose concept_ids JSON array contains the given concept name."""
-    # concept_ids stores concept names (not UUIDs), so match by name directly.
-    result = await session.execute(
-        text(
-            "SELECT article.id, article.slug, article.title, article.file_path, "
-            "article.concept_ids, article.confidence, article.linter_score, "
-            "article.summary, article.created_at, article.updated_at, "
-            "article.source_ids, article.provider "
-            "FROM article, json_each(article.concept_ids) AS je "
-            "WHERE je.value = :concept_name"
-        ),
-        {"concept_name": concept_name},
-    )
-    rows = result.fetchall()
-    articles = []
-    for row in rows:
-        articles.append(
-            Article(
-                id=row[0],
-                slug=row[1],
-                title=row[2],
-                file_path=row[3],
-                concept_ids=row[4],
-                confidence=row[5],
-                linter_score=row[6],
-                summary=row[7],
-                created_at=row[8],
-                updated_at=row[9],
-                source_ids=row[10],
-                provider=row[11],
-            )
-        )
-    return articles
+    """Load articles whose concept_ids JSON array contains the given concept name.
+
+    Uses ORM query + Python filter for database portability (works on both
+    SQLite and PostgreSQL without dialect-specific JSON functions).
+    """
+    result = await session.execute(select(Article))
+    all_articles = list(result.scalars().all())
+    return [a for a in all_articles if concept_name in (a.concept_ids or [])]
 
 
 async def _check_pair_cache(session: AsyncSession, article_a: Article, article_b: Article) -> list[dict] | None:
     """Check if we have a cached result for this article pair."""
     ids = sorted([article_a.id, article_b.id])
     result = await session.execute(
-        text(
-            "SELECT result_json, article_a_updated_at, article_b_updated_at "
-            "FROM lintpaircache "
-            "WHERE article_a_id = :a_id AND article_b_id = :b_id"
-        ),
-        {"a_id": ids[0], "b_id": ids[1]},
+        select(LintPairCache).where(
+            LintPairCache.article_a_id == ids[0],
+            LintPairCache.article_b_id == ids[1],
+        )
     )
-    row = result.fetchone()
-    if not row:
+    cached = result.scalars().first()
+    if not cached:
         return None
     # Check if articles have been updated since cache was written
-    cached_a_updated = row[1]
-    cached_b_updated = row[2]
     current_a = str(article_a.updated_at) if ids[0] == article_a.id else str(article_b.updated_at)
     current_b = str(article_b.updated_at) if ids[1] == article_b.id else str(article_a.updated_at)
-    if cached_a_updated == current_a and cached_b_updated == current_b:
-        return json.loads(row[0])
+    if cached.article_a_updated_at == current_a and cached.article_b_updated_at == current_b:
+        return json.loads(cached.result_json)
     return None
 
 
@@ -156,25 +130,19 @@ async def _save_pair_cache(
     b_art = article_b if ids[1] == article_b.id else article_a
     # Delete old cache entry if exists
     await session.execute(
-        text("DELETE FROM lintpaircache WHERE article_a_id = :a AND article_b_id = :b"),
-        {"a": ids[0], "b": ids[1]},
+        delete(LintPairCache).where(
+            LintPairCache.article_a_id == ids[0],
+            LintPairCache.article_b_id == ids[1],
+        )
     )
-    await session.execute(
-        text(
-            "INSERT INTO lintpaircache (id, article_a_id, article_b_id, "
-            "article_a_updated_at, article_b_updated_at, result_json, checked_at) "
-            "VALUES (:id, :a_id, :b_id, :a_up, :b_up, :result, :now)"
-        ),
-        {
-            "id": str(hashlib.sha256(f"{ids[0]}|{ids[1]}".encode()).hexdigest()[:32]),
-            "a_id": ids[0],
-            "b_id": ids[1],
-            "a_up": str(a_art.updated_at),
-            "b_up": str(b_art.updated_at),
-            "result": json.dumps(result_data),
-            "now": str(utcnow_naive()),
-        },
-    )
+    session.add(LintPairCache(
+        id=hashlib.sha256(f"{ids[0]}|{ids[1]}".encode()).hexdigest()[:32],
+        article_a_id=ids[0],
+        article_b_id=ids[1],
+        article_a_updated_at=str(a_art.updated_at),
+        article_b_updated_at=str(b_art.updated_at),
+        result_json=json.dumps(result_data),
+    ))
 
 
 async def detect_contradictions(
@@ -193,10 +161,11 @@ async def detect_contradictions(
 
     # Load concepts
     result = await session.execute(
-        text("SELECT c.id, c.name FROM concept c ORDER BY c.article_count DESC LIMIT :limit"),
-        {"limit": cfg.max_concepts_per_run},
+        select(Concept)
+        .order_by(Concept.article_count.desc())  # type: ignore[attr-defined]
+        .limit(cfg.max_concepts_per_run)
     )
-    concepts = result.fetchall()
+    concepts = list(result.scalars().all())
 
     # Collect all pairs across concepts first (for progress tracking)
     all_work: list[tuple[str | None, str, list[tuple[Article, Article]]]] = []
@@ -204,38 +173,18 @@ async def detect_contradictions(
     if not concepts:
         log.info("No concepts found, falling back to top-N article comparison")
         result = await session.execute(
-            text(
-                "SELECT id, slug, title, file_path, concept_ids, confidence, "
-                "linter_score, summary, created_at, updated_at, source_ids, provider "
-                "FROM article ORDER BY updated_at DESC LIMIT :limit"
-            ),
-            {"limit": cfg.max_contradiction_pairs_per_concept * 2},
+            select(Article)
+            .order_by(Article.updated_at.desc())  # type: ignore[attr-defined]
+            .limit(cfg.max_contradiction_pairs_per_concept * 2)
         )
-        rows = result.fetchall()
-        articles = [
-            Article(
-                id=r[0],
-                slug=r[1],
-                title=r[2],
-                file_path=r[3],
-                concept_ids=r[4],
-                confidence=r[5],
-                linter_score=r[6],
-                summary=r[7],
-                created_at=r[8],
-                updated_at=r[9],
-                source_ids=r[10],
-                provider=r[11],
-            )
-            for r in rows
-        ]
+        articles = list(result.scalars().all())
         pairs = list(itertools.combinations(articles, 2))
         if len(pairs) > cfg.max_contradiction_pairs_per_concept:
             pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
         all_work.append((None, "all-articles", pairs))
     else:
-        for concept_row in concepts:
-            concept_id, concept_name = concept_row
+        for concept_obj in concepts:
+            concept_id, concept_name = concept_obj.id, concept_obj.name
             articles = await _get_articles_for_concept(session, concept_name)
             if len(articles) < 2:
                 continue
@@ -317,19 +266,23 @@ async def _compare_article_pair(
 ) -> list[ContradictionFinding]:
     """Compare a single article pair via LLM and return any findings."""
     cfg = settings.linter
-    claims_a = _extract_claims(article_a, settings.data_dir)
-    claims_b = _extract_claims(article_b, settings.data_dir)
+    claims_a = _extract_claims(article_a)
+    claims_b = _extract_claims(article_b)
 
     if not claims_a or not claims_b:
         return []
 
-    claims_a_text = "\n".join(f"- {c}" for c in claims_a)
-    claims_b_text = "\n".join(f"- {c}" for c in claims_b)
+    # Sanitize inputs to limit prompt injection surface
+    _MAX_TITLE = 200
+    _MAX_CLAIM = 500
+    _MAX_CLAIMS_TEXT = 2000
+    claims_a_text = "\n".join(f"- {c[:_MAX_CLAIM]}" for c in claims_a)[:_MAX_CLAIMS_TEXT]
+    claims_b_text = "\n".join(f"- {c[:_MAX_CLAIM]}" for c in claims_b)[:_MAX_CLAIMS_TEXT]
 
     user_msg = CONTRADICTION_USER_TEMPLATE.format(
-        title_a=article_a.title,
+        title_a=article_a.title[:_MAX_TITLE],
         claims_a=claims_a_text,
-        title_b=article_b.title,
+        title_b=article_b.title[:_MAX_TITLE],
         claims_b=claims_b_text,
     )
 

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -14,11 +14,10 @@ import random
 from pathlib import Path
 
 import structlog
-from sqlalchemy import delete, text
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from wikimind._datetime import utcnow_naive
 from wikimind.config import Settings
 from wikimind.engine.linter.prompts import CONTRADICTION_SYSTEM_PROMPT, CONTRADICTION_USER_TEMPLATE
 from wikimind.engine.llm_router import LLMRouter
@@ -135,14 +134,16 @@ async def _save_pair_cache(
             LintPairCache.article_b_id == ids[1],
         )
     )
-    session.add(LintPairCache(
-        id=hashlib.sha256(f"{ids[0]}|{ids[1]}".encode()).hexdigest()[:32],
-        article_a_id=ids[0],
-        article_b_id=ids[1],
-        article_a_updated_at=str(a_art.updated_at),
-        article_b_updated_at=str(b_art.updated_at),
-        result_json=json.dumps(result_data),
-    ))
+    session.add(
+        LintPairCache(
+            id=hashlib.sha256(f"{ids[0]}|{ids[1]}".encode()).hexdigest()[:32],
+            article_a_id=ids[0],
+            article_b_id=ids[1],
+            article_a_updated_at=str(a_art.updated_at),
+            article_b_updated_at=str(b_art.updated_at),
+            result_json=json.dumps(result_data),
+        )
+    )
 
 
 async def detect_contradictions(

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -23,9 +23,12 @@ from wikimind.models import (
 log = structlog.get_logger()
 
 
-def _content_hash(article_id: str, article_title: str) -> str:
-    """Compute a stable sha256 for cross-run dedup of dismissed findings."""
-    raw = f"{LintFindingKind.ORPHAN}|{article_id}|{article_title}"
+def _content_hash(article_id: str) -> str:
+    """Compute a stable sha256 for cross-run dedup of dismissed findings.
+
+    Keyed by article ID only — not the title, which may change.
+    """
+    raw = f"{LintFindingKind.ORPHAN}|{article_id}"
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
@@ -70,7 +73,7 @@ async def detect_orphans(
                 report_id=report_id,
                 severity=LintSeverity.INFO,
                 description=f"Article '{article_title}' has no inbound or outbound links",
-                content_hash=_content_hash(article_id, article_title),
+                content_hash=_content_hash(article_id),
                 article_id=article_id,
                 article_title=article_title,
             )

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -72,6 +72,15 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
     settings = get_settings()
     router = get_llm_router()
 
+    # Guard against concurrent runs
+    existing = await session.execute(
+        select(LintReport).where(LintReport.status == LintReportStatus.IN_PROGRESS)
+    )
+    in_progress = existing.scalars().first()
+    if in_progress:
+        log.info("Lint run already in progress", report_id=in_progress.id)
+        return in_progress
+
     # Snapshot article count
     count_result = await session.execute(select(func.count()).select_from(Article))
     article_count = count_result.scalar() or 0

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -73,9 +73,7 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
     router = get_llm_router()
 
     # Guard against concurrent runs
-    existing = await session.execute(
-        select(LintReport).where(LintReport.status == LintReportStatus.IN_PROGRESS)
-    )
+    existing = await session.execute(select(LintReport).where(LintReport.status == LintReportStatus.IN_PROGRESS))
     in_progress = existing.scalars().first()
     if in_progress:
         log.info("Lint run already in progress", report_id=in_progress.id)

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -153,6 +153,17 @@ class LinterService:
         finding.dismissed_at = now
         session.add(finding)
 
+        # Update parent report counts
+        report = await session.get(LintReport, finding.report_id)
+        if report:
+            if kind == LintFindingKind.CONTRADICTION:
+                report.contradictions_count = max(0, report.contradictions_count - 1)
+            elif kind == LintFindingKind.ORPHAN:
+                report.orphans_count = max(0, report.orphans_count - 1)
+            report.total_findings = max(0, report.total_findings - 1)
+            report.dismissed_count += 1
+            session.add(report)
+
         # Record in DismissedFinding for cross-run suppression
         existing = await session.get(DismissedFinding, finding.content_hash)
         if not existing:


### PR DESCRIPTION
## Summary
- Remove unused `data_dir` param from `_extract_claims`
- Replace SQLite-only `json_each` with portable ORM query (PostgreSQL compatible)
- Fix orphan content hash stability (use article_id only, not title)
- Add concurrent lint run guard
- Remove unenforced budget config settings
- Sanitize LLM prompt inputs (truncate titles/claims)
- Convert raw SQL pair cache to ORM (`LintPairCache` model)
- Update report counts on dismiss
- Summary cards show live counts from finding arrays
- Fix polling interval memory leak on unmount

Follows up on code review of #131.

## Test plan
- [x] `make verify` passes (485 tests)
- [ ] Dismiss a finding → summary card + tab counts both update
- [ ] Run lint twice quickly → second run returns existing in-progress report
- [ ] Re-run lint after dismiss → dismissed findings stay suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)