### PR TITLE
feat(settings): Settings UI with providers, cost dashboard, budget warnings (#29)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@
 # Monthly spending ceiling across all providers (USD)
 # WIKIMIND_LLM__MONTHLY_BUDGET_USD=50.0
 
+# Budget warning threshold (fraction 0.0–1.0; WebSocket alert at this % of budget)
+# WIKIMIND_LLM__BUDGET_WARNING_PCT=0.8
+
+# How often (seconds) the router re-queries CostLog for budget checks
+# WIKIMIND_LLM__BUDGET_CHECK_CACHE_SECONDS=60
+
 # ----------------------------------------------------------------------------
 # Per-Provider Model Overrides (optional)
 # ----------------------------------------------------------------------------

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,16 +133,16 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 372
+        "line_number": 374
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 398
       }
     ]
   },
-  "generated_at": "2026-04-15T17:30:55Z"
+  "generated_at": "2026-04-16T00:56:48Z"
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { WikiExplorerView } from "./components/wiki/WikiExplorerView";
 import { AskView } from "./components/ask/AskView";
 import { GraphView } from "./components/graph/GraphView";
 import { HealthView } from "./components/health/HealthView";
+import { SettingsView } from "./components/settings/SettingsView";
 import { useWebSocket } from "./hooks/useWebSocket";
 
 export function App() {
@@ -22,6 +23,7 @@ export function App() {
         <Route path="/wiki/:slug" element={<WikiExplorerView />} />
         <Route path="/graph" element={<GraphView />} />
         <Route path="/health" element={<HealthView />} />
+        <Route path="/settings" element={<SettingsView />} />
         <Route path="*" element={<Navigate to="/inbox" replace />} />
       </Routes>
     </Layout>

--- a/apps/web/src/api/settings.ts
+++ b/apps/web/src/api/settings.ts
@@ -64,3 +64,20 @@ export function testProvider(provider: string): Promise<TestResult> {
     query: { provider },
   });
 }
+
+export function setDefaultProvider(provider: string): Promise<{ provider: string; status: string }> {
+  return apiFetch("/settings/llm/default-provider", {
+    method: "POST",
+    body: { provider },
+  });
+}
+
+export function updateSettings(updates: {
+  monthly_budget_usd?: number;
+  fallback_enabled?: boolean;
+}): Promise<{ status: string }> {
+  return apiFetch("/settings", {
+    method: "PATCH",
+    body: updates,
+  });
+}

--- a/apps/web/src/api/settings.ts
+++ b/apps/web/src/api/settings.ts
@@ -1,0 +1,66 @@
+import { apiFetch } from "./client";
+
+export interface ProviderInfo {
+  enabled: boolean;
+  model: string;
+  configured: boolean;
+}
+
+export interface SettingsResponse {
+  data_dir: string;
+  gateway_port: number;
+  llm: {
+    default_provider: string;
+    fallback_enabled: boolean;
+    monthly_budget_usd: number;
+    providers: Record<string, ProviderInfo>;
+  };
+  sync: {
+    enabled: boolean;
+    interval_minutes: number;
+    bucket: string | null;
+  };
+}
+
+export interface CostEntry {
+  cost_usd: number;
+  call_count: number;
+}
+
+export interface CostBreakdown {
+  month: string;
+  total_usd: number;
+  budget_usd: number;
+  budget_pct: number;
+  by_provider: Record<string, CostEntry>;
+  by_task_type: Record<string, CostEntry>;
+}
+
+export interface TestResult {
+  provider: string;
+  status: "ok" | "error";
+  latency_ms?: number;
+  error?: string;
+}
+
+export function getSettings(): Promise<SettingsResponse> {
+  return apiFetch<SettingsResponse>("/settings");
+}
+
+export function getCostBreakdown(): Promise<CostBreakdown> {
+  return apiFetch<CostBreakdown>("/settings/llm/cost/breakdown");
+}
+
+export function setApiKey(provider: string, apiKey: string): Promise<void> {
+  return apiFetch<void>("/settings/llm/api-key", {
+    method: "POST",
+    body: { provider, api_key: apiKey },
+  });
+}
+
+export function testProvider(provider: string): Promise<TestResult> {
+  return apiFetch<TestResult>("/settings/llm/test", {
+    method: "POST",
+    query: { provider },
+  });
+}

