### PR TITLE
feat: schema overhaul Phase 3 -- concept page compiler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,12 @@
 # WIKIMIND_EMBEDDING__CHUNK_OVERLAP_TOKENS=50
 
 # ----------------------------------------------------------------------------
+# Concept Taxonomy (optional)
+# ----------------------------------------------------------------------------
+# Minimum source articles before a concept page is auto-generated
+# WIKIMIND_TAXONOMY__CONCEPT_PAGE_MIN_SOURCES=2
+
+# ----------------------------------------------------------------------------
 # Wiki Linter (optional)
 # ----------------------------------------------------------------------------
 # Enable orphan detection (requires populated Backlink table — issue #95)

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Thumbs.db
 
 # Serena MCP tool — auto-generated per-worktree config + cache + memories
 .serena/
+.venv

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,16 +133,16 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 369
+        "line_number": 370
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 393
+        "line_number": 394
       }
     ]
   },
-  "generated_at": "2026-04-13T15:10:17Z"
+  "generated_at": "2026-04-14T15:01:59Z"
 }

--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/Users/mg/mg-work/manav/work/ai-experiments/wikimind/.venv

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/Users/mg/mg-work/manav/work/ai-experiments/wikimind/.venv

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -139,6 +139,7 @@ class TaxonomyConfig(BaseModel):
 
     rebuild_threshold: int = 5
     max_hierarchy_depth: int = 3
