### PR TITLE
fix: isolate sweep sessions to prevent greenlet and identity-map errors (#163)

### DIFF
--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -87,18 +87,22 @@ async def _sweep_single_article(
     # Write the updated file
     file_path.write_text(new_content, encoding="utf-8")
 
-    # Persist Backlink rows — use merge() to handle duplicates gracefully.
-    # The old per-row commit + IntegrityError approach caused identity-map
-    # conflicts (SAWarning) when the selectin eager loading on Article
-    # already loaded the Backlink into the session (#163). merge() resolves
-    # this by reconciling new instances with existing identity-map entries.
+    # Persist Backlink rows — use get-or-create to handle duplicates
+    # gracefully. The selectin eager loading on Article pre-populates the
+    # identity map with existing Backlinks, so merge() would conflict
+    # (SAWarning + IntegrityError). Instead we check for each backlink
+    # by composite PK and only insert when it doesn't already exist (#163).
     for rb in resolved:
-        bl = Backlink(
-            source_article_id=article.id,
-            target_article_id=rb.target_id,
-            context=rb.candidate_text,
-        )
-        await session.merge(bl)
+        existing = await session.get(Backlink, (article.id, rb.target_id))
+        if existing is not None:
+            existing.context = rb.candidate_text
+        else:
+            bl = Backlink(
+                source_article_id=article.id,
+                target_article_id=rb.target_id,
+                context=rb.candidate_text,
+            )
+            session.add(bl)
 
     # Single commit for all backlinks of this article.
     await session.commit()

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -16,7 +16,6 @@ import re
 from pathlib import Path
 
 import structlog
-from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -38,6 +37,10 @@ async def _sweep_single_article(
     session: AsyncSession,
 ) -> bool:
     """Resolve unresolved brackets in a single article's .md file.
+
+    Each article gets its own session (passed in by the caller) to avoid
+    identity-map conflicts when multiple articles create Backlinks for
+    overlapping article pairs (issue #163).
 
     Returns True if any replacement was made (file rewritten + backlinks
     persisted), False if the file was unchanged.
@@ -84,23 +87,21 @@ async def _sweep_single_article(
     # Write the updated file
     file_path.write_text(new_content, encoding="utf-8")
 
-    # Persist Backlink rows (per-row commit + IntegrityError catch)
+    # Persist Backlink rows — use merge() to handle duplicates gracefully.
+    # The old per-row commit + IntegrityError approach caused identity-map
+    # conflicts (SAWarning) when the selectin eager loading on Article
+    # already loaded the Backlink into the session (#163). merge() resolves
+    # this by reconciling new instances with existing identity-map entries.
     for rb in resolved:
         bl = Backlink(
             source_article_id=article.id,
             target_article_id=rb.target_id,
             context=rb.candidate_text,
         )
-        session.add(bl)
-        try:
-            await session.commit()
-        except IntegrityError:
-            await session.rollback()
-            log.debug(
-                "sweep: skipped duplicate backlink",
-                source=article.id,
-                target=rb.target_id,
-            )
+        await session.merge(bl)
+
+    # Single commit for all backlinks of this article.
+    await session.commit()
 
     log.info(
         "sweep: article updated",
@@ -120,48 +121,58 @@ async def sweep_wikilinks(ctx) -> None:
        Article table (excluding self).
     4. For each newly-resolved link:
        a. Replace the [[Title]] in the file with [Title](/wiki/{target_id}).
-       b. Create a Backlink row (skip on IntegrityError -- it means the
-          row already exists from a prior sweep or fresh compile).
+       b. Create a Backlink row (skip if it already exists from a prior
+          sweep or fresh compile).
     5. If any replacements were made, write the file back to disk.
+
+    Each article is processed in its own database session to avoid
+    identity-map conflicts between articles (issue #163). The Job
+    record is managed by a separate outer session.
 
     Idempotent: running the sweep on a wiki with no unresolved brackets
     is a no-op (no file writes, no DB changes).
     """
     log.info("sweep_wikilinks started")
 
-    async with get_session_factory()() as session:
+    session_factory = get_session_factory()
+
+    async with session_factory() as job_session:
         # Create job record
         job = Job(
             job_type=JobType.SWEEP_WIKILINKS,
             status=JobStatus.RUNNING,
             started_at=utcnow_naive(),
         )
-        session.add(job)
-        await session.commit()
+        job_session.add(job)
+        await job_session.commit()
 
         try:
-            result = await session.execute(select(Article))
+            result = await job_session.execute(select(Article))
             articles = list(result.scalars().all())
 
             if not articles:
                 job.status = JobStatus.COMPLETE
                 job.result_summary = "No articles to sweep"
-                session.add(job)
-                await session.commit()
+                job_session.add(job)
+                await job_session.commit()
                 log.info("sweep_wikilinks complete: no articles")
                 return
 
             updated_count = 0
             for article in articles:
-                changed = await _sweep_single_article(article, session)  # type: ignore[arg-type]
-                if changed:
-                    updated_count += 1
+                # Each article gets its own session to prevent identity-map
+                # conflicts when both the source compiler and the sweep
+                # create Backlinks for overlapping article pairs (#163).
+                async with session_factory() as article_session:
+                    changed = await _sweep_single_article(article, article_session)
+                    if changed:
+                        updated_count += 1
 
             job.status = JobStatus.COMPLETE
             job.completed_at = utcnow_naive()
             job.result_summary = f"Swept {len(articles)} articles, updated {updated_count}"
-            session.add(job)
-            await session.commit()
+            job_session.add(job)
+            await job_session.commit()
 
             log.info(
                 "sweep_wikilinks complete",
@@ -174,5 +185,5 @@ async def sweep_wikilinks(ctx) -> None:
             job.status = JobStatus.FAILED
             job.error = str(e)
             job.completed_at = utcnow_naive()
-            session.add(job)
-            await session.commit()
+            job_session.add(job)
+            await job_session.commit()

--- a/tests/unit/test_sweep_session.py
+++ b/tests/unit/test_sweep_session.py
@@ -180,8 +180,7 @@ async def test_sweep_wikilinks_uses_isolated_sessions(
     # Should have at least 3 calls: 1 job session + 2 per article
     # (one per article in the loop). The key assertion is > 1.
     assert counting_factory.call_count >= 3, (
-        f"Expected at least 3 session factory calls (1 job + 2 articles), "
-        f"got {counting_factory.call_count}"
+        f"Expected at least 3 session factory calls (1 job + 2 articles), got {counting_factory.call_count}"
     )
 
     # Verify the backlink was actually created.

--- a/tests/unit/test_sweep_session.py
+++ b/tests/unit/test_sweep_session.py
@@ -1,0 +1,196 @@
+"""Tests for sweep session isolation fix (issue #163).
+
+Verifies that:
+1. Sweep creates backlinks for articles with unresolved wikilinks.
+2. Sweep handles pre-existing (duplicate) backlinks without identity-map
+   conflicts or IntegrityError.
+3. sweep_wikilinks() uses isolated per-article sessions via
+   get_session_factory().
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlmodel import select
+
+from wikimind._datetime import utcnow_naive
+from wikimind.jobs.sweep import _sweep_single_article, sweep_wikilinks
+from wikimind.models import Article, Backlink, ConfidenceLevel
+
+
+async def _make_article(
+    session: AsyncSession,
+    title: str,
+    file_path: str,
+    slug: str | None = None,
+) -> Article:
+    """Create and persist a test article."""
+    article = Article(
+        id=str(uuid.uuid4()),
+        slug=slug or title.lower().replace(" ", "-"),
+        title=title,
+        file_path=file_path,
+        confidence=ConfidenceLevel.SOURCED,
+        created_at=utcnow_naive(),
+    )
+    session.add(article)
+    await session.commit()
+    await session.refresh(article)
+    return article
+
+
+@pytest.mark.asyncio
+async def test_sweep_creates_backlinks(db_session: AsyncSession, tmp_path: Path) -> None:
+    """Sweep resolves [[brackets]] and creates corresponding Backlink rows."""
+    target = await _make_article(db_session, "Quantum Computing", str(tmp_path / "qc.md"))
+
+    md_path = tmp_path / "source.md"
+    md_path.write_text("Research on [[Quantum Computing]] is advancing.\n")
+    source = await _make_article(db_session, "Physics Overview", str(md_path))
+
+    changed = await _sweep_single_article(source, db_session)
+
+    assert changed is True
+    content = md_path.read_text()
+    assert f"[Quantum Computing](/wiki/{target.id})" in content
+
+    result = await db_session.execute(
+        select(Backlink).where(
+            Backlink.source_article_id == source.id,
+            Backlink.target_article_id == target.id,
+        )
+    )
+    bl = result.scalar_one_or_none()
+    assert bl is not None
+    assert bl.context == "Quantum Computing"
+
+
+@pytest.mark.asyncio
+async def test_sweep_handles_duplicate_backlinks(async_engine: AsyncEngine, tmp_path: Path) -> None:
+    """When a Backlink already exists, sweep uses merge() without SAWarning or error.
+
+    Uses separate sessions (as production code does): one for setup, one
+    for the sweep. This mirrors the real scenario where the compiler
+    created the Backlink in a prior session.
+    """
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    # Setup: create articles and a pre-existing backlink.
+    async with factory() as setup_session:
+        target = await _make_article(setup_session, "Machine Learning", str(tmp_path / "ml.md"))
+
+        md_path = tmp_path / "source.md"
+        md_path.write_text("Exploring [[Machine Learning]] techniques.\n")
+        source = await _make_article(setup_session, "AI Guide", str(md_path))
+
+        # Pre-create the backlink (simulates prior compilation)
+        existing_bl = Backlink(
+            source_article_id=source.id,
+            target_article_id=target.id,
+            context="pre-existing",
+        )
+        setup_session.add(existing_bl)
+        await setup_session.commit()
+        source_id = source.id
+        target_id = target.id
+
+    # Sweep in a fresh session — no SAWarning or IntegrityError should occur.
+    async with factory() as sweep_session:
+        # Re-load the article in this session's identity map.
+        result = await sweep_session.execute(select(Article).where(Article.id == source_id))
+        source_reloaded = result.scalar_one()
+
+        changed = await _sweep_single_article(source_reloaded, sweep_session)
+
+    assert changed is True
+    content = md_path.read_text()
+    assert f"[Machine Learning](/wiki/{target_id})" in content
+
+    # Verify exactly one backlink row exists (not two).
+    async with factory() as verify_session:
+        result = await verify_session.execute(
+            select(Backlink).where(
+                Backlink.source_article_id == source_id,
+                Backlink.target_article_id == target_id,
+            )
+        )
+        links = list(result.scalars().all())
+        assert len(links) == 1
+
+
+class _CountingSessionFactory:
+    """Wraps an async_sessionmaker to count how many sessions are created."""
+
+    def __init__(self, real_factory: async_sessionmaker):
+        self._real = real_factory
+        self.call_count = 0
+
+    def __call__(self):
+        self.call_count += 1
+        return self._real()
+
+
+@pytest.mark.asyncio
+async def test_sweep_wikilinks_uses_isolated_sessions(
+    async_engine: AsyncEngine,
+    tmp_path: Path,
+) -> None:
+    """sweep_wikilinks() creates a separate session per article via get_session_factory().
+
+    We mock get_session_factory to return a counting wrapper, then verify
+    multiple sessions are created (one for the job + one per article).
+    """
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    # Pre-populate: one article with an unresolved bracket, one target
+    async with factory() as setup_session:
+        target = Article(
+            id=str(uuid.uuid4()),
+            slug="deep-learning",
+            title="Deep Learning",
+            file_path=str(tmp_path / "dl.md"),
+            confidence=ConfidenceLevel.SOURCED,
+            created_at=utcnow_naive(),
+        )
+        md_path = tmp_path / "intro.md"
+        md_path.write_text("Introduction to [[Deep Learning]] methods.\n")
+        source = Article(
+            id=str(uuid.uuid4()),
+            slug="intro-ai",
+            title="Intro to AI",
+            file_path=str(md_path),
+            confidence=ConfidenceLevel.SOURCED,
+            created_at=utcnow_naive(),
+        )
+        setup_session.add_all([target, source])
+        await setup_session.commit()
+        source_id = source.id
+        target_id = target.id
+
+    counting_factory = _CountingSessionFactory(factory)
+
+    with patch("wikimind.jobs.sweep.get_session_factory", return_value=counting_factory):
+        await sweep_wikilinks(ctx=None)
+
+    # Should have at least 3 calls: 1 job session + 2 per article
+    # (one per article in the loop). The key assertion is > 1.
+    assert counting_factory.call_count >= 3, (
+        f"Expected at least 3 session factory calls (1 job + 2 articles), "
+        f"got {counting_factory.call_count}"
+    )
+
+    # Verify the backlink was actually created.
+    async with factory() as verify_session:
+        result = await verify_session.execute(
+            select(Backlink).where(
+                Backlink.source_article_id == source_id,
+                Backlink.target_article_id == target_id,
+            )
+        )
+        bl = result.scalar_one_or_none()
+        assert bl is not None


### PR DESCRIPTION
## Summary

- **Per-article isolated sessions**: `sweep_wikilinks()` now creates a separate database session for each article via `get_session_factory()`, preventing identity-map conflicts when multiple articles create Backlinks for overlapping article pairs.
- **get-or-create instead of merge/add for backlinks**: Replaced the old per-row commit + IntegrityError pattern (and the intermediate `merge()` approach) with `session.get()` by composite PK, then `add()` only when the row is new — avoids both SAWarning and greenlet errors from `selectin` eager loading on Article.
- **Removed per-row commit pattern**: All backlinks for a single article are now committed in a single transaction rather than one commit per backlink row.

## Test plan

- [x] `make pre-commit` passes
- [x] `mypy src/wikimind/jobs/sweep.py` passes
- [x] `pytest tests/unit/test_sweep_session.py tests/unit/test_sweep.py -v` — all 11 tests pass
- [ ] Manual: ingest a source with `[[brackets]]` targeting an existing article, verify sweep resolves links and creates backlinks without errors
- [ ] Manual: re-run sweep on an article with pre-existing backlinks, verify no duplicate rows or SAWarnings

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)