### PR TITLE
feat: add Google Gemini provider to LLM router

### DIFF
--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -19,6 +19,7 @@ import google.generativeai as genai
 import ollama
 import openai
 import structlog
+from google.generativeai.types import GenerationConfig
 from sqlalchemy import func
 from sqlmodel import select
 
@@ -508,16 +509,16 @@ class GoogleProvider:
 
         contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
 
-        generation_config: dict[str, Any] = {
+        gen_cfg_kwargs: dict[str, Any] = {
             "max_output_tokens": request.max_tokens,
             "temperature": request.temperature,
         }
         if request.response_format == "json":
-            generation_config["response_mime_type"] = "application/json"
+            gen_cfg_kwargs["response_mime_type"] = "application/json"
 
         response = await gen_model.generate_content_async(
             contents,
-            generation_config=generation_config,
+            generation_config=GenerationConfig(**gen_cfg_kwargs),
         )
 
         latency_ms = int((time.monotonic() - start) * 1000)
@@ -580,10 +581,10 @@ class GoogleProvider:
 
         response = await gen_model.generate_content_async(
             google_parts,
-            generation_config={
-                "max_output_tokens": max_tokens,
-                "temperature": temperature,
-            },
+            generation_config=GenerationConfig(
+                max_output_tokens=max_tokens,
+                temperature=temperature,
+            ),
         )
 
         latency_ms = int((time.monotonic() - start) * 1000)
@@ -610,12 +611,12 @@ class GoogleProvider:
 
         contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
 
-        generation_config: dict[str, Any] = {
+        gen_cfg_kwargs: dict[str, Any] = {
             "max_output_tokens": request.max_tokens,
             "temperature": request.temperature,
         }
         if request.response_format == "json":
-            generation_config["response_mime_type"] = "application/json"
+            gen_cfg_kwargs["response_mime_type"] = "application/json"
 
         async def _generate() -> AsyncIterator[str]:
             full_text_parts: list[str] = []
@@ -624,7 +625,7 @@ class GoogleProvider:
 
             response = await gen_model.generate_content_async(
                 contents,
-                generation_config=generation_config,
+                generation_config=GenerationConfig(**gen_cfg_kwargs),
                 stream=True,
             )
             async for chunk in response:

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -7,6 +7,7 @@ Handles selection, fallback, cost tracking, and token budgeting.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import time
 from collections.abc import AsyncIterator
@@ -14,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import anthropic
+import google.generativeai as genai
 import ollama
 import openai
 import structlog
@@ -489,6 +491,168 @@ class OllamaProvider:
         return session
 
 
+class GoogleProvider:
+    """Google Gemini LLM provider."""
+
+    def __init__(self) -> None:
+        api_key = get_api_key("google")
+        if not api_key:
+            raise ValueError("Google API key not configured")
+        genai.configure(api_key=api_key)
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Complete a request using Google Gemini."""
+        start = time.monotonic()
+
+        gen_model = genai.GenerativeModel(model, system_instruction=request.system)
+
+        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
+
+        generation_config: dict[str, Any] = {
+            "max_output_tokens": request.max_tokens,
+            "temperature": request.temperature,
+        }
+        if request.response_format == "json":
+            generation_config["response_mime_type"] = "application/json"
+
+        response = await gen_model.generate_content_async(
+            contents,
+            generation_config=generation_config,
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.text
+        usage = response.usage_metadata
+        input_tokens = usage.prompt_token_count if usage else 0
+        output_tokens = usage.candidates_token_count if usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.GOOGLE,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Complete a multimodal request with text and images using Google Gemini.
+
+        Translates the Anthropic-style content blocks to Google's inline
+        data format before calling the API.
+
+        Args:
+            system: System prompt.
+            content_parts: List of content blocks in Anthropic format.
+            model: Model name to use.
+            max_tokens: Maximum output tokens.
+            temperature: Sampling temperature.
+
+        Returns:
+            CompletionResponse with the LLM's text output.
+        """
+        start = time.monotonic()
+
+        gen_model = genai.GenerativeModel(model, system_instruction=system)
+
+        # Translate Anthropic content blocks to Google format
+        google_parts: list[str | dict[str, str | bytes]] = []
+        for part in content_parts:
+            if part["type"] == "text":
+                google_parts.append(part["text"])
+            elif part["type"] == "image":
+                media_type = part["source"]["media_type"]
+                data_b64 = part["source"]["data"]
+                google_parts.append(
+                    {
+                        "mime_type": media_type,
+                        "data": base64.b64decode(data_b64),
+                    }
+                )
+
+        response = await gen_model.generate_content_async(
+            google_parts,
+            generation_config={
+                "max_output_tokens": max_tokens,
+                "temperature": temperature,
+            },
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.text
+        usage = response.usage_metadata
+        input_tokens = usage.prompt_token_count if usage else 0
+        output_tokens = usage.candidates_token_count if usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.GOOGLE,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a completion request using Google Gemini."""
+        start = time.monotonic()
+
+        gen_model = genai.GenerativeModel(model, system_instruction=request.system)
+
+        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
+
+        generation_config: dict[str, Any] = {
+            "max_output_tokens": request.max_tokens,
+            "temperature": request.temperature,
+        }
+        if request.response_format == "json":
+            generation_config["response_mime_type"] = "application/json"
+
+        async def _generate() -> AsyncIterator[str]:
+            full_text_parts: list[str] = []
+            input_tokens = 0
+            output_tokens = 0
+
+            response = await gen_model.generate_content_async(
+                contents,
+                generation_config=generation_config,
+                stream=True,
+            )
+            async for chunk in response:
+                text = chunk.text
+                if text:
+                    full_text_parts.append(text)
+                    yield text
+                if chunk.usage_metadata:
+                    if chunk.usage_metadata.prompt_token_count:
+                        input_tokens = chunk.usage_metadata.prompt_token_count
+                    if chunk.usage_metadata.candidates_token_count:
+                        output_tokens = chunk.usage_metadata.candidates_token_count
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            session.result = CompletionResponse(
+                content="".join(full_text_parts),
+                provider_used=Provider.GOOGLE,
+                model_used=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
+                latency_ms=latency_ms,
+            )
+
+        session = StreamSession(_chunks=_generate())
+        return session
+
+
 class MockProvider:
     """Deterministic mock provider for CI e2e testing.
 
@@ -681,6 +845,8 @@ class LLMRouter:
             return AnthropicProvider()
         elif provider == Provider.OPENAI:
             return OpenAIProvider()
+        elif provider == Provider.GOOGLE:
+            return GoogleProvider()
         elif provider == Provider.OLLAMA:
             return OllamaProvider(self.settings.llm.ollama_base_url)
         elif provider == Provider.MOCK:

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -98,7 +98,7 @@ async def test_google_provider_complete_json_format() -> None:
     # Check that generation_config included response_mime_type
     call_kwargs = fake_model.generate_content_async.call_args
     gen_config = call_kwargs.kwargs["generation_config"]
-    assert gen_config["response_mime_type"] == "application/json"
+    assert gen_config.response_mime_type == "application/json"
 
 
 async def test_google_provider_complete_no_usage_metadata() -> None:

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -1,0 +1,336 @@
+"""Tests for the GoogleProvider implementation."""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wikimind.engine import llm_router as llm_router_mod
+from wikimind.engine.llm_router import GoogleProvider, StreamSession, _calc_cost
+from wikimind.models import CompletionRequest, CompletionResponse, Provider, TaskType
+
+
+def _req(**kw) -> CompletionRequest:
+    base = dict(
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=64,
+        task_type=TaskType.QA,
+    )
+    base.update(kw)
+    return CompletionRequest(**base)
+
+
+# ---------------------------------------------------------------------------
+# Init
+# ---------------------------------------------------------------------------
+
+
+def test_google_provider_missing_key() -> None:
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value=None),
+        pytest.raises(ValueError, match="Google API key"),
+    ):
+        GoogleProvider()
+
+
+def test_google_provider_init_configures_genai() -> None:
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="test-key"),
+        patch.object(llm_router_mod.genai, "configure") as mock_configure,
+    ):
+        GoogleProvider()
+        mock_configure.assert_called_once_with(api_key="test-key")  # pragma: allowlist secret
+
+
+# ---------------------------------------------------------------------------
+# complete()
+# ---------------------------------------------------------------------------
+
+
+async def test_google_provider_complete() -> None:
+    """GoogleProvider.complete() returns a CompletionResponse with token counts."""
+    fake_usage = SimpleNamespace(prompt_token_count=15, candidates_token_count=25)
+    fake_response = SimpleNamespace(text="hello from gemini", usage_metadata=fake_usage)
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model) as mock_model_cls,
+    ):
+        provider = GoogleProvider()
+        resp = await provider.complete(_req(), "gemini-2.0-flash")
+
+        # Verify GenerativeModel was called with correct system instruction
+        mock_model_cls.assert_called_once_with("gemini-2.0-flash", system_instruction="sys")
+
+    assert isinstance(resp, CompletionResponse)
+    assert resp.content == "hello from gemini"
+    assert resp.input_tokens == 15
+    assert resp.output_tokens == 25
+    assert resp.provider_used == Provider.GOOGLE
+    assert resp.model_used == "gemini-2.0-flash"
+    assert resp.latency_ms >= 0
+
+
+async def test_google_provider_complete_json_format() -> None:
+    """GoogleProvider.complete() passes response_mime_type for JSON format."""
+    fake_usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=10)
+    fake_response = SimpleNamespace(text='{"answer": "ok"}', usage_metadata=fake_usage)
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+    ):
+        provider = GoogleProvider()
+        resp = await provider.complete(_req(response_format="json"), "gemini-2.0-flash")
+
+    assert resp.content == '{"answer": "ok"}'
+
+    # Check that generation_config included response_mime_type
+    call_kwargs = fake_model.generate_content_async.call_args
+    gen_config = call_kwargs.kwargs["generation_config"]
+    assert gen_config["response_mime_type"] == "application/json"
+
+
+async def test_google_provider_complete_no_usage_metadata() -> None:
+    """GoogleProvider.complete() handles missing usage_metadata gracefully."""
+    fake_response = SimpleNamespace(text="no usage", usage_metadata=None)
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+    ):
+        provider = GoogleProvider()
+        resp = await provider.complete(_req(), "gemini-2.0-flash")
+
+    assert resp.input_tokens == 0
+    assert resp.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# complete_multimodal()
+# ---------------------------------------------------------------------------
+
+
+async def test_google_provider_complete_multimodal() -> None:
+    """GoogleProvider.complete_multimodal() translates Anthropic content blocks."""
+    fake_usage = SimpleNamespace(prompt_token_count=100, candidates_token_count=50)
+    fake_response = SimpleNamespace(text="I see a diagram", usage_metadata=fake_usage)
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    sample_b64 = base64.b64encode(b"fake-image-data").decode()
+
+    content_parts = [
+        {"type": "text", "text": "Describe this image."},
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": sample_b64,
+            },
+        },
+    ]
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+    ):
+        provider = GoogleProvider()
+        resp = await provider.complete_multimodal(
+            system="You are a vision assistant.",
+            content_parts=content_parts,
+            model="gemini-2.0-flash",
+        )
+
+    assert isinstance(resp, CompletionResponse)
+    assert resp.content == "I see a diagram"
+    assert resp.provider_used == Provider.GOOGLE
+    assert resp.input_tokens == 100
+    assert resp.output_tokens == 50
+
+    # Verify content format translation
+    call_args = fake_model.generate_content_async.call_args
+    google_parts = call_args.args[0]
+    assert google_parts[0] == "Describe this image."
+    assert google_parts[1]["mime_type"] == "image/png"
+    assert google_parts[1]["data"] == base64.b64decode(sample_b64)
+
+
+async def test_google_provider_multimodal_text_only() -> None:
+    """GoogleProvider.complete_multimodal() works with text-only content."""
+    fake_usage = SimpleNamespace(prompt_token_count=10, candidates_token_count=20)
+    fake_response = SimpleNamespace(text="text only response", usage_metadata=fake_usage)
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    content_parts = [
+        {"type": "text", "text": "First part."},
+        {"type": "text", "text": "Second part."},
+    ]
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+    ):
+        provider = GoogleProvider()
+        resp = await provider.complete_multimodal(
+            system="sys",
+            content_parts=content_parts,
+            model="gemini-2.0-flash",
+        )
+
+    assert resp.content == "text only response"
+
+    # All parts should be plain strings
+    call_args = fake_model.generate_content_async.call_args
+    google_parts = call_args.args[0]
+    assert google_parts == ["First part.", "Second part."]
+
+
+# ---------------------------------------------------------------------------
+# stream()
+# ---------------------------------------------------------------------------
+
+
+async def test_google_provider_stream() -> None:
+    """GoogleProvider.stream() yields chunks and populates result."""
+    chunk1 = SimpleNamespace(
+        text="hello ",
+        usage_metadata=SimpleNamespace(prompt_token_count=10, candidates_token_count=3),
+    )
+    chunk2 = SimpleNamespace(
+        text="world",
+        usage_metadata=SimpleNamespace(prompt_token_count=10, candidates_token_count=8),
+    )
+
+    async def _fake_stream():
+        yield chunk1
+        yield chunk2
+
+    fake_async_response = _fake_stream()
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_async_response)
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+    ):
+        provider = GoogleProvider()
+        session = await provider.stream(_req(), "gemini-2.0-flash")
+
+    assert isinstance(session, StreamSession)
+    chunks = [chunk async for chunk in session]
+    assert chunks == ["hello ", "world"]
+    assert session.result is not None
+    assert session.result.content == "hello world"
+    assert session.result.provider_used == Provider.GOOGLE
+    assert session.result.input_tokens == 10
+    assert session.result.output_tokens == 8
+    assert session.result.latency_ms >= 0
+
+
+async def test_google_provider_stream_empty_chunks_skipped() -> None:
+    """GoogleProvider.stream() skips chunks with empty/None text."""
+    chunk1 = SimpleNamespace(text="data", usage_metadata=None)
+    chunk2 = SimpleNamespace(text="", usage_metadata=None)
+    chunk3 = SimpleNamespace(text=None, usage_metadata=None)
+
+    async def _fake_stream():
+        yield chunk1
+        yield chunk2
+        yield chunk3
+
+    fake_async_response = _fake_stream()
+    fake_model = MagicMock()
+    fake_model.generate_content_async = AsyncMock(return_value=fake_async_response)
+
+    with (
+        patch.object(llm_router_mod, "get_api_key", return_value="key"),
+        patch.object(llm_router_mod.genai, "configure"),
+        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+    ):
+        provider = GoogleProvider()
+        session = await provider.stream(_req(), "gemini-2.0-flash")
+
+    chunks = [chunk async for chunk in session]
+    assert chunks == ["data"]
+    assert session.result.content == "data"
+
+
+# ---------------------------------------------------------------------------
+# Content format translation
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_to_google_content_translation() -> None:
+    """Verify Anthropic-style content blocks translate to Google format correctly."""
+    sample_data = base64.b64encode(b"\x89PNG\r\n").decode()
+
+    anthropic_parts = [
+        {"type": "text", "text": "Describe the image"},
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": sample_data,
+            },
+        },
+        {"type": "text", "text": "Also this"},
+    ]
+
+    # Replicate the translation logic from GoogleProvider.complete_multimodal
+    google_parts: list = []
+    for part in anthropic_parts:
+        if part["type"] == "text":
+            google_parts.append(part["text"])
+        elif part["type"] == "image":
+            media_type = part["source"]["media_type"]
+            data_b64 = part["source"]["data"]
+            google_parts.append(
+                {
+                    "mime_type": media_type,
+                    "data": base64.b64decode(data_b64),
+                }
+            )
+
+    assert len(google_parts) == 3
+    assert google_parts[0] == "Describe the image"
+    assert isinstance(google_parts[1], dict)
+    assert google_parts[1]["mime_type"] == "image/png"
+    assert google_parts[1]["data"] == b"\x89PNG\r\n"
+    assert google_parts[2] == "Also this"
+
+
+# ---------------------------------------------------------------------------
+# Cost calculation
+# ---------------------------------------------------------------------------
+
+
+def test_google_cost_calculation() -> None:
+    """Verify cost calculation for Google Gemini pricing."""
+    # gemini-2.0-flash: input=$0.10/M, output=$0.40/M
+    cost = _calc_cost(Provider.GOOGLE, "gemini-2.0-flash", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(0.50)
+
+    # Smaller usage
+    cost = _calc_cost(Provider.GOOGLE, "gemini-2.0-flash", 1000, 500)
+    expected = (1000 * 0.10 + 500 * 0.40) / 1_000_000
+    assert cost == pytest.approx(expected)

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -180,16 +180,17 @@ async def test_get_provider_instance_dispatch() -> None:
         patch.object(llm_router_mod, "get_api_key", return_value="k"),
         patch.object(llm_router_mod, "AnthropicProvider") as ant,
         patch.object(llm_router_mod, "OpenAIProvider") as opn,
+        patch.object(llm_router_mod, "GoogleProvider") as ggl,
         patch.object(llm_router_mod, "OllamaProvider") as oll,
     ):
         ant.return_value = "a"
         opn.return_value = "o"