+    concept_page_min_sources: int = 2
 
 
 class LinterConfig(BaseModel):

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -42,6 +42,7 @@ from wikimind.models import (
 )
 from wikimind.services.activity_log import append_log_entry
 from wikimind.services.taxonomy import (
+    maybe_trigger_concept_pages,
     maybe_trigger_taxonomy_rebuild,
     update_article_counts,
     upsert_concepts,
@@ -354,6 +355,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             await upsert_concepts(result.concepts, session)
             await update_article_counts(session)
             await maybe_trigger_taxonomy_rebuild(session)
+            await maybe_trigger_concept_pages(session)
         except Exception:
             log.warning("taxonomy upsert failed", article_id=article.id)
 

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -93,6 +93,7 @@ Valid JSON only. No preamble, no markdown fences.""",
 
 
 def get_prompt_template(template_key: str) -> str | None:
+    """Look up a prompt template by key."""
     return PROMPT_TEMPLATES.get(template_key)
 
 
@@ -164,12 +165,15 @@ async def _collect_contradictions(source_article_ids: list[str], session: AsyncS
 
 
 class ConceptCompiler:
+    """Registry-driven compiler that synthesizes concept pages from source articles."""
+
     def __init__(self) -> None:
         self.router = get_llm_router()
         self.settings = get_settings()
         self._last_provider_used: Provider | None = None
 
     async def compile_concept_page(self, concept: Concept, session: AsyncSession) -> Article | None:
+        """Compile a concept page by synthesizing all source articles tagged with this concept."""
         kind_def = await self._load_kind_def(concept.concept_kind, session)
         if kind_def is None:
             kind_def = await self._load_kind_def("topic", session)
@@ -196,7 +200,10 @@ class ConceptCompiler:
         request = CompletionRequest(
             system=prompt,
             messages=[{"role": "user", "content": "Synthesize a concept page from these sources."}],
-            max_tokens=8192, temperature=0.3, response_format="json", task_type=TaskType.COMPILE,
+            max_tokens=8192,
+            temperature=0.3,
+            response_format="json",
+            task_type=TaskType.COMPILE,
         )
         try:
             response = await self.router.complete(request, session=session)
@@ -214,8 +221,13 @@ class ConceptCompiler:
         result = await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == kind_name))
         return result.scalar_one_or_none()
 
-    async def _save_concept_page(self, compilation: ConceptCompilationResult, concept: Concept,
-                                  source_articles: list[Article], session: AsyncSession) -> Article:
+    async def _save_concept_page(
+        self,
+        compilation: ConceptCompilationResult,
+        concept: Concept,
+        source_articles: list[Article],
+        session: AsyncSession,
+    ) -> Article:
         slug = slugify(concept.name)
         now = utcnow_naive()
         source_ids = [a.id for a in source_articles]
@@ -232,18 +244,27 @@ class ConceptCompiler:
             existing.updated_at = now
             existing.page_type = PageType.CONCEPT
             session.add(existing)
-            old_links = await session.execute(select(Backlink).where(
-                Backlink.source_article_id == existing.id, Backlink.relation_type == RelationType.SYNTHESIZES))
+            old_links = await session.execute(
+                select(Backlink).where(
+                    Backlink.source_article_id == existing.id, Backlink.relation_type == RelationType.SYNTHESIZES
+                )
+            )
             for bl in old_links.scalars().all():
                 await session.delete(bl)
             await session.commit()
             await session.refresh(existing)
             article = existing
         else:
-            article = Article(slug=f"concept-{slug}", title=compilation.title,
-                file_path=str(file_path), summary=compilation.overview,
-                concept_ids=json.dumps([concept.name]), source_ids=json.dumps(source_ids),
-                provider=self._last_provider_used, page_type=PageType.CONCEPT)
+            article = Article(
+                slug=f"concept-{slug}",
+                title=compilation.title,
+                file_path=str(file_path),
+                summary=compilation.overview,
+                concept_ids=json.dumps([concept.name]),
+                source_ids=json.dumps(source_ids),
+                provider=self._last_provider_used,
+                page_type=PageType.CONCEPT,
+            )
             session.add(article)
             await session.commit()
             await session.refresh(article)
@@ -253,12 +274,14 @@ class ConceptCompiler:
 
     async def _find_existing_concept_article(self, concept_name: str, session: AsyncSession) -> Article | None:
         slug = f"concept-{slugify(concept_name)}"
-        result = await session.execute(select(Article).where(
-            Article.slug == slug, Article.page_type == PageType.CONCEPT))
+        result = await session.execute(
+            select(Article).where(Article.slug == slug, Article.page_type == PageType.CONCEPT)
+        )
         return result.scalar_one_or_none()
 
-    def _write_concept_file(self, compilation: ConceptCompilationResult, concept: Concept,
-                            source_articles: list[Article]) -> Path:
+    def _write_concept_file(
+        self, compilation: ConceptCompilationResult, concept: Concept, source_articles: list[Article]
+    ) -> Path:
         wiki_dir = Path(self.settings.data_dir) / "wiki"
         slug = slugify(concept.name)
         concept_dir = wiki_dir / slug
@@ -321,19 +344,25 @@ provider: {self._last_provider_used or "unknown"}
         file_path.write_text(content, encoding="utf-8")
         return file_path
 
-    async def _create_synthesizes_links(self, concept_article_id: str, source_article_ids: list[str],
-                                         session: AsyncSession) -> None:
+    async def _create_synthesizes_links(
+        self, concept_article_id: str, source_article_ids: list[str], session: AsyncSession
+    ) -> None:
         for source_id in source_article_ids:
-            bl = Backlink(source_article_id=concept_article_id, target_article_id=source_id,
-                relation_type=RelationType.SYNTHESIZES, context="Concept page synthesizes from source article")
+            bl = Backlink(
+                source_article_id=concept_article_id,
+                target_article_id=source_id,
+                relation_type=RelationType.SYNTHESIZES,
+                context="Concept page synthesizes from source article",
+            )
             session.add(bl)
             try:
                 await session.commit()
             except IntegrityError:
                 await session.rollback()
 
-    async def _create_related_to_links(self, concept_article: Article, related_concepts: list[str],
-                                        session: AsyncSession) -> None:
+    async def _create_related_to_links(
+        self, concept_article: Article, related_concepts: list[str], session: AsyncSession
+    ) -> None:
         if not related_concepts:
             return
         for related_name in related_concepts:
@@ -341,15 +370,19 @@ provider: {self._last_provider_used or "unknown"}
             if not normalized:
                 continue
             target_slug = f"concept-{normalized}"
-            result = await session.execute(select(Article).where(
-                Article.slug == target_slug, Article.page_type == PageType.CONCEPT))
+            result = await session.execute(
+                select(Article).where(Article.slug == target_slug, Article.page_type == PageType.CONCEPT)
+            )
             target = result.scalar_one_or_none()
             if target is None:
                 continue
             for src_id, tgt_id in [(concept_article.id, target.id), (target.id, concept_article.id)]:
-                bl = Backlink(source_article_id=src_id, target_article_id=tgt_id,
+                bl = Backlink(
+                    source_article_id=src_id,
+                    target_article_id=tgt_id,
                     relation_type=RelationType.RELATED_TO,
-                    context=f"Related: {concept_article.title} <-> {target.title}")
+                    context=f"Related: {concept_article.title} <-> {target.title}",
+                )
                 session.add(bl)
                 try:
                     await session.commit()

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -1,0 +1,357 @@
+"""Registry-driven concept page compiler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+from slugify import slugify
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
+from wikimind.engine.llm_router import get_llm_router
+from wikimind.models import (
+    Article,
+    Backlink,
+    CompletionRequest,
+    Concept,
+    ConceptCompilationResult,
+    ConceptKindDef,
+    PageType,
+    Provider,
+    RelationType,
+    TaskType,
+)
+
+log = structlog.get_logger()
+
+PROMPT_TEMPLATES: dict[str, str] = {
+    "concept_synthesis_topic": """You are synthesizing a concept page for a personal knowledge wiki.
+The concept is "{concept_name}" ({concept_description}).
+Below are summaries from {source_count} source articles tagged with this concept.
+
+{source_material}
+
+{contradiction_section}
+
+Produce a synthesis: Overview, Key Themes (JSON list), Consensus & Conflicts,
+Open Questions (JSON list), Timeline, Sources Summary, Article Body (## headings, 300+ words),
+Related Concepts (JSON list).
+
+Output as JSON:
+{{"title": "string", "overview": "string", "key_themes": ["string"],
+"consensus_conflicts": "string", "open_questions": ["string"],
+"timeline": "string", "sources_summary": "string",
+"article_body": "string", "related_concepts": ["string"]}}
+
+Valid JSON only. No preamble, no markdown fences.""",
+    "concept_synthesis_person": """You are synthesizing a concept page about a person.
+The person is "{concept_name}" ({concept_description}).
+Below are summaries from {source_count} source articles.
+
+{source_material}
+
+{contradiction_section}
+
+Produce a synthesis with the same JSON schema as above.
+Valid JSON only. No preamble, no markdown fences.""",
+    "concept_synthesis_org": """You are synthesizing a concept page about an organization.
+The organization is "{concept_name}" ({concept_description}).
+Below are summaries from {source_count} source articles.
+
+{source_material}
+
+{contradiction_section}
+
+Produce a synthesis with the same JSON schema as above.
+Valid JSON only. No preamble, no markdown fences.""",
+    "concept_synthesis_product": """You are synthesizing a concept page about a product.
+The product is "{concept_name}" ({concept_description}).
+Below are summaries from {source_count} source articles.
+
+{source_material}
+
+{contradiction_section}
+
+Produce a synthesis with the same JSON schema as above.
+Valid JSON only. No preamble, no markdown fences.""",
+    "concept_synthesis_paper": """You are synthesizing a concept page about a research paper.
+The paper is "{concept_name}" ({concept_description}).
+Below are summaries from {source_count} source articles.
+
+{source_material}
+
+{contradiction_section}
+
+Produce a synthesis with the same JSON schema as above.
+Valid JSON only. No preamble, no markdown fences.""",
+}
+
+
+def get_prompt_template(template_key: str) -> str | None:
+    return PROMPT_TEMPLATES.get(template_key)
+
+
+async def _collect_source_articles(concept_name: str, session: AsyncSession) -> list[Article]:
+    normalized = slugify(concept_name)
+    result = await session.execute(select(Article))
+    articles: list[Article] = []
+    for article in result.scalars().all():
+        if article.page_type != PageType.SOURCE:
+            continue
+        if not article.concept_ids:
+            continue
+        try:
+            concept_ids = json.loads(article.concept_ids)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(concept_ids, list):
+            continue
+        for cid in concept_ids:
+            if slugify(str(cid)) == normalized:
+                articles.append(article)
+                break
+    return articles
+
+
+def _build_source_material(articles: list[Article]) -> str:
+    parts: list[str] = []
+    for i, article in enumerate(articles, 1):
+        section = f"### Source {i}: {article.title}\n"
+        if article.summary:
+            section += f"Summary: {article.summary}\n"
+        try:
+            fc = Path(article.file_path).read_text(encoding="utf-8")
+            if len(fc) > 5000:
+                fc = fc[:5000] + "\n[...truncated...]"
+            section += f"\nContent:\n{fc}\n"
+        except (OSError, ValueError):
+            pass
+        parts.append(section)
+    return "\n---\n".join(parts)
+
+
+async def _collect_contradictions(source_article_ids: list[str], session: AsyncSession) -> str:
+    if not source_article_ids:
+        return ""
+    result = await session.execute(
+        select(Backlink).where(
+            Backlink.relation_type == RelationType.CONTRADICTS,
+            Backlink.source_article_id.in_(source_article_ids),  # type: ignore[union-attr]
+            Backlink.target_article_id.in_(source_article_ids),  # type: ignore[union-attr]
+        )
+    )
+    contradictions = list(result.scalars().all())
+    if not contradictions:
+        return ""
+    lines: list[str] = ["Known contradictions between sources:"]
+    for bl in contradictions:
+        line = f"- Article {bl.source_article_id} vs {bl.target_article_id}"
+        if bl.context:
+            line += f": {bl.context}"
+        if bl.resolution:
+            line += f" [RESOLVED: {bl.resolution}]"
+            if bl.resolution_note:
+                line += f" -- {bl.resolution_note}"
+        else:
+            line += " [UNRESOLVED]"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+class ConceptCompiler:
+    def __init__(self) -> None:
+        self.router = get_llm_router()
+        self.settings = get_settings()
+        self._last_provider_used: Provider | None = None
+
+    async def compile_concept_page(self, concept: Concept, session: AsyncSession) -> Article | None:
+        kind_def = await self._load_kind_def(concept.concept_kind, session)
+        if kind_def is None:
+            kind_def = await self._load_kind_def("topic", session)
+            if kind_def is None:
+                return None
+        template = get_prompt_template(kind_def.prompt_template_key)
+        if template is None:
+            return None
+        source_articles = await _collect_source_articles(concept.name, session)
+        min_sources = self.settings.taxonomy.concept_page_min_sources
+        if len(source_articles) < min_sources:
+            return None
+        source_material = _build_source_material(source_articles)
+        source_ids = [a.id for a in source_articles]
+        ct = await _collect_contradictions(source_ids, session)
+        contradiction_section = ct if ct else "No known contradictions."
+        prompt = template.format(
+            concept_name=concept.description or concept.name,
+            concept_description=concept.description or concept.name,
+            source_count=len(source_articles),
+            source_material=source_material,
+            contradiction_section=contradiction_section,
+        )
+        request = CompletionRequest(
+            system=prompt,
+            messages=[{"role": "user", "content": "Synthesize a concept page from these sources."}],
+            max_tokens=8192, temperature=0.3, response_format="json", task_type=TaskType.COMPILE,
+        )
+        try:
+            response = await self.router.complete(request, session=session)
+            self._last_provider_used = response.provider_used
+        except Exception:
+            return None
+        try:
+            data = self.router.parse_json_response(response)
+            compilation = ConceptCompilationResult(**data)
+        except Exception:
+            return None
+        return await self._save_concept_page(compilation, concept, source_articles, session)
+
+    async def _load_kind_def(self, kind_name: str, session: AsyncSession) -> ConceptKindDef | None:
+        result = await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == kind_name))
+        return result.scalar_one_or_none()
+
+    async def _save_concept_page(self, compilation: ConceptCompilationResult, concept: Concept,
+                                  source_articles: list[Article], session: AsyncSession) -> Article:
+        slug = slugify(concept.name)
+        now = utcnow_naive()
+        source_ids = [a.id for a in source_articles]
+        existing = await self._find_existing_concept_article(concept.name, session)
+        file_path = self._write_concept_file(compilation, concept, source_articles)
+        if existing is not None:
+            Path(existing.file_path).unlink(missing_ok=True)
+            existing.title = compilation.title
+            existing.summary = compilation.overview
+            existing.file_path = str(file_path)
+            existing.concept_ids = json.dumps([concept.name])
+            existing.source_ids = json.dumps(source_ids)
+            existing.provider = self._last_provider_used
+            existing.updated_at = now
+            existing.page_type = PageType.CONCEPT
+            session.add(existing)
+            old_links = await session.execute(select(Backlink).where(
+                Backlink.source_article_id == existing.id, Backlink.relation_type == RelationType.SYNTHESIZES))
+            for bl in old_links.scalars().all():
+                await session.delete(bl)
+            await session.commit()
+            await session.refresh(existing)
+            article = existing
+        else:
+            article = Article(slug=f"concept-{slug}", title=compilation.title,
+                file_path=str(file_path), summary=compilation.overview,
+                concept_ids=json.dumps([concept.name]), source_ids=json.dumps(source_ids),
+                provider=self._last_provider_used, page_type=PageType.CONCEPT)
+            session.add(article)
+            await session.commit()
+            await session.refresh(article)
+        await self._create_synthesizes_links(article.id, source_ids, session)
+        await self._create_related_to_links(article, compilation.related_concepts, session)
+        return article
+
+    async def _find_existing_concept_article(self, concept_name: str, session: AsyncSession) -> Article | None:
+        slug = f"concept-{slugify(concept_name)}"
+        result = await session.execute(select(Article).where(
+            Article.slug == slug, Article.page_type == PageType.CONCEPT))
+        return result.scalar_one_or_none()
+
+    def _write_concept_file(self, compilation: ConceptCompilationResult, concept: Concept,
+                            source_articles: list[Article]) -> Path:
+        wiki_dir = Path(self.settings.data_dir) / "wiki"
+        slug = slugify(concept.name)
+        concept_dir = wiki_dir / slug
+        concept_dir.mkdir(parents=True, exist_ok=True)
+        file_path = concept_dir / f"{slug}.md"
+        now = utcnow_naive()
+        source_ids = [a.id for a in source_articles]
+        sources_lines = [f"- [{a.title}](/wiki/{a.id})" for a in source_articles]
+        themes = "\n".join(f"- {t}" for t in compilation.key_themes)
+        questions = "\n".join(f"- {q}" for q in compilation.open_questions)
+        related = "\n".join(f"- [[{r}]]" for r in compilation.related_concepts)
+        content = f"""---
+page_type: concept
+title: "{compilation.title}"
+slug: concept-{slug}
+concept_id: {concept.id}
+concept_kind: {concept.concept_kind}
+synthesized_from: {json.dumps(source_ids)}
+source_count: {len(source_articles)}
+last_synthesized: {now.isoformat()}
+provider: {self._last_provider_used or "unknown"}
+---
+
+## Overview
+
+{compilation.overview}
+
+## Key Themes
+
+{themes}
+
+## Consensus & Conflicts
+
+{compilation.consensus_conflicts}
+
+## Open Questions
+
+{questions}
+
+## Timeline
+
+{compilation.timeline}
+
+## Analysis
+
+{compilation.article_body}
+
+## Related Concepts
+
+{related}
+
+## Sources
+
+{chr(10).join(sources_lines)}
+
+## Sources Summary
+
+{compilation.sources_summary}
+"""
+        file_path.write_text(content, encoding="utf-8")
+        return file_path
+
+    async def _create_synthesizes_links(self, concept_article_id: str, source_article_ids: list[str],
+                                         session: AsyncSession) -> None:
+        for source_id in source_article_ids:
+            bl = Backlink(source_article_id=concept_article_id, target_article_id=source_id,
+                relation_type=RelationType.SYNTHESIZES, context="Concept page synthesizes from source article")
+            session.add(bl)
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()
+
+    async def _create_related_to_links(self, concept_article: Article, related_concepts: list[str],
+                                        session: AsyncSession) -> None:
+        if not related_concepts:
+            return
+        for related_name in related_concepts:
+            normalized = slugify(related_name)
+            if not normalized:
+                continue
+            target_slug = f"concept-{normalized}"
+            result = await session.execute(select(Article).where(
+                Article.slug == target_slug, Article.page_type == PageType.CONCEPT))
+            target = result.scalar_one_or_none()
+            if target is None:
+                continue
+            for src_id, tgt_id in [(concept_article.id, target.id), (target.id, concept_article.id)]:
+                bl = Backlink(source_article_id=src_id, target_article_id=tgt_id,
+                    relation_type=RelationType.RELATED_TO,
+                    context=f"Related: {concept_article.title} <-> {target.title}")
+                session.add(bl)
+                try:
+                    await session.commit()
+                except IntegrityError:
+                    await session.rollback()

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -142,8 +142,8 @@ async def _collect_contradictions(source_article_ids: list[str], session: AsyncS
     result = await session.execute(
         select(Backlink).where(
             Backlink.relation_type == RelationType.CONTRADICTS,
-            Backlink.source_article_id.in_(source_article_ids),  # type: ignore[union-attr]
-            Backlink.target_article_id.in_(source_article_ids),  # type: ignore[union-attr]
+            Backlink.source_article_id.in_(source_article_ids),  # type: ignore[attr-defined]
+            Backlink.target_article_id.in_(source_article_ids),  # type: ignore[attr-defined]
         )
     )
     contradictions = list(result.scalars().all())

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -336,9 +336,6 @@ class CompilationResult(BaseModel):
     backlink_suggestions: list[str]
     open_questions: list[str]
     article_body: str  # Full markdown
-    page_type: PageType = PageType.SOURCE
-    compiled: datetime | None = None
-    provider: Provider | None = None
 
 
 class TypedBacklinkSuggestion(BaseModel):
@@ -346,6 +343,39 @@ class TypedBacklinkSuggestion(BaseModel):
 
     target: str
     relation_type: RelationType = RelationType.REFERENCES
+
+
+class SourceCompilationResult(CompilationResult):
+    """Compilation result for source pages."""
+
+    page_type: PageType = PageType.SOURCE
+
+
+class ConceptCompilationResult(BaseModel):
+    """Compilation result for concept pages."""
+
+    title: str
+    overview: str
+    key_themes: list[str]
+    consensus_conflicts: str
+    open_questions: list[str]
+    timeline: str
+    sources_summary: str
+    article_body: str  # Full markdown
+    related_concepts: list[str] = []
+    page_type: PageType = PageType.CONCEPT
+
+
+class AnswerCompilationResult(BaseModel):
+    """Compilation result for answer pages."""
+
+    title: str
+    question: str
+    answer: str
+    sources_cited: list[str]
+    concepts: list[str]
+    article_body: str  # Full markdown
+    page_type: PageType = PageType.ANSWER
 
 
 class SourceFrontmatter(BaseModel):

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -336,6 +336,10 @@ class CompilationResult(BaseModel):
     backlink_suggestions: list[str]
     open_questions: list[str]
     article_body: str  # Full markdown
+    # System-controlled fields — overwritten by Python after LLM response
+    page_type: PageType = PageType.SOURCE
+    compiled: datetime | None = None
+    provider: Provider | None = None
 
 
 class TypedBacklinkSuggestion(BaseModel):
@@ -439,39 +443,6 @@ class MetaFrontmatter(BaseModel):
     title: str
     slug: str
     generated: datetime | None = None
-
-
-class SourceCompilationResult(CompilationResult):
-    """Compilation result for source pages."""
-
-    page_type: PageType = PageType.SOURCE
-
-
-class ConceptCompilationResult(BaseModel):
-    """Compilation result for concept pages."""
-
-    title: str
-    overview: str
-    key_themes: list[str]
-    consensus_conflicts: str
-    open_questions: list[str]
-    timeline: str
-    sources_summary: str
-    article_body: str  # Full markdown
-    related_concepts: list[str] = []
-    page_type: PageType = PageType.CONCEPT
-
-
-class AnswerCompilationResult(BaseModel):
-    """Compilation result for answer pages."""
-
-    title: str
-    question: str
-    answer: str
-    sources_cited: list[str]
-    concepts: list[str]
-    article_body: str  # Full markdown
-    page_type: PageType = PageType.ANSWER
 
 
 class QueryResult(BaseModel):

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -132,6 +132,23 @@ async def update_article_counts(session: AsyncSession) -> None:
     await session.commit()
 
 
+async def maybe_trigger_concept_pages(session: AsyncSession) -> list[str]:
+    settings = get_settings()
+    min_sources = settings.taxonomy.concept_page_min_sources
+    result = await session.execute(select(Concept).where(Concept.article_count >= min_sources))
+    eligible = list(result.scalars().all())
+    if not eligible: return []
+    from wikimind.engine.concept_compiler import ConceptCompiler
+    compiler = ConceptCompiler()
+    compiled: list[str] = []
+    for concept in eligible:
+        try:
+            article = await compiler.compile_concept_page(concept, session)
+            if article is not None: compiled.append(concept.name)
+        except Exception: log.warning("Concept page compilation failed", concept=concept.name, exc_info=True)
+    return compiled
+
+
 async def maybe_trigger_taxonomy_rebuild(session: AsyncSession) -> bool:
     """Trigger a taxonomy rebuild if unparented concepts exceed the threshold.
 

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -133,19 +133,24 @@ async def update_article_counts(session: AsyncSession) -> None:
 
 
 async def maybe_trigger_concept_pages(session: AsyncSession) -> list[str]:
+    """Generate concept pages for concepts with enough source articles."""
     settings = get_settings()
     min_sources = settings.taxonomy.concept_page_min_sources
     result = await session.execute(select(Concept).where(Concept.article_count >= min_sources))
     eligible = list(result.scalars().all())
-    if not eligible: return []
-    from wikimind.engine.concept_compiler import ConceptCompiler
+    if not eligible:
+        return []
+    from wikimind.engine.concept_compiler import ConceptCompiler  # noqa: PLC0415
+
     compiler = ConceptCompiler()
     compiled: list[str] = []
     for concept in eligible:
         try:
             article = await compiler.compile_concept_page(concept, session)
-            if article is not None: compiled.append(concept.name)
-        except Exception: log.warning("Concept page compilation failed", concept=concept.name, exc_info=True)
+            if article is not None:
+                compiled.append(concept.name)
+        except Exception:
+            log.warning("Concept page compilation failed", concept=concept.name, exc_info=True)
     return compiled
 
 

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -1,0 +1,237 @@
+"""Tests for the registry-driven concept page compiler."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+import pytest
+from sqlmodel import select
+from wikimind.engine.concept_compiler import (
+    ConceptCompiler, PROMPT_TEMPLATES, _collect_contradictions,
+    _collect_source_articles, get_prompt_template,
+)
+from wikimind.models import (
+    Article, Backlink, CompletionResponse, Concept, ConceptCompilationResult,
+    ConceptKindDef, PageType, Provider, RelationType,
+)
+
+def _fake_resp(name="Test"):
+    return json.dumps({"title": name, "overview": "Overview.", "key_themes": ["t1", "t2"],
+        "consensus_conflicts": "Agreement.", "open_questions": ["Q?"],
+        "timeline": "Evolved.", "sources_summary": "S1 did X. S2 did Y.",
+        "article_body": "## Analysis\n\nBody. " * 20, "related_concepts": ["rel"]})
+
+async def _seed_kind(s, name="topic"):
+    k = ConceptKindDef(name=name, prompt_template_key=f"concept_synthesis_{name}",
+        required_sections=json.dumps(["overview"]), linter_rules=json.dumps(["has_summary"]))
+    s.add(k); await s.commit(); return k
+
+async def _mk_art(s, tp, slug, title, concepts, summary="Sum."):
+    d = tp / "wiki" / "test"; d.mkdir(parents=True, exist_ok=True)
+    fp = d / f"{slug}.md"; fp.write_text(f"# {title}\n{summary}", encoding="utf-8")
+    a = Article(slug=slug, title=title, file_path=str(fp), summary=summary,
+        concept_ids=json.dumps(concepts), page_type=PageType.SOURCE)
+    s.add(a); await s.commit(); await s.refresh(a); return a
+
+class TestPromptTemplates:
+    def test_all_exist(self):
+        for k in ["topic", "person", "org", "product", "paper"]:
+            assert get_prompt_template(f"concept_synthesis_{k}") is not None
+    def test_unknown_none(self):
+        assert get_prompt_template("nope") is None
+    def test_placeholders(self):
+        for k, t in PROMPT_TEMPLATES.items():
+            assert "{concept_name}" in t and "{source_material}" in t
+
+@pytest.mark.asyncio
+class TestCollectSourceArticles:
+    async def test_collects_matching(self, db_session, tmp_path):
+        a1 = await _mk_art(db_session, tmp_path, "a1", "A1", ["ml", "ai"])
+        a2 = await _mk_art(db_session, tmp_path, "a2", "A2", ["ml"])
+        await _mk_art(db_session, tmp_path, "a3", "A3", ["bio"])
+        r = await _collect_source_articles("ml", db_session)
+        assert {x.id for x in r} == {a1.id, a2.id}
+    async def test_excludes_concept(self, db_session, tmp_path):
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        d = tmp_path / "wiki" / "ml"; d.mkdir(parents=True, exist_ok=True)
+        fp = d / "c.md"; fp.write_text("# C", encoding="utf-8")
+        ca = Article(slug="concept-ml", title="ML", file_path=str(fp),
+            concept_ids=json.dumps(["ml"]), page_type=PageType.CONCEPT)
+        db_session.add(ca); await db_session.commit()
+        r = await _collect_source_articles("ml", db_session)
+        assert len(r) == 1 and r[0].page_type == PageType.SOURCE
+    async def test_normalized(self, db_session, tmp_path):
+        await _mk_art(db_session, tmp_path, "a1", "A1", ["Machine Learning"])
+        assert len(await _collect_source_articles("machine-learning", db_session)) == 1
+
+@pytest.mark.asyncio
+class TestSynthesizesLinks:
+    async def test_creates(self, db_session, tmp_path):
+        await _seed_kind(db_session)
+        a1 = await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        a2 = await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        c = Concept(name="ml", description="ML", concept_kind="topic")
+        db_session.add(c); await db_session.commit()
+        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
+            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
+        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        mr.parse_json_response = lambda r: json.loads(r.content)
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+            art = await ConceptCompiler().compile_concept_page(c, db_session)
+        assert art is not None and art.page_type == PageType.CONCEPT
+        res = await db_session.execute(select(Backlink).where(
+            Backlink.source_article_id == art.id, Backlink.relation_type == RelationType.SYNTHESIZES))
+        links = list(res.scalars().all())
+        assert len(links) == 2
+        assert {bl.target_article_id for bl in links} == {a1.id, a2.id}
+
+@pytest.mark.asyncio
+class TestConceptPageOutput:
+    async def test_writes_md(self, db_session, tmp_path):
+        await _seed_kind(db_session)
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        c = Concept(name="ml", description="ML", concept_kind="topic")
+        db_session.add(c); await db_session.commit()
+        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
+            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
+        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        mr.parse_json_response = lambda r: json.loads(r.content)
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+            art = await ConceptCompiler().compile_concept_page(c, db_session)
+        assert art is not None
+        content = Path(art.file_path).read_text(encoding="utf-8")
+        assert "page_type: concept" in content
+        for s in ["## Overview", "## Key Themes", "## Consensus & Conflicts",
+                   "## Open Questions", "## Timeline", "## Sources"]:
+            assert s in content
+
+@pytest.mark.asyncio
+class TestTriggerThreshold:
+    async def test_below_min(self, db_session, tmp_path):
+        await _seed_kind(db_session)
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        c = Concept(name="ml", description="ML", concept_kind="topic")
+        db_session.add(c); await db_session.commit()
+        mr = AsyncMock()
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+            assert await ConceptCompiler().compile_concept_page(c, db_session) is None
+        mr.complete.assert_not_called()
+    async def test_at_min(self, db_session, tmp_path):
+        await _seed_kind(db_session)
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        c = Concept(name="ml", description="ML", concept_kind="topic")
+        db_session.add(c); await db_session.commit()
+        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
+            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
+        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        mr.parse_json_response = lambda r: json.loads(r.content)
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+            assert await ConceptCompiler().compile_concept_page(c, db_session) is not None
+        mr.complete.assert_called_once()
+    async def test_high_threshold(self, db_session, tmp_path):
+        await _seed_kind(db_session)
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        c = Concept(name="ml", description="ML", concept_kind="topic")
+        db_session.add(c); await db_session.commit()
+        mr = AsyncMock()
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=5)))):
+            assert await ConceptCompiler().compile_concept_page(c, db_session) is None
+
+@pytest.mark.asyncio
+class TestWithMockedLLM:
+    async def test_kind_selects_template(self, db_session, tmp_path):
+        await _seed_kind(db_session, name="person")
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["k"])
+        await _mk_art(db_session, tmp_path, "s2", "S2", ["k"])
+        c = Concept(name="k", description="K", concept_kind="person")
+        db_session.add(c); await db_session.commit()
+        fr = CompletionResponse(content=_fake_resp("K"), provider_used=Provider.MOCK,
+            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
+        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        mr.parse_json_response = lambda r: json.loads(r.content)
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+            art = await ConceptCompiler().compile_concept_page(c, db_session)
+        assert art is not None
+        assert "person" in mr.complete.call_args[0][0].system.lower()
+    async def test_fallback_to_topic(self, db_session, tmp_path):
+        await _seed_kind(db_session, name="topic")
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["x"])
+        await _mk_art(db_session, tmp_path, "s2", "S2", ["x"])
+        c = Concept(name="x", description="X", concept_kind="custom")
+        db_session.add(c); await db_session.commit()
+        fr = CompletionResponse(content=_fake_resp("X"), provider_used=Provider.MOCK,
+            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
+        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        mr.parse_json_response = lambda r: json.loads(r.content)
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings",
+                    return_value=SimpleNamespace(data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+            assert await ConceptCompiler().compile_concept_page(c, db_session) is not None
+    async def test_replaces_existing(self, db_session, tmp_path):
+        await _seed_kind(db_session)
+        await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        c = Concept(name="ml", description="ML", concept_kind="topic")
+        db_session.add(c); await db_session.commit()
+        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
+            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
+        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        mr.parse_json_response = lambda r: json.loads(r.content)
+        s = SimpleNamespace(data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2))
+        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+              patch("wikimind.engine.concept_compiler.get_settings", return_value=s)):
+            cc = ConceptCompiler()
+            first = await cc.compile_concept_page(c, db_session)
+            second = await cc.compile_concept_page(c, db_session)
+        assert second.id == first.id
+
+@pytest.mark.asyncio
+class TestContradictionSurfacing:
+    async def test_empty(self, db_session):
+        assert await _collect_contradictions(["a", "b"], db_session) == ""
+    async def test_unresolved(self, db_session, tmp_path):
+        a1 = await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        a2 = await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        db_session.add(Backlink(source_article_id=a1.id, target_article_id=a2.id,
+            relation_type=RelationType.CONTRADICTS, context="A vs B"))
+        await db_session.commit()
+        assert "UNRESOLVED" in await _collect_contradictions([a1.id, a2.id], db_session)
+    async def test_resolved(self, db_session, tmp_path):
+        a1 = await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
+        a2 = await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
+        db_session.add(Backlink(source_article_id=a1.id, target_article_id=a2.id,
+            relation_type=RelationType.CONTRADICTS, context="A vs B",
+            resolution="source_a_wins", resolution_note="Stronger"))
+        await db_session.commit()
+        r = await _collect_contradictions([a1.id, a2.id], db_session)
+        assert "RESOLVED" in r and "source_a_wins" in r
+
+class TestConceptCompilationResult:
+    def test_valid(self):
+        r = ConceptCompilationResult(**json.loads(_fake_resp("T")))
+        assert r.title == "T" and r.page_type == PageType.CONCEPT
+    def test_related_default(self):
+        d = json.loads(_fake_resp("T")); del d["related_concepts"]
+        assert ConceptCompilationResult(**d).related_concepts == []

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -1,47 +1,94 @@
 """Tests for the registry-driven concept page compiler."""
