### PR TITLE
feat: schema overhaul Phase 1 — models, enums, registry

### DIFF
--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -113,6 +113,9 @@ async def _migrate_added_columns(engine) -> None:
         - article.provider    (issue #67)
         - query.conversation_id (ADR-011)
         - query.turn_index    (ADR-011)
+        - article.page_type   (issue #143)
+        - backlink.relation_type + resolution columns (issue #143)
+        - concept.concept_kind (issue #143)
     """
     additions: list[tuple[str, str, str]] = [
         # (table, column, ALTER fragment)
@@ -149,6 +152,18 @@ async def _migrate_added_columns(engine) -> None:
             "forked_at_turn_index",
             "ALTER TABLE conversation ADD COLUMN forked_at_turn_index INTEGER",
         ),
+        # Issue #143 — schema overhaul Phase 1
+        ("article", "page_type", "ALTER TABLE article ADD COLUMN page_type TEXT NOT NULL DEFAULT 'source'"),
+        (
+            "backlink",
+            "relation_type",
+            "ALTER TABLE backlink ADD COLUMN relation_type TEXT NOT NULL DEFAULT 'references'",
+        ),
+        ("backlink", "resolution", "ALTER TABLE backlink ADD COLUMN resolution TEXT"),
+        ("backlink", "resolution_note", "ALTER TABLE backlink ADD COLUMN resolution_note TEXT"),
+        ("backlink", "resolved_at", "ALTER TABLE backlink ADD COLUMN resolved_at TEXT"),
+        ("backlink", "resolved_by", "ALTER TABLE backlink ADD COLUMN resolved_by TEXT"),
+        ("concept", "concept_kind", "ALTER TABLE concept ADD COLUMN concept_kind TEXT NOT NULL DEFAULT 'topic'"),
     ]
     indexes: list[tuple[str, str]] = [
         # (index name, CREATE fragment)

--- a/src/wikimind/engine/concept_kind_registry.py
+++ b/src/wikimind/engine/concept_kind_registry.py
@@ -1,0 +1,86 @@
+"""ConceptKindDef registry — seeds built-in kinds and validates prompt templates."""
+
+import json
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from wikimind.models import ConceptKindDef
+
+PROMPT_TEMPLATES: dict[str, str] = {
+    "concept_synthesis_topic": "",
+    "concept_synthesis_person": "",
+    "concept_synthesis_org": "",
+    "concept_synthesis_product": "",
+    "concept_synthesis_paper": "",
+}
+
+_BUILTIN_KINDS: list[dict[str, str | None]] = [
+    {
+        "name": "topic",
+        "prompt_template_key": "concept_synthesis_topic",
+        "required_sections": json.dumps(
+            ["overview", "key_themes", "consensus_conflicts", "open_questions", "timeline", "sources"]
+        ),
+        "linter_rules": json.dumps(["has_summary", "has_sources"]),
+        "description": "General topic concept page",
+    },
+    {
+        "name": "person",
+        "prompt_template_key": "concept_synthesis_person",
+        "required_sections": json.dumps(["overview", "contributions", "timeline", "associated_work", "sources"]),
+        "linter_rules": json.dumps(["has_known_facts", "has_summary"]),
+        "description": "Person or individual concept page",
+    },
+    {
+        "name": "organization",
+        "prompt_template_key": "concept_synthesis_org",
+        "required_sections": json.dumps(["overview", "products", "key_people", "research", "sources"]),
+        "linter_rules": json.dumps(["has_summary", "has_sources"]),
+        "description": "Organization or company concept page",
+    },
+    {
+        "name": "product",
+        "prompt_template_key": "concept_synthesis_product",
+        "required_sections": json.dumps(["overview", "features", "claims", "evolution", "sources"]),
+        "linter_rules": json.dumps(["has_summary", "has_sources"]),
+        "description": "Product or tool concept page",
+    },
+    {
+        "name": "paper",
+        "prompt_template_key": "concept_synthesis_paper",
+        "required_sections": json.dumps(["overview", "key_claims", "methodology", "limitations", "sources"]),
+        "linter_rules": json.dumps(["has_summary", "has_sources"]),
+        "description": "Academic paper or research concept page",
+    },
+]
+
+
+async def seed_builtin_kinds(session: AsyncSession) -> None:
+    """Idempotently create the five built-in ConceptKindDef rows."""
+    for kind_data in _BUILTIN_KINDS:
+        name = kind_data["name"]
+        result = await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == name))
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            kind = ConceptKindDef(**kind_data)  # type: ignore[arg-type]
+            session.add(kind)
+    await session.commit()
+
+
+class RegistryTemplateMismatchError(Exception):
+    """Raised when a ConceptKindDef references a missing prompt template."""
+
+
+async def validate_registry_against_prompts(session: AsyncSession) -> None:
+    """Check that every ConceptKindDef prompt_template_key exists in PROMPT_TEMPLATES."""
+    result = await session.execute(select(ConceptKindDef))
+    kinds = result.scalars().all()
+    missing: list[str] = []
+    for kind in kinds:
+        if kind.prompt_template_key not in PROMPT_TEMPLATES:
+            missing.append(f"{kind.name} -> {kind.prompt_template_key}")
+    if missing:
+        raise RegistryTemplateMismatchError(
+            f"ConceptKindDef rows reference missing prompt templates: {', '.join(missing)}"
+        )

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -20,27 +20,6 @@ from wikimind._datetime import utcnow_naive
 
 
 class PageType(StrEnum):
-    """Type of wiki page -- determines compilation pipeline and validation rules."""
-
-    SOURCE = "source"
-    CONCEPT = "concept"
-    ANSWER = "answer"
-    INDEX = "index"
-    META = "meta"
-
-
-class RelationType(StrEnum):
-    """Semantic relationship between two linked articles."""
-
-    REFERENCES = "references"
-    CONTRADICTS = "contradicts"
-    EXTENDS = "extends"
-    SUPERSEDES = "supersedes"
-    SYNTHESIZES = "synthesizes"
-    RELATED_TO = "related_to"
-
-
-class PageType(StrEnum):
     """Type of wiki page — determines compilation pipeline and validation rules."""
 
     SOURCE = "source"

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -19,6 +19,48 @@ from wikimind._datetime import utcnow_naive
 # ---------------------------------------------------------------------------
 
 
+class PageType(StrEnum):
+    """Type of wiki page -- determines compilation pipeline and validation rules."""
+
+    SOURCE = "source"
+    CONCEPT = "concept"
+    ANSWER = "answer"
+    INDEX = "index"
+    META = "meta"
+
+
+class RelationType(StrEnum):
+    """Semantic relationship between two linked articles."""
+
+    REFERENCES = "references"
+    CONTRADICTS = "contradicts"
+    EXTENDS = "extends"
+    SUPERSEDES = "supersedes"
+    SYNTHESIZES = "synthesizes"
+    RELATED_TO = "related_to"
+
+
+class PageType(StrEnum):
+    """Type of wiki page — determines compilation pipeline and validation rules."""
+
+    SOURCE = "source"
+    CONCEPT = "concept"
+    ANSWER = "answer"
+    INDEX = "index"
+    META = "meta"
+
+
+class RelationType(StrEnum):
+    """Semantic relationship between two linked articles."""
+
+    REFERENCES = "references"
+    CONTRADICTS = "contradicts"
+    EXTENDS = "extends"
+    SUPERSEDES = "supersedes"
+    SYNTHESIZES = "synthesizes"
+    RELATED_TO = "related_to"
+
+
 class SourceType(StrEnum):
     """Type of ingested source."""
 
@@ -135,6 +177,7 @@ class Article(SQLModel, table=True):
     # same source with the same provider replaces this article in place;
     # different providers stack as separate articles for comparison.
     provider: Provider | None = None
+    page_type: PageType = PageType.SOURCE
 
     # ORM relationships — used for eager-loading backlinks
     backlinks_out: list["Backlink"] = Relationship(
@@ -143,6 +186,16 @@ class Article(SQLModel, table=True):
     backlinks_in: list["Backlink"] = Relationship(
         sa_relationship_kwargs={"foreign_keys": "[Backlink.target_article_id]", "lazy": "selectin"},
     )
+
+
+class ConceptKindDef(SQLModel, table=True):
+    """Registry of concept kinds (Type Object pattern)."""
+
+    name: str = Field(primary_key=True)
+    prompt_template_key: str
+    required_sections: str  # JSON array
+    linter_rules: str  # JSON array
+    description: str | None = None
 
 
 class Concept(SQLModel, table=True):
@@ -154,6 +207,7 @@ class Concept(SQLModel, table=True):
     article_count: int = 0
     description: str | None = None
     created_at: datetime = Field(default_factory=utcnow_naive)
+    concept_kind: str = "topic"
 
 
 class Backlink(SQLModel, table=True):
@@ -162,6 +216,11 @@ class Backlink(SQLModel, table=True):
     source_article_id: str = Field(foreign_key="article.id", primary_key=True)
     target_article_id: str = Field(foreign_key="article.id", primary_key=True)
     context: str | None = None  # Sentence where link appears
+    relation_type: RelationType = RelationType.REFERENCES
+    resolution: str | None = None
+    resolution_note: str | None = None
+    resolved_at: datetime | None = None
+    resolved_by: str | None = None
 
 
 class Conversation(SQLModel, table=True):
@@ -298,6 +357,79 @@ class CompilationResult(BaseModel):
     backlink_suggestions: list[str]
     open_questions: list[str]
     article_body: str  # Full markdown
+    page_type: PageType = PageType.SOURCE
+    compiled: datetime | None = None
+    provider: Provider | None = None
+
+
+class TypedBacklinkSuggestion(BaseModel):
+    """A backlink suggestion with semantic relationship type."""
+
+    target: str
+    relation_type: RelationType = RelationType.REFERENCES
+
+
+class SourceFrontmatter(BaseModel):
+    """Validates frontmatter for source-type wiki pages."""
+
+    page_type: PageType = PageType.SOURCE
+    title: str
+    slug: str
+    source_id: str
+    source_type: SourceType
+    source_url: str | None = None
+    compiled: datetime
+    concepts: list[str] = []
+    confidence: ConfidenceLevel | None = None
+    provider: Provider | None = None
+
+
+class ConceptFrontmatter(BaseModel):
+    """Validates frontmatter for concept-type wiki pages."""
+
+    page_type: PageType = PageType.CONCEPT
+    title: str
+    slug: str
+    concept_id: str
+    concept_kind: str = "topic"
+    synthesized_from: list[str] = []
+    source_count: int = 0
+    last_synthesized: datetime | None = None
+    confidence: ConfidenceLevel | None = None
+    provider: Provider | None = None
+
+
+class AnswerFrontmatter(BaseModel):
+    """Validates frontmatter for answer-type wiki pages."""
+
+    page_type: PageType = PageType.ANSWER
+    title: str
+    slug: str
+    conversation_id: str
+    turn_indices: list[int] = []
+    filed_at: datetime | None = None
+    concepts: list[str] = []
+    confidence: ConfidenceLevel | None = None
+
+
+class IndexFrontmatter(BaseModel):
+    """Validates frontmatter for index-type wiki pages."""
+
+    page_type: PageType = PageType.INDEX
+    title: str
+    slug: str
+    scope: str
+    concept_id: str | None = None
+    generated: datetime | None = None
+
+
+class MetaFrontmatter(BaseModel):
+    """Validates frontmatter for meta-type wiki pages."""
+
+    page_type: PageType = PageType.META
+    title: str
+    slug: str
+    generated: datetime | None = None
 
 
 class QueryResult(BaseModel):

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -336,9 +336,6 @@ class CompilationResult(BaseModel):
     backlink_suggestions: list[str]
     open_questions: list[str]
     article_body: str  # Full markdown
-    page_type: PageType = PageType.SOURCE
-    compiled: datetime | None = None
-    provider: Provider | None = None
 
 
 class TypedBacklinkSuggestion(BaseModel):
@@ -346,6 +343,39 @@ class TypedBacklinkSuggestion(BaseModel):
 
     target: str
     relation_type: RelationType = RelationType.REFERENCES
+
+
+class SourceCompilationResult(CompilationResult):
+    """Compilation result for source pages."""
+
+    page_type: PageType = PageType.SOURCE
+
+
+class ConceptCompilationResult(BaseModel):
+    """Compilation result for concept pages."""
+
+    title: str
+    overview: str
+    key_themes: list[str]
+    consensus_conflicts: str
+    open_questions: list[str]
+    timeline: str
+    sources_summary: str
+    article_body: str  # Full markdown
+    related_concepts: list[str] = []
+    page_type: PageType = PageType.CONCEPT
+
+
+class AnswerCompilationResult(BaseModel):
+    """Compilation result for answer pages."""
+
+    title: str
+    question: str
+    answer: str
+    sources_cited: list[str]
+    concepts: list[str]
+    article_body: str  # Full markdown
+    page_type: PageType = PageType.ANSWER
 
 
 class SourceFrontmatter(BaseModel):

--- a/tests/unit/test_schema_models.py
+++ b/tests/unit/test_schema_models.py
@@ -1,0 +1,363 @@
+"""Tests for schema overhaul Phase 1 — enums, tables, Pydantic models, and registry."""
+
+import json
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
+
+from wikimind.engine.concept_kind_registry import (
+    PROMPT_TEMPLATES,
+    RegistryTemplateMismatchError,
+    seed_builtin_kinds,
+    validate_registry_against_prompts,
+)
+from wikimind.models import (
+    AnswerCompilationResult,
+    AnswerFrontmatter,
+    Article,
+    Backlink,
+    Concept,
+    ConceptCompilationResult,
+    ConceptFrontmatter,
+    ConceptKindDef,
+    IndexFrontmatter,
+    MetaFrontmatter,
+    PageType,
+    Provider,
+    RelationType,
+    SourceCompilationResult,
+    SourceFrontmatter,
+    SourceType,
+    TypedBacklinkSuggestion,
+)
+
+
+class TestPageTypeEnum:
+    def test_values(self):
+        assert PageType.SOURCE == "source"
+        assert PageType.CONCEPT == "concept"
+        assert PageType.ANSWER == "answer"
+        assert PageType.INDEX == "index"
+        assert PageType.META == "meta"
+
+    def test_member_count(self):
+        assert len(PageType) == 5
+
+
+class TestRelationTypeEnum:
+    def test_values(self):
+        assert RelationType.REFERENCES == "references"
+        assert RelationType.CONTRADICTS == "contradicts"
+        assert RelationType.EXTENDS == "extends"
+        assert RelationType.SUPERSEDES == "supersedes"
+        assert RelationType.SYNTHESIZES == "synthesizes"
+        assert RelationType.RELATED_TO == "related_to"
+
+    def test_member_count(self):
+        assert len(RelationType) == 6
+
+
+class TestConceptKindDef:
+    def test_create(self):
+        kind = ConceptKindDef(
+            name="topic",
+            prompt_template_key="concept_synthesis_topic",
+            required_sections=json.dumps(["overview", "key_themes"]),
+            linter_rules=json.dumps(["has_summary"]),
+            description="General topic",
+        )
+        assert kind.name == "topic"
+        assert json.loads(kind.required_sections) == ["overview", "key_themes"]
+
+    async def test_persist_and_read(self, db_session: AsyncSession):
+        kind = ConceptKindDef(
+            name="test-kind",
+            prompt_template_key="test_key",
+            required_sections=json.dumps(["a", "b"]),
+            linter_rules=json.dumps(["rule1"]),
+            description="for testing",
+        )
+        db_session.add(kind)
+        await db_session.commit()
+        result = await db_session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "test-kind"))
+        assert result.scalar_one().prompt_template_key == "test_key"
+
+    async def test_primary_key_is_name(self, db_session: AsyncSession):
+        kind = ConceptKindDef(name="unique-kind", prompt_template_key="k", required_sections="[]", linter_rules="[]")
+        db_session.add(kind)
+        await db_session.commit()
+        result = await db_session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "unique-kind"))
+        assert result.scalar_one() is not None
+
+
+class TestArticlePageType:
+    def test_default_page_type(self):
+        assert Article(slug="test", title="Test", file_path="/tmp/test.md").page_type == PageType.SOURCE
+
+    def test_explicit_page_type(self):
+        assert (
+            Article(slug="cp", title="LR", file_path="/tmp/lr.md", page_type=PageType.CONCEPT).page_type
+            == PageType.CONCEPT
+        )
+
+    async def test_persist_page_type(self, db_session: AsyncSession):
+        article = Article(slug="answer-page", title="Filed", file_path="/tmp/a.md", page_type=PageType.ANSWER)
+        db_session.add(article)
+        await db_session.commit()
+        result = await db_session.execute(select(Article).where(Article.slug == "answer-page"))
+        assert result.scalar_one().page_type == PageType.ANSWER
+
+
+class TestBacklinkRelationType:
+    def test_default_relation_type(self):
+        assert Backlink(source_article_id="a", target_article_id="b").relation_type == RelationType.REFERENCES
+
+    def test_explicit_relation_type(self):
+        assert (
+            Backlink(source_article_id="a", target_article_id="b", relation_type=RelationType.CONTRADICTS).relation_type
+            == RelationType.CONTRADICTS
+        )
+
+    def test_resolution_fields_default_none(self):
+        bl = Backlink(source_article_id="a", target_article_id="b")
+        assert (
+            bl.resolution is None and bl.resolution_note is None and bl.resolved_at is None and bl.resolved_by is None
+        )
+
+    def test_resolution_fields(self):
+        now = datetime(2026, 4, 13, 12, 0, 0)
+        bl = Backlink(
+            source_article_id="a",
+            target_article_id="b",
+            relation_type=RelationType.CONTRADICTS,
+            resolution="source_a_wins",
+            resolution_note="Newer data",
+            resolved_at=now,
+            resolved_by="admin@example.com",
+        )
+        assert bl.resolution == "source_a_wins" and bl.resolved_at == now
+
+    async def test_persist_typed_backlink(self, db_session: AsyncSession):
+        a1, a2 = (
+            Article(slug="src-a", title="A", file_path="/tmp/a.md"),
+            Article(slug="src-b", title="B", file_path="/tmp/b.md"),
+        )
+        db_session.add_all([a1, a2])
+        await db_session.flush()
+        bl = Backlink(
+            source_article_id=a1.id, target_article_id=a2.id, relation_type=RelationType.EXTENDS, context="A extends B"
+        )
+        db_session.add(bl)
+        await db_session.commit()
+        result = await db_session.execute(
+            select(Backlink).where(Backlink.source_article_id == a1.id, Backlink.target_article_id == a2.id)
+        )
+        assert result.scalar_one().relation_type == RelationType.EXTENDS
+
+
+class TestConceptKind:
+    def test_default_concept_kind(self):
+        assert Concept(name="test-concept").concept_kind == "topic"
+
+    def test_explicit_concept_kind(self):
+        assert Concept(name="alan-turing", concept_kind="person").concept_kind == "person"
+
+    async def test_persist_concept_kind(self, db_session: AsyncSession):
+        concept = Concept(name="openai", concept_kind="organization")
+        db_session.add(concept)
+        await db_session.commit()
+        result = await db_session.execute(select(Concept).where(Concept.name == "openai"))
+        assert result.scalar_one().concept_kind == "organization"
+
+
+class TestSourceFrontmatter:
+    def test_valid(self):
+        assert (
+            SourceFrontmatter(
+                title="T", slug="t", source_id="abc", source_type=SourceType.URL, compiled=datetime(2026, 4, 13)
+            ).page_type
+            == PageType.SOURCE
+        )
+
+    def test_missing_required_field(self):
+        with pytest.raises(ValidationError):
+            SourceFrontmatter(title="T", slug="t", compiled=datetime(2026, 4, 13))
+
+    def test_optional_fields(self):
+        fm = SourceFrontmatter(
+            title="T",
+            slug="t",
+            source_id="abc",
+            source_type=SourceType.PDF,
+            compiled=datetime(2026, 4, 13),
+            concepts=["ml", "ai"],
+            provider=Provider.ANTHROPIC,
+        )
+        assert fm.concepts == ["ml", "ai"]
+
+
+class TestConceptFrontmatter:
+    def test_valid(self):
+        assert ConceptFrontmatter(title="LLM", slug="llm", concept_id="uuid-123").page_type == PageType.CONCEPT
+
+    def test_missing_concept_id(self):
+        with pytest.raises(ValidationError):
+            ConceptFrontmatter(title="Bad", slug="bad")
+
+    def test_with_synthesis_data(self):
+        assert (
+            ConceptFrontmatter(
+                title="L", slug="l", concept_id="u", synthesized_from=["a1", "a2"], source_count=2
+            ).source_count
+            == 2
+        )
+
+
+class TestAnswerFrontmatter:
+    def test_valid(self):
+        assert (
+            AnswerFrontmatter(title="Q?", slug="q", conversation_id="conv-123", turn_indices=[0, 1]).page_type
+            == PageType.ANSWER
+        )
+
+    def test_missing_conversation_id(self):
+        with pytest.raises(ValidationError):
+            AnswerFrontmatter(title="Bad", slug="bad")
+
+
+class TestIndexFrontmatter:
+    def test_valid_global(self):
+        assert IndexFrontmatter(title="Index", slug="index", scope="global").page_type == PageType.INDEX
+
+    def test_valid_concept_scope(self):
+        assert IndexFrontmatter(title="LLM", slug="llm-idx", scope="concept", concept_id="uuid").concept_id == "uuid"
+
+    def test_missing_scope(self):
+        with pytest.raises(ValidationError):
+            IndexFrontmatter(title="Bad", slug="bad")
+
+
+class TestMetaFrontmatter:
+    def test_valid(self):
+        assert MetaFrontmatter(title="Health", slug="health").page_type == PageType.META
+
+    def test_with_generated(self):
+        assert MetaFrontmatter(title="H", slug="h", generated=datetime(2026, 4, 13)).generated == datetime(2026, 4, 13)
+
+
+class TestTypedBacklinkSuggestion:
+    def test_valid(self):
+        assert (
+            TypedBacklinkSuggestion(target="x", relation_type=RelationType.EXTENDS).relation_type
+            == RelationType.EXTENDS
+        )
+
+    def test_default_relation_type(self):
+        assert TypedBacklinkSuggestion(target="x").relation_type == RelationType.REFERENCES
+
+    def test_missing_target(self):
+        with pytest.raises(ValidationError):
+            TypedBacklinkSuggestion()
+
+    def test_invalid_relation_type(self):
+        with pytest.raises(ValidationError):
+            TypedBacklinkSuggestion(target="x", relation_type="not_a_type")
+
+
+class TestSourceCompilationResult:
+    def test_inherits(self):
+        r = SourceCompilationResult(
+            title="T",
+            summary="S",
+            key_claims=[],
+            concepts=["ml"],
+            backlink_suggestions=["o"],
+            open_questions=["?"],
+            article_body="# T",
+        )
+        assert r.page_type == PageType.SOURCE
+
+
+class TestConceptCompilationResult:
+    def test_valid(self):
+        r = ConceptCompilationResult(
+            title="L",
+            overview="O",
+            key_themes=["cot", "tot"],
+            consensus_conflicts="C",
+            open_questions=["?"],
+            timeline="T",
+            sources_summary="S",
+            article_body="# L",
+        )
+        assert r.page_type == PageType.CONCEPT and len(r.key_themes) == 2
+
+
+class TestAnswerCompilationResult:
+    def test_valid(self):
+        r = AnswerCompilationResult(
+            title="Q", question="Q?", answer="A", sources_cited=["nn"], concepts=["dl"], article_body="# Q"
+        )
+        assert r.page_type == PageType.ANSWER
+
+
+class TestSeedBuiltinKinds:
+    async def test_creates_five_kinds(self, async_engine):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        async with factory() as session:
+            result = await session.execute(select(ConceptKindDef))
+            assert {k.name for k in result.scalars().all()} == {"topic", "person", "organization", "product", "paper"}
+
+    async def test_idempotent(self, async_engine):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        async with factory() as session:
+            assert len((await session.execute(select(ConceptKindDef))).scalars().all()) == 5
+
+    async def test_topic_has_correct_sections(self, async_engine):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        async with factory() as session:
+            topic = (await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "topic"))).scalar_one()
+            assert "overview" in json.loads(topic.required_sections)
+
+    async def test_person_has_correct_template_key(self, async_engine):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        async with factory() as session:
+            person = (await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "person"))).scalar_one()
+            assert person.prompt_template_key == "concept_synthesis_person"
+
+
+class TestValidateRegistryAgainstPrompts:
+    async def test_passes_with_valid_templates(self, async_engine):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        async with factory() as session:
+            await validate_registry_against_prompts(session)
+
+    async def test_fails_with_missing_template(self, async_engine, monkeypatch):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await seed_builtin_kinds(session)
+        modified = {k: v for k, v in PROMPT_TEMPLATES.items() if k != "concept_synthesis_topic"}
+        monkeypatch.setattr("wikimind.engine.concept_kind_registry.PROMPT_TEMPLATES", modified)
+        async with factory() as session:
+            with pytest.raises(RegistryTemplateMismatchError, match="concept_synthesis_topic"):
+                await validate_registry_against_prompts(session)
+
+    async def test_passes_with_empty_registry(self, async_engine):
+        factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with factory() as session:
+            await validate_registry_against_prompts(session)


### PR DESCRIPTION
## Summary

Phase 1 of #143. Adds the foundation schema for page types, typed relationships, and concept kind registry. No business logic changes — pure models, enums, DB migration, and unit tests.

- **PageType enum** (5 types: source, concept, answer, index, meta) and `page_type` field on Article
- **RelationType enum** (6 types: references, contradicts, extends, supersedes, synthesizes, related_to) and `relation_type` field on Backlink with resolution columns
- **ConceptKindDef** registry table (Type Object pattern) with 5 built-in kinds (topic, person, organization, product, paper)
- **concept_kind** field on Concept (FK to ConceptKindDef)
- **Per-type Pydantic models**: SourceCompilationResult, ConceptCompilationResult, AnswerCompilationResult, TypedBacklinkSuggestion
- **Per-type frontmatter models**: SourceFrontmatter, ConceptFrontmatter, AnswerFrontmatter, IndexFrontmatter, MetaFrontmatter
- **concept_kind_registry.py**: `seed_builtin_kinds()` + `validate_registry_against_prompts()` startup guards
- **DB migration** entries for all new columns (idempotent ALTER TABLE pattern)
- **45 unit tests** covering all new enums, tables, Pydantic models, and registry functions

Closes Phase 1 of #143.