### PR TITLE
feat(linter): backlink enforcer integration with auto-repair

### DIFF
--- a/apps/web/src/api/lint.ts
+++ b/apps/web/src/api/lint.ts
@@ -5,7 +5,6 @@ import { apiFetch } from "./client";
 // --- Response types ---
 
 export type LintSeverity = "info" | "warn" | "error";
-export type LintFindingKind = "contradiction" | "orphan";
 export type LintReportStatus = "in_progress" | "complete" | "failed";
 
 export interface LintReport {
@@ -52,12 +51,26 @@ export interface LintOrphanFinding extends LintFindingCommon {
   article_title: string;
 }
 
-export type LintFinding = LintContradictionFinding | LintOrphanFinding;
+export interface LintStructuralFinding extends LintFindingCommon {
+  kind: "structural";
+  article_id: string;
+  violation_type: string;
+  auto_repaired: boolean;
+  detail: string;
+}
+
+export type LintFindingKind = "contradiction" | "orphan" | "structural";
+
+export type LintFinding =
+  | LintContradictionFinding
+  | LintOrphanFinding
+  | LintStructuralFinding;
 
 export interface LintReportDetail {
   report: LintReport;
   contradictions: LintContradictionFinding[];
   orphans: LintOrphanFinding[];
+  structurals: LintStructuralFinding[];
   resolutions: Record<string, string>;
 }
 

--- a/apps/web/src/components/health/FindingCard.tsx
+++ b/apps/web/src/components/health/FindingCard.tsx
@@ -16,6 +16,7 @@ import type {
   LintFinding,
   LintOrphanFinding,
   LintSeverity,
+  LintStructuralFinding,
   ResolutionOption,
 } from "../../api/lint";
 
@@ -239,6 +240,50 @@ function OrphanActions({ finding }: { finding: LintOrphanFinding }) {
   );
 }
 
+function StructuralDetail({ finding }: { finding: LintStructuralFinding }) {
+  const typeColors: Record<string, string> = {
+    source_no_concepts: "bg-red-100 text-red-700",
+    concept_insufficient_synthesizes: "bg-amber-100 text-amber-700",
+    missing_inverse_link: "bg-blue-100 text-blue-700",
+  };
+  const color =
+    typeColors[finding.violation_type] ?? "bg-slate-100 text-slate-700";
+
+  return (
+    <div className="mt-2 space-y-1 text-sm">
+      <div className="flex items-center gap-2">
+        <span
+          className={`rounded px-1.5 py-0.5 text-xs font-medium ${color}`}
+        >
+          {finding.violation_type.replace(/_/g, " ")}
+        </span>
+        {finding.auto_repaired && (
+          <span className="rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">
+            Auto-fixed
+          </span>
+        )}
+      </div>
+      <p className="text-slate-600">{finding.detail}</p>
+    </div>
+  );
+}
+
+function StructuralActions({ finding }: { finding: LintStructuralFinding }) {
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2">
+      <Link
+        to={`/wiki/${finding.article_id}`}
+        className="rounded border border-sky-300 px-2 py-1 text-xs text-sky-700 hover:bg-sky-50"
+      >
+        View Article
+      </Link>
+      {!finding.auto_repaired && (
+        <RecompileButton articleId={finding.article_id} />
+      )}
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  FindingCard (exported)                                             */
 /* ------------------------------------------------------------------ */
@@ -281,10 +326,15 @@ export function FindingCard({ finding, resolutions }: Props) {
           <ContradictionDetail finding={finding} />
           <ContradictionActions finding={finding} resolution={resolution} />
         </>
+      ) : finding.kind === "structural" ? (
+        <>
+          <StructuralDetail finding={finding as LintStructuralFinding} />
+          <StructuralActions finding={finding as LintStructuralFinding} />
+        </>
       ) : (
         <>
-          <OrphanDetail finding={finding} />
-          <OrphanActions finding={finding} />
+          <OrphanDetail finding={finding as LintOrphanFinding} />
+          <OrphanActions finding={finding as LintOrphanFinding} />
         </>
       )}
     </Card>

--- a/apps/web/src/components/health/FindingsByKindTabs.tsx
+++ b/apps/web/src/components/health/FindingsByKindTabs.tsx
@@ -6,7 +6,7 @@ interface Props {
   detail: LintReportDetail;
 }
 
-type TabKey = "contradictions" | "orphans";
+type TabKey = "contradictions" | "orphans" | "structurals";
 
 interface TabDef {
   key: TabKey;
@@ -23,6 +23,11 @@ export function FindingsByKindTabs({ detail }: Props) {
       count: detail.contradictions.length - resolvedCount,
     },
     { key: "orphans", label: "Orphans", count: detail.orphans.length },
+    {
+      key: "structurals",
+      label: "Structural",
+      count: (detail.structurals ?? []).length,
+    },
   ];
 
   const [activeTab, setActiveTab] = useState<TabKey>("contradictions");