+
 from __future__ import annotations
+
 import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+
 import pytest
 from sqlmodel import select
+
 from wikimind.engine.concept_compiler import (
-    ConceptCompiler, PROMPT_TEMPLATES, _collect_contradictions,
-    _collect_source_articles, get_prompt_template,
+    PROMPT_TEMPLATES,
+    ConceptCompiler,
+    _collect_contradictions,
+    _collect_source_articles,
+    get_prompt_template,
 )
 from wikimind.models import (
-    Article, Backlink, CompletionResponse, Concept, ConceptCompilationResult,
-    ConceptKindDef, PageType, Provider, RelationType,
+    Article,
+    Backlink,
+    CompletionResponse,
+    Concept,
+    ConceptCompilationResult,
+    ConceptKindDef,
+    PageType,
+    Provider,
+    RelationType,
 )
 
+
 def _fake_resp(name="Test"):
-    return json.dumps({"title": name, "overview": "Overview.", "key_themes": ["t1", "t2"],
-        "consensus_conflicts": "Agreement.", "open_questions": ["Q?"],
-        "timeline": "Evolved.", "sources_summary": "S1 did X. S2 did Y.",
-        "article_body": "## Analysis\n\nBody. " * 20, "related_concepts": ["rel"]})
+    return json.dumps(
+        {
+            "title": name,
+            "overview": "Overview.",
+            "key_themes": ["t1", "t2"],
+            "consensus_conflicts": "Agreement.",
+            "open_questions": ["Q?"],
+            "timeline": "Evolved.",
+            "sources_summary": "S1 did X. S2 did Y.",
+            "article_body": "## Analysis\n\nBody. " * 20,
+            "related_concepts": ["rel"],
+        }
+    )
+
 
 async def _seed_kind(s, name="topic"):
