### PR TITLE
fix: greenlet_spawn error — isolate concept compilation session (#152)

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -18,6 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
+from wikimind.database import get_session_factory
 from wikimind.engine.frontmatter_validator import validate_frontmatter
 from wikimind.engine.llm_router import get_llm_router
 from wikimind.engine.wikilink_resolver import (
@@ -359,8 +360,6 @@ Compile this into a wiki article following the JSON schema exactly."""
             # identity-map conflicts when both the source compiler and
             # concept compiler create Backlinks for overlapping article
             # pairs (issue #152 — greenlet_spawn error).
-            from wikimind.database import get_session_factory  # noqa: PLC0415
-
             async with get_session_factory()() as concept_session:
                 await maybe_trigger_concept_pages(concept_session)
         except Exception:

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -355,7 +355,14 @@ Compile this into a wiki article following the JSON schema exactly."""
             await upsert_concepts(result.concepts, session)
             await update_article_counts(session)
             await maybe_trigger_taxonomy_rebuild(session)
-            await maybe_trigger_concept_pages(session)
+            # Concept page generation must use its own session to avoid
+            # identity-map conflicts when both the source compiler and
+            # concept compiler create Backlinks for overlapping article
+            # pairs (issue #152 — greenlet_spawn error).
+            from wikimind.database import get_session_factory  # noqa: PLC0415
+
+            async with get_session_factory()() as concept_session:
+                await maybe_trigger_concept_pages(concept_session)
         except Exception:
             log.warning("taxonomy upsert failed", article_id=article.id)
 

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -348,6 +348,15 @@ provider: {self._last_provider_used or "unknown"}
         self, concept_article_id: str, source_article_ids: list[str], session: AsyncSession
     ) -> None:
         for source_id in source_article_ids:
+            # Guard against duplicate Backlinks (issue #152).
+            existing = await session.execute(
+                select(Backlink).where(
+                    Backlink.source_article_id == concept_article_id,
+                    Backlink.target_article_id == source_id,
+                )
+            )
+            if existing.scalars().first() is not None:
+                continue
             bl = Backlink(
                 source_article_id=concept_article_id,
                 target_article_id=source_id,
@@ -377,6 +386,15 @@ provider: {self._last_provider_used or "unknown"}
             if target is None:
                 continue
             for src_id, tgt_id in [(concept_article.id, target.id), (target.id, concept_article.id)]:
+                # Guard against duplicate Backlinks (issue #152).
+                existing = await session.execute(
+                    select(Backlink).where(
+                        Backlink.source_article_id == src_id,
+                        Backlink.target_article_id == tgt_id,
+                    )
+                )
+                if existing.scalars().first() is not None:
+                    continue
                 bl = Backlink(
                     source_article_id=src_id,
                     target_article_id=tgt_id,

--- a/tests/unit/test_greenlet_fix.py
+++ b/tests/unit/test_greenlet_fix.py
@@ -1,0 +1,98 @@
+"""Tests for greenlet_spawn fix -- concept compilation uses separate session."""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from wikimind.models import Article, Backlink, PageType, RelationType
+
+
+@pytest.mark.asyncio
+async def test_synthesizes_link_skips_existing(db_session: AsyncSession):
+    """_create_synthesizes_links should not create duplicate Backlinks."""
+    from wikimind.engine.concept_compiler import ConceptCompiler
+
+    a1 = Article(
+        id=str(uuid.uuid4()),
+        slug="concept-test",
+        title="Concept",
+        file_path="/tmp/c.md",
+        page_type=PageType.CONCEPT,
+    )
+    a2 = Article(
+        id=str(uuid.uuid4()),
+        slug="source-test",
+        title="Source",
+        file_path="/tmp/s.md",
+        page_type=PageType.SOURCE,
+    )
+    db_session.add_all([a1, a2])
+
+    # Pre-create a synthesizes link
+    bl = Backlink(
+        source_article_id=a1.id,
+        target_article_id=a2.id,
+        relation_type=RelationType.SYNTHESIZES,
+        context="existing",
+    )
+    db_session.add(bl)
+    await db_session.commit()
+
+    compiler = ConceptCompiler()
+    # Should NOT raise IntegrityError or create a duplicate
+    await compiler._create_synthesizes_links(a1.id, [a2.id], db_session)
+
+    result = await db_session.execute(
+        select(Backlink).where(
+            Backlink.source_article_id == a1.id,
+            Backlink.target_article_id == a2.id,
+        )
+    )
+    links = list(result.scalars().all())
+    assert len(links) == 1  # No duplicate
+
+
+@pytest.mark.asyncio
+async def test_related_to_link_skips_existing(db_session: AsyncSession):
+    """_create_related_to_links should not create duplicate Backlinks."""
+    from wikimind.engine.concept_compiler import ConceptCompiler
+
+    a1 = Article(
+        id=str(uuid.uuid4()),
+        slug="concept-a",
+        title="Concept A",
+        file_path="/tmp/a.md",
+        page_type=PageType.CONCEPT,
+    )
+    a2 = Article(
+        id=str(uuid.uuid4()),
+        slug="concept-b",
+        title="Concept B",
+        file_path="/tmp/b.md",
+        page_type=PageType.CONCEPT,
+    )
+    db_session.add_all([a1, a2])
+
+    # Pre-create a related_to link in one direction
+    bl = Backlink(
+        source_article_id=a1.id,
+        target_article_id=a2.id,
+        relation_type=RelationType.RELATED_TO,
+        context="existing",
+    )
+    db_session.add(bl)
+    await db_session.commit()
+
+    compiler = ConceptCompiler()
+    await compiler._create_related_to_links(a1, ["concept-b"], db_session)
+
+    result = await db_session.execute(
+        select(Backlink).where(
+            Backlink.source_article_id == a1.id,
+            Backlink.target_article_id == a2.id,
+        )
+    )
+    links = list(result.scalars().all())
+    assert len(links) == 1  # No duplicate in forward direction

--- a/tests/unit/test_greenlet_fix.py
+++ b/tests/unit/test_greenlet_fix.py
@@ -6,14 +6,13 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from wikimind.engine.concept_compiler import ConceptCompiler
 from wikimind.models import Article, Backlink, PageType, RelationType
 
 
 @pytest.mark.asyncio
 async def test_synthesizes_link_skips_existing(db_session: AsyncSession):
     """_create_synthesizes_links should not create duplicate Backlinks."""
-    from wikimind.engine.concept_compiler import ConceptCompiler
-
     a1 = Article(
         id=str(uuid.uuid4()),
         slug="concept-test",
@@ -57,8 +56,6 @@ async def test_synthesizes_link_skips_existing(db_session: AsyncSession):
 @pytest.mark.asyncio
 async def test_related_to_link_skips_existing(db_session: AsyncSession):
     """_create_related_to_links should not create duplicate Backlinks."""
-    from wikimind.engine.concept_compiler import ConceptCompiler
-
     a1 = Article(
         id=str(uuid.uuid4()),
         slug="concept-a",


### PR DESCRIPTION
## Summary
- Isolate concept page generation in its own async session to prevent identity-map conflicts when both the source compiler and concept compiler create Backlinks for overlapping article pairs
- Add existence checks before creating Backlinks in `_create_synthesizes_links()` and `_create_related_to_links()` to prevent duplicate row conflicts
- Root cause: source compiler and concept compiler shared one session, both creating Backlinks for overlapping article pairs, triggering `greenlet_spawn` error

Closes #152

## Test plan
- [x] `test_synthesizes_link_skips_existing` — verifies no duplicate synthesizes links are created
- [x] `test_related_to_link_skips_existing` — verifies no duplicate related_to links are created
- [x] Full test suite passes (647 passed, 3 skipped)
- [x] All pre-commit hooks pass