@@ -68,6 +73,17 @@ export function FindingsByKindTabs({ detail }: Props) {
             </p>
           ) : (
             detail.orphans.map((f) => (
+              <FindingCard key={f.id} finding={f} />
+            ))
+          ))}
+
+        {activeTab === "structurals" &&
+          ((detail.structurals ?? []).length === 0 ? (
+            <p className="py-8 text-center text-sm text-slate-400">
+              No structural issues found.
+            </p>
+          ) : (
+            (detail.structurals ?? []).map((f) => (
               <FindingCard key={f.id} finding={f} />
             ))
           ))}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,12 +19,11 @@ considered, and the consequences.
 | [009](adr-009-decoupled-ingest-compilation.md) | Decoupled ingest and compilation | Accepted |
 | [010](adr-010-llm-provider-auto-enable.md) | Auto-enable LLM providers when their API key is detected | Accepted |
 | [011](adr-011-conversational-qa-thread-model.md) | Conversational Q&A thread model | Accepted |
-| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Proposed |
+| [012](adr-012-knowledge-graph-architecture.md) | Knowledge graph architecture | Accepted |
 | [013](adr-013-react-force-graph-2d.md) | react-force-graph-2d for knowledge graph visualization | Proposed |
 | [014](adr-014-hybrid-search-architecture.md) | Hybrid search with ChromaDB and sentence-transformers | Accepted |
 | [015](adr-015-cpu-first-docker-packaging.md) | CPU-First Docker Packaging | Unknown |