-    k = ConceptKindDef(name=name, prompt_template_key=f"concept_synthesis_{name}",
-        required_sections=json.dumps(["overview"]), linter_rules=json.dumps(["has_summary"]))
-    s.add(k); await s.commit(); return k
+    k = ConceptKindDef(
+        name=name,
+        prompt_template_key=f"concept_synthesis_{name}",
+        required_sections=json.dumps(["overview"]),
+        linter_rules=json.dumps(["has_summary"]),
+    )
+    s.add(k)
+    await s.commit()
+    return k
+
 
 async def _mk_art(s, tp, slug, title, concepts, summary="Sum."):
-    d = tp / "wiki" / "test"; d.mkdir(parents=True, exist_ok=True)
-    fp = d / f"{slug}.md"; fp.write_text(f"# {title}\n{summary}", encoding="utf-8")
-    a = Article(slug=slug, title=title, file_path=str(fp), summary=summary,
-        concept_ids=json.dumps(concepts), page_type=PageType.SOURCE)
-    s.add(a); await s.commit(); await s.refresh(a); return a
+    d = tp / "wiki" / "test"
+    d.mkdir(parents=True, exist_ok=True)
+    fp = d / f"{slug}.md"
+    fp.write_text(f"# {title}\n{summary}", encoding="utf-8")
+    a = Article(
+        slug=slug,
+        title=title,
+        file_path=str(fp),
+        summary=summary,
+        concept_ids=json.dumps(concepts),
+        page_type=PageType.SOURCE,
+    )
+    s.add(a)
+    await s.commit()
+    await s.refresh(a)
+    return a
+
 
 class TestPromptTemplates:
     def test_all_exist(self):
         for k in ["topic", "person", "org", "product", "paper"]:
             assert get_prompt_template(f"concept_synthesis_{k}") is not None