--- a/apps/web/src/components/settings/ApiKeyModal.tsx
+++ b/apps/web/src/components/settings/ApiKeyModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "../shared/Button";
+import { setApiKey } from "../../api/settings";
+
+interface ApiKeyModalProps {
+  provider: string;
+  onClose: () => void;
+}
+
+export function ApiKeyModal({ provider, onClose }: ApiKeyModalProps) {
+  const [value, setValue] = useState("");
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: () => setApiKey(provider, value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+      onClose();
+    },
+  });
+
+  const displayName = provider.charAt(0).toUpperCase() + provider.slice(1);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-semibold text-slate-800">
+          Set API Key — {displayName}
+        </h2>
+
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Paste your API key here"
+          className="mb-4 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+        />
+
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            disabled={value.trim() === "" || mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            {mutation.isPending ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/CostDashboard.tsx
+++ b/apps/web/src/components/settings/CostDashboard.tsx
@@ -1,0 +1,114 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card } from "../shared/Card";
+import { Spinner } from "../shared/Spinner";
+import { getCostBreakdown } from "../../api/settings";
+
+interface CostDashboardProps {
+  warningThresholdPct?: number;
+}
+
+export function CostDashboard({ warningThresholdPct = 80 }: CostDashboardProps) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["cost-breakdown"],
+    queryFn: getCostBreakdown,
+    staleTime: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <Card className="flex items-center justify-center p-6">
+        <Spinner />
+      </Card>
+    );
+  }
+
+  if (!data || data.total_usd === 0) {
+    return (
+      <Card className="p-4">
+        <p className="text-sm text-slate-500">No cost data yet.</p>
+      </Card>
+    );
+  }
+
+  const pct = Math.min(data.budget_pct, 100);
+  const gaugeColor =
+    data.budget_pct >= 100
+      ? "bg-red-500"
+      : data.budget_pct >= warningThresholdPct
+        ? "bg-amber-500"
+        : "bg-emerald-500";
+
+  function formatCost(usd: number): string {
+    return `$${usd.toFixed(2)}`;
+  }
+
+  function formatTaskType(key: string): string {
+    return key
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="mb-4">
+        <div className="h-4 w-full rounded-full bg-slate-200">
+          <div
+            className={`h-4 rounded-full transition-all ${gaugeColor}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <p className="mt-1 text-sm text-slate-600">
+          {formatCost(data.total_usd)} / {formatCost(data.budget_usd)} ({data.budget_pct.toFixed(1)}%)
+        </p>
+      </div>
+
+      {Object.keys(data.by_provider).length > 0 && (
+        <div className="mb-4">
+          <h3 className="mb-2 text-sm font-semibold text-slate-700">By Provider</h3>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                <th className="pb-1 font-medium">Provider</th>
+                <th className="pb-1 font-medium">Cost</th>
+                <th className="pb-1 font-medium">Calls</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(data.by_provider).map(([provider, entry]) => (
+                <tr key={provider} className="border-b border-slate-100">
+                  <td className="py-1 capitalize text-slate-700">{provider}</td>
+                  <td className="py-1 text-slate-700">{formatCost(entry.cost_usd)}</td>
+                  <td className="py-1 text-slate-700">{entry.call_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {Object.keys(data.by_task_type).length > 0 && (
+        <div>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700">By Task Type</h3>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                <th className="pb-1 font-medium">Task Type</th>
+                <th className="pb-1 font-medium">Cost</th>
+                <th className="pb-1 font-medium">Calls</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(data.by_task_type).map(([taskType, entry]) => (
+                <tr key={taskType} className="border-b border-slate-100">
+                  <td className="py-1 text-slate-700">{formatTaskType(taskType)}</td>
+                  <td className="py-1 text-slate-700">{formatCost(entry.cost_usd)}</td>
+                  <td className="py-1 text-slate-700">{entry.call_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/settings/ProviderCard.tsx
+++ b/apps/web/src/components/settings/ProviderCard.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "../shared/Badge";
 import { Button } from "../shared/Button";
 import { Card } from "../shared/Card";
 import type { ProviderInfo } from "../../api/settings";
-import { testProvider } from "../../api/settings";
+import { testProvider, setDefaultProvider } from "../../api/settings";
 
 interface ProviderCardProps {
   name: string;
@@ -23,6 +23,14 @@ const NO_KEY_PROVIDERS = new Set(["ollama", "mock"]);
 
 export function ProviderCard({ name, info, isDefault, onSetKey }: ProviderCardProps) {
   const [testState, setTestState] = useState<TestState>({ kind: "idle" });
+  const queryClient = useQueryClient();
+
+  const makeDefault = useMutation({
+    mutationFn: () => setDefaultProvider(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+  });
 
   const testMutation = useMutation({
     mutationFn: () => testProvider(name),
@@ -87,6 +95,16 @@ export function ProviderCard({ name, info, isDefault, onSetKey }: ProviderCardPr
         >
           {getTestLabel()}
         </Button>
+        {info.enabled && info.configured && !isDefault && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={makeDefault.isPending}
+            onClick={() => makeDefault.mutate()}
+          >
+            {makeDefault.isPending ? "Setting..." : "Make Default"}
+          </Button>
+        )}
       </div>
     </Card>
   );

--- a/apps/web/src/components/settings/ProviderCard.tsx
+++ b/apps/web/src/components/settings/ProviderCard.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Badge } from "../shared/Badge";
+import { Button } from "../shared/Button";
+import { Card } from "../shared/Card";
+import type { ProviderInfo } from "../../api/settings";
+import { testProvider } from "../../api/settings";
+
+interface ProviderCardProps {
+  name: string;
+  info: ProviderInfo;
+  isDefault: boolean;
+  onSetKey: (provider: string) => void;
+}
+
+type TestState =
+  | { kind: "idle" }
+  | { kind: "testing" }
+  | { kind: "success"; latency_ms: number }
+  | { kind: "error"; message: string };
+
+const NO_KEY_PROVIDERS = new Set(["ollama", "mock"]);
+
+export function ProviderCard({ name, info, isDefault, onSetKey }: ProviderCardProps) {
+  const [testState, setTestState] = useState<TestState>({ kind: "idle" });
+
+  const testMutation = useMutation({
+    mutationFn: () => testProvider(name),
+    onMutate: () => setTestState({ kind: "testing" }),
+    onSuccess: (result) => {
+      if (result.status === "ok") {
+        setTestState({ kind: "success", latency_ms: result.latency_ms ?? 0 });
+      } else {
+        setTestState({ kind: "error", message: result.error ?? "Unknown error" });
+      }
+    },
+    onError: (err) => {
+      const message = err instanceof Error ? err.message : "Test failed";
+      setTestState({ kind: "error", message });
+    },
+  });
+
+  const needsKey = !NO_KEY_PROVIDERS.has(name.toLowerCase());
+
+  function getTestLabel(): string {
+    if (testState.kind === "testing") return "Testing...";
+    if (testState.kind === "success") return `✓ ${testState.latency_ms}ms`;
+    if (testState.kind === "error") return `✗ ${testState.message}`;
+    return "Test";
+  }
+
+  return (
+    <Card
+      className={`p-4 ${isDefault ? "border-l-4 border-l-brand-300" : ""}`}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-slate-800 capitalize">{name}</span>
+          {isDefault && <Badge tone="info">Default</Badge>}
+        </div>
+        <Badge tone={info.enabled ? "success" : "neutral"}>
+          {info.enabled ? "Enabled" : "Disabled"}
+        </Badge>
+      </div>
+
+      <p className="mb-3 text-sm text-slate-500">{info.model}</p>
+
+      <div className="mb-3">
+        {info.configured ? (
+          <Badge tone="success">Configured</Badge>
+        ) : (
+          <Badge tone="neutral">Not configured</Badge>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        {needsKey && (
+          <Button variant="ghost" size="sm" onClick={() => onSetKey(name)}>
+            Set Key
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={testState.kind === "testing"}
+          onClick={() => testMutation.mutate()}
+        >
+          {getTestLabel()}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card } from "../shared/Card";
+import { Spinner } from "../shared/Spinner";
+import { ProviderCard } from "./ProviderCard";
+import { ApiKeyModal } from "./ApiKeyModal";
+import { CostDashboard } from "./CostDashboard";
+import { SyncStatus } from "./SyncStatus";
+import { getSettings } from "../../api/settings";
+
+export function SettingsView() {
+  const [apiKeyModalProvider, setApiKeyModalProvider] = useState<string | null>(null);
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ["settings"],
+    queryFn: getSettings,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner size={32} />
+      </div>
+    );
+  }
+
+  if (!settings) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-slate-500">Failed to load settings.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <h1 className="mb-6 text-2xl font-bold text-slate-800">Settings</h1>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-lg font-semibold text-slate-700">LLM Providers</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Object.entries(settings.llm.providers).map(([name, info]) => (
+            <ProviderCard
+              key={name}
+              name={name}
+              info={info}
+              isDefault={name === settings.llm.default_provider}
+              onSetKey={setApiKeyModalProvider}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-lg font-semibold text-slate-700">Cost</h2>
+        <CostDashboard warningThresholdPct={80} />
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-lg font-semibold text-slate-700">Sync</h2>
+        <SyncStatus sync={settings.sync} />
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-lg font-semibold text-slate-700">System</h2>
+        <Card className="p-4">
+          <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+            <span className="text-slate-500">Data directory</span>
+            <span className="font-mono text-slate-700">{settings.data_dir}</span>
+
+            <span className="text-slate-500">Default provider</span>
+            <span className="capitalize text-slate-700">{settings.llm.default_provider}</span>
+
+            <span className="text-slate-500">Fallback</span>
+            <span className="text-slate-700">{settings.llm.fallback_enabled ? "Enabled" : "Disabled"}</span>
+
+            <span className="text-slate-500">Monthly budget</span>
+            <span className="text-slate-700">${settings.llm.monthly_budget_usd.toFixed(2)}</span>
+          </div>
+        </Card>
+      </section>
+
+      {apiKeyModalProvider !== null && (
+        <ApiKeyModal
+          provider={apiKeyModalProvider}
+          onClose={() => setApiKeyModalProvider(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -1,19 +1,33 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "../shared/Card";
+import { Button } from "../shared/Button";
 import { Spinner } from "../shared/Spinner";
 import { ProviderCard } from "./ProviderCard";
 import { ApiKeyModal } from "./ApiKeyModal";
 import { CostDashboard } from "./CostDashboard";
 import { SyncStatus } from "./SyncStatus";
-import { getSettings } from "../../api/settings";
+import { getSettings, updateSettings } from "../../api/settings";
 
 export function SettingsView() {
   const [apiKeyModalProvider, setApiKeyModalProvider] = useState<string | null>(null);
+  const [editingBudget, setEditingBudget] = useState(false);
+  const [budgetValue, setBudgetValue] = useState("");
+
+  const queryClient = useQueryClient();
 
   const { data: settings, isLoading } = useQuery({
     queryKey: ["settings"],
     queryFn: getSettings,
+  });
+
+  const patchSettings = useMutation({
+    mutationFn: updateSettings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+      queryClient.invalidateQueries({ queryKey: ["cost-breakdown"] });
+      setEditingBudget(false);
+    },
   });
 
   if (isLoading) {
@@ -72,10 +86,62 @@ export function SettingsView() {
             <span className="capitalize text-slate-700">{settings.llm.default_provider}</span>
 
             <span className="text-slate-500">Fallback</span>
-            <span className="text-slate-700">{settings.llm.fallback_enabled ? "Enabled" : "Disabled"}</span>
+            <button
+              type="button"
+              className={`inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                settings.llm.fallback_enabled ? "bg-emerald-500" : "bg-slate-300"
+              }`}
+              onClick={() =>
+                patchSettings.mutate({ fallback_enabled: !settings.llm.fallback_enabled })
+              }
+              disabled={patchSettings.isPending}
+            >
+              <span
+                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                  settings.llm.fallback_enabled ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
 
             <span className="text-slate-500">Monthly budget</span>
-            <span className="text-slate-700">${settings.llm.monthly_budget_usd.toFixed(2)}</span>
+            {editingBudget ? (
+              <form
+                className="flex items-center gap-2"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  const val = parseFloat(budgetValue);
+                  if (val > 0) patchSettings.mutate({ monthly_budget_usd: val });
+                }}
+              >
+                <span className="text-slate-500">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={budgetValue}
+                  onChange={(e) => setBudgetValue(e.target.value)}
+                  className="w-24 rounded border border-slate-300 px-2 py-0.5 text-sm text-slate-700 focus:border-brand-300 focus:outline-none"
+                  autoFocus
+                />
+                <Button variant="ghost" size="sm" type="submit" disabled={patchSettings.isPending}>
+                  Save
+                </Button>
+                <Button variant="ghost" size="sm" type="button" onClick={() => setEditingBudget(false)}>
+                  Cancel
+                </Button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="text-left text-slate-700 hover:text-brand-600 hover:underline"
+                onClick={() => {
+                  setBudgetValue(settings.llm.monthly_budget_usd.toFixed(2));
+                  setEditingBudget(true);
+                }}
+              >
+                ${settings.llm.monthly_budget_usd.toFixed(2)}
+              </button>
+            )}
           </div>
         </Card>
       </section>

--- a/apps/web/src/components/settings/SyncStatus.tsx
+++ b/apps/web/src/components/settings/SyncStatus.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "../shared/Badge";
+import { Card } from "../shared/Card";
+
+interface SyncStatusProps {
+  sync: {
+    enabled: boolean;
+    interval_minutes: number;
+    bucket: string | null;
+  };
+}
+
+export function SyncStatus({ sync }: SyncStatusProps) {
+  return (
+    <Card className="p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <span className="font-semibold text-slate-700">Sync</span>
+        <Badge tone={sync.enabled ? "success" : "neutral"}>
+          {sync.enabled ? "Enabled" : "Disabled"}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+        <span className="text-slate-500">Status</span>
+        <span className="text-slate-700">{sync.enabled ? "Enabled" : "Not configured"}</span>
+
+        <span className="text-slate-500">Interval</span>
+        <span className="text-slate-700">Every {sync.interval_minutes} minutes</span>
+
+        <span className="text-slate-500">Bucket</span>
+        {sync.bucket ? (
+          <span className="text-slate-700">{sync.bucket}</span>
+        ) : (
+          <span className="italic text-slate-400">Not set</span>
+        )}
+
+        <span className="text-slate-500">Last sync</span>
+        <span className="italic text-slate-400">Never</span>
+      </div>
+
+      <p className="mt-4 text-xs text-slate-400">
+        Configure sync in your .env file (WIKIMIND_SYNC__ENABLED=true)
+      </p>
+    </Card>
+  );
+}

--- a/apps/web/src/components/shared/Layout.tsx
+++ b/apps/web/src/components/shared/Layout.tsx
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { to: "/wiki", label: "Wiki", icon: "📚" },
   { to: "/graph", label: "Graph", icon: "🕸️" },
   { to: "/health", label: "Health", icon: "🩺" },
+  { to: "/settings", label: "Settings", icon: "⚙️" },
 ];
 
 export function Layout({ children }: LayoutProps) {

--- a/apps/web/src/hooks/useWebSocket.ts
+++ b/apps/web/src/hooks/useWebSocket.ts
@@ -13,6 +13,7 @@ const RECONNECT_DELAY_MS = 2000;
 export function useWebSocket(): void {
   const setState = useWebSocketStore((s) => s.setState);
   const ingest = useWebSocketStore((s) => s.ingest);
+  const pushToast = useWebSocketStore((s) => s.pushToast);
   const queryClient = useQueryClient();
   const socketRef = useRef<WebSocket | null>(null);
   const reconnectRef = useRef<number | null>(null);
@@ -55,6 +56,22 @@ export function useWebSocket(): void {
             queryClient.invalidateQueries({ queryKey: ["articles"] });
             queryClient.invalidateQueries({ queryKey: ["lint"] });
           }
+          if (event.event === "budget.warning") {
+            pushToast({
+              kind: "info",
+              title: "Budget warning",
+              detail: `Monthly spend at ${event.pct}% of budget ($${event.spend_usd.toFixed(2)}/$${event.budget_usd.toFixed(2)})`,
+            });
+            queryClient.invalidateQueries({ queryKey: ["cost-breakdown"] });
+          }
+          if (event.event === "budget.exceeded") {
+            pushToast({
+              kind: "error",
+              title: "Budget exceeded",
+              detail: `Monthly spend exceeded budget ($${event.spend_usd.toFixed(2)}/$${event.budget_usd.toFixed(2)})`,
+            });
+            queryClient.invalidateQueries({ queryKey: ["cost-breakdown"] });
+          }
         } catch {
           // Ignore non-JSON frames
         }
@@ -93,5 +110,5 @@ export function useWebSocket(): void {
       }
       socketRef.current = null;
     };
-  }, [setState, ingest, queryClient]);
+  }, [setState, ingest, pushToast, queryClient]);
 }

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -151,4 +151,6 @@ export type WSEvent =
   | { event: "compilation.failed"; source_id: string; error: string }
   | { event: "sync.complete"; pushed: number; pulled: number; conflicts?: number }
   | { event: "linter.alert"; type: string; articles: string[] }
-  | { event: "article.recompiled"; article_id: string; page_type: string; status: string };
+  | { event: "article.recompiled"; article_id: string; page_type: string; status: string }
+  | { event: "budget.warning"; spend_usd: number; budget_usd: number; pct: number }
+  | { event: "budget.exceeded"; spend_usd: number; budget_usd: number };

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ considered, and the consequences.
 | [016](adr-016-article-recompilation.md) | Article recompilation as a first-class action | Accepted |
 | [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
 | [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
+| [019](adr-019-runtime-user-preferences.md) | Runtime User Preferences via DB Override Table | Accepted |
 
 ## ADR Format
 

--- a/docs/adr/adr-019-runtime-user-preferences.md
+++ b/docs/adr/adr-019-runtime-user-preferences.md
@@ -1,0 +1,37 @@
+# ADR-019: Runtime User Preferences via DB Override Table
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind loads all configuration from `.env` / environment variables via Pydantic `BaseSettings` with an `@lru_cache` singleton. This means changing the default LLM provider, monthly budget, or fallback toggle requires editing `.env` and restarting the app.
+
+The Settings UI (#29) needs to let users change a small set of frequently-toggled values at runtime without restarting. mcp-context-forge solves this with database-backed runtime config — provider state lives in DB tables, toggled via API, committed immediately.
+
+## Decision
+
+Introduce a `UserPreference` key-value table for runtime overrides. Only three settings are runtime-changeable:
+
+| Key | Type | Default |
+|-----|------|---------|
+| `llm.default_provider` | str | "anthropic" |
+| `llm.monthly_budget_usd` | float | 50.0 |
+| `llm.fallback_enabled` | bool | true |
+
+**Precedence:** DB row wins if it exists. Otherwise falls back to `.env` defaults.
+
+**Startup:** After `init_db()`, `_apply_db_preferences()` reads all `UserPreference` rows and applies them to the in-memory Settings singleton. This ensures DB overrides survive restarts.
+
+**Write path:** API endpoints (`POST /settings/llm/default-provider`, `PATCH /settings`) write to the DB table AND mutate the in-memory singleton for immediate effect.
+
+**Read path:** `GET /settings` overlays DB values onto the response.
+
+## Consequences
+
+- Users can change default provider, budget, and fallback from the UI without restart.
+- `.env` remains the canonical source for infrastructure config (host, port, data_dir, API keys).
+- The `user_preference` table is lightweight (max 3 rows). No schema migration needed — auto-created by SQLModel.
+- Deleting the DB reverts all preferences to `.env` defaults cleanly.
+- Budget warning thresholds (`budget_warning_pct`, `budget_check_cache_seconds`) remain `.env`-only — they are operational tuning knobs, not user-facing settings.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -991,7 +991,7 @@ paths:
       tags:
       - Settings
       summary: Get All Settings
-      description: Return all application settings.
+      description: Return all application settings, with DB overrides applied.
       operationId: get_all_settings_settings_get
       responses:
         '200':
@@ -999,6 +999,55 @@ paths:
           content:
             application/json:
               schema: {}
+    patch:
+      tags:
+      - Settings
+      summary: Update Settings
+      description: Update runtime settings. Changes persist to DB across restarts.
+      operationId: update_settings_settings_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SettingsUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /settings/llm/default-provider:
+    post:
+      tags:
+      - Settings
+      summary: Set Default Provider
+      description: Set the default LLM provider. Persists to DB, survives restarts.
+      operationId: set_default_provider_settings_llm_default_provider_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DefaultProviderRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /settings/llm/api-key:
     post:
       tags:
@@ -1533,6 +1582,16 @@ components:
       - turn_count
       title: ConversationSummary
       description: Conversation summary for the history sidebar — adds turn count.
+    DefaultProviderRequest:
+      properties:
+        provider:
+          type: string
+          title: Provider
+      type: object
+      required:
+      - provider
+      title: DefaultProviderRequest
+      description: Request to set the default LLM provider.
     FileBackSelectionRequest:
       properties:
         selections:
@@ -2005,6 +2064,26 @@ components:
       - resolution
       title: ResolveContradictionRequest
       description: Request to resolve a contradiction between two articles.
+    SettingsUpdateRequest:
+      properties:
+        monthly_budget_usd:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Monthly Budget Usd
+        default_provider:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Default Provider
+        fallback_enabled:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Fallback Enabled
+      type: object
+      title: SettingsUpdateRequest
+      description: Request to update settings.
     Source:
       properties:
         id:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1050,6 +1050,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /settings/llm/cost/breakdown:
+    get:
+      tags:
+      - Settings
+      summary: Get Llm Cost Breakdown
+      description: Cost breakdown by provider and task type for current month.
+      operationId: get_llm_cost_breakdown_settings_llm_cost_breakdown_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
   /settings/llm/cost:
     get:
       tags:

--- a/docs/superpowers/specs/2026-04-15-settings-ui-budget-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-15-settings-ui-budget-enforcement-design.md
@@ -1,0 +1,300 @@
+# Settings UI + Budget Enforcement — Design Spec
+
+**Epic:** #5 (Sync + Multi-provider) — Phase 5A
+**Closes:** #29 (Settings UI — providers, sync, cost) — partially (sync UI deferred)
+**Date:** 2026-04-15
+
+## Goal
+
+Build a Settings page that lets users manage LLM provider API keys, monitor cost, and receive budget warnings — without editing config files. Add soft budget enforcement to the LLM router so users know when they're approaching or exceeding their monthly spend limit.
+
+## Scope
+
+**In scope:**
+- Settings page with provider cards, cost dashboard, sync status, system info
+- API key management via OS keychain (existing POST endpoint)
+- Provider connection testing (existing POST endpoint)
+- Cost breakdown endpoint (new)
+- Budget check in LLM router with WebSocket warnings (new)
+
+**Out of scope (deferred):**
+- Google Gemini provider implementation (config exists, no provider class)
+- Cloud sync service backend (#28, #74) — sync UI section is read-only, reflecting config
+- Runtime config updates / PATCH endpoints (`.env` + keychain is sufficient)
+- Settings persistence layer (no new tables)
+- Budget hard limits (soft warnings only)
+
+## Architecture
+
+No new persistence. The existing backend already handles:
+- **API keys** → OS keychain via `config.set_api_key()` / `POST /settings/llm/api-key`
+- **Provider config** → `.env` / env vars via Pydantic `Settings` (auto-enable on key detection)
+- **Cost tracking** → `CostLog` table, per-call entries from `LLMRouter.complete()`
+- **Settings read** → `GET /settings` returns full config
+
+New work:
+1. **Backend**: Budget check in LLM router + cost breakdown endpoint + WS budget events
+2. **Frontend**: Settings page with provider cards, cost dashboard, API key modal
+
+---
+
+## Backend Changes
+
+### 1. Budget Check in LLM Router
+
+**File:** `src/wikimind/engine/llm_router.py`
+
+Add two new fields to `LLMConfig` in `config.py`:
+
+```python
+class LLMConfig(BaseModel):
+    # ... existing fields ...
+    budget_warning_pct: float = 0.8           # emit warning at this fraction of budget
+    budget_check_cache_seconds: int = 60      # cache spend query to avoid DB pressure
+```
+
+Add a budget check method to `LLMRouter` that runs after each successful LLM call (alongside the existing cost logging). The check:
+
+1. Queries `CostLog` for current month's total spend (cached for `budget_check_cache_seconds`)
+2. Compares against `settings.llm.monthly_budget_usd`
+3. At **warning threshold** (`budget_warning_pct`, default 80%): emits `budget.warning` WebSocket event (once per app lifetime, tracked via `LLMRouter` instance flag — resets on restart)
+4. At **100%**: emits `budget.exceeded` WebSocket event (once per app lifetime, same mechanism)
+5. **Never blocks** — calls always proceed. This is telemetry, not enforcement.
+
+```python
+# In LLMRouter.__init__:
+self._budget_warning_sent = False
+self._budget_exceeded_sent = False
+self._cached_spend: float | None = None
+self._cache_expires_at: float = 0.0
+```
+
+The check runs in `complete()` after cost logging succeeds, using a fire-and-forget pattern (asyncio.create_task) so it doesn't add latency to the LLM response path.
+
+### 2. Cost Breakdown Endpoint
+
+**File:** `src/wikimind/api/routes/settings.py`
+
+New endpoint:
+
+```
+GET /settings/llm/cost/breakdown
+```
+
+Response:
+```json
+{
+  "month": "2026-04",
+  "total_usd": 12.34,
+  "budget_usd": 50.0,
+  "budget_pct": 24.7,
+  "by_provider": {
+    "anthropic": { "cost_usd": 10.50, "call_count": 42 },
+    "openai": { "cost_usd": 1.84, "call_count": 15 }
+  },
+  "by_task_type": {
+    "compile": { "cost_usd": 8.20, "call_count": 30 },
+    "qa": { "cost_usd": 3.10, "call_count": 20 },
+    "lint": { "cost_usd": 1.04, "call_count": 7 }
+  }
+}
+```
+
+Implementation: Two GROUP BY queries on `CostLog` filtered to current month — one by `provider`, one by `task_type`. Uses `get_session_factory()()` (same pattern as existing `get_llm_cost`).
+
+### 3. WebSocket Budget Events
+
+**File:** `src/wikimind/api/routes/ws.py`
+
+Two new emitter functions:
+
+```python
+async def emit_budget_warning(spend_usd: float, budget_usd: float, pct: float):
+    """Emitted once when monthly spend crosses 80% of budget."""
+
+async def emit_budget_exceeded(spend_usd: float, budget_usd: float):
+    """Emitted once when monthly spend crosses 100% of budget."""
+```
+
+These are called from the LLM router's budget check, not from API routes.
+
+---
+
+## Frontend Changes
+
+### 1. Settings Page Route
+
+**Files:** `apps/web/src/App.tsx`, `apps/web/src/components/shared/Layout.tsx`
+
+- Add `/settings` route to App.tsx
+- Add Settings nav item to Layout.tsx (gear icon or similar, at bottom of nav)
+
+### 2. API Module
+
+**File (new):** `apps/web/src/api/settings.ts`
+
+Functions wrapping the existing and new backend endpoints:
+
+```typescript
+// GET /settings → full settings object
+export function getSettings(): Promise<SettingsResponse>
+
+// GET /settings/llm/cost → monthly summary
+export function getCostSummary(): Promise<CostSummary>
+
+// GET /settings/llm/cost/breakdown → per-provider + per-task breakdown
+export function getCostBreakdown(): Promise<CostBreakdown>
+
+// POST /settings/llm/api-key → set key in keychain
+export function setApiKey(provider: string, apiKey: string): Promise<void>
+
+// POST /settings/llm/test?provider=X → test provider connection
+export function testProvider(provider: string): Promise<TestResult>
+```
+
+### 3. Settings View
+
+**File (new):** `apps/web/src/components/settings/SettingsView.tsx`
+
+Main page component with four sections rendered as Card components:
+
+#### Section A: LLM Providers
+
+A grid of provider cards (one per provider from GET /settings response). Each card shows:
+
+- **Provider name** + enabled/disabled Badge
+- **Model** name (e.g., "claude-sonnet-4-5")
+- **API key status**: "Configured" (green badge) or "Not configured" (neutral badge)
+- **"Set Key" button** → opens ApiKeyModal (only for providers that need keys: anthropic, openai, google)
+- **"Test" button** → calls POST /settings/llm/test, shows latency on success or error message
+- **"Default" badge** if this is the default provider
+
+The default provider card gets a subtle highlight (e.g., `border-brand-200` instead of `border-slate-200`).
+
+Ollama and Mock providers show their status but no key management (no API key needed).
+
+#### Section B: Cost Dashboard
+
+- **Budget gauge**: horizontal progress bar showing spend vs budget
+  - Green when < 80%
+  - Amber when 80-99%
+  - Red when >= 100%
+  - Text: "$12.34 / $50.00 (24.7%)"
+- **Per-provider breakdown**: simple table or small horizontal bars showing each provider's spend
+- **Per-task breakdown**: simple table showing spend by task type (compile, qa, lint, etc.)
+- Data from `GET /settings/llm/cost/breakdown`
+- Auto-refreshes via React Query with 60-second stale time
+
+#### Section C: Sync Status
+
+Read-only panel reflecting current sync config from `GET /settings` response. Minor backend change: extend the sync section in `get_all_settings()` to also return `bucket` (currently only returns `enabled` and `interval_minutes`).
+
+- **Status badge**: "Disabled" (neutral) or "Enabled" (green) — from `sync.enabled`
+- **Interval**: e.g., "Every 15 minutes" — from `sync.interval_minutes`
+- **Bucket**: bucket name or "Not set" — from `sync.bucket` (null when unconfigured)
+- **Last sync**: "Never" (no SyncLog entries exist yet — backend not implemented)
+- Hint text: "Configure sync in your .env file (WIKIMIND_SYNC__ENABLED=true)"
+
+This section is ready for the sync backend (#28, #74) to land later. When the sync service exists, this section will show live status and add a manual sync button.
+
+#### Section D: System Info
+
+Read-only reference panel:
+- Data directory path
+- Default provider name
+- Fallback enabled/disabled
+- Monthly budget (from config)
+- Hint text: "Configure these values in your .env file"
+
+### 4. API Key Modal
+
+**File (new):** `apps/web/src/components/settings/ApiKeyModal.tsx`
+
+Simple modal with:
+- Provider name in header
+- Password input field (masked)
+- "Save" button → calls `setApiKey()` → invalidates settings query → closes modal
+- "Cancel" button
+
+Uses a `<dialog>` element or absolute positioned div (follow existing patterns — no modal library).
+
+### 5. Provider Card
+
+**File (new):** `apps/web/src/components/settings/ProviderCard.tsx`
+
+Extracted component for the per-provider card. Contains the test button state machine (idle → testing → success/error).
+
+### 6. Cost Dashboard
+
+**File (new):** `apps/web/src/components/settings/CostDashboard.tsx`
+
+Contains the budget gauge and breakdown tables. Separated from SettingsView to keep files focused.
+
+### 7. WebSocket Budget Event Handling
+
+**File:** `apps/web/src/hooks/useWebSocket.ts`
+
+Add handlers for `budget.warning` and `budget.exceeded` events:
+- Show toast notification via the existing toast system in `useWebSocketStore`
+- `budget.warning`: info toast — "Monthly spend at 80% of budget"
+- `budget.exceeded`: warning toast — "Monthly budget exceeded"
+
+**File:** `apps/web/src/types/api.ts`
+
+Add to WSEvent union:
+```typescript
+| { event: "budget.warning"; spend_usd: number; budget_usd: number; pct: number }
+| { event: "budget.exceeded"; spend_usd: number; budget_usd: number }
+```
+
+---
+
+## File Summary
+
+| Action | File | What |
+|--------|------|------|
+| Modify | `src/wikimind/config.py` | Add budget_warning_pct, budget_check_cache_seconds to LLMConfig |
+| Modify | `src/wikimind/engine/llm_router.py` | Budget check after cost log, cached spend query, WS emit |
+| Modify | `src/wikimind/api/routes/settings.py` | Add GET /settings/llm/cost/breakdown |
+| Modify | `src/wikimind/api/routes/ws.py` | Add emit_budget_warning, emit_budget_exceeded |
+| Create | `apps/web/src/api/settings.ts` | API functions for settings endpoints |
+| Create | `apps/web/src/components/settings/SettingsView.tsx` | Main settings page |
+| Create | `apps/web/src/components/settings/ProviderCard.tsx` | Per-provider card component |
+| Create | `apps/web/src/components/settings/CostDashboard.tsx` | Budget gauge + breakdown |
+| Create | `apps/web/src/components/settings/SyncStatus.tsx` | Read-only sync config panel |
+| Create | `apps/web/src/components/settings/ApiKeyModal.tsx` | API key input modal |
+| Modify | `apps/web/src/App.tsx` | Add /settings route |
+| Modify | `apps/web/src/components/shared/Layout.tsx` | Add Settings nav item |
+| Modify | `apps/web/src/hooks/useWebSocket.ts` | Handle budget WS events |
+| Modify | `apps/web/src/types/api.ts` | Add budget event types, settings response types |
+
+---
+
+## Testing
+
+### Backend
+- **Budget check**: Unit test that mocks CostLog query, verifies WS events fire at 80% and 100% thresholds, verifies they only fire once
+- **Cost breakdown endpoint**: Test with seeded CostLog entries, verify grouping by provider and task_type
+- **Cache behavior**: Verify budget check uses cached value within 60s window
+
+### Frontend
+- **Provider card**: Renders correctly for configured/unconfigured providers, test button shows latency
+- **API key modal**: Set key flow calls correct endpoint, invalidates queries
+- **Cost dashboard**: Budget gauge colors change at thresholds, breakdown tables render
+- **WebSocket events**: Toast appears on budget.warning and budget.exceeded
+
+### Manual Verification
+1. Open Settings page → see provider cards with current state
+2. Click "Set Key" on a provider → enter key → save → card shows "Configured"
+3. Click "Test" → see latency result
+4. Cost dashboard shows current month spend with gauge
+5. Trigger compilations → cost updates on refresh
+6. When spend crosses 80% → toast notification appears
+
+---
+
+## PR Strategy
+
+**Single PR** — this is a cohesive feature (settings page + budget warnings). Backend and frontend changes are tightly coupled and small enough to review together.
+
+Estimated: ~12 files changed, moderate scope.

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -53,6 +53,7 @@ async def get_all_settings():
         "sync": {
             "enabled": settings.sync.enabled,
             "interval_minutes": settings.sync.interval_minutes,
+            "bucket": settings.sync.bucket,
         },
     }
 
@@ -84,6 +85,61 @@ async def test_llm_connection(provider: str):
         return {"provider": provider, "status": "ok", "latency_ms": response.latency_ms}
     except Exception as e:
         return {"provider": provider, "status": "error", "error": str(e)}
+
+
+@router.get("/llm/cost/breakdown")
+async def get_llm_cost_breakdown():
+    """Cost breakdown by provider and task type for current month."""
+    start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)
+    settings = get_settings()
+
+    async with get_session_factory()() as session:
+        total_result = await session.execute(
+            select(func.sum(CostLog.cost_usd)).where(CostLog.created_at >= start_of_month)
+        )
+        total = total_result.scalar() or 0.0
+
+        provider_result = await session.execute(
+            select(CostLog.provider, func.sum(CostLog.cost_usd), func.count())
+            .where(CostLog.created_at >= start_of_month)
+            .group_by(CostLog.provider)
+        )
+        provider_rows = provider_result.all()
+
+        task_result = await session.execute(
+            select(CostLog.task_type, func.sum(CostLog.cost_usd), func.count())
+            .where(CostLog.created_at >= start_of_month)
+            .group_by(CostLog.task_type)
+        )
+        task_rows = task_result.all()
+
+    budget = settings.llm.monthly_budget_usd
+    budget_pct = round(total / budget * 100, 1) if budget else 0.0
+    month = utcnow_naive().strftime("%Y-%m")
+
+    by_provider = {
+        row[0].value if hasattr(row[0], "value") else str(row[0]): {
+            "cost_usd": round(row[1] or 0.0, 4),
+            "call_count": row[2],
+        }
+        for row in provider_rows
+    }
+    by_task_type = {
+        row[0].value if hasattr(row[0], "value") else str(row[0]): {
+            "cost_usd": round(row[1] or 0.0, 4),
+            "call_count": row[2],
+        }
+        for row in task_rows
+    }
+
+    return {
+        "month": month,
+        "total_usd": round(total, 4),
+        "budget_usd": budget,
+        "budget_pct": budget_pct,
+        "by_provider": by_provider,
+        "by_task_type": by_task_type,
+    }
 
 
 @router.get("/llm/cost")

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -73,10 +73,13 @@ async def set_provider_api_key(request: APIKeyRequest):
 async def test_llm_connection(provider: str):
     """Test if a provider is configured and reachable."""
     router_instance = get_llm_router()
+    # Temporarily disable fallback so we only test the requested provider
+    original_fallback = router_instance.settings.llm.fallback_enabled
+    router_instance.settings.llm.fallback_enabled = False
     try:
         request = CompletionRequest(
             system="You are a test assistant.",
-            messages=[{"role": "user", "content": "Say 'ok' in one word."}],
+            messages=[{"role": "user", "content": 'Respond with the json object: {"status": "ok"}'}],
             max_tokens=10,
             task_type=TaskType.QA,
             preferred_provider=Provider(provider),
@@ -85,6 +88,8 @@ async def test_llm_connection(provider: str):
         return {"provider": provider, "status": "ok", "latency_ms": response.latency_ms}
     except Exception as e:
         return {"provider": provider, "status": "error", "error": str(e)}
+    finally:
+        router_instance.settings.llm.fallback_enabled = original_fallback
 
 
 @router.get("/llm/cost/breakdown")

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -10,7 +10,7 @@ from wikimind._datetime import utcnow_naive
 from wikimind.config import get_api_key, get_settings, set_api_key
 from wikimind.database import get_session_factory
 from wikimind.engine.llm_router import get_llm_router
-from wikimind.models import CompletionRequest, CostLog, Provider, TaskType
+from wikimind.models import CompletionRequest, CostLog, Provider, TaskType, UserPreference
 
 router = APIRouter()
 
@@ -30,17 +30,54 @@ class SettingsUpdateRequest(BaseModel):
     fallback_enabled: bool | None = None
 
 
+class DefaultProviderRequest(BaseModel):
+    """Request to set the default LLM provider."""
+
+    provider: str
+
+
+# ---------------------------------------------------------------------------
+# DB preference helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_preference(key: str) -> str | None:
+    async with get_session_factory()() as session:
+        pref = await session.get(UserPreference, key)
+        return pref.value if pref else None
+
+
+async def _set_preference(key: str, value: str) -> None:
+    async with get_session_factory()() as session:
+        pref = await session.get(UserPreference, key)
+        if pref:
+            pref.value = value
+            pref.updated_at = utcnow_naive()
+        else:
+            pref = UserPreference(key=key, value=value)
+        session.add(pref)
+        await session.commit()
+
+
 @router.get("")
 async def get_all_settings():
-    """Return all application settings."""
+    """Return all application settings, with DB overrides applied."""
     settings = get_settings()
+
+    # Apply DB overrides
+    default_provider = await _get_preference("llm.default_provider") or settings.llm.default_provider
+    budget_pref = await _get_preference("llm.monthly_budget_usd")
+    monthly_budget = float(budget_pref) if budget_pref else settings.llm.monthly_budget_usd
+    fallback_pref = await _get_preference("llm.fallback_enabled")
+    fallback_enabled = (fallback_pref.lower() == "true") if fallback_pref else settings.llm.fallback_enabled
+
     return {
         "data_dir": settings.data_dir,
         "gateway_port": settings.gateway_port,
         "llm": {
-            "default_provider": settings.llm.default_provider,
-            "fallback_enabled": settings.llm.fallback_enabled,
-            "monthly_budget_usd": settings.llm.monthly_budget_usd,
+            "default_provider": default_provider,
+            "fallback_enabled": fallback_enabled,
+            "monthly_budget_usd": monthly_budget,
             "providers": {
                 p.value: {
                     "enabled": getattr(settings.llm, p.value).enabled,
@@ -56,6 +93,52 @@ async def get_all_settings():
             "bucket": settings.sync.bucket,
         },
     }
+
+
+@router.post("/llm/default-provider")
+async def set_default_provider(request: DefaultProviderRequest):
+    """Set the default LLM provider. Persists to DB, survives restarts."""
+    valid_providers = [p.value for p in Provider]
+    if request.provider not in valid_providers:
+        raise HTTPException(status_code=400, detail=f"Unknown provider: {request.provider}")
+
+    settings = get_settings()
+    provider_cfg = getattr(settings.llm, request.provider, None)
+    if not provider_cfg or not provider_cfg.enabled:
+        raise HTTPException(status_code=400, detail=f"Provider {request.provider} is not enabled")
+
+    # Providers that need API keys
+    if request.provider not in ("ollama", "mock") and not get_api_key(request.provider):
+        raise HTTPException(status_code=400, detail=f"Provider {request.provider} has no API key configured")
+
+    await _set_preference("llm.default_provider", request.provider)
+    settings.llm.default_provider = request.provider
+    return {"provider": request.provider, "status": "ok"}
+
+
+@router.patch("")
+async def update_settings(request: SettingsUpdateRequest):
+    """Update runtime settings. Changes persist to DB across restarts."""
+    settings = get_settings()
+
+    if request.monthly_budget_usd is not None:
+        if request.monthly_budget_usd <= 0:
+            raise HTTPException(status_code=400, detail="Budget must be positive")
+        await _set_preference("llm.monthly_budget_usd", str(request.monthly_budget_usd))
+        settings.llm.monthly_budget_usd = request.monthly_budget_usd
+
+    if request.fallback_enabled is not None:
+        await _set_preference("llm.fallback_enabled", str(request.fallback_enabled).lower())
+        settings.llm.fallback_enabled = request.fallback_enabled
+
+    if request.default_provider is not None:
+        valid_providers = [p.value for p in Provider]
+        if request.default_provider not in valid_providers:
+            raise HTTPException(status_code=400, detail=f"Unknown provider: {request.default_provider}")
+        await _set_preference("llm.default_provider", request.default_provider)
+        settings.llm.default_provider = request.default_provider
+
+    return {"status": "ok"}
 
 
 @router.post("/llm/api-key")

--- a/src/wikimind/api/routes/ws.py
+++ b/src/wikimind/api/routes/ws.py
@@ -179,3 +179,26 @@ async def emit_article_recompiled(article_id: str, page_type: str, status: str =
             "status": status,
         }
     )
+
+
+async def emit_budget_warning(spend_usd: float, budget_usd: float, pct: float):
+    """Emitted once when monthly spend crosses the warning threshold."""
+    await manager.broadcast(
+        {
+            "event": "budget.warning",
+            "spend_usd": round(spend_usd, 4),
+            "budget_usd": budget_usd,
+            "pct": round(pct, 1),
+        }
+    )
+
+
+async def emit_budget_exceeded(spend_usd: float, budget_usd: float):
+    """Emitted once when monthly spend crosses 100% of budget."""
+    await manager.broadcast(
+        {
+            "event": "budget.exceeded",
+            "spend_usd": round(spend_usd, 4),
+            "budget_usd": budget_usd,
+        }
+    )

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -95,6 +95,8 @@ class LLMConfig(BaseModel):
     default_provider: str = "anthropic"
     fallback_enabled: bool = True
     monthly_budget_usd: float = 50.0
+    budget_warning_pct: float = 0.8
+    budget_check_cache_seconds: int = 60
     anthropic: AnthropicConfig = Field(default_factory=AnthropicConfig)
     openai: OpenAIConfig = Field(default_factory=OpenAIConfig)
     google: GoogleConfig = Field(default_factory=GoogleConfig)

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -6,6 +6,7 @@ Handles selection, fallback, cost tracking, and token budgeting.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from collections.abc import AsyncIterator
@@ -16,8 +17,13 @@ import anthropic
 import ollama
 import openai
 import structlog
+from sqlalchemy import func
+from sqlmodel import select
 
+from wikimind._datetime import utcnow_naive
+from wikimind.api.routes.ws import emit_budget_exceeded, emit_budget_warning
 from wikimind.config import get_api_key, get_settings
+from wikimind.database import get_session_factory
 from wikimind.models import CompletionRequest, CompletionResponse, CostLog, Provider, TaskType
 
 log = structlog.get_logger()
@@ -638,6 +644,10 @@ class LLMRouter:
 
     def __init__(self):
         self.settings = get_settings()
+        self._budget_warning_sent = False
+        self._budget_exceeded_sent = False
+        self._cached_spend: float | None = None
+        self._cache_expires_at: float = 0.0
 
     def _get_provider_order(self, preferred: Provider | None) -> list[Provider]:
         """Return ordered list of providers to try."""
@@ -682,6 +692,38 @@ class LLMRouter:
         cfg = getattr(self.settings.llm, provider.value, None)
         return cfg.model if cfg else "unknown"
 
+    async def _check_budget(self) -> None:
+        if self._budget_warning_sent and self._budget_exceeded_sent:
+            return
+
+        now = time.time()
+        if self._cached_spend is not None and now < self._cache_expires_at:
+            spend = self._cached_spend
+        else:
+            start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)
+            async with get_session_factory()() as session:
+                result = await session.execute(
+                    select(func.sum(CostLog.cost_usd)).where(CostLog.created_at >= start_of_month)
+                )
+                spend = result.scalar() or 0.0
+            self._cached_spend = spend
+            self._cache_expires_at = now + self.settings.llm.budget_check_cache_seconds
+
+        budget = self.settings.llm.monthly_budget_usd
+        if budget <= 0:
+            return
+        pct = spend / budget * 100
+
+        if pct >= self.settings.llm.budget_warning_pct * 100 and not self._budget_warning_sent:
+            log.warning("Budget warning threshold reached", spend_usd=spend, budget_usd=budget, pct=round(pct, 1))
+            await emit_budget_warning(spend, budget, pct)
+            self._budget_warning_sent = True
+
+        if pct >= 100.0 and not self._budget_exceeded_sent:
+            log.error("Budget exceeded", spend_usd=spend, budget_usd=budget)
+            await emit_budget_exceeded(spend, budget)
+            self._budget_exceeded_sent = True
+
     async def complete(
         self,
         request: CompletionRequest,
@@ -721,6 +763,8 @@ class LLMRouter:
                     cost_usd=response.cost_usd,
                     latency_ms=response.latency_ms,
                 )
+                task = asyncio.create_task(self._check_budget())
+                task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
                 return response
 
             except Exception as e:

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -13,11 +13,12 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from sqlmodel import select
 
 from wikimind.api.routes import ingest, jobs, lint, query, wiki, ws
 from wikimind.api.routes import settings as settings_router
 from wikimind.config import get_settings
-from wikimind.database import close_db, init_db
+from wikimind.database import close_db, get_session_factory, init_db
 from wikimind.errors import WikiMindError
 from wikimind.ingest.service import _DOCLING_AVAILABLE, _get_docling_converter
 from wikimind.middleware.correlation import CorrelationIdMiddleware
@@ -25,8 +26,23 @@ from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
 from wikimind.middleware.request_logging import RequestLoggingMiddleware
 from wikimind.middleware.security_headers import SecurityHeadersMiddleware
+from wikimind.models import UserPreference
 
 log = structlog.get_logger()
+
+
+async def _apply_db_preferences() -> None:
+    """Apply persisted user preferences to the in-memory settings singleton."""
+    async with get_session_factory()() as session:
+        result = await session.execute(select(UserPreference))
+        for pref in result.scalars().all():
+            settings = get_settings()
+            if pref.key == "llm.default_provider":
+                settings.llm.default_provider = pref.value
+            elif pref.key == "llm.monthly_budget_usd":
+                settings.llm.monthly_budget_usd = float(pref.value)
+            elif pref.key == "llm.fallback_enabled":
+                settings.llm.fallback_enabled = pref.value.lower() == "true"
 
 
 @asynccontextmanager
@@ -39,6 +55,7 @@ async def lifespan(app: FastAPI):
 
     log.info("WikiMind gateway starting", port=settings.gateway_port)
     await init_db()
+    await _apply_db_preferences()
     log.info("Database initialized")
 
     # Warm up the Docling converter in a background thread so ML model

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -289,6 +289,17 @@ class SyncLog(SQLModel, table=True):
     error: str | None = None
 
 
+class UserPreference(SQLModel, table=True):
+    """Lightweight key-value store for runtime settings overrides.
+
+    Precedence: DB row wins if it exists, otherwise falls back to .env defaults.
+    """
+
+    key: str = Field(primary_key=True)
+    value: str
+    updated_at: datetime = Field(default_factory=utcnow_naive)
+
+
 # ---------------------------------------------------------------------------
 # Pydantic Models (not persisted — used for processing pipeline)
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from keyring.backend import KeyringBackend
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
+import wikimind.database as _db_mod
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.main import app
@@ -102,7 +103,13 @@ async def db_session(async_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, 
 
 @pytest.fixture
 async def client(async_engine: AsyncEngine) -> AsyncGenerator[AsyncClient, None]:
-    """FastAPI test client wired to in-memory database."""
+    """FastAPI test client wired to in-memory database.
+
+    Both the FastAPI dependency (``get_session``) and the module-level
+    ``get_session_factory`` singleton are redirected to the same in-memory
+    engine so that route handlers that call ``get_session_factory()`` directly
+    (rather than through FastAPI's DI) also use the hermetic test DB.
+    """
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
 
     async def _override_session() -> AsyncGenerator[AsyncSession, None]:
@@ -111,11 +118,17 @@ async def client(async_engine: AsyncEngine) -> AsyncGenerator[AsyncClient, None]
 
     app.dependency_overrides[get_session] = _override_session
 
+    # Patch the module-level session-factory singleton so direct callers
+    # (e.g. _get_preference, _set_preference) also use the test DB.
+    original_factory = _db_mod._session_factory
+    _db_mod._session_factory = factory
+
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
     app.dependency_overrides.clear()
+    _db_mod._session_factory = original_factory
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_budget_check.py
+++ b/tests/unit/test_budget_check.py
@@ -1,0 +1,167 @@
+"""Tests for LLMRouter budget check logic."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wikimind.engine import llm_router as llm_router_mod
+from wikimind.engine.llm_router import LLMRouter
+
+
+def _make_router(budget_usd=50.0, warning_pct=0.8, cache_seconds=60):
+    llm_settings = SimpleNamespace(
+        default_provider="anthropic",
+        fallback_enabled=True,
+        monthly_budget_usd=budget_usd,
+        budget_warning_pct=warning_pct,
+        budget_check_cache_seconds=cache_seconds,
+        anthropic=SimpleNamespace(enabled=True, model="claude-sonnet-4-5"),
+        openai=SimpleNamespace(enabled=False, model="gpt-4o-mini"),
+        google=SimpleNamespace(enabled=False, model="gemini-2.0-flash"),
+        ollama=SimpleNamespace(enabled=False, model="llama3"),
+        mock=SimpleNamespace(enabled=False, model="mock-1"),
+        ollama_base_url="http://localhost:11434",
+    )
+    settings = SimpleNamespace(llm=llm_settings)
+    with patch.object(llm_router_mod, "get_settings", return_value=settings):
+        return LLMRouter()
+
+
+def _mock_session_factory(spend: float):
+    scalar_result = MagicMock()
+    scalar_result.scalar = MagicMock(return_value=spend)
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=scalar_result)
+    # async context manager for the session scope: async with ctx as session
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    # session_factory() returns ctx  (the async context manager)
+    session_factory = MagicMock(return_value=ctx)
+    # get_session_factory() (with return_value=session_factory) means:
+    #   calling the patched get_session_factory returns session_factory
+    # In code: get_session_factory()() -> session_factory() -> ctx
+    # async with ctx as session_var
+    return session_factory
+
+
+async def test_budget_warning_fires_at_threshold() -> None:
+    router = _make_router(budget_usd=100.0, warning_pct=0.8)
+    factory = _mock_session_factory(spend=85.0)
+
+    with (
+        patch.object(llm_router_mod, "get_session_factory", return_value=factory),
+        patch("wikimind.engine.llm_router.emit_budget_warning", new_callable=AsyncMock) as mock_warn,
+        patch("wikimind.engine.llm_router.emit_budget_exceeded", new_callable=AsyncMock) as mock_exceeded,
+    ):
+        await router._check_budget()
+
+    mock_warn.assert_awaited_once()
+    mock_exceeded.assert_not_awaited()
+    assert router._budget_warning_sent is True
+    assert router._budget_exceeded_sent is False
+
+
+async def test_budget_exceeded_fires_at_100pct() -> None:
+    router = _make_router(budget_usd=100.0, warning_pct=0.8)
+    factory = _mock_session_factory(spend=110.0)
+
+    with (
+        patch.object(llm_router_mod, "get_session_factory", return_value=factory),
+        patch("wikimind.engine.llm_router.emit_budget_warning", new_callable=AsyncMock) as mock_warn,
+        patch("wikimind.engine.llm_router.emit_budget_exceeded", new_callable=AsyncMock) as mock_exceeded,
+    ):
+        await router._check_budget()
+
+    mock_warn.assert_awaited_once()
+    mock_exceeded.assert_awaited_once()
+    assert router._budget_warning_sent is True
+    assert router._budget_exceeded_sent is True
+
+
+async def test_warning_fires_only_once() -> None:
+    router = _make_router(budget_usd=100.0, warning_pct=0.8)
+    factory = _mock_session_factory(spend=85.0)
+
+    with (
+        patch.object(llm_router_mod, "get_session_factory", return_value=factory),
+        patch("wikimind.engine.llm_router.emit_budget_warning", new_callable=AsyncMock) as mock_warn,
+        patch("wikimind.engine.llm_router.emit_budget_exceeded", new_callable=AsyncMock),
+    ):
+        await router._check_budget()
+        # invalidate cache so second call re-queries
+        router._cache_expires_at = 0.0
+        await router._check_budget()
+
+    assert mock_warn.await_count == 1
+
+
+async def test_exceeded_fires_only_once() -> None:
+    router = _make_router(budget_usd=100.0, warning_pct=0.8)
+    factory = _mock_session_factory(spend=110.0)
+
+    with (
+        patch.object(llm_router_mod, "get_session_factory", return_value=factory),
+        patch("wikimind.engine.llm_router.emit_budget_warning", new_callable=AsyncMock),
+        patch("wikimind.engine.llm_router.emit_budget_exceeded", new_callable=AsyncMock) as mock_exceeded,
+    ):
+        await router._check_budget()
+        router._cache_expires_at = 0.0
+        await router._check_budget()
+
+    assert mock_exceeded.await_count == 1
+
+
+async def test_cache_prevents_requery_within_ttl() -> None:
+    router = _make_router(budget_usd=100.0, warning_pct=0.8, cache_seconds=60)
+    session_factory = _mock_session_factory(spend=85.0)
+    # session_factory() -> ctx, ctx.__aenter__ -> session
+    session = session_factory.return_value.__aenter__.return_value
+
+    with (
+        patch.object(llm_router_mod, "get_session_factory", return_value=session_factory),
+        patch("wikimind.engine.llm_router.emit_budget_warning", new_callable=AsyncMock),
+        patch("wikimind.engine.llm_router.emit_budget_exceeded", new_callable=AsyncMock),
+    ):
+        await router._check_budget()
+        first_call_count = session.execute.await_count
+        # Reset warning flag so second call doesn't short-circuit at the top,
+        # but cache is still valid so no DB query should happen.
+        router._budget_warning_sent = False
+        await router._check_budget()
+
+    # session.execute should not have been called again
+    assert session.execute.await_count == first_call_count
+
+
+async def test_below_threshold_no_events() -> None:
+    router = _make_router(budget_usd=100.0, warning_pct=0.8)
+    factory = _mock_session_factory(spend=50.0)
+
+    with (
+        patch.object(llm_router_mod, "get_session_factory", return_value=factory),
+        patch("wikimind.engine.llm_router.emit_budget_warning", new_callable=AsyncMock) as mock_warn,
+        patch("wikimind.engine.llm_router.emit_budget_exceeded", new_callable=AsyncMock) as mock_exceeded,
+    ):
+        await router._check_budget()
+
+    mock_warn.assert_not_awaited()
+    mock_exceeded.assert_not_awaited()
+    assert router._budget_warning_sent is False
+    assert router._budget_exceeded_sent is False
+
+
+async def test_both_flags_set_returns_early_without_query() -> None:
+    router = _make_router()
+    router._budget_warning_sent = True
+    router._budget_exceeded_sent = True
+    factory = _mock_session_factory(spend=999.0)
+
+    with patch.object(llm_router_mod, "get_session_factory", return_value=factory):
+        await router._check_budget()
+
+    factory.assert_not_called()

--- a/tests/unit/test_budget_check.py
+++ b/tests/unit/test_budget_check.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 
 from wikimind.engine import llm_router as llm_router_mod
 from wikimind.engine.llm_router import LLMRouter

--- a/tests/unit/test_cost_breakdown.py
+++ b/tests/unit/test_cost_breakdown.py
@@ -1,0 +1,120 @@
+"""Tests for GET /settings/llm/cost/breakdown endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wikimind.models import Provider, TaskType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_session_factory(total: float, provider_rows: list, task_rows: list):
+    """Return a mocked session_factory that returns pre-canned query results.
+
+    Code pattern: async with get_session_factory()() as session:
+    patch return_value=session_factory so get_session_factory() returns session_factory,
+    then session_factory() returns ctx (async context manager), ctx.__aenter__ -> session.
+    """
+    call_count = 0
+
+    async def _execute(stmt):
+        nonlocal call_count
+        result = MagicMock()
+        if call_count == 0:
+            result.scalar = MagicMock(return_value=total)
+        elif call_count == 1:
+            result.all = MagicMock(return_value=provider_rows)
+        else:
+            result.all = MagicMock(return_value=task_rows)
+        call_count += 1
+        return result
+
+    session = MagicMock()
+    session.execute = _execute
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session_factory = MagicMock(return_value=ctx)
+    return session_factory
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_cost_log_returns_zeros(client) -> None:
+    session_factory = _make_fake_session_factory(total=0.0, provider_rows=[], task_rows=[])
+    from wikimind.api.routes import settings as settings_mod
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.get("/settings/llm/cost/breakdown")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_usd"] == 0.0
+    assert data["by_provider"] == {}
+    assert data["by_task_type"] == {}
+    assert data["budget_pct"] == 0.0
+
+
+async def test_seeded_entries_group_by_provider(client) -> None:
+    provider_rows = [
+        (Provider.ANTHROPIC, 10.50, 42),
+        (Provider.OPENAI, 2.00, 5),
+    ]
+    task_rows = [
+        (TaskType.QA, 8.20, 30),
+    ]
+    session_factory = _make_fake_session_factory(total=12.50, provider_rows=provider_rows, task_rows=task_rows)
+    from wikimind.api.routes import settings as settings_mod
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.get("/settings/llm/cost/breakdown")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_usd"] == 12.50
+    assert "anthropic" in data["by_provider"]
+    assert data["by_provider"]["anthropic"]["cost_usd"] == pytest.approx(10.50)
+    assert data["by_provider"]["anthropic"]["call_count"] == 42
+    assert "openai" in data["by_provider"]
+
+
+async def test_seeded_entries_group_by_task_type(client) -> None:
+    provider_rows = [(Provider.ANTHROPIC, 8.20, 30)]
+    task_rows = [
+        (TaskType.QA, 5.00, 20),
+        (TaskType.COMPILE, 3.20, 10),
+    ]
+    session_factory = _make_fake_session_factory(total=8.20, provider_rows=provider_rows, task_rows=task_rows)
+    from wikimind.api.routes import settings as settings_mod
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.get("/settings/llm/cost/breakdown")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    by_task = {k.lower(): v for k, v in data["by_task_type"].items()}
+    assert "qa" in by_task
+    assert by_task["qa"]["call_count"] == 20
+
+
+async def test_budget_percentage_calculated_correctly(client) -> None:
+    session_factory = _make_fake_session_factory(total=25.0, provider_rows=[], task_rows=[])
+    from wikimind.api.routes import settings as settings_mod
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.get("/settings/llm/cost/breakdown")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    budget = data["budget_usd"]
+    expected_pct = round(25.0 / budget * 100, 1)
+    assert data["budget_pct"] == pytest.approx(expected_pct, abs=0.1)

--- a/tests/unit/test_cost_breakdown.py
+++ b/tests/unit/test_cost_breakdown.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from wikimind.api.routes import settings as settings_mod
 from wikimind.models import Provider, TaskType
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -51,8 +51,6 @@ def _make_fake_session_factory(total: float, provider_rows: list, task_rows: lis
 
 async def test_empty_cost_log_returns_zeros(client) -> None:
     session_factory = _make_fake_session_factory(total=0.0, provider_rows=[], task_rows=[])
-    from wikimind.api.routes import settings as settings_mod
-
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
         resp = await client.get("/settings/llm/cost/breakdown")
 
@@ -73,8 +71,6 @@ async def test_seeded_entries_group_by_provider(client) -> None:
         (TaskType.QA, 8.20, 30),
     ]
     session_factory = _make_fake_session_factory(total=12.50, provider_rows=provider_rows, task_rows=task_rows)
-    from wikimind.api.routes import settings as settings_mod
-
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
         resp = await client.get("/settings/llm/cost/breakdown")
 
@@ -94,8 +90,6 @@ async def test_seeded_entries_group_by_task_type(client) -> None:
         (TaskType.COMPILE, 3.20, 10),
     ]
     session_factory = _make_fake_session_factory(total=8.20, provider_rows=provider_rows, task_rows=task_rows)
-    from wikimind.api.routes import settings as settings_mod
-
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
         resp = await client.get("/settings/llm/cost/breakdown")
 
@@ -108,8 +102,6 @@ async def test_seeded_entries_group_by_task_type(client) -> None:
 
 async def test_budget_percentage_calculated_correctly(client) -> None:
     session_factory = _make_fake_session_factory(total=25.0, provider_rows=[], task_rows=[])
-    from wikimind.api.routes import settings as settings_mod
-
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
         resp = await client.get("/settings/llm/cost/breakdown")
 

--- a/tests/unit/test_user_preference.py
+++ b/tests/unit/test_user_preference.py
@@ -1,0 +1,168 @@
+"""Tests for UserPreference-backed runtime settings overrides.
+
+Covers:
+- POST /settings/llm/default-provider (valid, invalid, not-enabled)
+- PATCH /settings (budget, fallback)
+- GET /settings reflecting DB overrides
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wikimind.api.routes import settings as settings_mod
+from wikimind.models import UserPreference
+
+# ---------------------------------------------------------------------------
+# Session-factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_with_pref(pref: UserPreference | None):
+    """Return a fake session_factory where session.get() returns *pref*.
+
+    Pattern used by helpers:
+        async with get_session_factory()() as session:
+            pref = await session.get(UserPreference, key)
+    """
+    session = MagicMock()
+    session.get = AsyncMock(return_value=pref)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session_factory = MagicMock(return_value=ctx)
+    return session_factory, session
+
+
+def _make_multi_call_session_factory(responses: list):
+    """Return a fake session_factory whose session.get() cycles through *responses*.
+
+    Each entry in *responses* is the return value for a successive .get() call.
+    Used when multiple helper calls (each opening its own session) need different results.
+    """
+    call_index = 0
+
+    async def _get(model, key):
+        nonlocal call_index
+        val = responses[call_index] if call_index < len(responses) else None
+        call_index += 1
+        return val
+
+    session = MagicMock()
+    session.get = _get
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+
+    # scalars().all() for _apply_db_preferences style queries — not used here
+    scalars_result = MagicMock()
+    scalars_result.all = MagicMock(return_value=[])
+    execute_result = MagicMock()
+    execute_result.scalars = MagicMock(return_value=scalars_result)
+    session.execute = AsyncMock(return_value=execute_result)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session_factory = MagicMock(return_value=ctx)
+    return session_factory
+
+
+# ---------------------------------------------------------------------------
+# POST /settings/llm/default-provider
+# ---------------------------------------------------------------------------
+
+
+async def test_set_default_provider_valid(client) -> None:
+    """Setting a valid, enabled provider with an API key configured returns 200."""
+    session_factory, _ = _make_session_with_pref(None)
+
+    with (
+        patch.object(settings_mod, "get_session_factory", return_value=session_factory),
+        patch.object(settings_mod, "get_api_key", return_value="sk-fake"),
+    ):
+        resp = await client.post("/settings/llm/default-provider", json={"provider": "anthropic"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["provider"] == "anthropic"
+    assert data["status"] == "ok"
+
+
+async def test_set_default_provider_invalid(client) -> None:
+    """Sending an unknown provider name returns 400."""
+    resp = await client.post("/settings/llm/default-provider", json={"provider": "nonexistent"})
+    assert resp.status_code == 400
+    assert "Unknown provider" in resp.json()["detail"]
+
+
+async def test_set_default_provider_not_enabled(client) -> None:
+    """Requesting a known but disabled provider returns 400."""
+    # mock provider is disabled by default (enabled=False in MockConfig)
+    resp = await client.post("/settings/llm/default-provider", json={"provider": "mock"})
+    assert resp.status_code == 400
+    assert "not enabled" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /settings
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_budget(client) -> None:
+    """Patching monthly_budget_usd persists the preference and returns ok."""
+    session_factory, _ = _make_session_with_pref(None)
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.patch("/settings", json={"monthly_budget_usd": 99.5})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+async def test_patch_budget_invalid(client) -> None:
+    """A non-positive budget value returns 400."""
+    resp = await client.patch("/settings", json={"monthly_budget_usd": -1.0})
+    assert resp.status_code == 400
+    assert "positive" in resp.json()["detail"]
+
+
+async def test_patch_fallback(client) -> None:
+    """Patching fallback_enabled=false persists the preference and returns ok."""
+    session_factory, _ = _make_session_with_pref(None)
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.patch("/settings", json={"fallback_enabled": False})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# GET /settings reflects DB overrides
+# ---------------------------------------------------------------------------
+
+
+async def test_get_settings_reflects_overrides(client) -> None:
+    """GET /settings should return DB-overridden values when preferences exist."""
+    budget_pref = UserPreference(key="llm.monthly_budget_usd", value="123.45")
+    fallback_pref = UserPreference(key="llm.fallback_enabled", value="false")
+    provider_pref = UserPreference(key="llm.default_provider", value="anthropic")
+
+    # _get_preference is called three times (default_provider, budget, fallback)
+    session_factory = _make_multi_call_session_factory([provider_pref, budget_pref, fallback_pref])
+
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.get("/settings")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["llm"]["monthly_budget_usd"] == pytest.approx(123.45)
+    assert data["llm"]["fallback_enabled"] is False
+    assert data["llm"]["default_provider"] == "anthropic"


### PR DESCRIPTION
## Summary

- **Settings page** (`/settings`) with 4 sections: LLM Providers, Cost Dashboard, Sync Status, System Info
- **Provider cards** showing status, model, API key config, test connection button
- **Cost dashboard** with budget gauge (green/amber/red thresholds), per-provider and per-task breakdowns
- **Budget soft-limit** — LLM router emits `budget.warning` (configurable, default 80%) and `budget.exceeded` WebSocket events; never blocks calls
- **Cost breakdown endpoint** — `GET /settings/llm/cost/breakdown` with GROUP BY provider + task_type
- **Sync status** — read-only panel reflecting current .env config, ready for sync backend (#28, #74)
- Configurable thresholds: `budget_warning_pct` and `budget_check_cache_seconds` in LLMConfig (env var overridable)

Closes #29 (partially — sync backend deferred to #28/#74)

## Test plan

- [x] Open `/settings` — see provider cards with current state
- [ ] Click "Set Key" on a provider — enter key — save — card shows "Configured"
- [x] Click "Test" on configured provider — see latency result
- [x] Cost dashboard shows current month spend with budget gauge
- [x] Sync section shows current config state
- [x] System info shows data directory, default provider, budget
- [x] 11 new backend tests pass (`test_budget_check.py`, `test_cost_breakdown.py`)
- [x] `make pre-commit` passes
- [x] mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)