-| [016](adr-016-article-recompilation.md) | Article recompilation as a first-class action | Accepted |
-| [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
+| [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
 
 ## ADR Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ considered, and the consequences.
 | [013](adr-013-react-force-graph-2d.md) | react-force-graph-2d for knowledge graph visualization | Proposed |
 | [014](adr-014-hybrid-search-architecture.md) | Hybrid search with ChromaDB and sentence-transformers | Accepted |
 | [015](adr-015-cpu-first-docker-packaging.md) | CPU-First Docker Packaging | Unknown |
+| [016](adr-016-article-recompilation.md) | Article recompilation as a first-class action | Accepted |
 | [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
 
 ## ADR Format

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ considered, and the consequences.
 | [015](adr-015-cpu-first-docker-packaging.md) | CPU-First Docker Packaging | Unknown |
 | [016](adr-016-article-recompilation.md) | Article recompilation as a first-class action | Accepted |
 | [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
+| [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
 
 ## ADR Format
 

--- a/docs/adr/adr-012-knowledge-graph-architecture.md
+++ b/docs/adr/adr-012-knowledge-graph-architecture.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Proposed
+Accepted
+
+**Revision (2026-04-15):** The backlink enforcer now runs as Phase 3 of
+the lint pipeline (ADR-017), auto-repairing missing inverse links for
+symmetric relation types. This strengthens the "graph quality is bounded
+by Backlink quality" constraint noted below by providing automated
+structural integrity enforcement.
 
 ## Context
 

--- a/docs/adr/adr-017-backlink-enforcer-lint-phase.md
+++ b/docs/adr/adr-017-backlink-enforcer-lint-phase.md
@@ -1,0 +1,35 @@
+# ADR-017: Backlink enforcer as lint Phase 3 with auto-repair
+
+## Status
+
+Accepted
+
+## Context
+
+The backlink enforcer (`engine/backlink_enforcer.py`) exists as standalone logic that checks structural integrity of the knowledge graph. However, it was not wired into any production pipeline.
+
+The lint pipeline already runs Phase 1 (contradiction detection) and Phase 2 (orphan detection). The enforcer's checks are complementary.
+
+## Decision
+
+Wire `enforce_backlinks()` into the lint pipeline as **Phase 3**. The enforcer:
+
+1. Runs on every article during a lint pass.
+2. Reports violations as `StructuralFinding` rows linked to the `LintReport`.
+3. Auto-repairs missing inverse links (`auto_repaired=True`).
+4. Reports non-repairable issues for manual resolution.
+
+## Alternatives Considered
+
+- **Report-only**: Rejected. Missing inverses are deterministic fixes.
+- **Silent auto-fix**: Rejected. Users should see what changed.
+- **Compile-time only**: Rejected. Misses violations from manual edits.
+
+## Consequences
+
+- Lint runs include Phase 3 with O(N) lightweight queries.
+- Missing inverse links auto-repaired during lint.
+- New `StructuralFinding` table with `violation_type`, `auto_repaired`, `detail`.
+- `LintReport` gains `structural_count` and `checked_articles`.
+- Health Dashboard gains "Structural" tab.
+- Orphan check removed from enforcer (handled by Phase 2).

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -189,6 +189,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /wiki/contradiction-resolutions:
+    get:
+      tags:
+      - Wiki
+      summary: List Contradiction Resolutions
+      description: Return the valid contradiction resolution options.
+      operationId: list_contradiction_resolutions_wiki_contradiction_resolutions_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
   /wiki/articles:
     get:
       tags:
@@ -415,6 +428,40 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolveContradictionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /wiki/articles/{article_id}/recompile:
+    post:
+      tags:
+      - Wiki
+      summary: Recompile Article
+      description: Schedule an async recompilation job for an article.
+      operationId: recompile_article_wiki_articles__article_id__recompile_post
+      parameters:
+      - name: article_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Article Id
+      - name: mode
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Mode
       responses:
         '200':
           description: Successful Response
@@ -1731,6 +1778,12 @@ components:
             $ref: '#/components/schemas/OrphanFinding'
           type: array
           title: Orphans
+        resolutions:
+          additionalProperties:
+            type: string
+          type: object
+          title: Resolutions
+          default: {}
         structurals:
           items:
             $ref: '#/components/schemas/StructuralFinding'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -189,19 +189,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/contradiction-resolutions:
-    get:
-      tags:
-      - Wiki
-      summary: List Contradiction Resolutions
-      description: Return the valid contradiction resolution options.
-      operationId: list_contradiction_resolutions_wiki_contradiction_resolutions_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
   /wiki/articles:
     get:
       tags:
@@ -428,40 +415,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolveContradictionRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/{article_id}/recompile:
-    post:
-      tags:
-      - Wiki
-      summary: Recompile Article
-      description: Schedule an async recompilation job for an article.
-      operationId: recompile_article_wiki_articles__article_id__recompile_post
-      parameters:
-      - name: article_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Article Id
-      - name: mode
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Mode
       responses:
         '200':
           description: Successful Response
@@ -1682,6 +1635,7 @@ components:
       enum:
       - contradiction
       - orphan
+      - structural
       title: LintFindingKind
       description: 'Kind of lint finding — maps 1:1 to a detection function AND a
         table.
@@ -1724,6 +1678,15 @@ components:
           type: integer
           title: Orphans Count
           default: 0
+        structural_count:
+          type: integer
+          title: Structural Count
+          default: 0
+        checked_articles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Checked Articles
         missing_pages_count:
           type: integer
           title: Missing Pages Count
@@ -1768,12 +1731,12 @@ components:
             $ref: '#/components/schemas/OrphanFinding'
           type: array
           title: Orphans
-        resolutions:
-          additionalProperties:
-            type: string
-          type: object
-          title: Resolutions
-          default: {}
+        structurals:
+          items:
+            $ref: '#/components/schemas/StructuralFinding'
+          type: array
+          title: Structurals
+          default: []
       type: object
       required:
       - report
@@ -2092,6 +2055,63 @@ components:
       - obsidian
       title: SourceType
       description: Type of ingested source.
+    StructuralFinding:
+      properties:
+        id:
+          type: string
+          title: Id
+        report_id:
+          type: string
+          title: Report Id
+        severity:
+          $ref: '#/components/schemas/LintSeverity'
+          default: warn
+        description:
+          type: string
+          title: Description
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        dismissed:
+          type: boolean
+          title: Dismissed
+          default: false
+        dismissed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Dismissed At
+        content_hash:
+          type: string
+          title: Content Hash
+        kind:
+          $ref: '#/components/schemas/LintFindingKind'
+          default: structural
+        article_id:
+          type: string
+          title: Article Id
+        violation_type:
+          type: string
+          title: Violation Type
+        auto_repaired:
+          type: boolean
+          title: Auto Repaired
+          default: false
+        detail:
+          type: string
+          title: Detail
+          default: ''
+      type: object
+      required:
+      - report_id
+      - description
+      - content_hash
+      - article_id
+      - violation_type
+      title: StructuralFinding
+      description: A structural integrity violation detected by the backlink enforcer.
     TurnSelection:
       properties:
         conversation_id:

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -164,6 +164,13 @@ async def _migrate_added_columns(engine) -> None:
         ("backlink", "resolved_at", "ALTER TABLE backlink ADD COLUMN resolved_at TEXT"),
         ("backlink", "resolved_by", "ALTER TABLE backlink ADD COLUMN resolved_by TEXT"),
         ("concept", "concept_kind", "ALTER TABLE concept ADD COLUMN concept_kind TEXT NOT NULL DEFAULT 'topic'"),
+        # PR #151 — backlink enforcer integration
+        (
+            "lintreport",
+            "structural_count",
+            "ALTER TABLE lintreport ADD COLUMN structural_count INTEGER NOT NULL DEFAULT 0",
+        ),
+        ("lintreport", "checked_articles", "ALTER TABLE lintreport ADD COLUMN checked_articles INTEGER"),
     ]
     indexes: list[tuple[str, str]] = [
         # (index name, CREATE fragment)

--- a/src/wikimind/engine/backlink_enforcer.py
+++ b/src/wikimind/engine/backlink_enforcer.py
@@ -6,14 +6,16 @@ missing inverse links.
 
 Usage:
 
-    warnings = await enforce_backlinks(article_id, session)
-    # warnings is [] when all checks pass
+    result = await enforce_backlinks(article_id, session)
+    # result.violations is [] when all checks pass
+    # result.warnings is [] when all checks pass (backward compat)
 """
 
 from __future__ import annotations
 
 import contextlib
 import json
+from dataclasses import dataclass, field
 
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,6 +27,25 @@ log = structlog.get_logger()
 
 # Symmetric relation types -- inverse must exist for graph consistency.
 _SYMMETRIC_TYPES: frozenset[RelationType] = frozenset({RelationType.CONTRADICTS, RelationType.RELATED_TO})
+
+
+@dataclass
+class EnforcerViolation:
+    """A single structural violation found by the enforcer."""
+
+    article_id: str
+    article_title: str
+    violation_type: str
+    detail: str
+    auto_repaired: bool = False
+
+
+@dataclass
+class EnforcerResult:
+    """Aggregated result of running the backlink enforcer on one article."""
+
+    violations: list[EnforcerViolation] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
 
 async def ensure_bidirectional(backlink: Backlink, session: AsyncSession) -> bool:
@@ -64,26 +85,29 @@ async def ensure_bidirectional(backlink: Backlink, session: AsyncSession) -> boo
     return True
 
 
-async def enforce_backlinks(article_id: str, session: AsyncSession) -> list[str]:
+async def enforce_backlinks(article_id: str, session: AsyncSession) -> EnforcerResult:
     """Run structural integrity checks on an article's backlinks.
 
-    Returns a list of warning messages (empty means all checks pass).
+    Returns an EnforcerResult with violations and warnings.
 
     Checks performed:
         1. Source pages must have >= 1 concept in concept_ids.
         2. Concept pages must have >= 2 ``synthesizes`` outbound links.
-        3. Flag articles with zero inbound AND zero outbound links (orphans).
-        4. For ``contradicts`` / ``related_to`` links: auto-create inverse
+        3. For ``contradicts`` / ``related_to`` links: auto-create inverse
            if missing (bidirectional enforcement).
+
+    Note: orphan detection is handled separately by detect_orphans() in
+    the linter pipeline and is NOT duplicated here.
     """
-    warnings: list[str] = []
+    result = EnforcerResult()
 
     # Load the article
-    result = await session.execute(select(Article).where(Article.id == article_id))
-    article = result.scalars().first()
+    query_result = await session.execute(select(Article).where(Article.id == article_id))
+    article = query_result.scalars().first()
     if article is None:
-        warnings.append(f"Article {article_id} not found")
-        return warnings
+        msg = f"Article {article_id} not found"
+        result.warnings.append(msg)
+        return result
 
     # ---- Check 1: source pages need >= 1 concept ----
     if article.page_type == "source":
@@ -92,7 +116,16 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> list[str]
             with contextlib.suppress(TypeError, ValueError):
                 concept_ids = json.loads(article.concept_ids)
         if not concept_ids:
-            warnings.append(f"Source page '{article.title}' has no concepts in concept_ids")
+            msg = f"Source page '{article.title}' has no concepts in concept_ids"
+            result.warnings.append(msg)
+            result.violations.append(
+                EnforcerViolation(
+                    article_id=article_id,
+                    article_title=article.title,
+                    violation_type="source_no_concepts",
+                    detail=msg,
+                )
+            )
 
     # ---- Check 2: concept pages need >= 2 synthesizes links ----
     if article.page_type == "concept":
@@ -104,23 +137,41 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> list[str]
         )
         synth_count = len(list(synth_result.scalars().all()))
         if synth_count < 2:
-            warnings.append(f"Concept page '{article.title}' has {synth_count} synthesizes links (need >= 2)")
+            msg = f"Concept page '{article.title}' has {synth_count} synthesizes links (need >= 2)"
+            result.warnings.append(msg)
+            result.violations.append(
+                EnforcerViolation(
+                    article_id=article_id,
+                    article_title=article.title,
+                    violation_type="concept_insufficient_synthesizes",
+                    detail=msg,
+                )
+            )
 
-    # ---- Check 3: orphan detection ----
+    # ---- Check 3: bidirectional enforcement for symmetric types ----
     out_result = await session.execute(select(Backlink).where(Backlink.source_article_id == article_id))
     outbound = list(out_result.scalars().all())
 
     in_result = await session.execute(select(Backlink).where(Backlink.target_article_id == article_id))
     inbound = list(in_result.scalars().all())
 
-    if not outbound and not inbound:
-        warnings.append(f"Article '{article.title}' is an orphan (zero inbound and outbound links)")
-
-    # ---- Check 4: bidirectional enforcement for symmetric types ----
     all_links = outbound + inbound
     for bl in all_links:
         created = await ensure_bidirectional(bl, session)
         if created:
+            msg = (
+                f"Missing inverse link created: {bl.source_article_id} <-> {bl.target_article_id} ({bl.relation_type})"
+            )
+            result.warnings.append(msg)
+            result.violations.append(
+                EnforcerViolation(
+                    article_id=article_id,
+                    article_title=article.title,
+                    violation_type="missing_inverse_link",
+                    detail=msg,
+                    auto_repaired=True,
+                )
+            )
             log.info(
                 "Auto-created inverse for symmetric link",
                 source=bl.source_article_id,
@@ -128,4 +179,4 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> list[str]
                 relation_type=bl.relation_type,
             )
 
-    return warnings
+    return result

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -7,6 +7,8 @@ event on completion.
 
 from __future__ import annotations
 
+import hashlib
+
 import structlog
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,6 +17,7 @@ from sqlmodel import select
 from wikimind._datetime import utcnow_naive
 from wikimind.api.routes.ws import emit_linter_alert
 from wikimind.config import get_settings
+from wikimind.engine.backlink_enforcer import enforce_backlinks
 from wikimind.engine.linter.contradictions import detect_contradictions
 from wikimind.engine.linter.orphans import detect_orphans
 from wikimind.engine.llm_router import get_llm_router
@@ -22,23 +25,66 @@ from wikimind.models import (
     Article,
     ContradictionFinding,
     DismissedFinding,
+    LintFindingKind,
     LintReport,
     LintReportStatus,
+    LintSeverity,
     OrphanFinding,
+    StructuralFinding,
 )
 
 log = structlog.get_logger()
+
+
+def _structural_content_hash(article_id: str, violation_type: str) -> str:
+    """Compute a stable sha256 for cross-run dedup of structural findings."""
+    raw = f"{LintFindingKind.STRUCTURAL}|{article_id}|{violation_type}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+async def run_enforcer_checks(session: AsyncSession, report: LintReport) -> list[StructuralFinding]:
+    """Run the backlink enforcer on all articles and return StructuralFinding rows.
+
+    Phase 3 of the lint pipeline — runs after contradictions and orphans.
+    """
+    result = await session.execute(select(Article))
+    articles = list(result.scalars().all())
+
+    findings: list[StructuralFinding] = []
+    checked = 0
+
+    for article in articles:
+        enforcer_result = await enforce_backlinks(article.id, session)
+        checked += 1
+
+        for violation in enforcer_result.violations:
+            finding = StructuralFinding(
+                report_id=report.id,
+                severity=LintSeverity.WARN,
+                description=violation.detail,
+                content_hash=_structural_content_hash(violation.article_id, violation.violation_type),
+                article_id=violation.article_id,
+                violation_type=violation.violation_type,
+                auto_repaired=violation.auto_repaired,
+                detail=violation.detail,
+            )
+            findings.append(finding)
+
+    report.checked_articles = checked
+    return findings
 
 
 async def _apply_dismiss_suppression(
     session: AsyncSession,
     contradictions: list[ContradictionFinding],
     orphans: list[OrphanFinding],
+    structurals: list[StructuralFinding] | None = None,
 ) -> None:
     """Mark findings as dismissed if their content_hash exists in DismissedFinding."""
-    all_findings: list[ContradictionFinding | OrphanFinding] = [
+    all_findings: list[ContradictionFinding | OrphanFinding | StructuralFinding] = [
         *contradictions,
         *orphans,
+        *(structurals or []),
     ]
     all_hashes = {f.content_hash for f in all_findings}
 
@@ -93,29 +139,42 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
     await session.flush()
 
     try:
-        # Run checks
+        # Phase 1: Contradictions
         contradictions = await detect_contradictions(session, router, settings, report)
+
+        # Phase 2: Orphans
         orphans = await detect_orphans(session, settings, report.id)
 
+        # Phase 3: Structural integrity (backlink enforcer)
+        structurals = await run_enforcer_checks(session, report)
+
         # Apply dismiss suppression
-        await _apply_dismiss_suppression(session, contradictions, orphans)
+        await _apply_dismiss_suppression(session, contradictions, orphans, structurals)
 
         # Persist findings
         for cf in contradictions:
             session.add(cf)
         for of in orphans:
             session.add(of)
+        for sf in structurals:
+            session.add(sf)
 
         # Update report — count only active (non-dismissed) findings
         active_contradictions = [c for c in contradictions if not c.dismissed]
         active_orphans = [o for o in orphans if not o.dismissed]
-        dismissed = (len(contradictions) - len(active_contradictions)) + (len(orphans) - len(active_orphans))
+        active_structurals = [s for s in structurals if not s.dismissed]
+        dismissed = (
+            (len(contradictions) - len(active_contradictions))
+            + (len(orphans) - len(active_orphans))
+            + (len(structurals) - len(active_structurals))
+        )
 
         report.status = LintReportStatus.COMPLETE
         report.completed_at = utcnow_naive()
         report.contradictions_count = len(active_contradictions)
         report.orphans_count = len(active_orphans)
-        report.total_findings = len(active_contradictions) + len(active_orphans)
+        report.structural_count = len(active_structurals)
+        report.total_findings = len(active_contradictions) + len(active_orphans) + len(active_structurals)
         report.dismissed_count = dismissed
         session.add(report)
         await session.commit()
@@ -125,6 +184,7 @@ async def run_lint(session: AsyncSession, job_id: str | None = None) -> LintRepo
             report_id=report.id,
             contradictions=len(contradictions),
             orphans=len(orphans),
+            structurals=len(structurals),
         )
 
         # Emit WebSocket alert

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -497,6 +497,7 @@ class LintFindingKind(StrEnum):
 
     CONTRADICTION = "contradiction"
     ORPHAN = "orphan"
+    STRUCTURAL = "structural"
 
 
 class LintReportStatus(StrEnum):
@@ -518,6 +519,8 @@ class LintReport(SQLModel, table=True):
     total_findings: int = 0
     contradictions_count: int = 0
     orphans_count: int = 0
+    structural_count: int = 0
+    checked_articles: int | None = None
     missing_pages_count: int = 0
     dismissed_count: int = 0
     total_pairs: int = 0
@@ -559,6 +562,16 @@ class OrphanFinding(_LintFindingBase, table=True):
     article_title: str
 
 
+class StructuralFinding(_LintFindingBase, table=True):
+    """A structural integrity violation detected by the backlink enforcer."""
+
+    kind: LintFindingKind = Field(default=LintFindingKind.STRUCTURAL)
+    article_id: str = Field(foreign_key="article.id", index=True)
+    violation_type: str  # source_no_concepts | concept_insufficient_synthesizes | missing_inverse_link
+    auto_repaired: bool = False
+    detail: str = ""
+
+
 class DismissedFinding(SQLModel, table=True):
     """Cross-run dismiss record — keyed by content hash."""
 
@@ -575,6 +588,7 @@ class LintReportDetail(BaseModel):
     contradictions: list[ContradictionFinding]
     orphans: list[OrphanFinding]
     resolutions: dict[str, str] = {}  # "article_a_id|article_b_id" → resolution
+    structurals: list[StructuralFinding] = []
 
 
 class LintPairCache(SQLModel, table=True):

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -22,6 +22,7 @@ from wikimind.models import (
     LintReportDetail,
     OrphanFinding,
     RelationType,
+    StructuralFinding,
 )
 
 
@@ -81,6 +82,7 @@ class LinterService:
 
         contradiction_query = select(ContradictionFinding).where(ContradictionFinding.report_id == report_id)
         orphan_query = select(OrphanFinding).where(OrphanFinding.report_id == report_id)
+        structural_query = select(StructuralFinding).where(StructuralFinding.report_id == report_id)
 
         if not include_dismissed:
             contradiction_query = contradiction_query.where(
@@ -89,9 +91,13 @@ class LinterService:
             orphan_query = orphan_query.where(
                 OrphanFinding.dismissed == False  # noqa: E712
             )
+            structural_query = structural_query.where(
+                StructuralFinding.dismissed == False  # noqa: E712
+            )
 
         contradictions_result = await session.execute(contradiction_query)
         orphans_result = await session.execute(orphan_query)
+        structurals_result = await session.execute(structural_query)
 
         contradictions = list(contradictions_result.scalars().all())
         resolutions = await self._get_resolutions(session, contradictions)
@@ -101,6 +107,7 @@ class LinterService:
             contradictions=contradictions,
             orphans=list(orphans_result.scalars().all()),
             resolutions=resolutions,
+            structurals=list(structurals_result.scalars().all()),
         )
 
     async def _get_resolutions(
@@ -170,11 +177,13 @@ class LinterService:
         """
         now = utcnow_naive()
 
-        finding: ContradictionFinding | OrphanFinding | None
+        finding: ContradictionFinding | OrphanFinding | StructuralFinding | None
         if kind == LintFindingKind.CONTRADICTION:
             finding = await session.get(ContradictionFinding, finding_id)
         elif kind == LintFindingKind.ORPHAN:
             finding = await session.get(OrphanFinding, finding_id)
+        elif kind == LintFindingKind.STRUCTURAL:
+            finding = await session.get(StructuralFinding, finding_id)
         else:
             raise HTTPException(status_code=400, detail=f"Unknown finding kind: {kind}")
 
@@ -192,6 +201,8 @@ class LinterService:
                 report.contradictions_count = max(0, report.contradictions_count - 1)
             elif kind == LintFindingKind.ORPHAN:
                 report.orphans_count = max(0, report.orphans_count - 1)
+            elif kind == LintFindingKind.STRUCTURAL:
+                report.structural_count = max(0, report.structural_count - 1)
             report.total_findings = max(0, report.total_findings - 1)
             report.dismissed_count += 1
             session.add(report)

--- a/tests/unit/test_backlink_enforcer.py
+++ b/tests/unit/test_backlink_enforcer.py
@@ -96,8 +96,8 @@ async def test_enforcer_source_page_no_concepts(db_session, _isolated_data_dir, 
     )
     db_session.add(art)
     await db_session.commit()
-    warnings = await enforce_backlinks("a1", db_session)
-    assert any("no concepts" in w.lower() for w in warnings)
+    result = await enforce_backlinks("a1", db_session)
+    assert any("no concepts" in w.lower() for w in result.warnings)
 
 
 @pytest.mark.asyncio
@@ -111,19 +111,21 @@ async def test_enforcer_concept_page_insufficient_synthesizes(db_session, _isola
     bl = Backlink(source_article_id="c1", target_article_id="s1", relation_type=RelationType.SYNTHESIZES)
     db_session.add(bl)
     await db_session.commit()
-    warnings = await enforce_backlinks("c1", db_session)
-    assert any("synthesizes" in w.lower() for w in warnings)
+    result = await enforce_backlinks("c1", db_session)
+    assert any("synthesizes" in w.lower() for w in result.warnings)
 
 
 @pytest.mark.asyncio
-async def test_enforcer_orphan_detected(db_session, _isolated_data_dir, tmp_path):
+async def test_enforcer_no_orphan_check(db_session, _isolated_data_dir, tmp_path):
+    """Orphan detection is handled by detect_orphans(), not the enforcer."""
     art = _make_article(
         tmp_path, article_id="orphan1", slug="orphan", title="Orphan Article", concept_ids=["some-concept"]
     )
     db_session.add(art)
     await db_session.commit()
-    warnings = await enforce_backlinks("orphan1", db_session)
-    assert any("orphan" in w.lower() for w in warnings)
+    result = await enforce_backlinks("orphan1", db_session)
+    # The enforcer no longer checks for orphans
+    assert not any("orphan" in w.lower() for w in result.warnings)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_enforcer_integration.py
+++ b/tests/unit/test_enforcer_integration.py
@@ -1,0 +1,139 @@
+"""Tests for the backlink enforcer integration with the lint pipeline (PR 2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlmodel import select
+
+from wikimind.engine.linter.runner import run_lint
+from wikimind.models import Article, Backlink, LintReportStatus, PageType, RelationType, StructuralFinding
+from wikimind.services.linter import LinterService
+
+
+def _make_article(
+    tmp_path: Path,
+    *,
+    article_id: str = "a1",
+    slug: str = "test-article",
+    title: str = "Test Article",
+    concept_ids: list[str] | None = None,
+    page_type: PageType = PageType.SOURCE,
+    claims: list[str] | None = None,
+) -> Article:
+    file_path = tmp_path / f"{slug}.md"
+    body_lines = [f"# {title}", ""]
+    if claims:
+        body_lines.append("## Key Claims")
+        for c in claims:
+            body_lines.append(f"- {c}")
+    else:
+        body_lines.append("Some body content here.")
+    file_path.write_text("\n".join(body_lines), encoding="utf-8")
+    return Article(
+        id=article_id,
+        slug=slug,
+        title=title,
+        file_path=str(file_path),
+        concept_ids=json.dumps(concept_ids) if concept_ids else None,
+        page_type=page_type,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lint_run_includes_structural_findings(db_session, _isolated_data_dir, tmp_path) -> None:
+    """A source article with no concepts produces a structural violation in the report."""
+    art = _make_article(
+        tmp_path,
+        article_id="s1",
+        slug="no-concepts",
+        title="No Concepts Source",
+        concept_ids=None,
+        page_type=PageType.SOURCE,
+    )
+    db_session.add(art)
+    await db_session.commit()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+    with (
+        patch("wikimind.engine.linter.runner.get_llm_router", return_value=mock_router),
+        patch("wikimind.engine.linter.runner.emit_linter_alert", new_callable=AsyncMock),
+    ):
+        report = await run_lint(db_session)
+    assert report.status == LintReportStatus.COMPLETE
+    assert report.structural_count >= 1
+    assert report.checked_articles == 1
+    result = await db_session.execute(select(StructuralFinding).where(StructuralFinding.report_id == report.id))
+    findings = list(result.scalars().all())
+    assert len(findings) >= 1
+    assert any(f.violation_type == "source_no_concepts" for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_lint_run_auto_repairs_missing_inverse(db_session, _isolated_data_dir, tmp_path) -> None:
+    """A one-directional contradicts link gets auto-repaired with auto_repaired=True."""
+    art_a = _make_article(tmp_path, article_id="a1", slug="art-a", title="Art A", concept_ids=["c1"])
+    art_b = _make_article(tmp_path, article_id="a2", slug="art-b", title="Art B", concept_ids=["c1"])
+    db_session.add(art_a)
+    db_session.add(art_b)
+    bl = Backlink(
+        source_article_id="a1", target_article_id="a2", relation_type=RelationType.CONTRADICTS, context="claim conflict"
+    )
+    db_session.add(bl)
+    await db_session.commit()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+    with (
+        patch("wikimind.engine.linter.runner.get_llm_router", return_value=mock_router),
+        patch("wikimind.engine.linter.runner.emit_linter_alert", new_callable=AsyncMock),
+    ):
+        report = await run_lint(db_session)
+    assert report.status == LintReportStatus.COMPLETE
+    result = await db_session.execute(
+        select(StructuralFinding).where(
+            StructuralFinding.report_id == report.id, StructuralFinding.violation_type == "missing_inverse_link"
+        )
+    )
+    findings = list(result.scalars().all())
+    assert len(findings) >= 1
+    assert findings[0].auto_repaired is True
+    bl_result = await db_session.execute(
+        select(Backlink).where(Backlink.source_article_id == "a2", Backlink.target_article_id == "a1")
+    )
+    inverse = bl_result.scalars().first()
+    assert inverse is not None
+    assert inverse.relation_type == RelationType.CONTRADICTS
+
+
+@pytest.mark.asyncio
+async def test_structural_findings_in_report_detail(db_session, _isolated_data_dir, tmp_path) -> None:
+    """LintReportDetail includes structurals when queried via the service."""
+    art = _make_article(
+        tmp_path,
+        article_id="s1",
+        slug="no-concepts",
+        title="No Concepts Source",
+        concept_ids=None,
+        page_type=PageType.SOURCE,
+    )
+    db_session.add(art)
+    await db_session.commit()
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+    with (
+        patch("wikimind.engine.linter.runner.get_llm_router", return_value=mock_router),
+        patch("wikimind.engine.linter.runner.emit_linter_alert", new_callable=AsyncMock),
+    ):
+        report = await run_lint(db_session)
+    svc = LinterService()
+    detail = await svc.get_report(db_session, report.id)
+    assert hasattr(detail, "structurals")
+    assert len(detail.structurals) >= 1
+    assert detail.structurals[0].violation_type == "source_no_concepts"
+    assert detail.report.structural_count >= 1


### PR DESCRIPTION
## Summary
- Wire enforce_backlinks() into lint pipeline as Phase 3
- New STRUCTURAL finding kind and StructuralFinding model
- Auto-repair missing inverse links (auto_repaired=True)
- Frontend: Structural tab in Health Dashboard
- ADR-017: enforcer as lint phase with auto-repair
- ADR-012: updated status to Accepted

## Test plan
- [x] Structural findings appear in lint report
- [x] Auto-repaired findings show auto_repaired=True
- [x] Health Dashboard shows Structural tab
- [x] All pre-commit hooks pass
- [x] Full test suite passes