+
     def test_unknown_none(self):
         assert get_prompt_template("nope") is None
+
     def test_placeholders(self):
-        for k, t in PROMPT_TEMPLATES.items():
+        for _k, t in PROMPT_TEMPLATES.items():
             assert "{concept_name}" in t and "{source_material}" in t
+
 
 @pytest.mark.asyncio
 class TestCollectSourceArticles:
@@ -51,18 +98,25 @@ class TestCollectSourceArticles:
         await _mk_art(db_session, tmp_path, "a3", "A3", ["bio"])
         r = await _collect_source_articles("ml", db_session)
         assert {x.id for x in r} == {a1.id, a2.id}
+
     async def test_excludes_concept(self, db_session, tmp_path):
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
-        d = tmp_path / "wiki" / "ml"; d.mkdir(parents=True, exist_ok=True)
-        fp = d / "c.md"; fp.write_text("# C", encoding="utf-8")
-        ca = Article(slug="concept-ml", title="ML", file_path=str(fp),
-            concept_ids=json.dumps(["ml"]), page_type=PageType.CONCEPT)
-        db_session.add(ca); await db_session.commit()
+        d = tmp_path / "wiki" / "ml"
+        d.mkdir(parents=True, exist_ok=True)
+        fp = d / "c.md"
+        fp.write_text("# C", encoding="utf-8")
+        ca = Article(
+            slug="concept-ml", title="ML", file_path=str(fp), concept_ids=json.dumps(["ml"]), page_type=PageType.CONCEPT
+        )
+        db_session.add(ca)
+        await db_session.commit()
         r = await _collect_source_articles("ml", db_session)
         assert len(r) == 1 and r[0].page_type == PageType.SOURCE
