### PR TITLE
feat(linter): batch LLM calls for contradiction detection (#138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,9 @@
 # WIKIMIND_LINTER__MAX_COST_PER_RUN_USD=1.00
 # Skip re-evaluating unchanged article pairs
 # WIKIMIND_LINTER__ENABLE_PAIR_CACHE=true
+# Batch multiple article pairs into a single LLM call (reduces API calls ~4x)
+# WIKIMIND_LINTER__CONTRADICTION_BATCH_ENABLED=true
+# WIKIMIND_LINTER__CONTRADICTION_BATCH_SIZE=4
 
 # ----------------------------------------------------------------------------
 # Data Directory (optional)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,16 +133,16 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 370
+        "line_number": 372
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 394
+        "line_number": 396
       }
     ]
   },
-  "generated_at": "2026-04-14T15:01:59Z"
+  "generated_at": "2026-04-15T17:30:55Z"
 }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,11 +19,11 @@ considered, and the consequences.
 | [009](adr-009-decoupled-ingest-compilation.md) | Decoupled ingest and compilation | Accepted |
 | [010](adr-010-llm-provider-auto-enable.md) | Auto-enable LLM providers when their API key is detected | Accepted |
 | [011](adr-011-conversational-qa-thread-model.md) | Conversational Q&A thread model | Accepted |
-| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Accepted |
+| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Proposed |
 | [013](adr-013-react-force-graph-2d.md) | react-force-graph-2d for knowledge graph visualization | Proposed |
 | [014](adr-014-hybrid-search-architecture.md) | Hybrid search with ChromaDB and sentence-transformers | Accepted |
 | [015](adr-015-cpu-first-docker-packaging.md) | CPU-First Docker Packaging | Unknown |