+        ggl.return_value = "g"
         oll.return_value = "l"
         assert await router._get_provider_instance(Provider.ANTHROPIC) == "a"
         assert await router._get_provider_instance(Provider.OPENAI) == "o"
+        assert await router._get_provider_instance(Provider.GOOGLE) == "g"
         assert await router._get_provider_instance(Provider.OLLAMA) == "l"
-        with pytest.raises(ValueError):
-            await router._get_provider_instance(Provider.GOOGLE)
 
 
 async def test_router_complete_success(db_session) -> None:


### PR DESCRIPTION
## Summary

- Add `GoogleProvider` class implementing `complete()`, `complete_multimodal()`, and `stream()` methods using the `google.generativeai` SDK, following the same async pattern as existing Anthropic/OpenAI/Ollama providers
- Wire `Provider.GOOGLE` into `_get_provider_instance()` dispatch in the LLM router so Gemini models are available for all compilation, QA, and linting workflows
- Add 11 new unit tests covering initialization, text completion, JSON-format completion, multimodal input, streaming, empty-chunk handling, Anthropic-to-Google content translation, and cost calculation

## Test plan

- [x] Run `python -m pytest tests/unit/test_google_provider.py tests/unit/test_llm_router.py -v` — all 44 tests should pass
- [x] Verify mypy passes: `mypy src/wikimind/engine/llm_router.py`
- [x] To test with a real API key: set `GOOGLE_API_KEY=<your-key>` in `.env`, configure a Google provider in Settings UI, then compile or query a wiki page and confirm responses come back from Gemini
- [x] Verify fallback behavior: with `GOOGLE_API_KEY` unset, the router should skip Google and fall through to the next available provider