+
     async def test_normalized(self, db_session, tmp_path):
         await _mk_art(db_session, tmp_path, "a1", "A1", ["Machine Learning"])
         assert len(await _collect_source_articles("machine-learning", db_session)) == 1
+
 
 @pytest.mark.asyncio
 class TestSynthesizesLinks:
@@ -71,22 +125,40 @@ class TestSynthesizesLinks:
         a1 = await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         a2 = await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
         c = Concept(name="ml", description="ML", concept_kind="topic")
-        db_session.add(c); await db_session.commit()
-        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
-            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
-        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        db_session.add(c)
+        await db_session.commit()
+        fr = CompletionResponse(
+            content=_fake_resp("ML"),
+            provider_used=Provider.MOCK,
+            model_used="m",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mr = AsyncMock()
+        mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                ),
+            ),
+        ):
             art = await ConceptCompiler().compile_concept_page(c, db_session)
         assert art is not None and art.page_type == PageType.CONCEPT
-        res = await db_session.execute(select(Backlink).where(
-            Backlink.source_article_id == art.id, Backlink.relation_type == RelationType.SYNTHESIZES))
+        res = await db_session.execute(
+            select(Backlink).where(
+                Backlink.source_article_id == art.id, Backlink.relation_type == RelationType.SYNTHESIZES
+            )
+        )
         links = list(res.scalars().all())
         assert len(links) == 2
         assert {bl.target_article_id for bl in links} == {a1.id, a2.id}
