### PR TITLE
feat: schema overhaul Phase 5 -- answer pages, index/meta, frontend

### DIFF
--- a/apps/web/src/components/wiki/ArticleCardGrid.tsx
+++ b/apps/web/src/components/wiki/ArticleCardGrid.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useArticles } from "../../hooks/useArticles";
 import type { Article, ConfidenceLevel } from "../../types/api";
 import { ConfidenceBadge } from "./ConfidenceBadge";
+import { PageTypeIndicator } from "./PageTypeIndicator";
 import { Spinner } from "../shared/Spinner";
 
 interface ArticleCardGridProps {
@@ -73,6 +74,7 @@ function ArticleCard({ article }: { article: Article }) {
       className="group block rounded-lg border border-slate-200 bg-white p-4 shadow-sm transition hover:border-brand-300 hover:shadow-md"
     >
       <div className="mb-2 flex items-center gap-2">
+        <PageTypeIndicator pageType={article.page_type} />
         {article.confidence ? (
           <ConfidenceBadge level={article.confidence as ConfidenceLevel} />
         ) : null}

--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -6,6 +6,7 @@ import rehypeRaw from "rehype-raw";
 import type { ArticleResponse, ConfidenceLevel } from "../../types/api";
 import { getBaseUrl } from "../../api/client";
 import { ConfidenceBadge } from "./ConfidenceBadge";
+import { PageTypeIndicator } from "./PageTypeIndicator";
 import { Badge } from "../shared/Badge";
 
 interface ArticleReaderProps {
@@ -14,7 +15,6 @@ interface ArticleReaderProps {
 
 const CONFIDENCE_TAG_REGEX = /\[(sourced|mixed|inferred|opinion)\]/gi;
 const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
-// Match a YAML frontmatter block at the very start of the document.
 const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 
 function escapeHtml(s: string): string {
@@ -26,16 +26,6 @@ function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;");
 }
 
-// Pre-process the markdown to:
-//   1. Strip the YAML frontmatter block emitted by the compiler (it leaks into
-//      the visible article body otherwise — react-markdown doesn't parse YAML).
-//   2. Convert any remaining [[wikilinks]] (which are by definition unresolved —
-//      the compiler rewrites resolved ones into standard [text](/wiki/<id>)
-//      markdown links at save time) into a dimmed <span> so the reader can see
-//      the reference exists but knows there's no article to click through to.
-// Matches ![alt](src) where src is NOT a URL (no / or http) — these are
-// LLM-generated figure references like ![description](Figure 1) that render
-// as broken images. Real images are displayed in the FiguresPanel below.
 const BROKEN_IMAGE_REGEX = /!\[[^\]]*\]\((?!\/|https?:\/\/)[^)]+\)\n*/g;
 
 function preprocessMarkdown(content: string): string {
@@ -48,16 +38,48 @@ function preprocessMarkdown(content: string): string {
     });
 }
 
+/** Extract synthesized_from article IDs from concept page frontmatter. */
+function extractSynthesizedFrom(content: string): string[] {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return [];
+  const fm = match[0];
+  const synMatch = fm.match(/synthesized_from:\s*\n((?:\s*-\s*.+\n)*)/);
+  if (!synMatch) return [];
+  return synMatch[1]
+    .split("\n")
+    .map((line) => line.replace(/^\s*-\s*/, "").trim())
+    .filter(Boolean);
+}
+
+/** Extract concept_kind from concept page frontmatter. */
+function extractConceptKind(content: string): string | null {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return null;
+  const kindMatch = match[0].match(/concept_kind:\s*(.+)/);
+  return kindMatch ? kindMatch[1].trim() : null;
+}
+
 export function ArticleReader({ article }: ArticleReaderProps) {
   const processed = useMemo(
     () => preprocessMarkdown(article.content ?? ""),
     [article.content],
   );
 
+  const isConcept = article.page_type === "concept";
+  const synthesizedFrom = useMemo(
+    () => (isConcept ? extractSynthesizedFrom(article.content ?? "") : []),
+    [article.content, isConcept],
+  );
+  const conceptKind = useMemo(
+    () => (isConcept ? extractConceptKind(article.content ?? "") : null),
+    [article.content, isConcept],
+  );
+
   return (
     <article className="mx-auto max-w-3xl p-8">
       <header className="mb-6 border-b border-slate-200 pb-5">
         <div className="mb-3 flex flex-wrap items-center gap-2">
+          <PageTypeIndicator pageType={article.page_type} />
           {article.confidence ? (
             <ConfidenceBadge level={article.confidence as ConfidenceLevel} />
           ) : null}
@@ -65,6 +87,9 @@ export function ArticleReader({ article }: ArticleReaderProps) {
             <Badge tone="info">
               Linter {(article.linter_score * 100).toFixed(0)}%
             </Badge>
+          ) : null}
+          {isConcept && conceptKind ? (
+            <Badge tone="neutral">{conceptKind}</Badge>
           ) : null}
           {article.concepts.slice(0, 3).map((concept) => (
             <Badge key={concept} tone="brand">
@@ -75,6 +100,26 @@ export function ArticleReader({ article }: ArticleReaderProps) {
         <h1 className="text-3xl font-bold text-slate-900">{article.title}</h1>
         {article.summary ? (
           <p className="mt-2 text-base text-slate-600">{article.summary}</p>
+        ) : null}
+
+        {isConcept && synthesizedFrom.length > 0 ? (
+          <div className="mt-3 rounded-md border border-brand-100 bg-brand-50 p-3">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-brand-700">
+              Synthesized from
+            </p>
+            <ul className="flex flex-wrap gap-2">
+              {synthesizedFrom.map((sourceId) => (
+                <li key={sourceId}>
+                  <Link
+                    to={`/wiki/${encodeURIComponent(sourceId)}`}
+                    className="inline-block rounded-md border border-brand-200 bg-white px-2 py-0.5 text-xs text-brand-700 hover:bg-brand-50"
+                  >
+                    {sourceId}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
         ) : null}
       </header>
 
@@ -106,8 +151,6 @@ export function ArticleReader({ article }: ArticleReaderProps) {
               );
             },
             img: ({ node: _node, src, alt, ...props }) => {
-              // Prefix /images/ paths with the API base URL so they
-              // resolve to the backend, not the Vite dev server.
               const resolvedSrc =
                 src && src.startsWith("/images/")
                   ? `${getBaseUrl()}${src}`
@@ -142,8 +185,6 @@ export function ArticleReader({ article }: ArticleReaderProps) {
   );
 }
 
-// Walk text children and replace [sourced]/[inferred]/[opinion]/[mixed]
-// markers with inline confidence badges. Non-string children are passed through.
 function decorateConfidence(children: React.ReactNode): React.ReactNode {
   if (typeof children === "string") {
     return splitConfidence(children);

--- a/apps/web/src/components/wiki/BacklinkPanel.tsx
+++ b/apps/web/src/components/wiki/BacklinkPanel.tsx
@@ -1,10 +1,31 @@
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import type { ArticleResponse, BacklinkEntry } from "../../types/api";
+import type { ArticleResponse, BacklinkEntry, RelationType } from "../../types/api";
 
 interface BacklinkPanelProps {
   article: ArticleResponse | null;
   hasFigures?: boolean;
   figureCount?: number;
+}
+
+const RELATION_STYLE: Record<RelationType, { label: string; className: string }> = {
+  references: { label: "References", className: "text-brand-700 hover:bg-brand-50" },
+  contradicts: { label: "Contradicts", className: "text-rose-700 hover:bg-rose-50" },
+  extends: { label: "Extends", className: "text-sky-700 hover:bg-sky-50" },
+  supersedes: { label: "Supersedes", className: "text-amber-700 hover:bg-amber-50" },
+  synthesizes: { label: "Synthesizes", className: "text-violet-700 hover:bg-violet-50" },
+  related_to: { label: "Related to", className: "text-slate-600 hover:bg-slate-100" },
+};
+
+function groupByRelationType(links: BacklinkEntry[]): Map<string, BacklinkEntry[]> {
+  const groups = new Map<string, BacklinkEntry[]>();
+  for (const link of links) {
+    const key = link.relation_type ?? "references";
+    const existing = groups.get(key) ?? [];
+    existing.push(link);
+    groups.set(key, existing);
+  }
+  return groups;
 }
 
 export function BacklinkPanel({ article, hasFigures, figureCount }: BacklinkPanelProps) {
@@ -21,8 +42,8 @@ export function BacklinkPanel({ article, hasFigures, figureCount }: BacklinkPane
 
   return (
     <div className="flex h-full flex-col gap-5 overflow-y-auto p-4">
-      <Section title="Linked from" links={inLinks} emptyText="Nothing links here yet" />
-      <Section title="Links to" links={outLinks} emptyText="No outgoing links" />
+      <TypedSection title="Linked from" links={inLinks} emptyText="Nothing links here yet" />
+      <TypedSection title="Links to" links={outLinks} emptyText="No outgoing links" />
 
       {hasFigures && (
         <div>
@@ -66,13 +87,15 @@ export function BacklinkPanel({ article, hasFigures, figureCount }: BacklinkPane
   );
 }
 
-interface SectionProps {
+interface TypedSectionProps {
   title: string;
   links: BacklinkEntry[];
   emptyText: string;
 }
 
-function Section({ title, links, emptyText }: SectionProps) {
+function TypedSection({ title, links, emptyText }: TypedSectionProps) {
+  const grouped = useMemo(() => groupByRelationType(links), [links]);
+
   return (
     <div>
       <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
@@ -80,20 +103,54 @@ function Section({ title, links, emptyText }: SectionProps) {
       </h3>
       {links.length === 0 ? (
         <p className="text-xs text-slate-400">{emptyText}</p>
-      ) : (
+      ) : grouped.size === 1 && grouped.has("references") ? (
+        // Simple list when all links are plain references
         <ul className="space-y-1">
           {links.map((link) => (
-            <li key={link.id}>
-              <Link
-                to={`/wiki/${encodeURIComponent(link.slug)}`}
-                className="block truncate rounded px-2 py-1 text-sm text-brand-700 hover:bg-brand-50"
-              >
-                {link.title}
-              </Link>
-            </li>
+            <BacklinkItem key={link.id} link={link} />
           ))}
         </ul>
+      ) : (
+        // Grouped by relation type
+        <div className="space-y-3">
+          {Array.from(grouped.entries()).map(([relType, groupLinks]) => {
+            const style = RELATION_STYLE[relType as RelationType] ?? RELATION_STYLE.references;
+            return (
+              <div key={relType}>
+                <p className="mb-1 text-xs font-medium text-slate-500">
+                  {style.label}
+                </p>
+                <ul className="space-y-1">
+                  {groupLinks.map((link) => (
+                    <BacklinkItem key={link.id} link={link} />
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
       )}
     </div>
+  );
+}
+
+function BacklinkItem({ link }: { link: BacklinkEntry }) {
+  const relType = (link.relation_type ?? "references") as RelationType;
+  const style = RELATION_STYLE[relType] ?? RELATION_STYLE.references;
+
+  return (
+    <li>
+      <Link
+        to={`/wiki/${encodeURIComponent(link.slug)}`}
+        className={`block truncate rounded px-2 py-1 text-sm ${style.className}`}
+      >
+        {link.title}
+        {link.relation_type === "contradicts" && link.resolution ? (
+          <span className="ml-1 text-xs text-slate-400">
+            ({link.resolution})
+          </span>
+        ) : null}
+      </Link>
+    </li>
   );
 }

--- a/apps/web/src/components/wiki/PageTypeIndicator.tsx
+++ b/apps/web/src/components/wiki/PageTypeIndicator.tsx
@@ -1,0 +1,29 @@
+import type { PageType } from "../../types/api";
+import { Badge, type BadgeTone } from "../shared/Badge";
+
+const PAGE_TYPE_CONFIG: Record<
+  PageType,
+  { label: string; tone: BadgeTone }
+> = {
+  source: { label: "Source", tone: "info" },
+  concept: { label: "Concept", tone: "brand" },
+  answer: { label: "Answer", tone: "success" },
+  index: { label: "Index", tone: "neutral" },
+  meta: { label: "Meta", tone: "neutral" },
+};
+
+interface PageTypeIndicatorProps {
+  pageType: PageType;
+  className?: string;
+}
+
+export function PageTypeIndicator({ pageType, className }: PageTypeIndicatorProps) {
+  const config = PAGE_TYPE_CONFIG[pageType];
+  if (!config) return null;
+
+  return (
+    <Badge tone={config.tone} className={className}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -15,6 +15,16 @@ export type IngestStatus = "pending" | "processing" | "compiled" | "failed";
 
 export type ConfidenceLevel = "sourced" | "mixed" | "inferred" | "opinion";
 
+export type PageType = "source" | "concept" | "answer" | "index" | "meta";
+
+export type RelationType =
+  | "references"
+  | "contradicts"
+  | "extends"
+  | "supersedes"
+  | "synthesizes"
+  | "related_to";
+
 export type JobStatus = "queued" | "running" | "complete" | "failed";
 
 export type JobType =
@@ -47,6 +57,7 @@ export interface Article {
   summary: string | null;
   confidence: ConfidenceLevel | null;
   linter_score: number | null;
+  page_type: PageType;
   source_count: number;
   backlink_count: number;
   created_at: string;
@@ -57,6 +68,8 @@ export interface BacklinkEntry {
   id: string;
   title: string;
   slug: string;
+  relation_type?: RelationType;
+  resolution?: string | null;
 }
 
 export interface ArticleSourceRef {
@@ -69,6 +82,7 @@ export interface ArticleSourceRef {
 
 export interface ArticleResponse extends Article {
   content: string;
+  page_type: PageType;
   backlinks_in: BacklinkEntry[];
   backlinks_out: BacklinkEntry[];
   concepts: string[];

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -213,6 +213,14 @@ paths:
           - type: string
           - type: 'null'
           title: Confidence
+      - name: page_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Page Type
       - name: limit
         in: query
         required: false
@@ -1095,6 +1103,9 @@ components:
           type: string
           format: date-time
           title: Updated At
+        page_type:
+          $ref: '#/components/schemas/PageType'
+          default: source
       type: object
       required:
       - id
@@ -1179,6 +1190,9 @@ components:
           type: string
           format: date-time
           title: Updated At
+        page_type:
+          $ref: '#/components/schemas/PageType'
+          default: source
       type: object
       required:
       - id
@@ -1222,6 +1236,15 @@ components:
         slug:
           type: string
           title: Slug
+        relation_type:
+          anyOf:
+          - $ref: '#/components/schemas/RelationType'
+          - type: 'null'
+        resolution:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resolution
       type: object
       required:
       - id
@@ -1770,6 +1793,17 @@ components:
       - article_title
       title: OrphanFinding
       description: An article with zero inbound AND zero outbound backlinks.
+    PageType:
+      type: string
+      enum:
+      - source
+      - concept
+      - answer
+      - index
+      - meta
+      title: PageType
+      description: Type of wiki page — determines compilation pipeline and validation
+        rules.
     QueryRequest:
       properties:
         question:

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -37,7 +37,9 @@ async def list_articles(
     service: WikiService = Depends(get_wiki_service),
 ):
     """List wiki articles with optional filtering and source provenance."""
-    return await service.list_articles(session, concept=concept, confidence=confidence, page_type=page_type, limit=limit, offset=offset)
+    return await service.list_articles(
+        session, concept=concept, confidence=confidence, page_type=page_type, limit=limit, offset=offset
+    )
 
 
 @router.get("/articles/{id_or_slug}", response_model=ArticleResponse)

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -30,13 +30,14 @@ router = APIRouter()
 async def list_articles(
     concept: str | None = None,
     confidence: str | None = None,
+    page_type: str | None = None,
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
 ):
     """List wiki articles with optional filtering and source provenance."""
-    return await service.list_articles(session, concept=concept, confidence=confidence, limit=limit, offset=offset)
+    return await service.list_articles(session, concept=concept, confidence=confidence, page_type=page_type, limit=limit, offset=offset)
 
 
 @router.get("/articles/{id_or_slug}", response_model=ArticleResponse)

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -25,6 +25,7 @@ from wikimind.models import (
     CompletionRequest,
     Conversation,
     CostLog,
+    PageType,
     Query,
     QueryRequest,
     QueryResult,
@@ -591,6 +592,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                 file_path=str(file_path),
                 summary=(queries[0].answer[:200] if queries else None),
                 confidence=None,  # per #84 / Option 2 — Q&A confidence is on Query, not Article
+                page_type=PageType.ANSWER,
                 created_at=now,
                 updated_at=now,
             )

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -680,6 +680,8 @@ class BacklinkEntry(BaseModel):
     id: str
     title: str
     slug: str
+    relation_type: RelationType | None = None
+    resolution: str | None = None
 
 
 class ArticleResponse(BaseModel):
@@ -698,6 +700,7 @@ class ArticleResponse(BaseModel):
     sources: list[SourceResponse] = []
     created_at: datetime
     updated_at: datetime
+    page_type: PageType = PageType.SOURCE
 
 
 class ArticleSummaryResponse(BaseModel):
@@ -719,6 +722,7 @@ class ArticleSummaryResponse(BaseModel):
     backlink_count: int = 0
     created_at: datetime
     updated_at: datetime
+    page_type: PageType = PageType.SOURCE
 
 
 class CitationArticleRef(BaseModel):

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -38,6 +38,7 @@ from wikimind.models import (
     ConversationSummary,
     FileBackSelectionRequest,
     ForkRequest,
+    PageType,
     Query,
     QueryRequest,
     QueryResponse,
@@ -581,6 +582,7 @@ class QueryService:
             file_path=str(file_path),
             summary=(selected_turns[0].query.answer[:200] if selected_turns else None),
             confidence=None,
+            page_type=PageType.ANSWER,
             created_at=now,
             updated_at=now,
         )

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -158,6 +158,7 @@ async def _build_article_summary(article: Article, session: AsyncSession) -> Art
         summary=article.summary,
         confidence=article.confidence,
         linter_score=article.linter_score,
+        page_type=article.page_type,
         sources=[_to_source_summary(s) for s in sources],
         source_count=len(sources),
         backlink_count=backlink_count,
@@ -214,10 +215,11 @@ class WikiService:
         session: AsyncSession,
         concept: str | None = None,
         confidence: str | None = None,
+        page_type: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[ArticleSummaryResponse]:
-        """List wiki articles with optional filtering by concept or confidence.
+        """List wiki articles with optional filtering by concept, confidence, or page_type.
 
         Each returned summary embeds a lightweight list of source
         descriptors so callers can show provenance directly in listing
@@ -229,6 +231,7 @@ class WikiService:
                 ``json_each()`` to unnest ``Article.concept_ids`` and
                 match against the requested concept name.
             confidence: Optional confidence level filter.
+            page_type: Optional page type filter (source, concept, answer, index, meta).
             limit: Maximum number of results.
             offset: Pagination offset.
 
@@ -247,6 +250,8 @@ class WikiService:
             )
         if confidence:
             query = query.where(Article.confidence == confidence)
+        if page_type:
+            query = query.where(Article.page_type == page_type)
         result = await session.execute(query)
         articles = list(result.scalars().all())
         return [await _build_article_summary(a, session) for a in articles]
@@ -286,19 +291,25 @@ class WikiService:
 
         # Resolve incoming backlinks (articles that link TO this one)
         bl_in_result = await session.execute(
-            select(Backlink.source_article_id, Article.title, Article.slug)
+            select(Backlink.source_article_id, Article.title, Article.slug, Backlink.relation_type, Backlink.resolution)
             .join(Article, Article.id == Backlink.source_article_id)  # type: ignore[arg-type]
             .where(Backlink.target_article_id == article.id)
         )
-        backlinks_in = [BacklinkEntry(id=row[0], title=row[1], slug=row[2]) for row in bl_in_result.all()]
+        backlinks_in = [
+            BacklinkEntry(id=row[0], title=row[1], slug=row[2], relation_type=row[3], resolution=row[4])
+            for row in bl_in_result.all()
+        ]
 
         # Resolve outgoing backlinks (articles this one links TO)
         bl_out_result = await session.execute(
-            select(Backlink.target_article_id, Article.title, Article.slug)
+            select(Backlink.target_article_id, Article.title, Article.slug, Backlink.relation_type, Backlink.resolution)
             .join(Article, Article.id == Backlink.target_article_id)  # type: ignore[arg-type]
             .where(Backlink.source_article_id == article.id)
         )
-        backlinks_out = [BacklinkEntry(id=row[0], title=row[1], slug=row[2]) for row in bl_out_result.all()]
+        backlinks_out = [
+            BacklinkEntry(id=row[0], title=row[1], slug=row[2], relation_type=row[3], resolution=row[4])
+            for row in bl_out_result.all()
+        ]
 
         source_ids = _parse_source_ids(article.source_ids)
         sources = await _fetch_sources(session, source_ids)
@@ -312,6 +323,7 @@ class WikiService:
             summary=article.summary,
             confidence=article.confidence,
             linter_score=article.linter_score,
+            page_type=article.page_type,
             concepts=concepts,
             backlinks_in=backlinks_in,
             backlinks_out=backlinks_out,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -291,7 +291,7 @@ class WikiService:
 
         # Resolve incoming backlinks (articles that link TO this one)
         bl_in_result = await session.execute(
-            select(Backlink.source_article_id, Article.title, Article.slug, Backlink.relation_type, Backlink.resolution)
+            select(Backlink.source_article_id, Article.title, Article.slug, Backlink.relation_type, Backlink.resolution)  # type: ignore[call-overload]
             .join(Article, Article.id == Backlink.source_article_id)  # type: ignore[arg-type]
             .where(Backlink.target_article_id == article.id)
         )
@@ -302,7 +302,7 @@ class WikiService:
 
         # Resolve outgoing backlinks (articles this one links TO)
         bl_out_result = await session.execute(
-            select(Backlink.target_article_id, Article.title, Article.slug, Backlink.relation_type, Backlink.resolution)
+            select(Backlink.target_article_id, Article.title, Article.slug, Backlink.relation_type, Backlink.resolution)  # type: ignore[call-overload]
             .join(Article, Article.id == Backlink.target_article_id)  # type: ignore[arg-type]
             .where(Backlink.source_article_id == article.id)
         )

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -41,9 +41,9 @@ def _first_sentence(text: str) -> str:
     return sentence
 
 
-def _page_type_label(page_type: PageType) -> str:
+def _page_type_label(page_type: str) -> str:
     """Return a human-readable label for a page type."""
-    labels = {
+    labels: dict[str, str] = {
         PageType.SOURCE: "Source",
         PageType.CONCEPT: "Concept",
         PageType.ANSWER: "Answer",

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -67,7 +67,7 @@ def _article_entry(article: Article) -> str:
     return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
 
 
-async def regenerate_index_md(session: AsyncSession) -> Path:
+async def regenerate_index_md(session: AsyncSession) -> Path:  # noqa: PLR0912
     """Regenerate the wiki/index.md content catalog from the database.
 
     Reads all Articles + their concepts, groups by concept, writes a
@@ -122,13 +122,7 @@ async def regenerate_index_md(session: AsyncSession) -> Path:
     # Build the markdown content with page_type frontmatter
     now = utcnow_naive()
     frontmatter = (
-        "---\n"
-        "page_type: index\n"
-        "title: Wiki Index\n"
-        "slug: index\n"
-        "scope: global\n"
-        f"generated: {now.isoformat()}\n"
-        "---\n\n"
+        f"---\npage_type: index\ntitle: Wiki Index\nslug: index\nscope: global\ngenerated: {now.isoformat()}\n---\n\n"
     )
 
     lines: list[str] = [frontmatter, _INDEX_HEADER]
@@ -209,14 +203,7 @@ async def generate_meta_health_page(session: AsyncSession) -> Path:
     orphan_count = sum(1 for a in articles if a.id not in linked_ids)
 
     now = utcnow_naive()
-    frontmatter = (
-        "---\n"
-        "page_type: meta\n"
-        "title: Wiki Health\n"
-        "slug: wiki-health\n"
-        f"generated: {now.isoformat()}\n"
-        "---\n\n"
-    )
+    frontmatter = f"---\npage_type: meta\ntitle: Wiki Health\nslug: wiki-health\ngenerated: {now.isoformat()}\n---\n\n"
 
     lines: list[str] = [frontmatter]
     lines.append("# Wiki Health\n\n")

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -9,15 +9,16 @@ from __future__ import annotations
 
 import contextlib
 import json
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 
 import structlog
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
-from wikimind.models import Article, Concept
+from wikimind.models import Article, Backlink, Concept, PageType
 
 log = structlog.get_logger()
 
@@ -40,11 +41,39 @@ def _first_sentence(text: str) -> str:
     return sentence
 
 
+def _page_type_label(page_type: PageType) -> str:
+    """Return a human-readable label for a page type."""
+    labels = {
+        PageType.SOURCE: "Source",
+        PageType.CONCEPT: "Concept",
+        PageType.ANSWER: "Answer",
+        PageType.INDEX: "Index",
+        PageType.META: "Meta",
+    }
+    return labels.get(page_type, str(page_type))
+
+
+def _article_entry(article: Article) -> str:
+    """Format a single article as a markdown list entry with optional type badge."""
+    summary_part = ""
+    if article.summary:
+        summary_part = f" \u2014 {_first_sentence(article.summary)}"
+
+    # Add page type badge for non-source articles
+    type_badge = ""
+    if article.page_type != PageType.SOURCE:
+        type_badge = f" `[{_page_type_label(article.page_type)}]`"
+
+    return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
+
+
 async def regenerate_index_md(session: AsyncSession) -> Path:
     """Regenerate the wiki/index.md content catalog from the database.
 
     Reads all Articles + their concepts, groups by concept, writes a
-    markdown catalog. Rewritten in place on every call (NOT append-only).
+    markdown catalog with page_type frontmatter. Concept pages are shown
+    prominently as entry points. Rewritten in place on every call
+    (NOT append-only).
 
     Args:
         session: Async database session.
@@ -65,6 +94,11 @@ async def regenerate_index_md(session: AsyncSession) -> Path:
     concepts: list[Concept] = list(concepts_result.scalars().all())
     concept_map: dict[str, str] = {c.id: c.name for c in concepts}
 
+    # Count articles by page_type
+    type_counts: Counter[str] = Counter()
+    for article in articles:
+        type_counts[article.page_type] += 1
+
     # Group articles by concept name
     concept_articles: dict[str, list[Article]] = defaultdict(list)
     uncategorized: list[Article] = []
@@ -81,36 +115,141 @@ async def regenerate_index_md(session: AsyncSession) -> Path:
             uncategorized.append(article)
             continue
 
-        # The compiler stores concept *names* (not UUIDs) in concept_ids.
-        # Try the Concept table first (UUID → name); fall back to using
-        # the raw value directly as the heading (which is a name already).
         for raw_id in raw_ids:
             name = concept_map.get(raw_id, raw_id)
             concept_articles[name].append(article)
 
-    # Build the markdown content
-    lines: list[str] = [_INDEX_HEADER]
+    # Build the markdown content with page_type frontmatter
+    now = utcnow_naive()
+    frontmatter = (
+        "---\n"
+        "page_type: index\n"
+        "title: Wiki Index\n"
+        "slug: index\n"
+        "scope: global\n"
+        f"generated: {now.isoformat()}\n"
+        "---\n\n"
+    )
 
-    # Concepts sorted alphabetically, articles sorted alphabetically within each
+    lines: list[str] = [frontmatter, _INDEX_HEADER]
+
+    # Article counts by type
+    if articles:
+        lines.append(f"**{len(articles)} articles** \u2014 ")
+        type_parts: list[str] = []
+        for pt in [PageType.SOURCE, PageType.CONCEPT, PageType.ANSWER, PageType.INDEX, PageType.META]:
+            count = type_counts.get(pt, 0)
+            if count > 0:
+                type_parts.append(f"{count} {_page_type_label(pt).lower()}")
+        lines.append(", ".join(type_parts) + "\n\n")
+
+    # Concept pages first (entry points)
+    concept_page_articles = [a for a in articles if a.page_type == PageType.CONCEPT]
+    if concept_page_articles:
+        lines.append("## Concept Pages\n\n")
+        for article in sorted(concept_page_articles, key=lambda a: a.slug):
+            lines.append(_article_entry(article))
+        lines.append("\n")
+
+    # Concepts sorted alphabetically
     for concept_name in sorted(concept_articles):
         lines.append(f"## {concept_name}\n\n")
         for article in sorted(concept_articles[concept_name], key=lambda a: a.slug):
-            summary_part = ""
-            if article.summary:
-                summary_part = f" \u2014 {_first_sentence(article.summary)}"
-            lines.append(f"- [[{article.slug}]]{summary_part}\n")
+            lines.append(_article_entry(article))
         lines.append("\n")
 
     # Uncategorized section at the bottom
     if uncategorized:
         lines.append("## Uncategorized\n\n")
         for article in sorted(uncategorized, key=lambda a: a.slug):
-            summary_part = ""
-            if article.summary:
-                summary_part = f" \u2014 {_first_sentence(article.summary)}"
-            lines.append(f"- [[{article.slug}]]{summary_part}\n")
+            lines.append(_article_entry(article))
         lines.append("\n")
 
     index_path.write_text("".join(lines), encoding="utf-8")
     log.info("index.md regenerated", article_count=len(articles))
     return index_path
+
+
+async def generate_meta_health_page(session: AsyncSession) -> Path:
+    """Generate a meta page with wiki health statistics.
+
+    Creates ``wiki/meta/wiki-health.md`` with deterministic summary
+    statistics: article counts by type, link counts by relation type,
+    and orphan count. Called during linter runs or on-demand.
+
+    Args:
+        session: Async database session.
+
+    Returns:
+        The Path to the written meta page file.
+    """
+    settings = get_settings()
+    meta_dir = Path(settings.data_dir) / "wiki" / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    health_path = meta_dir / "wiki-health.md"
+
+    articles_result = await session.execute(select(Article))
+    articles: list[Article] = list(articles_result.scalars().all())
+
+    type_counts: Counter[str] = Counter()
+    for article in articles:
+        type_counts[article.page_type] += 1
+
+    backlinks_result = await session.execute(select(Backlink))
+    backlinks: list[Backlink] = list(backlinks_result.scalars().all())
+
+    relation_counts: Counter[str] = Counter()
+    for bl in backlinks:
+        relation_counts[bl.relation_type] += 1
+
+    linked_ids: set[str] = set()
+    for bl in backlinks:
+        linked_ids.add(bl.source_article_id)
+        linked_ids.add(bl.target_article_id)
+    orphan_count = sum(1 for a in articles if a.id not in linked_ids)
+
+    now = utcnow_naive()
+    frontmatter = (
+        "---\n"
+        "page_type: meta\n"
+        "title: Wiki Health\n"
+        "slug: wiki-health\n"
+        f"generated: {now.isoformat()}\n"
+        "---\n\n"
+    )
+
+    lines: list[str] = [frontmatter]
+    lines.append("# Wiki Health\n\n")
+    lines.append(f"Generated: {now.strftime('%Y-%m-%d %H:%M UTC')}\n\n")
+
+    lines.append("## Articles by Type\n\n")
+    lines.append("| Type | Count |\n")
+    lines.append("|------|-------|\n")
+    total = 0
+    for pt in [PageType.SOURCE, PageType.CONCEPT, PageType.ANSWER, PageType.INDEX, PageType.META]:
+        count = type_counts.get(pt, 0)
+        total += count
+        lines.append(f"| {_page_type_label(pt)} | {count} |\n")
+    lines.append(f"| **Total** | **{total}** |\n")
+    lines.append("\n")
+
+    lines.append("## Links by Relation Type\n\n")
+    lines.append("| Relation | Count |\n")
+    lines.append("|----------|-------|\n")
+    link_total = 0
+    for rt in sorted(relation_counts.keys()):
+        count = relation_counts[rt]
+        link_total += count
+        lines.append(f"| {rt} | {count} |\n")
+    if link_total > 0:
+        lines.append(f"| **Total** | **{link_total}** |\n")
+    else:
+        lines.append("| (none) | 0 |\n")
+    lines.append("\n")
+
+    lines.append("## Orphan Articles\n\n")
+    lines.append(f"**{orphan_count}** articles with no inbound or outbound links.\n")
+
+    health_path.write_text("".join(lines), encoding="utf-8")
+    log.info("wiki-health.md generated", article_count=total, orphan_count=orphan_count)
+    return health_path

--- a/tests/unit/test_phase5.py
+++ b/tests/unit/test_phase5.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from unittest.mock import AsyncMock, patch
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from wikimind.engine.qa_agent import QAAgent
 from wikimind.models import (
     Article,
+    ArticleResponse,
+    ArticleSummaryResponse,
     Backlink,
-    Concept,
+    BacklinkEntry,
+    Conversation,
     PageType,
+    Query,
     RelationType,
 )
 from wikimind.services.wiki_index import (
@@ -22,7 +23,6 @@ from wikimind.services.wiki_index import (
     generate_meta_health_page,
     regenerate_index_md,
 )
-
 
 # ---------------------------------------------------------------------------
 # _page_type_label
@@ -189,8 +189,6 @@ class TestAnswerPageType:
     @pytest.mark.anyio
     async def test_file_back_sets_answer_page_type(self, db_session: AsyncSession) -> None:
         """When filing back a conversation, the Article should have page_type=ANSWER."""
-        from wikimind.models import Conversation, Query
-
         conv = Conversation(title="Test conversation")
         db_session.add(conv)
         await db_session.flush()
@@ -204,8 +202,6 @@ class TestAnswerPageType:
         )
         db_session.add(q)
         await db_session.commit()
-
-        from wikimind.engine.qa_agent import QAAgent
 
         agent = QAAgent()
         article, was_update = await agent._file_back_thread(conv.id, db_session)
@@ -221,8 +217,6 @@ class TestAnswerPageType:
 class TestApiResponseFields:
     def test_article_response_has_page_type(self) -> None:
         """ArticleResponse should include page_type field."""
-        from wikimind.models import ArticleResponse
-
         resp = ArticleResponse(
             id="1",
             slug="test",
@@ -240,8 +234,6 @@ class TestApiResponseFields:
 
     def test_backlink_entry_has_relation_type(self) -> None:
         """BacklinkEntry should include relation_type field."""
-        from wikimind.models import BacklinkEntry
-
         entry = BacklinkEntry(
             id="1",
             title="Test",
@@ -255,8 +247,6 @@ class TestApiResponseFields:
 
     def test_article_summary_response_has_page_type(self) -> None:
         """ArticleSummaryResponse should include page_type field."""
-        from wikimind.models import ArticleSummaryResponse
-
         resp = ArticleSummaryResponse(
             id="1",
             slug="test",

--- a/tests/unit/test_phase5.py
+++ b/tests/unit/test_phase5.py
@@ -1,0 +1,272 @@
+"""Tests for Phase 5 — answer pages, index/meta generation, API page_type fields."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from wikimind.models import (
+    Article,
+    Backlink,
+    Concept,
+    PageType,
+    RelationType,
+)
+from wikimind.services.wiki_index import (
+    _article_entry,
+    _page_type_label,
+    generate_meta_health_page,
+    regenerate_index_md,
+)
+
+
+# ---------------------------------------------------------------------------
+# _page_type_label
+# ---------------------------------------------------------------------------
+
+
+class TestPageTypeLabel:
+    def test_all_types_have_labels(self) -> None:
+        for pt in PageType:
+            label = _page_type_label(pt)
+            assert isinstance(label, str)
+            assert len(label) > 0
+
+
+# ---------------------------------------------------------------------------
+# _article_entry
+# ---------------------------------------------------------------------------
+
+
+class TestArticleEntry:
+    def test_source_article_no_badge(self) -> None:
+        a = Article(slug="my-article", title="My Article", file_path="/x.md", page_type=PageType.SOURCE)
+        entry = _article_entry(a)
+        assert "- [[my-article]]" in entry
+        assert "`[" not in entry  # no type badge for source
+
+    def test_concept_article_has_badge(self) -> None:
+        a = Article(slug="concept-page", title="Concept", file_path="/x.md", page_type=PageType.CONCEPT)
+        entry = _article_entry(a)
+        assert "`[Concept]`" in entry
+
+    def test_answer_article_has_badge(self) -> None:
+        a = Article(slug="answer-page", title="Answer", file_path="/x.md", page_type=PageType.ANSWER)
+        entry = _article_entry(a)
+        assert "`[Answer]`" in entry
+
+
+# ---------------------------------------------------------------------------
+# regenerate_index_md — page_type frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateIndexMdPageType:
+    @pytest.mark.anyio
+    async def test_frontmatter_includes_page_type(self, db_session: AsyncSession) -> None:
+        """The index should have page_type: index in its frontmatter."""
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "page_type: index" in content
+        assert "scope: global" in content
+
+    @pytest.mark.anyio
+    async def test_article_counts_by_type(self, db_session: AsyncSession) -> None:
+        """The index should show article counts grouped by type."""
+        a1 = Article(slug="src-1", title="Source 1", file_path="/x.md", page_type=PageType.SOURCE)
+        a2 = Article(slug="ans-1", title="Answer 1", file_path="/x.md", page_type=PageType.ANSWER)
+        db_session.add_all([a1, a2])
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "2 articles" in content
+        assert "1 source" in content
+        assert "1 answer" in content
+
+    @pytest.mark.anyio
+    async def test_concept_pages_section(self, db_session: AsyncSession) -> None:
+        """Concept-type articles should appear in a 'Concept Pages' section."""
+        a = Article(slug="llm-reasoning", title="LLM Reasoning", file_path="/x.md", page_type=PageType.CONCEPT)
+        db_session.add(a)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "## Concept Pages" in content
+        assert "[[llm-reasoning]]" in content
+
+    @pytest.mark.anyio
+    async def test_answer_articles_get_badge(self, db_session: AsyncSession) -> None:
+        """Answer articles should get a [Answer] badge in the index."""
+        a = Article(slug="qa-answer", title="QA Answer", file_path="/x.md", page_type=PageType.ANSWER)
+        db_session.add(a)
+        await db_session.commit()
+
+        path = await regenerate_index_md(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "`[Answer]`" in content
+
+
+# ---------------------------------------------------------------------------
+# generate_meta_health_page
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMetaHealthPage:
+    @pytest.mark.anyio
+    async def test_empty_database_produces_health_page(self, db_session: AsyncSession) -> None:
+        """An empty DB should produce a valid health page."""
+        path = await generate_meta_health_page(db_session)
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert "page_type: meta" in content
+        assert "# Wiki Health" in content
+        assert "**Total** | **0**" in content
+        assert "**0** articles with no inbound or outbound links" in content
+
+    @pytest.mark.anyio
+    async def test_health_page_counts_articles_by_type(self, db_session: AsyncSession) -> None:
+        """Health page should count articles by page_type."""
+        a1 = Article(slug="src-1", title="Source 1", file_path="/x.md", page_type=PageType.SOURCE)
+        a2 = Article(slug="ans-1", title="Answer 1", file_path="/x.md", page_type=PageType.ANSWER)
+        a3 = Article(slug="src-2", title="Source 2", file_path="/x.md", page_type=PageType.SOURCE)
+        db_session.add_all([a1, a2, a3])
+        await db_session.commit()
+
+        path = await generate_meta_health_page(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "| Source | 2 |" in content
+        assert "| Answer | 1 |" in content
+        assert "**Total** | **3**" in content
+
+    @pytest.mark.anyio
+    async def test_health_page_counts_orphans(self, db_session: AsyncSession) -> None:
+        """Health page should count articles with no links as orphans."""
+        a1 = Article(slug="linked", title="Linked", file_path="/x.md")
+        a2 = Article(slug="orphan", title="Orphan", file_path="/x.md")
+        db_session.add_all([a1, a2])
+        await db_session.flush()
+
+        bl = Backlink(source_article_id=a1.id, target_article_id=a1.id)
+        db_session.add(bl)
+        await db_session.commit()
+
+        path = await generate_meta_health_page(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "**1** articles with no inbound or outbound links" in content
+
+    @pytest.mark.anyio
+    async def test_health_page_counts_link_types(self, db_session: AsyncSession) -> None:
+        """Health page should count links by relation_type."""
+        a1 = Article(slug="a1", title="A1", file_path="/x.md")
+        a2 = Article(slug="a2", title="A2", file_path="/x.md")
+        db_session.add_all([a1, a2])
+        await db_session.flush()
+
+        bl1 = Backlink(source_article_id=a1.id, target_article_id=a2.id, relation_type=RelationType.REFERENCES)
+        bl2 = Backlink(source_article_id=a2.id, target_article_id=a1.id, relation_type=RelationType.CONTRADICTS)
+        db_session.add_all([bl1, bl2])
+        await db_session.commit()
+
+        path = await generate_meta_health_page(db_session)
+        content = path.read_text(encoding="utf-8")
+        assert "| contradicts | 1 |" in content
+        assert "| references | 1 |" in content
+        assert "**Total** | **2**" in content
+
+
+# ---------------------------------------------------------------------------
+# Answer page filing sets correct page_type
+# ---------------------------------------------------------------------------
+
+
+class TestAnswerPageType:
+    @pytest.mark.anyio
+    async def test_file_back_sets_answer_page_type(self, db_session: AsyncSession) -> None:
+        """When filing back a conversation, the Article should have page_type=ANSWER."""
+        from wikimind.models import Conversation, Query
+
+        conv = Conversation(title="Test conversation")
+        db_session.add(conv)
+        await db_session.flush()
+
+        q = Query(
+            question="What is X?",
+            answer="X is Y.",
+            confidence="high",
+            conversation_id=conv.id,
+            turn_index=0,
+        )
+        db_session.add(q)
+        await db_session.commit()
+
+        from wikimind.engine.qa_agent import QAAgent
+
+        agent = QAAgent()
+        article, was_update = await agent._file_back_thread(conv.id, db_session)
+        assert article.page_type == PageType.ANSWER
+        assert not was_update
+
+
+# ---------------------------------------------------------------------------
+# API response includes page_type and relation_type
+# ---------------------------------------------------------------------------
+
+
+class TestApiResponseFields:
+    def test_article_response_has_page_type(self) -> None:
+        """ArticleResponse should include page_type field."""
+        from wikimind.models import ArticleResponse
+
+        resp = ArticleResponse(
+            id="1",
+            slug="test",
+            title="Test",
+            summary=None,
+            confidence=None,
+            linter_score=None,
+            page_type=PageType.CONCEPT,
+            content="# Test",
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+        )
+        data = resp.model_dump()
+        assert data["page_type"] == "concept"
+
+    def test_backlink_entry_has_relation_type(self) -> None:
+        """BacklinkEntry should include relation_type field."""
+        from wikimind.models import BacklinkEntry
+
+        entry = BacklinkEntry(
+            id="1",
+            title="Test",
+            slug="test",
+            relation_type=RelationType.CONTRADICTS,
+            resolution="source_a_wins",
+        )
+        data = entry.model_dump()
+        assert data["relation_type"] == "contradicts"
+        assert data["resolution"] == "source_a_wins"
+
+    def test_article_summary_response_has_page_type(self) -> None:
+        """ArticleSummaryResponse should include page_type field."""
+        from wikimind.models import ArticleSummaryResponse
+
+        resp = ArticleSummaryResponse(
+            id="1",
+            slug="test",
+            title="Test",
+            summary=None,
+            confidence=None,
+            linter_score=None,
+            page_type=PageType.ANSWER,
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+        )
+        data = resp.model_dump()
+        assert data["page_type"] == "answer"

--- a/tests/unit/test_wiki_index.py
+++ b/tests/unit/test_wiki_index.py
@@ -45,11 +45,12 @@ class TestRegenerateIndexMd:
 
     @pytest.mark.anyio
     async def test_empty_database_produces_header_only(self, db_session: AsyncSession) -> None:
-        """An empty DB should produce a file with just the header."""
+        """An empty DB should produce a file with frontmatter and the header."""
         path = await regenerate_index_md(db_session)
         assert path.exists()
         content = path.read_text(encoding="utf-8")
-        assert content == _INDEX_HEADER
+        assert "page_type: index" in content
+        assert _INDEX_HEADER in content
 
     @pytest.mark.anyio
     async def test_articles_grouped_by_concept(self, db_session: AsyncSession) -> None:


### PR DESCRIPTION
## Summary

Phase 5 of the schema overhaul (#143). Adds answer page filing, typed index/meta page generation, and frontend page type support.

- **Answer pages**: Q&A file-back now sets `page_type=answer` on created Articles (both whole-conversation and selection-based file-back)
- **Index generation**: `regenerate_index_md()` writes `page_type: index` frontmatter, shows article counts by type, groups concept pages prominently
- **Meta page**: New `generate_meta_health_page()` produces `wiki/meta/wiki-health.md` with article counts by type, link counts by relation type, orphan count
- **API**: `ArticleResponse`/`ArticleSummaryResponse` include `page_type`; `BacklinkEntry` includes `relation_type` and `resolution`; `list_articles` accepts `page_type` filter
- **Frontend**: `PageTypeIndicator` badge component, concept page layout in `ArticleReader` (synthesized_from links, concept_kind), typed links in `BacklinkPanel` grouped by relation type
- **Tests**: 16 new tests covering answer page filing, index frontmatter, meta page generation, API response fields

Depends on Phase 1 model changes (PageType, RelationType enums, page_type on Article, relation_type on Backlink).

Closes #143 (Phase 5)

## Test plan

- [x] 16 new unit tests pass (test_phase5.py)
- [x] Existing wiki_index tests updated and pass (test_wiki_index.py)
- [x] Full test suite: 551 passed, 0 failed
- [x] Frontend TypeScript compiles without errors in changed files