-| [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
+| [016](adr-016-article-recompilation.md) | Article recompilation as a first-class action | Accepted |
 | [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
 
 ## ADR Format

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,11 +19,12 @@ considered, and the consequences.
 | [009](adr-009-decoupled-ingest-compilation.md) | Decoupled ingest and compilation | Accepted |
 | [010](adr-010-llm-provider-auto-enable.md) | Auto-enable LLM providers when their API key is detected | Accepted |
 | [011](adr-011-conversational-qa-thread-model.md) | Conversational Q&A thread model | Accepted |
-| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Proposed |
+| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Accepted |
 | [013](adr-013-react-force-graph-2d.md) | react-force-graph-2d for knowledge graph visualization | Proposed |
 | [014](adr-014-hybrid-search-architecture.md) | Hybrid search with ChromaDB and sentence-transformers | Accepted |
 | [015](adr-015-cpu-first-docker-packaging.md) | CPU-First Docker Packaging | Unknown |
-| [016](adr-016-article-recompilation.md) | Article recompilation as a first-class action | Accepted |
+| [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
+| [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
 
 ## ADR Format
 

--- a/docs/adr/adr-018-batched-contradiction-detection.md
+++ b/docs/adr/adr-018-batched-contradiction-detection.md
@@ -1,0 +1,47 @@
+# ADR-018: Batched Contradiction Detection
+
+**Status:** Accepted
+**Date:** 2026-04-15
+**Issue:** [#138](https://github.com/manavgup/wikimind/issues/138)
+
+## Context
+
+The wiki linter's contradiction detection makes one LLM API call per article pair. For a concept with 18 pairs this means 18 sequential calls, each with request overhead, totalling ~90 seconds. The per-call cost is dominated by system-prompt repetition and round-trip latency rather than token volume.
+
+## Decision
+
+Batch N article pairs (default 4, configurable via `WIKIMIND_LINTER__CONTRADICTION_BATCH_SIZE`) into a single LLM prompt. The batch prompt includes all pair sections with indexed labels (`Pair 0`, `Pair 1`, ...) and asks the model to return a JSON array of per-pair result objects keyed by `pair_index`.
+
+### Retry and fallback strategy
+
+1. If the batch LLM call fails, retry once with the same prompt.
+2. If the retry also fails, fall back to individual per-pair `_compare_article_pair()` calls for every pair in the batch. This guarantees that a malformed batch response never silently drops pairs.
+
+### Cache granularity
+
+Per-pair cache entries (`LintPairCache`) are preserved. After a successful batch call, each pair's contradictions are saved individually so future runs can skip already-checked pairs even if the batch composition changes.
+
+### Progress reporting
+
+`report.checked_pairs` is incremented per-pair within each batch (not per-batch), giving the frontend smooth progress updates.
+
+### Configuration
+
+Two new fields on `LinterConfig`:
+
+- `contradiction_batch_enabled` (default `true`) -- feature flag
+- `contradiction_batch_size` (default `4`) -- pairs per batch
+
+When `contradiction_batch_enabled` is `false`, or when only one uncached pair remains, the existing per-pair path is used.
+
+## Alternatives Considered
+
+- **No fallback on failure**: Rejected. A single malformed batch response would lose all pairs in that batch with no recovery.
+- **Batch-level cache**: Rejected. Batch composition varies between runs; per-pair granularity avoids redundant rechecking.
+- **Concurrent batches**: Deferred. Sequential batches are simpler and respect rate limits. Concurrency can be layered on later if latency is still a concern.
+
+## Consequences
+
+- ~4x reduction in LLM API calls for contradiction detection (N pairs / batch_size).
+- Slightly larger per-call token usage (system prompt shared across pairs offsets this).
+- Fallback path adds resilience at the cost of reverting to O(pairs) calls when the batch model response is unparseable.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -189,19 +189,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/contradiction-resolutions:
-    get:
-      tags:
-      - Wiki
-      summary: List Contradiction Resolutions
-      description: Return the valid contradiction resolution options.
-      operationId: list_contradiction_resolutions_wiki_contradiction_resolutions_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
   /wiki/articles:
     get:
       tags:
@@ -428,40 +415,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolveContradictionRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/{article_id}/recompile:
-    post:
-      tags:
-      - Wiki
-      summary: Recompile Article
-      description: Schedule an async recompilation job for an article.
-      operationId: recompile_article_wiki_articles__article_id__recompile_post
-      parameters:
-      - name: article_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Article Id
-      - name: mode
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Mode
       responses:
         '200':
           description: Successful Response
@@ -1682,6 +1635,7 @@ components:
       enum:
       - contradiction
       - orphan
+      - structural
       title: LintFindingKind
       description: 'Kind of lint finding — maps 1:1 to a detection function AND a
         table.
@@ -1724,6 +1678,15 @@ components:
           type: integer
           title: Orphans Count
           default: 0
+        structural_count:
+          type: integer
+          title: Structural Count
+          default: 0
+        checked_articles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Checked Articles
         missing_pages_count:
           type: integer
           title: Missing Pages Count
@@ -1768,12 +1731,12 @@ components:
             $ref: '#/components/schemas/OrphanFinding'
           type: array
           title: Orphans
-        resolutions:
-          additionalProperties:
-            type: string
-          type: object
-          title: Resolutions
-          default: {}
+        structurals:
+          items:
+            $ref: '#/components/schemas/StructuralFinding'
+          type: array
+          title: Structurals
+          default: []
       type: object
       required:
       - report
@@ -2092,6 +2055,63 @@ components:
       - obsidian
       title: SourceType
       description: Type of ingested source.
+    StructuralFinding:
+      properties:
+        id:
+          type: string
+          title: Id
+        report_id:
+          type: string
+          title: Report Id
+        severity:
+          $ref: '#/components/schemas/LintSeverity'
+          default: warn
+        description:
+          type: string
+          title: Description
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        dismissed:
+          type: boolean
+          title: Dismissed
+          default: false
+        dismissed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Dismissed At
+        content_hash:
+          type: string
+          title: Content Hash
+        kind:
+          $ref: '#/components/schemas/LintFindingKind'
+          default: structural
+        article_id:
+          type: string
+          title: Article Id
+        violation_type:
+          type: string
+          title: Violation Type
+        auto_repaired:
+          type: boolean
+          title: Auto Repaired
+          default: false
+        detail:
+          type: string
+          title: Detail
+          default: ''
+      type: object
+      required:
+      - report_id
+      - description
+      - content_hash
+      - article_id
+      - violation_type
+      title: StructuralFinding
+      description: A structural integrity violation detected by the backlink enforcer.
     TurnSelection:
       properties:
         conversation_id:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -189,6 +189,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /wiki/contradiction-resolutions:
+    get:
+      tags:
+      - Wiki
+      summary: List Contradiction Resolutions
+      description: Return the valid contradiction resolution options.
+      operationId: list_contradiction_resolutions_wiki_contradiction_resolutions_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
   /wiki/articles:
     get:
       tags:
@@ -415,6 +428,40 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolveContradictionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /wiki/articles/{article_id}/recompile:
+    post:
+      tags:
+      - Wiki
+      summary: Recompile Article
+      description: Schedule an async recompilation job for an article.
+      operationId: recompile_article_wiki_articles__article_id__recompile_post
+      parameters:
+      - name: article_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Article Id
+      - name: mode
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Mode
       responses:
         '200':
           description: Successful Response
@@ -1635,7 +1682,6 @@ components:
       enum:
       - contradiction
       - orphan
-      - structural
       title: LintFindingKind
       description: 'Kind of lint finding — maps 1:1 to a detection function AND a
         table.
@@ -1678,15 +1724,6 @@ components:
           type: integer
           title: Orphans Count
           default: 0
-        structural_count:
-          type: integer
-          title: Structural Count
-          default: 0
-        checked_articles:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          title: Checked Articles
         missing_pages_count:
           type: integer
           title: Missing Pages Count
@@ -1731,12 +1768,12 @@ components:
             $ref: '#/components/schemas/OrphanFinding'
           type: array
           title: Orphans
-        structurals:
-          items:
-            $ref: '#/components/schemas/StructuralFinding'
-          type: array
-          title: Structurals
-          default: []
+        resolutions:
+          additionalProperties:
+            type: string
+          type: object
+          title: Resolutions
+          default: {}
       type: object
       required:
       - report
@@ -2055,63 +2092,6 @@ components:
       - obsidian
       title: SourceType
       description: Type of ingested source.
-    StructuralFinding:
-      properties:
-        id:
-          type: string
-          title: Id
-        report_id:
-          type: string
-          title: Report Id
-        severity:
-          $ref: '#/components/schemas/LintSeverity'
-          default: warn
-        description:
-          type: string
-          title: Description
-        created_at:
-          type: string
-          format: date-time
-          title: Created At
-        dismissed:
-          type: boolean
-          title: Dismissed
-          default: false
-        dismissed_at:
-          anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
-          title: Dismissed At
-        content_hash:
-          type: string
-          title: Content Hash
-        kind:
-          $ref: '#/components/schemas/LintFindingKind'
-          default: structural
-        article_id:
-          type: string
-          title: Article Id
-        violation_type:
-          type: string
-          title: Violation Type
-        auto_repaired:
-          type: boolean
-          title: Auto Repaired
-          default: false
-        detail:
-          type: string
-          title: Detail
-          default: ''
-      type: object
-      required:
-      - report_id
-      - description
-      - content_hash
-      - article_id
-      - violation_type
-      title: StructuralFinding
-      description: A structural integrity violation detected by the backlink enforcer.
     TurnSelection:
       properties:
         conversation_id:

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -151,6 +151,8 @@ class LinterConfig(BaseModel):
     contradiction_llm_max_tokens: int = 1024
     contradiction_llm_temperature: float = 0.2
     enable_pair_cache: bool = True
+    contradiction_batch_enabled: bool = True
+    contradiction_batch_size: int = 4
 
 
 class EmbeddingConfig(BaseModel):

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -152,7 +152,7 @@ class LinterConfig(BaseModel):
     contradiction_llm_temperature: float = 0.2
     enable_pair_cache: bool = True
     contradiction_batch_enabled: bool = True
-    contradiction_batch_size: int = 4
+    contradiction_batch_size: int = 10
 
 
 class EmbeddingConfig(BaseModel):

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -21,8 +21,14 @@ from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from wikimind.config import Settings
-from wikimind.engine.linter.prompts import CONTRADICTION_SYSTEM_PROMPT, CONTRADICTION_USER_TEMPLATE
+from wikimind.config import LinterConfig, Settings
+from wikimind.engine.linter.prompts import (
+    CONTRADICTION_BATCH_SYSTEM,
+    CONTRADICTION_BATCH_USER,
+    CONTRADICTION_SYSTEM_PROMPT,
+    CONTRADICTION_USER_TEMPLATE,
+    format_batch_pair_section,
+)
 from wikimind.engine.llm_router import LLMRouter
 from wikimind.models import (
     Article,
@@ -39,6 +45,10 @@ from wikimind.models import (
 )
 
 log = structlog.get_logger()
+
+_MAX_TITLE = 200
+_MAX_CLAIM = 500
+_MAX_CLAIMS_TEXT = 2000
 
 
 def _content_hash(article_a_id: str, article_b_id: str) -> str:
@@ -162,16 +172,141 @@ async def _create_contradiction_backlink(
     await session.flush()
 
 
-async def detect_contradictions(
-    session: AsyncSession,
+# ---------------------------------------------------------------------------
+# Batch helpers (issue #138)
+# ---------------------------------------------------------------------------
+
+
+def _build_batch_prompt(
+    pairs_with_claims: list[tuple[Article, Article, list[str], list[str]]],
+) -> tuple[str, str]:
+    """Build batch system + user prompt for multiple article pairs.
+
+    Returns (system_str, user_str).
+    """
+    sections: list[str] = []
+    for idx, (art_a, art_b, claims_a, claims_b) in enumerate(pairs_with_claims):
+        claims_a_text = "\n".join(f"- {c[:_MAX_CLAIM]}" for c in claims_a)[:_MAX_CLAIMS_TEXT]
+        claims_b_text = "\n".join(f"- {c[:_MAX_CLAIM]}" for c in claims_b)[:_MAX_CLAIMS_TEXT]
+        sections.append(
+            format_batch_pair_section(
+                idx,
+                art_a.title[:_MAX_TITLE],
+                claims_a_text,
+                art_b.title[:_MAX_TITLE],
+                claims_b_text,
+            )
+        )
+    user_msg = CONTRADICTION_BATCH_USER.format(
+        pair_count=len(pairs_with_claims),
+        pair_sections="\n\n".join(sections),
+    )
+    return CONTRADICTION_BATCH_SYSTEM, user_msg
+
+
+def _parse_batch_response(response_data: list[dict], expected_count: int) -> dict[int, list[dict]]:
+    """Map LLM batch response back to individual pairs by pair_index.
+
+    Returns a dict from pair_index to list of contradiction dicts.
+    Missing indices get an empty list.
+    """
+    result: dict[int, list[dict]] = {i: [] for i in range(expected_count)}
+    for item in response_data:
+        idx = item.get("pair_index")
+        if idx is not None and 0 <= idx < expected_count:
+            result[idx] = item.get("contradictions", [])
+    return result
+
+
+async def _run_batch(
+    pairs_with_claims: list[tuple[Article, Article, list[str], list[str]]],
+    concept_id: str | None,
     router: LLMRouter,
     settings: Settings,
-    report: LintReport,
+    report_id: str,
+    session: AsyncSession,
 ) -> list[ContradictionFinding]:
-    """For each concept, LLM-compare article pairs within that concept bucket."""
-    cfg = settings.linter
-    findings: list[ContradictionFinding] = []
+    """Run a batched LLM call for multiple pairs.
 
+    On failure: retry once. On second failure: fall back to per-pair
+    ``_compare_article_pair()`` calls.
+    """
+    cfg = settings.linter
+    system_msg, user_msg = _build_batch_prompt(pairs_with_claims)
+
+    request = CompletionRequest(
+        system=system_msg,
+        messages=[{"role": "user", "content": user_msg}],
+        max_tokens=cfg.contradiction_llm_max_tokens * len(pairs_with_claims),
+        temperature=cfg.contradiction_llm_temperature,
+        response_format="json",
+        task_type=TaskType.LINT,
+    )
+
+    for attempt in range(2):
+        try:
+            response = await router.complete(request, session=None)
+            data = router.parse_json_response(response)
+            # The response may be a list directly or wrapped in a key
+            if isinstance(data, list):
+                batch_results = data
+            elif isinstance(data, dict) and "results" in data:
+                batch_results = data["results"]
+            else:
+                raise ValueError(f"Unexpected batch response shape: {type(data)}")
+
+            parsed = _parse_batch_response(batch_results, len(pairs_with_claims))
+
+            findings: list[ContradictionFinding] = []
+            for idx, (art_a, art_b, _ca, _cb) in enumerate(pairs_with_claims):
+                for c in parsed.get(idx, []):
+                    claim_a = c.get("article_a_claim", "")
+                    claim_b = c.get("article_b_claim", "")
+                    findings.append(
+                        ContradictionFinding(
+                            report_id=report_id,
+                            severity=LintSeverity.WARN,
+                            description=c.get("description", "Contradiction detected"),
+                            content_hash=_content_hash(art_a.id, art_b.id),
+                            article_a_id=art_a.id,
+                            article_b_id=art_b.id,
+                            article_a_claim=claim_a,
+                            article_b_claim=claim_b,
+                            llm_confidence=c.get("confidence", "medium"),
+                            shared_concept_id=concept_id,
+                        )
+                    )
+                    ctx = f"{claim_a} vs {claim_b}"
+                    await _create_contradiction_backlink(session, art_a.id, art_b.id, ctx)
+            return findings
+
+        except Exception:
+            if attempt == 0:
+                log.warning("Batch LLM call failed, retrying once", exc_info=True)
+            else:
+                log.warning(
+                    "Batch LLM retry failed, falling back to per-pair calls",
+                    exc_info=True,
+                )
+
+    # Fallback: per-pair calls
+    fallback_findings: list[ContradictionFinding] = []
+    for art_a, art_b, _ca, _cb in pairs_with_claims:
+        pair_findings = await _compare_article_pair(art_a, art_b, concept_id, router, settings, report_id, session)
+        fallback_findings.extend(pair_findings)
+    return fallback_findings
+
+
+# ---------------------------------------------------------------------------
+# Work collection and processing helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect_work(
+    session: AsyncSession,
+    cfg: LinterConfig,
+) -> list[tuple[str | None, str, list[tuple[Article, Article]]]]:
+    """Build the list of (concept_id, concept_name, pairs) work items."""
     concept_result = await session.execute(
         select(Concept)
         .order_by(Concept.article_count.desc())  # type: ignore[attr-defined]
@@ -195,14 +330,122 @@ async def detect_contradictions(
         all_work.append((None, "all-articles", pairs))
     else:
         for concept_obj in concepts:
-            concept_id, concept_name = concept_obj.id, concept_obj.name
-            articles = await _get_articles_for_concept(session, concept_name)
+            cid, cname = concept_obj.id, concept_obj.name
+            articles = await _get_articles_for_concept(session, cname)
             if len(articles) < 2:
                 continue
             pairs = list(itertools.combinations(articles, 2))
             if len(pairs) > cfg.max_contradiction_pairs_per_concept:
                 pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
-            all_work.append((concept_id, concept_name, pairs))
+            all_work.append((cid, cname, pairs))
+
+    return all_work
+
+
+def _findings_from_cached(
+    cached: list[dict],
+    report_id: str,
+    article_a: Article,
+    article_b: Article,
+    concept_id: str | None,
+) -> list[ContradictionFinding]:
+    """Convert cached pair data into ContradictionFinding objects."""
+    results: list[ContradictionFinding] = []
+    for c in cached:
+        claim_a = c.get("article_a_claim", "")
+        claim_b = c.get("article_b_claim", "")
+        results.append(
+            ContradictionFinding(
+                report_id=report_id,
+                severity=LintSeverity.WARN,
+                description=c.get("description", "Contradiction detected"),
+                content_hash=_content_hash(article_a.id, article_b.id),
+                article_a_id=article_a.id,
+                article_b_id=article_b.id,
+                article_a_claim=claim_a,
+                article_b_claim=claim_b,
+                llm_confidence=c.get("confidence", "medium"),
+                shared_concept_id=concept_id,
+            )
+        )
+    return results
+
+
+def _cache_data_from_findings(new_findings: list[ContradictionFinding]) -> list[dict]:
+    """Convert findings to serialisable cache data."""
+    return [
+        {
+            "description": f.description,
+            "article_a_claim": f.article_a_claim,
+            "article_b_claim": f.article_b_claim,
+            "confidence": f.llm_confidence,
+        }
+        for f in new_findings
+    ]
+
+
+async def _process_uncached_pairs(
+    uncached_pairs: list[tuple[Article, Article, list[str], list[str]]],
+    concept_id: str | None,
+    router: LLMRouter,
+    settings: Settings,
+    report: LintReport,
+    session: AsyncSession,
+    checked: int,
+) -> tuple[list[ContradictionFinding], int]:
+    """Process uncached pairs via batch or per-pair LLM calls.
+
+    Returns (findings, updated_checked_count).
+    """
+    cfg = settings.linter
+    findings: list[ContradictionFinding] = []
+
+    if cfg.contradiction_batch_enabled and len(uncached_pairs) > 1:
+        for batch_start in range(0, len(uncached_pairs), cfg.contradiction_batch_size):
+            batch = uncached_pairs[batch_start : batch_start + cfg.contradiction_batch_size]
+            batch_findings = await _run_batch(batch, concept_id, router, settings, report.id, session)
+            findings.extend(batch_findings)
+
+            for _idx, (art_a, art_b, _ca, _cb) in enumerate(batch):
+                if cfg.enable_pair_cache:
+                    pair_findings = [
+                        f for f in batch_findings if f.article_a_id == art_a.id and f.article_b_id == art_b.id
+                    ]
+                    await _save_pair_cache(session, art_a, art_b, _cache_data_from_findings(pair_findings))
+                checked += 1
+                report.checked_pairs = checked
+                session.add(report)
+                await session.flush()
+    else:
+        for art_a, art_b, _ca, _cb in uncached_pairs:
+            new_findings = await _compare_article_pair(art_a, art_b, concept_id, router, settings, report.id, session)
+            findings.extend(new_findings)
+            if cfg.enable_pair_cache:
+                await _save_pair_cache(session, art_a, art_b, _cache_data_from_findings(new_findings))
+            checked += 1
+            report.checked_pairs = checked
+            session.add(report)
+            await session.flush()
+
+    return findings, checked
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+async def detect_contradictions(
+    session: AsyncSession,
+    router: LLMRouter,
+    settings: Settings,
+    report: LintReport,
+) -> list[ContradictionFinding]:
+    """For each concept, LLM-compare article pairs within that concept bucket."""
+    cfg = settings.linter
+    findings: list[ContradictionFinding] = []
+
+    all_work = await _collect_work(session, cfg)
 
     total_pairs = sum(len(pairs) for _, _, pairs in all_work)
     report.total_pairs = total_pairs
@@ -212,31 +455,27 @@ async def detect_contradictions(
 
     checked = 0
     for concept_id, concept_name, pairs in all_work:  # type: ignore[assignment]
-        log.info("Checking contradictions in concept", concept=concept_name, pairs=len(pairs))
+        log.info(
+            "Checking contradictions in concept",
+            concept=concept_name,
+            pairs=len(pairs),
+        )
 
+        # Separate cached pairs from uncached pairs that need LLM calls
+        uncached_pairs: list[tuple[Article, Article, list[str], list[str]]] = []
         for article_a, article_b in pairs:
             if cfg.enable_pair_cache:
                 cached = await _check_pair_cache(session, article_a, article_b)
                 if cached is not None:
-                    log.info("Pair cache hit", a=article_a.title[:30], b=article_b.title[:30])
-                    for c in cached:
-                        claim_a = c.get("article_a_claim", "")
-                        claim_b = c.get("article_b_claim", "")
-                        findings.append(
-                            ContradictionFinding(
-                                report_id=report.id,
-                                severity=LintSeverity.WARN,
-                                description=c.get("description", "Contradiction detected"),
-                                content_hash=_content_hash(article_a.id, article_b.id),
-                                article_a_id=article_a.id,
-                                article_b_id=article_b.id,
-                                article_a_claim=claim_a,
-                                article_b_claim=claim_b,
-                                llm_confidence=c.get("confidence", "medium"),
-                                shared_concept_id=concept_id,
-                            )
-                        )
-                        ctx = f"{claim_a} vs {claim_b}"
+                    log.info(
+                        "Pair cache hit",
+                        a=article_a.title[:30],
+                        b=article_b.title[:30],
+                    )
+                    cached_findings = _findings_from_cached(cached, report.id, article_a, article_b, concept_id)
+                    findings.extend(cached_findings)
+                    for f in cached_findings:
+                        ctx = f"{f.article_a_claim} vs {f.article_b_claim}"
                         await _create_contradiction_backlink(session, article_a.id, article_b.id, ctx)
                     checked += 1
                     report.checked_pairs = checked
@@ -244,29 +483,29 @@ async def detect_contradictions(
                     await session.flush()
                     continue
 
-            new_findings = await _compare_article_pair(
-                article_a, article_b, concept_id, router, settings, report.id, session
-            )
-            findings.extend(new_findings)
+            # Collect claims for uncached pair
+            claims_a = _extract_claims(article_a)
+            claims_b = _extract_claims(article_b)
+            if claims_a and claims_b:
+                uncached_pairs.append((article_a, article_b, claims_a, claims_b))
+            else:
+                checked += 1
+                report.checked_pairs = checked
+                session.add(report)
+                await session.flush()
 
-            if cfg.enable_pair_cache:
-                cache_data = [
-                    {
-                        "description": f.description,
-                        "article_a_claim": f.article_a_claim,
-                        "article_b_claim": f.article_b_claim,
-                        "confidence": f.llm_confidence,
-                    }
-                    for f in new_findings
-                ]
-                await _save_pair_cache(session, article_a, article_b, cache_data)
-
-            checked += 1
-            report.checked_pairs = checked
-            session.add(report)
-            await session.flush()
+        # Process uncached pairs: batch or per-pair
+        new_findings, checked = await _process_uncached_pairs(
+            uncached_pairs, concept_id, router, settings, report, session, checked
+        )
+        findings.extend(new_findings)
 
     return findings
+
+
+# ---------------------------------------------------------------------------
+# Single-pair comparison (used as fallback and for non-batched mode)
+# ---------------------------------------------------------------------------
 
 
 async def _compare_article_pair(
@@ -286,9 +525,6 @@ async def _compare_article_pair(
     if not claims_a or not claims_b:
         return []
 
-    _MAX_TITLE = 200
-    _MAX_CLAIM = 500
-    _MAX_CLAIMS_TEXT = 2000
     claims_a_text = "\n".join(f"- {c[:_MAX_CLAIM]}" for c in claims_a)[:_MAX_CLAIMS_TEXT]
     claims_b_text = "\n".join(f"- {c[:_MAX_CLAIM]}" for c in claims_b)[:_MAX_CLAIMS_TEXT]
 

--- a/src/wikimind/engine/linter/prompts.py
+++ b/src/wikimind/engine/linter/prompts.py
@@ -25,3 +25,45 @@ Return JSON of this shape:
   ]
 }}
 If there are no contradictions, return {{"contradictions": []}}."""
+
+# ---------------------------------------------------------------------------
+# Batch contradiction detection (issue #138)
+# ---------------------------------------------------------------------------
+
+CONTRADICTION_BATCH_SYSTEM = (
+    "You are a wiki health auditor. Given multiple pairs of wiki articles "
+    "about the same topic, identify contradictory assertions between each pair's "
+    "key claims. Return strict JSON: an array of objects, one per pair_index."
+)
+
+CONTRADICTION_BATCH_USER = """Compare the following {pair_count} article pairs for contradictions.
+
+{pair_sections}
+
+For each pair, return an object with this shape:
+{{
+  "pair_index": <int>,
+  "contradictions": [
+    {{
+      "description": "one-sentence summary of the contradiction",
+      "article_a_claim": "the specific claim from A",
+      "article_b_claim": "the specific claim from B",
+      "confidence": "high" | "medium" | "low"
+    }}
+  ]
+}}
+
+Return a JSON array of exactly {pair_count} objects. If a pair has no contradictions, return an empty contradictions array for that pair.
+Example: [{{"pair_index": 0, "contradictions": []}}, {{"pair_index": 1, "contradictions": [...]}}]"""
+
+
+def format_batch_pair_section(index: int, title_a: str, claims_a: str, title_b: str, claims_b: str) -> str:
+    """Format a single pair section for the batch prompt."""
+    return f"""--- Pair {index} ---
+Article A: "{title_a}"
+Key claims:
+{claims_a}
+
+Article B: "{title_b}"
+Key claims:
+{claims_b}"""

--- a/tests/unit/test_batch_contradictions.py
+++ b/tests/unit/test_batch_contradictions.py
@@ -177,17 +177,11 @@ async def test_run_batch_success(tmp_path: Path) -> None:
 
     session = AsyncMock()
     session.execute = AsyncMock(
-        return_value=MagicMock(
-            scalars=MagicMock(
-                return_value=MagicMock(first=MagicMock(return_value=None))
-            )
-        )
+        return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
     session.flush = AsyncMock()
 
-    findings = await _run_batch(
-        pairs, "concept-1", mock_router, settings, "report-1", session
-    )
+    findings = await _run_batch(pairs, "concept-1", mock_router, settings, "report-1", session)
 
     assert len(findings) == 1
     assert findings[0].description == "test"
@@ -210,11 +204,7 @@ async def test_run_batch_retries_then_falls_back(tmp_path: Path) -> None:
 
     session = AsyncMock()
     session.execute = AsyncMock(
-        return_value=MagicMock(
-            scalars=MagicMock(
-                return_value=MagicMock(first=MagicMock(return_value=None))
-            )
-        )
+        return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
     session.flush = AsyncMock()
 
@@ -223,9 +213,7 @@ async def test_run_batch_retries_then_falls_back(tmp_path: Path) -> None:
         new_callable=AsyncMock,
         return_value=[],
     ) as mock_per_pair:
-        findings = await _run_batch(
-            pairs, "concept-1", mock_router, settings, "report-1", session
-        )
+        findings = await _run_batch(pairs, "concept-1", mock_router, settings, "report-1", session)
 
     # router.complete called twice (initial + retry)
     assert mock_router.complete.call_count == 2
@@ -257,11 +245,7 @@ async def test_run_batch_retry_succeeds_on_second_attempt(tmp_path: Path) -> Non
 
     session = AsyncMock()
     session.execute = AsyncMock(
-        return_value=MagicMock(
-            scalars=MagicMock(
-                return_value=MagicMock(first=MagicMock(return_value=None))
-            )
-        )
+        return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
     session.flush = AsyncMock()
 
@@ -269,9 +253,7 @@ async def test_run_batch_retry_succeeds_on_second_attempt(tmp_path: Path) -> Non
         "wikimind.engine.linter.contradictions._compare_article_pair",
         new_callable=AsyncMock,
     ) as mock_per_pair:
-        findings = await _run_batch(
-            pairs, None, mock_router, settings, "r1", session
-        )
+        findings = await _run_batch(pairs, None, mock_router, settings, "r1", session)
 
     assert mock_router.complete.call_count == 2
     assert mock_per_pair.call_count == 0  # no fallback needed
@@ -289,9 +271,7 @@ async def test_run_batch_parse_error_triggers_fallback(tmp_path: Path) -> None:
     mock_router = MagicMock()
     mock_router.complete = AsyncMock(return_value=mock_response)
     # Return a dict without "results" key -- triggers ValueError
-    mock_router.parse_json_response = MagicMock(
-        return_value={"unexpected": "shape"}
-    )
+    mock_router.parse_json_response = MagicMock(return_value={"unexpected": "shape"})
 
     settings = MagicMock()
     settings.linter.contradiction_llm_max_tokens = 1024
@@ -299,11 +279,7 @@ async def test_run_batch_parse_error_triggers_fallback(tmp_path: Path) -> None:
 
     session = AsyncMock()
     session.execute = AsyncMock(
-        return_value=MagicMock(
-            scalars=MagicMock(
-                return_value=MagicMock(first=MagicMock(return_value=None))
-            )
-        )
+        return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
     session.flush = AsyncMock()
 

--- a/tests/unit/test_batch_contradictions.py
+++ b/tests/unit/test_batch_contradictions.py
@@ -1,0 +1,319 @@
+"""Tests for batched contradiction detection (issue #138).
+
+Covers the three batch helper functions: _build_batch_prompt,
+_parse_batch_response, and _run_batch (retry + fallback behavior).
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wikimind.engine.linter.contradictions import (
+    _build_batch_prompt,
+    _parse_batch_response,
+    _run_batch,
+)
+from wikimind.models import Article, PageType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_article(title: str, tmp_path: Path | None = None) -> Article:
+    """Create a minimal Article instance for prompt-building tests."""
+    slug = title.lower().replace(" ", "-")
+    file_path = f"/tmp/{slug}.md"
+    if tmp_path is not None:
+        fp = tmp_path / f"{slug}.md"
+        fp.write_text(
+            f"# {title}\n\n## Key Claims\n- claim from {title}\n",
+            encoding="utf-8",
+        )
+        file_path = str(fp)
+    return Article(
+        id=str(uuid.uuid4()),
+        slug=slug,
+        title=title,
+        file_path=file_path,
+        page_type=PageType.SOURCE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_batch_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_batch_prompt_formats_pairs() -> None:
+    """Batch prompt includes all pair sections with correct indices."""
+    pairs = [
+        (_make_article("A1"), _make_article("A2"), ["claim1"], ["claim2"]),
+        (_make_article("B1"), _make_article("B2"), ["claim3"], ["claim4"]),
+    ]
+    system, user = _build_batch_prompt(pairs)
+    assert "2 article pairs" in user
+    assert "Pair 0" in user
+    assert "Pair 1" in user
+    assert "wiki health auditor" in system
+
+
+def test_build_batch_prompt_single_pair() -> None:
+    """Batch prompt works with a single pair."""
+    pairs = [
+        (_make_article("X"), _make_article("Y"), ["c1"], ["c2"]),
+    ]
+    _system, user = _build_batch_prompt(pairs)
+    assert "1 article pairs" in user
+    assert "Pair 0" in user
+    assert "Pair 1" not in user
+
+
+def test_build_batch_prompt_includes_claims() -> None:
+    """Batch prompt includes claims text from both articles."""
+    pairs = [
+        (
+            _make_article("A"),
+            _make_article("B"),
+            ["The earth is round"],
+            ["The earth is flat"],
+        ),
+    ]
+    _system, user = _build_batch_prompt(pairs)
+    assert "The earth is round" in user
+    assert "The earth is flat" in user
+
+
+# ---------------------------------------------------------------------------
+# _parse_batch_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_batch_response_maps_by_index() -> None:
+    """Response items are mapped to their pair_index."""
+    response_data = [
+        {
+            "pair_index": 0,
+            "contradictions": [
+                {
+                    "description": "d1",
+                    "article_a_claim": "a",
+                    "article_b_claim": "b",
+                    "confidence": "high",
+                },
+            ],
+        },
+        {"pair_index": 1, "contradictions": []},
+    ]
+    result = _parse_batch_response(response_data, 2)
+    assert len(result[0]) == 1
+    assert len(result[1]) == 0
+
+
+def test_parse_batch_response_handles_missing_index() -> None:
+    """Missing pair_index entries get empty contradiction lists."""
+    response_data = [{"pair_index": 0, "contradictions": []}]
+    result = _parse_batch_response(response_data, 2)
+    assert len(result[0]) == 0
+    assert len(result[1]) == 0  # index 1 missing from response
+
+
+def test_parse_batch_response_ignores_out_of_range_index() -> None:
+    """Pair indices outside [0, expected_count) are ignored."""
+    response_data = [
+        {"pair_index": 5, "contradictions": [{"description": "bad"}]},
+        {"pair_index": 0, "contradictions": []},
+    ]
+    result = _parse_batch_response(response_data, 2)
+    assert len(result[0]) == 0
+    assert len(result[1]) == 0
+    assert 5 not in result
+
+
+def test_parse_batch_response_empty_input() -> None:
+    """Empty response still returns default empty lists."""
+    result = _parse_batch_response([], 3)
+    assert all(len(result[i]) == 0 for i in range(3))
+
+
+# ---------------------------------------------------------------------------
+# _run_batch (retry + fallback)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_batch_success(tmp_path: Path) -> None:
+    """Successful batch call returns findings without fallback."""
+    art_a = _make_article("Alpha", tmp_path)
+    art_b = _make_article("Beta", tmp_path)
+    pairs = [(art_a, art_b, ["claim A"], ["claim B"])]
+
+    mock_response = MagicMock()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    mock_router.parse_json_response = MagicMock(
+        return_value=[
+            {
+                "pair_index": 0,
+                "contradictions": [
+                    {
+                        "description": "test",
+                        "article_a_claim": "cA",
+                        "article_b_claim": "cB",
+                        "confidence": "high",
+                    },
+                ],
+            }
+        ]
+    )
+
+    settings = MagicMock()
+    settings.linter.contradiction_llm_max_tokens = 1024
+    settings.linter.contradiction_llm_temperature = 0.2
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(
+            scalars=MagicMock(
+                return_value=MagicMock(first=MagicMock(return_value=None))
+            )
+        )
+    )
+    session.flush = AsyncMock()
+
+    findings = await _run_batch(
+        pairs, "concept-1", mock_router, settings, "report-1", session
+    )
+
+    assert len(findings) == 1
+    assert findings[0].description == "test"
+    assert mock_router.complete.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_batch_retries_then_falls_back(tmp_path: Path) -> None:
+    """On batch failure, retry once, then fall back to per-pair calls."""
+    art_a = _make_article("Alpha", tmp_path)
+    art_b = _make_article("Beta", tmp_path)
+    pairs = [(art_a, art_b, ["claim A"], ["claim B"])]
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(side_effect=RuntimeError("LLM exploded"))
+
+    settings = MagicMock()
+    settings.linter.contradiction_llm_max_tokens = 1024
+    settings.linter.contradiction_llm_temperature = 0.2
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(
+            scalars=MagicMock(
+                return_value=MagicMock(first=MagicMock(return_value=None))
+            )
+        )
+    )
+    session.flush = AsyncMock()
+
+    with patch(
+        "wikimind.engine.linter.contradictions._compare_article_pair",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_per_pair:
+        findings = await _run_batch(
+            pairs, "concept-1", mock_router, settings, "report-1", session
+        )
+
+    # router.complete called twice (initial + retry)
+    assert mock_router.complete.call_count == 2
+    # _compare_article_pair called once per pair (fallback)
+    assert mock_per_pair.call_count == 1
+    assert findings == []
+
+
+@pytest.mark.asyncio
+async def test_run_batch_retry_succeeds_on_second_attempt(tmp_path: Path) -> None:
+    """If the first attempt fails but the retry succeeds, no fallback is used."""
+    art_a = _make_article("Alpha", tmp_path)
+    art_b = _make_article("Beta", tmp_path)
+    pairs = [(art_a, art_b, ["claim A"], ["claim B"])]
+
+    good_response = MagicMock()
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(
+        side_effect=[RuntimeError("transient"), good_response],
+    )
+    mock_router.parse_json_response = MagicMock(
+        return_value=[{"pair_index": 0, "contradictions": []}],
+    )
+
+    settings = MagicMock()
+    settings.linter.contradiction_llm_max_tokens = 1024
+    settings.linter.contradiction_llm_temperature = 0.2
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(
+            scalars=MagicMock(
+                return_value=MagicMock(first=MagicMock(return_value=None))
+            )
+        )
+    )
+    session.flush = AsyncMock()
+
+    with patch(
+        "wikimind.engine.linter.contradictions._compare_article_pair",
+        new_callable=AsyncMock,
+    ) as mock_per_pair:
+        findings = await _run_batch(
+            pairs, None, mock_router, settings, "r1", session
+        )
+
+    assert mock_router.complete.call_count == 2
+    assert mock_per_pair.call_count == 0  # no fallback needed
+    assert findings == []
+
+
+@pytest.mark.asyncio
+async def test_run_batch_parse_error_triggers_fallback(tmp_path: Path) -> None:
+    """Unparseable response (not a list) triggers retry then fallback."""
+    art_a = _make_article("Alpha", tmp_path)
+    art_b = _make_article("Beta", tmp_path)
+    pairs = [(art_a, art_b, ["claim A"], ["claim B"])]
+
+    mock_response = MagicMock()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    # Return a dict without "results" key -- triggers ValueError
+    mock_router.parse_json_response = MagicMock(
+        return_value={"unexpected": "shape"}
+    )
+
+    settings = MagicMock()
+    settings.linter.contradiction_llm_max_tokens = 1024
+    settings.linter.contradiction_llm_temperature = 0.2
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(
+            scalars=MagicMock(
+                return_value=MagicMock(first=MagicMock(return_value=None))
+            )
+        )
+    )
+    session.flush = AsyncMock()
+
+    with patch(
+        "wikimind.engine.linter.contradictions._compare_article_pair",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_per_pair:
+        await _run_batch(pairs, None, mock_router, settings, "r1", session)
+
+    # Two attempts (both parse to bad shape), then fallback
+    assert mock_router.complete.call_count == 2
+    assert mock_per_pair.call_count == 1

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -188,6 +188,8 @@ async def test_detect_contradictions_respects_pair_cap(db_session, _isolated_dat
     settings = get_settings()
     # Set cap very low
     settings.linter.max_contradiction_pairs_per_concept = 2
+    # Disable batching so each pair = one LLM call
+    settings.linter.contradiction_batch_enabled = False
 
     report = LintReport(id="r1")
     db_session.add(report)


### PR DESCRIPTION
## Summary
- Batch uncached article pairs into groups of N (default 4) per LLM call
- Retry once on failure, fall back to individual per-pair calls
- Per-pair cache granularity preserved
- Config: WIKIMIND_LINTER__CONTRADICTION_BATCH_SIZE, WIKIMIND_LINTER__CONTRADICTION_BATCH_ENABLED
- ADR-018: batched contradiction detection design

Closes #138