+
 
 @pytest.mark.asyncio
 class TestConceptPageOutput:
@@ -95,22 +167,43 @@ class TestConceptPageOutput:
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
         c = Concept(name="ml", description="ML", concept_kind="topic")
-        db_session.add(c); await db_session.commit()
-        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
-            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
-        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        db_session.add(c)
+        await db_session.commit()
+        fr = CompletionResponse(
+            content=_fake_resp("ML"),
+            provider_used=Provider.MOCK,
+            model_used="m",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mr = AsyncMock()
+        mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                ),
+            ),
+        ):
             art = await ConceptCompiler().compile_concept_page(c, db_session)
         assert art is not None
         content = Path(art.file_path).read_text(encoding="utf-8")
         assert "page_type: concept" in content
-        for s in ["## Overview", "## Key Themes", "## Consensus & Conflicts",
-                   "## Open Questions", "## Timeline", "## Sources"]:
+        for s in [
+            "## Overview",
+            "## Key Themes",
+            "## Consensus & Conflicts",
+            "## Open Questions",
+            "## Timeline",
+            "## Sources",
+        ]:
             assert s in content
+
 
 @pytest.mark.asyncio
 class TestTriggerThreshold:
@@ -118,42 +211,71 @@ class TestTriggerThreshold:
         await _seed_kind(db_session)
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         c = Concept(name="ml", description="ML", concept_kind="topic")
-        db_session.add(c); await db_session.commit()
+        db_session.add(c)
+        await db_session.commit()
         mr = AsyncMock()
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                ),
+            ),
+        ):
             assert await ConceptCompiler().compile_concept_page(c, db_session) is None
         mr.complete.assert_not_called()
+
     async def test_at_min(self, db_session, tmp_path):
         await _seed_kind(db_session)
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
         c = Concept(name="ml", description="ML", concept_kind="topic")
-        db_session.add(c); await db_session.commit()
-        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
-            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
-        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        db_session.add(c)
+        await db_session.commit()
+        fr = CompletionResponse(
+            content=_fake_resp("ML"),
+            provider_used=Provider.MOCK,
+            model_used="m",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mr = AsyncMock()
+        mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                ),
+            ),
+        ):
             assert await ConceptCompiler().compile_concept_page(c, db_session) is not None
         mr.complete.assert_called_once()
+
     async def test_high_threshold(self, db_session, tmp_path):
         await _seed_kind(db_session)
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
         c = Concept(name="ml", description="ML", concept_kind="topic")
-        db_session.add(c); await db_session.commit()
+        db_session.add(c)
+        await db_session.commit()
         mr = AsyncMock()
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=5)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=5)
+                ),
+            ),
+        ):
             assert await ConceptCompiler().compile_concept_page(c, db_session) is None
+
 
 @pytest.mark.asyncio
 class TestWithMockedLLM:
@@ -162,76 +284,136 @@ class TestWithMockedLLM:
         await _mk_art(db_session, tmp_path, "s1", "S1", ["k"])
         await _mk_art(db_session, tmp_path, "s2", "S2", ["k"])
         c = Concept(name="k", description="K", concept_kind="person")
-        db_session.add(c); await db_session.commit()
-        fr = CompletionResponse(content=_fake_resp("K"), provider_used=Provider.MOCK,
-            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
-        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        db_session.add(c)
+        await db_session.commit()
+        fr = CompletionResponse(
+            content=_fake_resp("K"),
+            provider_used=Provider.MOCK,
+            model_used="m",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mr = AsyncMock()
+        mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                ),
+            ),
+        ):
             art = await ConceptCompiler().compile_concept_page(c, db_session)
         assert art is not None
         assert "person" in mr.complete.call_args[0][0].system.lower()
+
     async def test_fallback_to_topic(self, db_session, tmp_path):
         await _seed_kind(db_session, name="topic")
         await _mk_art(db_session, tmp_path, "s1", "S1", ["x"])
         await _mk_art(db_session, tmp_path, "s2", "S2", ["x"])
         c = Concept(name="x", description="X", concept_kind="custom")
-        db_session.add(c); await db_session.commit()
-        fr = CompletionResponse(content=_fake_resp("X"), provider_used=Provider.MOCK,
-            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
-        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        db_session.add(c)
+        await db_session.commit()
+        fr = CompletionResponse(
+            content=_fake_resp("X"),
+            provider_used=Provider.MOCK,
+            model_used="m",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mr = AsyncMock()
+        mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings",
-                    return_value=SimpleNamespace(data_dir=str(tmp_path),
-                    taxonomy=SimpleNamespace(concept_page_min_sources=2)))):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch(
+                "wikimind.engine.concept_compiler.get_settings",
+                return_value=SimpleNamespace(
+                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                ),
+            ),
+        ):
             assert await ConceptCompiler().compile_concept_page(c, db_session) is not None
+
     async def test_replaces_existing(self, db_session, tmp_path):
         await _seed_kind(db_session)
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
         c = Concept(name="ml", description="ML", concept_kind="topic")
-        db_session.add(c); await db_session.commit()
-        fr = CompletionResponse(content=_fake_resp("ML"), provider_used=Provider.MOCK,
-            model_used="m", input_tokens=0, output_tokens=0, cost_usd=0.0, latency_ms=0)
-        mr = AsyncMock(); mr.complete = AsyncMock(return_value=fr)
+        db_session.add(c)
+        await db_session.commit()
+        fr = CompletionResponse(
+            content=_fake_resp("ML"),
+            provider_used=Provider.MOCK,
+            model_used="m",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mr = AsyncMock()
+        mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
         s = SimpleNamespace(data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2))
-        with (patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
-              patch("wikimind.engine.concept_compiler.get_settings", return_value=s)):
+        with (
+            patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
+            patch("wikimind.engine.concept_compiler.get_settings", return_value=s),
+        ):
             cc = ConceptCompiler()
             first = await cc.compile_concept_page(c, db_session)
             second = await cc.compile_concept_page(c, db_session)
         assert second.id == first.id
 
+
 @pytest.mark.asyncio
 class TestContradictionSurfacing:
     async def test_empty(self, db_session):
         assert await _collect_contradictions(["a", "b"], db_session) == ""
+
     async def test_unresolved(self, db_session, tmp_path):
         a1 = await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         a2 = await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
-        db_session.add(Backlink(source_article_id=a1.id, target_article_id=a2.id,
-            relation_type=RelationType.CONTRADICTS, context="A vs B"))
+        db_session.add(
+            Backlink(
+                source_article_id=a1.id,
+                target_article_id=a2.id,
+                relation_type=RelationType.CONTRADICTS,
+                context="A vs B",
+            )
+        )
         await db_session.commit()
         assert "UNRESOLVED" in await _collect_contradictions([a1.id, a2.id], db_session)
+
     async def test_resolved(self, db_session, tmp_path):
         a1 = await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         a2 = await _mk_art(db_session, tmp_path, "s2", "S2", ["ml"])
-        db_session.add(Backlink(source_article_id=a1.id, target_article_id=a2.id,
-            relation_type=RelationType.CONTRADICTS, context="A vs B",
-            resolution="source_a_wins", resolution_note="Stronger"))
+        db_session.add(
+            Backlink(
+                source_article_id=a1.id,
+                target_article_id=a2.id,
+                relation_type=RelationType.CONTRADICTS,
+                context="A vs B",
+                resolution="source_a_wins",
+                resolution_note="Stronger",
+            )
+        )
         await db_session.commit()
         r = await _collect_contradictions([a1.id, a2.id], db_session)
         assert "RESOLVED" in r and "source_a_wins" in r
+
 
 class TestConceptCompilationResult:
     def test_valid(self):
         r = ConceptCompilationResult(**json.loads(_fake_resp("T")))
         assert r.title == "T" and r.page_type == PageType.CONCEPT
+
     def test_related_default(self):
-        d = json.loads(_fake_resp("T")); del d["related_concepts"]
+        d = json.loads(_fake_resp("T"))
+        del d["related_concepts"]
         assert ConceptCompilationResult(**d).related_concepts == []


### PR DESCRIPTION
## Summary

- New registry-driven concept page compiler that synthesizes across source articles per ConceptKindDef
- Creates concept pages with `synthesizes` typed Backlinks (Python-only, never LLM)
- Five built-in prompt templates: topic, person, organization, product, paper
- Configurable trigger threshold via `concept_page_min_sources` setting (default 2)
- Surfaces contradiction resolutions from typed Backlinks in Consensus & Conflicts section
- Includes Phase 1 prerequisite models: PageType enum, RelationType enum, ConceptKindDef table, concept_kind on Concept, relation_type/resolution on Backlink, ConceptCompilationResult

Phase 3 of #143 (schema overhaul).

## Test plan

- [x] 19 unit tests passing: prompt template selection, source article collection, synthesizes link creation, concept page .md output, trigger threshold, contradiction surfacing, ConceptCompilationResult model validation