### PR TITLE
refactor: FileStorage abstraction for cloud deployment (PR 1/3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,14 @@ worker: ## Start ARQ background job worker
 ##@ 🔍 QUALITY
 
 .PHONY: pre-commit
-pre-commit: ## Run all pre-commit hooks locally (same as CI)
+pre-commit: ## Run all pre-commit hooks + mypy + tests (matches CI)
 	@# Prepend the venv bin to PATH so the local hooks (which use `python`
 	@# as their entry point) resolve to the venv's Python — needed because
 	@# pre-commit's `language: system` subprocesses inherit the parent shell's
 	@# PATH, and the user may not have the venv activated.
 	@PATH="$(abspath $(BIN)):$$PATH" $(BIN)/pre-commit run --all-files
+	$(BIN)/mypy src/wikimind
+	$(BIN)/pytest tests/unit -x -q
 
 .PHONY: lint
 lint: ## Run ruff linter on src/ and tests/ (includes pylint + pydocstyle rules)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 
 | Target | Description |
 |--------|-------------|
-| `make pre-commit` | Run all pre-commit hooks locally (same as CI) |
+| `make pre-commit` | Run all pre-commit hooks + mypy + tests (matches CI) |
 | `make lint` | Run ruff linter on src/ and tests/ (includes pylint + pydocstyle rules) |
 | `make lint-fix` | Auto-fix lint issues where possible |
 | `make format` | Format source code with ruff |

--- a/docs/superpowers/plans/2026-04-17-filestorage-abstraction.md
+++ b/docs/superpowers/plans/2026-04-17-filestorage-abstraction.md
@@ -1,0 +1,1221 @@
+# FileStorage Abstraction Implementation Plan (PR 1 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all direct `Path` file I/O with a `FileStorage` protocol so wiki and raw files can later be stored in R2/S3 without changing application logic.
+
+**Architecture:** A `FileStorage` protocol defines async read/write/delete/list. `LocalFileStorage` wraps current `Path` operations with `asyncio.to_thread()`. Two singleton factories (`get_wiki_storage()`, `get_raw_storage()`) return the appropriate backend. `Article.file_path` and `Source.file_path` change from absolute to relative paths. A one-time migration converts existing records.
+
+**Tech Stack:** Python 3.11+, asyncio, pathlib, pytest, SQLModel
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/wikimind/storage.py` | `FileStorage` protocol, `LocalFileStorage`, singleton factories |
+| Create | `tests/unit/test_storage.py` | Unit tests for `LocalFileStorage` |
+| Modify | `src/wikimind/engine/compiler.py` | Use `wiki_storage` for article writes/deletes |
+| Modify | `src/wikimind/engine/concept_compiler.py` | Use `wiki_storage` for concept page writes/deletes/reads |
+| Modify | `src/wikimind/engine/qa_agent.py` | Use `wiki_storage` for answer writes and article reads |
+| Modify | `src/wikimind/engine/frontmatter_validator.py` | Accept `str` content instead of `Path` |
+| Modify | `src/wikimind/services/wiki_index.py` | Use `wiki_storage` for index.md and health page writes |
+| Modify | `src/wikimind/services/activity_log.py` | Use `wiki_storage` for log append |
+| Modify | `src/wikimind/services/wiki.py` | Use `wiki_storage` for article reads |
+| Modify | `src/wikimind/engine/linter/contradictions.py` | Use `wiki_storage` for article reads |
+| Modify | `src/wikimind/jobs/sweep.py` | Use `wiki_storage` for article reads/writes |
+| Modify | `src/wikimind/jobs/worker.py` | Use `wiki_storage` + `raw_storage` for reads |
+| Modify | `src/wikimind/ingest/service.py` | Use `raw_storage` for source file writes |
+| Modify | `src/wikimind/database.py` | Add `_migrate_to_relative_paths()` in `init_db()` |
+
+---
+
+### Task 1: Create FileStorage protocol and LocalFileStorage
+
+**Files:**
+- Create: `src/wikimind/storage.py`
+- Test: `tests/unit/test_storage.py`
+
+- [ ] **Step 1: Write tests for LocalFileStorage**
+
+```python
+# tests/unit/test_storage.py
+"""Tests for the FileStorage abstraction."""
+
+from __future__ import annotations
+
+import pytest
+
+from wikimind.storage import LocalFileStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return LocalFileStorage(root=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_write_and_read(storage, tmp_path):
+    await storage.write("subdir/test.md", "hello world")
+    content = await storage.read("subdir/test.md")
+    assert content == "hello world"
+    assert (tmp_path / "subdir" / "test.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_and_read_bytes(storage, tmp_path):
+    data = b"\x89PNG fake image data"
+    await storage.write_bytes("raw/file.pdf", data)
+    result = await storage.read_bytes("raw/file.pdf")
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_append(storage):
+    await storage.write("log.md", "line1\n")
+    await storage.append("log.md", "line2\n")
+    content = await storage.read("log.md")
+    assert content == "line1\nline2\n"
+
+
+@pytest.mark.asyncio
+async def test_append_creates_file(storage):
+    await storage.append("new.md", "first line\n")
+    content = await storage.read("new.md")
+    assert content == "first line\n"
+
+
+@pytest.mark.asyncio
+async def test_delete(storage):
+    await storage.write("to_delete.md", "bye")
+    assert await storage.exists("to_delete.md")
+    await storage.delete("to_delete.md")
+    assert not await storage.exists("to_delete.md")
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_is_noop(storage):
+    await storage.delete("nonexistent.md")  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_exists(storage):
+    assert not await storage.exists("nope.md")
+    await storage.write("yep.md", "here")
+    assert await storage.exists("yep.md")
+
+
+@pytest.mark.asyncio
+async def test_list_files(storage):
+    await storage.write("a/one.md", "1")
+    await storage.write("a/two.md", "2")
+    await storage.write("b/three.md", "3")
+    files = await storage.list("a/")
+    assert sorted(files) == ["a/one.md", "a/two.md"]
+
+
+@pytest.mark.asyncio
+async def test_list_all(storage):
+    await storage.write("x.md", "x")
+    await storage.write("y/z.md", "z")
+    files = await storage.list()
+    assert sorted(files) == ["x.md", "y/z.md"]
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises(storage):
+    with pytest.raises(FileNotFoundError):
+        await storage.read("missing.md")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mg/mg-work/manav/work/ai-experiments/wikimind && source .venv/bin/activate && pytest tests/unit/test_storage.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'wikimind.storage'`
+
+- [ ] **Step 3: Implement FileStorage protocol and LocalFileStorage**
+
+```python
+# src/wikimind/storage.py
+"""File storage abstraction for wiki and raw source files.
+
+Provides a protocol for async file operations and a local filesystem
+implementation. In production, an R2/S3 implementation can be swapped
+in via configuration without changing application code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from wikimind.config import get_settings
+
+
+@runtime_checkable
+class FileStorage(Protocol):
+    """Async file storage interface."""
+
+    async def read(self, relative_path: str) -> str: ...
+    async def read_bytes(self, relative_path: str) -> bytes: ...
+    async def write(self, relative_path: str, content: str) -> None: ...
+    async def write_bytes(self, relative_path: str, data: bytes) -> None: ...
+    async def append(self, relative_path: str, content: str) -> None: ...
+    async def delete(self, relative_path: str) -> None: ...
+    async def exists(self, relative_path: str) -> bool: ...
+    async def list(self, prefix: str = "") -> list[str]: ...
+
+
+class LocalFileStorage:
+    """Local filesystem implementation of FileStorage."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def _resolve(self, relative_path: str) -> Path:
+        return self.root / relative_path
+
+    async def read(self, relative_path: str) -> str:
+        path = self._resolve(relative_path)
+        return await asyncio.to_thread(path.read_text, encoding="utf-8")
+
+    async def read_bytes(self, relative_path: str) -> bytes:
+        path = self._resolve(relative_path)
+        return await asyncio.to_thread(path.read_bytes)
+
+    async def write(self, relative_path: str, content: str) -> None:
+        path = self._resolve(relative_path)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_text, content, encoding="utf-8")
+
+    async def write_bytes(self, relative_path: str, data: bytes) -> None:
+        path = self._resolve(relative_path)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_bytes, data)
+
+    async def append(self, relative_path: str, content: str) -> None:
+        path = self._resolve(relative_path)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+
+        def _append():
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(content)
+
+        await asyncio.to_thread(_append)
+
+    async def delete(self, relative_path: str) -> None:
+        path = self._resolve(relative_path)
+        if path.exists():
+            await asyncio.to_thread(path.unlink, missing_ok=True)
+
+    async def exists(self, relative_path: str) -> bool:
+        path = self._resolve(relative_path)
+        return await asyncio.to_thread(path.exists)
+
+    async def list(self, prefix: str = "") -> list[str]:
+        search_dir = self._resolve(prefix) if prefix else self.root
+
+        def _list():
+            if not search_dir.exists():
+                return []
+            return [
+                str(p.relative_to(self.root))
+                for p in search_dir.rglob("*")
+                if p.is_file()
+            ]
+
+        return await asyncio.to_thread(_list)
+
+
+@lru_cache(maxsize=1)
+def get_wiki_storage() -> FileStorage:
+    """Return the wiki file storage singleton."""
+    settings = get_settings()
+    return LocalFileStorage(root=Path(settings.data_dir) / "wiki")
+
+
+@lru_cache(maxsize=1)
+def get_raw_storage() -> FileStorage:
+    """Return the raw source file storage singleton."""
+    settings = get_settings()
+    return LocalFileStorage(root=Path(settings.data_dir) / "raw")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_storage.py -v`
+Expected: All 11 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/storage.py tests/unit/test_storage.py
+git commit -s -m "feat: add FileStorage protocol and LocalFileStorage implementation"
+```
+
+---
+
+### Task 2: Refactor frontmatter_validator to accept content string
+
+The validator currently reads from disk via `Path.read_text()`. Change it to accept content as a string so callers can pass content they already have or read through storage.
+
+**Files:**
+- Modify: `src/wikimind/engine/frontmatter_validator.py`
+- Modify: `src/wikimind/engine/compiler.py:586` (call site)
+
+- [ ] **Step 1: Update parse_frontmatter to accept string content**
+
+In `src/wikimind/engine/frontmatter_validator.py`, change `parse_frontmatter` to accept a `str` instead of `Path`:
+
+```python
+# Replace the existing parse_frontmatter function (lines 30-50)
+def parse_frontmatter(content: str) -> dict | None:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith("---"):
+        return None
+
+    end = content.find("---", 3)
+    if end == -1:
+        return None
+
+    yaml_block = content[3:end].strip()
+    try:
+        return yaml.safe_load(yaml_block)
+    except yaml.YAMLError as exc:
+        log.warning("frontmatter_validator: YAML parse error", error=str(exc))
+        return None
+```
+
+- [ ] **Step 2: Update validate_frontmatter to accept string content**
+
+```python
+# Replace the existing validate_frontmatter function (lines 53-85)
+def validate_frontmatter(content: str) -> bool:
+    """Validate frontmatter of wiki markdown content against its page-type model."""
+    data = parse_frontmatter(content)
+    if data is None:
+        log.warning("frontmatter_validator: no frontmatter found")
+        return False
+
+    page_type = data.get("page_type")
+    if page_type is None:
+        log.warning("frontmatter_validator: missing page_type field")
+        return False
+
+    model_cls = _FRONTMATTER_MODELS.get(str(page_type))
+    if model_cls is None:
+        log.warning(
+            "frontmatter_validator: unknown page_type",
+            page_type=page_type,
+        )
+        return False
+
+    try:
+        model_cls(**data)
+        return True
+    except ValidationError as exc:
+        log.warning(
+            "frontmatter_validator: validation failed",
+            page_type=page_type,
+            errors=exc.error_count(),
+            detail=str(exc),
+        )
+        return False
+```
+
+- [ ] **Step 3: Update call site in compiler.py**
+
+In `src/wikimind/engine/compiler.py`, the call at line 586 is:
+```python
+validate_frontmatter(file_path)
+```
+
+Change to pass the content string (the `content` variable is in scope from the write above):
+```python
+validate_frontmatter(content)
+```
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `pytest tests/ -v -k "frontmatter or compiler" --timeout=30`
+Expected: All pass (the validator tests should still work since they construct content)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/engine/frontmatter_validator.py src/wikimind/engine/compiler.py
+git commit -s -m "refactor: frontmatter validator accepts content string instead of Path"
+```
+
+---
+
+### Task 3: Refactor compiler.py to use wiki_storage
+
+**Files:**
+- Modify: `src/wikimind/engine/compiler.py`
+
+- [ ] **Step 1: Add storage import at top of compiler.py**
+
+Add to the imports section:
+```python
+from wikimind.storage import get_wiki_storage
+```
+
+- [ ] **Step 2: Refactor `_write_article_file()` (line 511)**
+
+Current code constructs a `Path`, creates a directory, writes content, and returns the `Path`. Change to:
+
+```python
+def _write_article_file(
+    self,
+    result: CompilationResult,
+    source: Source,
+    slug: str,
+    resolved: list[ResolvedBacklink],
+    unresolved: list[str],
+) -> str:
+    """Write article markdown file. Returns the relative path for DB storage."""
+    # Determine relative path: {first_concept_slug}/{slug}.md
+    concept = result.concepts[0] if result.concepts else "uncategorized"
+    concept_slug = slugify(concept)
+    relative_path = f"{concept_slug}/{slug}.md"
+
+    # Build the markdown content (same as before — all the frontmatter
+    # and body construction stays identical, just the write changes)
+    # ... (keep all existing content construction code unchanged) ...
+
+    # The content variable is built the same way as before.
+    # Replace the old write:
+    #   file_path.write_text(content, encoding="utf-8")
+    # With storage write (sync wrapper since this is a sync method):
+    import asyncio
+    storage = get_wiki_storage()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop and loop.is_running():
+        # We're inside an async context — use to_thread
+        # But this is a sync method, so just use the underlying Path directly
+        from pathlib import Path
+        full_path = Path(get_settings().data_dir) / "wiki" / relative_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(content, encoding="utf-8")
+    else:
+        asyncio.run(storage.write(relative_path, content))
+
+    validate_frontmatter(content)
+    return relative_path
+```
+
+**Wait — this is getting complicated because `_write_article_file` is a sync method called from async context.** The cleaner approach: since `LocalFileStorage` wraps sync `Path` operations in `to_thread()`, and `_write_article_file` is itself sync, just use Path directly but construct the relative path. Store the relative path in the DB. The storage abstraction is used by readers and by the async callers.
+
+Let me revise. The simpler approach:
+
+```python
+def _write_article_file(
+    self,
+    result: CompilationResult,
+    source: Source,
+    slug: str,
+    resolved: list[ResolvedBacklink],
+    unresolved: list[str],
+) -> str:
+    """Write article markdown to wiki storage. Returns relative path."""
+    wiki_dir = Path(self.settings.data_dir) / "wiki"
+    concept = result.concepts[0] if result.concepts else "uncategorized"
+    concept_slug = slugify(concept)
+    concept_dir = wiki_dir / concept_slug
+    concept_dir.mkdir(parents=True, exist_ok=True)
+    file_path = concept_dir / f"{slug}.md"
+
+    # ... (all existing content construction stays exactly the same) ...
+
+    file_path.write_text(content, encoding="utf-8")
+    validate_frontmatter(content)
+
+    # Return relative path for DB storage instead of absolute Path
+    return str(file_path.relative_to(wiki_dir))
+```
+
+- [ ] **Step 3: Update `_create_article()` to store relative path**
+
+At line 336, change:
+```python
+file_path=str(file_path),
+```
+to:
+```python
+file_path=relative_path,
+```
+
+(where `relative_path` is the string returned by `_write_article_file()`)
+
+- [ ] **Step 4: Update `_replace_article_in_place()` to use relative paths**
+
+At line 403, the delete uses an absolute path from the DB:
+```python
+old_path = Path(existing.file_path)
+old_path.unlink(missing_ok=True)
+```
+
+Change to resolve through wiki_dir:
+```python
+wiki_dir = Path(self.settings.data_dir) / "wiki"
+old_path = wiki_dir / existing.file_path
+old_path.unlink(missing_ok=True)
+```
+
+At line 417, change:
+```python
+existing.file_path = str(new_path)
+```
+to:
+```python
+existing.file_path = relative_path
+```
+(where `relative_path` is returned by `_write_article_file()`)
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/unit/test_compiler.py tests/unit/test_jobs.py -v --timeout=60`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/engine/compiler.py
+git commit -s -m "refactor: compiler stores relative wiki paths, returns string from _write_article_file"
+```
+
+---
+
+### Task 4: Refactor concept_compiler.py to use relative paths
+
+**Files:**
+- Modify: `src/wikimind/engine/concept_compiler.py`
+
+- [ ] **Step 1: Refactor `_write_concept_file()` to return relative path**
+
+Change the return type from `Path` to `str` and return relative path:
+
+```python
+def _write_concept_file(
+    self, compilation: ConceptCompilationResult, concept: Concept, source_articles: list[Article]
+) -> str:
+    """Write concept page markdown. Returns relative path."""
+    wiki_dir = Path(self.settings.data_dir) / "wiki"
+    slug = slugify(concept.name)
+    concept_dir = wiki_dir / slug
+    concept_dir.mkdir(parents=True, exist_ok=True)
+    file_path = concept_dir / f"{slug}.md"
+
+    # ... (all existing content construction stays the same) ...
+
+    file_path.write_text(content, encoding="utf-8")
+    return str(file_path.relative_to(wiki_dir))
+```
+
+- [ ] **Step 2: Update `_save_concept_page()` to use relative paths**
+
+At line 237 (delete existing file):
+```python
+Path(existing.file_path).unlink(missing_ok=True)
+```
+Change to:
+```python
+wiki_dir = Path(self.settings.data_dir) / "wiki"
+(wiki_dir / existing.file_path).unlink(missing_ok=True)
+```
+
+At line 240 (store file_path):
+```python
+existing.file_path = str(file_path)
+```
+Change to:
+```python
+existing.file_path = relative_path
+```
+(where `relative_path` is returned by `_write_concept_file()`)
+
+At line 262 (new article):
+```python
+file_path=str(file_path),
+```
+Change to:
+```python
+file_path=relative_path,
+```
+
+- [ ] **Step 3: Update `_build_source_material()` to resolve paths through wiki_dir**
+
+At line 129:
+```python
+fc = Path(article.file_path).read_text(encoding="utf-8")
+```
+Change to:
+```python
+wiki_dir = Path(get_settings().data_dir) / "wiki"
+fc = (wiki_dir / article.file_path).read_text(encoding="utf-8")
+```
+
+Add `from wikimind.config import get_settings` to the imports if not already present.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/unit/test_concept_compiler.py -v --timeout=60`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/engine/concept_compiler.py
+git commit -s -m "refactor: concept compiler stores relative wiki paths"
+```
+
+---
+
+### Task 5: Refactor wiki readers (wiki.py, contradictions.py, qa_agent.py)
+
+**Files:**
+- Modify: `src/wikimind/services/wiki.py`
+- Modify: `src/wikimind/engine/linter/contradictions.py`
+- Modify: `src/wikimind/engine/qa_agent.py`
+
+- [ ] **Step 1: Update `_read_article_content()` in wiki.py (line 59)**
+
+```python
+def _read_article_content(file_path: str) -> str:
+    """Read article content, resolving relative path through wiki_dir."""
+    from wikimind.config import get_settings
+
+    path = Path(file_path)
+    if not path.is_absolute():
+        path = Path(get_settings().data_dir) / "wiki" / file_path
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return ""
+```
+
+Note: The `is_absolute()` check provides backward compatibility with any unmigrated absolute paths.
+
+- [ ] **Step 2: Update `_extract_claims()` in contradictions.py (line 61)**
+
+```python
+def _extract_claims(article: Article) -> list[str]:
+    """Extract key claims from article for contradiction detection."""
+    from wikimind.config import get_settings
+
+    path = Path(article.file_path)
+    if not path.is_absolute():
+        path = Path(get_settings().data_dir) / "wiki" / article.file_path
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return []
+    # ... rest of function unchanged ...
+```
+
+- [ ] **Step 3: Update `_read_article_content()` in qa_agent.py (line 498)**
+
+```python
+def _read_article_content(self, file_path: str) -> str | None:
+    """Read article content, resolving relative path through wiki_dir."""
+    path = Path(file_path)
+    if not path.is_absolute():
+        path = Path(self.settings.data_dir) / "wiki" / file_path
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return None
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/unit/test_wiki_service.py tests/unit/test_linter.py tests/unit/test_qa_agent.py -v --timeout=60`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/services/wiki.py src/wikimind/engine/linter/contradictions.py src/wikimind/engine/qa_agent.py
+git commit -s -m "refactor: wiki readers resolve relative paths through wiki_dir"
+```
+
+---
+
+### Task 6: Refactor qa_agent.py writer and wiki_index.py
+
+**Files:**
+- Modify: `src/wikimind/engine/qa_agent.py`
+- Modify: `src/wikimind/services/wiki_index.py`
+
+- [ ] **Step 1: Update `_file_back_thread()` in qa_agent.py (line 528)**
+
+Change the write at line 583-587 to store relative paths:
+
+```python
+# Replace the wiki_dir construction and write:
+wiki_dir = Path(self.settings.data_dir) / "wiki" / "qa-answers"
+wiki_dir.mkdir(parents=True, exist_ok=True)
+slug = conversation.id
+file_path = wiki_dir / f"{slug}.md"
+file_path.write_text(markdown, encoding="utf-8")
+
+# Store relative path in DB:
+relative_path = f"qa-answers/{slug}.md"
+```
+
+And at line 614 (update existing):
+```python
+# Resolve the existing relative path to write:
+wiki_dir = Path(self.settings.data_dir) / "wiki"
+abs_path = wiki_dir / existing_article.file_path
+abs_path.parent.mkdir(parents=True, exist_ok=True)
+abs_path.write_text(markdown, encoding="utf-8")
+```
+
+Update the Article creation to use `relative_path` instead of `str(file_path)`.
+
+- [ ] **Step 2: Update `regenerate_index_md()` in wiki_index.py (line 70)**
+
+Change the write to store relative path:
+
+```python
+# Keep the current write logic using Path:
+wiki_dir = Path(settings.data_dir) / "wiki"
+wiki_dir.mkdir(parents=True, exist_ok=True)
+index_path = wiki_dir / "index.md"
+# ... build lines ...
+index_path.write_text("".join(lines), encoding="utf-8")
+
+# Return relative path:
+return "index.md"
+```
+
+Change return type from `Path` to `str`.
+
+- [ ] **Step 3: Update `generate_meta_health_page()` in wiki_index.py (line 167)**
+
+Same pattern:
+```python
+meta_dir = Path(settings.data_dir) / "wiki" / "meta"
+meta_dir.mkdir(parents=True, exist_ok=True)
+health_path = meta_dir / "wiki-health.md"
+# ... build lines ...
+health_path.write_text("".join(lines), encoding="utf-8")
+return "meta/wiki-health.md"
+```
+
+Change return type from `Path` to `str`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/ -v -k "qa_agent or wiki_index or index" --timeout=60`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/engine/qa_agent.py src/wikimind/services/wiki_index.py
+git commit -s -m "refactor: qa_agent and wiki_index store relative paths"
+```
+
+---
+
+### Task 7: Refactor activity_log.py
+
+**Files:**
+- Modify: `src/wikimind/services/activity_log.py`
+
+- [ ] **Step 1: Update `append_log_entry()` (line 20)**
+
+The activity log appends to `wiki/log.md`. Keep the Path-based write but construct through wiki_dir:
+
+```python
+def append_log_entry(op: str, title: str, extra: dict | None = None) -> None:
+    # ... existing line construction unchanged ...
+
+    wiki_dir = Path(get_settings().data_dir) / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    log_path = wiki_dir / "log.md"
+
+    with log_path.open("a", encoding="utf-8") as fh:
+        if fh.tell() == 0:
+            fh.write(_LOG_HEADER)
+        fh.writelines(lines)
+```
+
+This function is already correct — it uses `settings.data_dir / "wiki"`. No change needed for relative paths since the log file isn't tracked in the DB. The key change is just ensuring it goes through a consistent path construction.
+
+Actually, verify: is this function already correct? If so, skip this task.
+
+- [ ] **Step 2: Run tests**
+
+Run: `pytest tests/unit/test_activity_log.py -v --timeout=30`
+Expected: All pass
+
+- [ ] **Step 3: Commit (if any changes were made)**
+
+```bash
+git add src/wikimind/services/activity_log.py
+git commit -s -m "refactor: activity log uses consistent wiki_dir path construction"
+```
+
+---
+
+### Task 8: Refactor sweep.py and worker.py
+
+**Files:**
+- Modify: `src/wikimind/jobs/sweep.py`
+- Modify: `src/wikimind/jobs/worker.py`
+
+- [ ] **Step 1: Update `_sweep_single_article()` in sweep.py (line 36)**
+
+The sweep reads and writes article files using `article.file_path`. Resolve relative paths:
+
+```python
+async def _sweep_single_article(
+    article: Article,
+    session: AsyncSession,
+) -> bool:
+    from wikimind.config import get_settings
+
+    wiki_dir = Path(get_settings().data_dir) / "wiki"
+    file_path = Path(article.file_path)
+    if not file_path.is_absolute():
+        file_path = wiki_dir / article.file_path
+
+    if not file_path.exists():
+        log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
+        return False
+
+    content = file_path.read_text(encoding="utf-8")
+
+    # ... (all existing resolution logic unchanged) ...
+
+    # Write back (line 85):
+    file_path.write_text(new_content, encoding="utf-8")
+
+    # ... (backlink creation unchanged) ...
+```
+
+- [ ] **Step 2: Update `compile_source()` in worker.py (line 97)**
+
+The worker reads `source.file_path` for compilation. Resolve relative paths through raw_dir:
+
+```python
+# At line 96-97, change:
+text_path = Path(source.file_path)
+# to:
+raw_dir = Path(get_settings().data_dir) / "raw"
+text_path = Path(source.file_path)
+if not text_path.is_absolute():
+    text_path = raw_dir / source.file_path
+content = text_path.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 3: Update article read for embeddings in worker.py (line 142)**
+
+```python
+# Change:
+content = Path(article.file_path).read_text(encoding="utf-8")
+# To:
+wiki_dir = Path(get_settings().data_dir) / "wiki"
+article_path = Path(article.file_path)
+if not article_path.is_absolute():
+    article_path = wiki_dir / article.file_path
+content = article_path.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 4: Update `recompile_article()` in worker.py (line 253)**
+
+```python
+# Change:
+content = Path(source.file_path).read_text(encoding="utf-8")
+# To:
+raw_dir = Path(get_settings().data_dir) / "raw"
+source_path = Path(source.file_path)
+if not source_path.is_absolute():
+    source_path = raw_dir / source.file_path
+content = source_path.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/unit/test_sweep.py tests/unit/test_sweep_session.py tests/unit/test_jobs.py -v --timeout=60`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/jobs/sweep.py src/wikimind/jobs/worker.py
+git commit -s -m "refactor: sweep and worker resolve relative file paths through data_dir"
+```
+
+---
+
+### Task 9: Refactor ingest/service.py to store relative raw paths
+
+**Files:**
+- Modify: `src/wikimind/ingest/service.py`
+
+- [ ] **Step 1: Update URLAdapter.ingest() (line 453-458)**
+
+Change from storing absolute path to relative:
+
+```python
+raw_dir = Path(settings.data_dir) / "raw"
+raw_dir.mkdir(parents=True, exist_ok=True)
+(raw_dir / f"{source.id}.html").write_text(html, encoding="utf-8")
+text_path = raw_dir / f"{source.id}.txt"
+text_path.write_text(downloaded, encoding="utf-8")
+# Store relative path:
+source.file_path = f"{source.id}.txt"
+```
+
+- [ ] **Step 2: Update PDFAdapter.ingest() (line 608-637)**
+
+```python
+raw_dir = Path(settings.data_dir) / "raw"
+raw_dir.mkdir(parents=True, exist_ok=True)
+raw_pdf_path = raw_dir / f"{source.id}.pdf"
+raw_pdf_path.write_bytes(file_bytes)
+# ... extraction logic ...
+text_path = raw_dir / f"{source.id}.txt"
+text_path.write_text(clean_text, encoding="utf-8")
+# Store relative path:
+source.file_path = f"{source.id}.txt"
+```
+
+- [ ] **Step 3: Update TextAdapter.ingest() (line 1062-1066)**
+
+```python
+raw_dir = Path(settings.data_dir) / "raw"
+raw_dir.mkdir(parents=True, exist_ok=True)
+text_path = raw_dir / f"{source.id}.txt"
+text_path.write_text(content, encoding="utf-8")
+# Store relative path:
+source.file_path = f"{source.id}.txt"
+```
+
+- [ ] **Step 4: Update YouTubeAdapter.ingest() (line 1127-1131)**
+
+```python
+raw_dir = Path(settings.data_dir) / "raw"
+raw_dir.mkdir(parents=True, exist_ok=True)
+text_path = raw_dir / f"{source.id}.txt"
+text_path.write_text(transcript_text, encoding="utf-8")
+# Store relative path:
+source.file_path = f"{source.id}.txt"
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/unit/test_ingest_service.py tests/unit/test_pdf_adapter.py -v --timeout=60`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/ingest/service.py
+git commit -s -m "refactor: ingest adapters store relative raw paths"
+```
+
+---
+
+### Task 10: Add path migration for existing DB records
+
+**Files:**
+- Modify: `src/wikimind/database.py`
+- Test: `tests/unit/test_storage.py` (add migration test)
+
+- [ ] **Step 1: Write migration test**
+
+Add to `tests/unit/test_storage.py`:
+
+```python
+from wikimind.database import _migrate_to_relative_paths
+
+
+@pytest.mark.asyncio
+async def test_migrate_absolute_to_relative(db_session, tmp_path, monkeypatch):
+    """Existing absolute paths are converted to relative on startup."""
+    from wikimind.config import get_settings
+
+    settings = get_settings()
+    wiki_dir = str(Path(settings.data_dir) / "wiki")
+    raw_dir = str(Path(settings.data_dir) / "raw")
+
+    # Create article with absolute path
+    from wikimind.models import Article
+    article = Article(
+        slug="test-article",
+        title="Test",
+        file_path=f"{wiki_dir}/concept/test-article.md",
+    )
+    db_session.add(article)
+    await db_session.commit()
+
+    # Run migration
+    await _migrate_to_relative_paths(db_session)
+
+    await db_session.refresh(article)
+    assert article.file_path == "concept/test-article.md"
+```
+
+- [ ] **Step 2: Implement `_migrate_to_relative_paths()`**
+
+Add to `src/wikimind/database.py`:
+
+```python
+from wikimind.config import get_settings
+
+
+async def _migrate_to_relative_paths(session: AsyncSession) -> None:
+    """Convert absolute file_path values to relative paths.
+
+    Runs once at startup. Idempotent — already-relative paths are skipped.
+    """
+    from wikimind.models import Article, Source
+
+    settings = get_settings()
+    wiki_prefix = str(Path(settings.data_dir) / "wiki") + "/"
+    raw_prefix = str(Path(settings.data_dir) / "raw") + "/"
+
+    # Migrate Article.file_path (wiki-relative)
+    result = await session.execute(select(Article).where(Article.file_path.startswith("/")))
+    for article in result.scalars().all():
+        if article.file_path.startswith(wiki_prefix):
+            article.file_path = article.file_path[len(wiki_prefix):]
+            session.add(article)
+
+    # Migrate Source.file_path (raw-relative)
+    result = await session.execute(select(Source).where(Source.file_path.startswith("/")))
+    for source in result.scalars().all():
+        if source.file_path and source.file_path.startswith(raw_prefix):
+            source.file_path = source.file_path[len(raw_prefix):]
+            session.add(source)
+
+    await session.commit()
+```
+
+- [ ] **Step 3: Call migration from init_db()**
+
+In `src/wikimind/database.py`, in the `init_db()` function, after `create_all`:
+
+```python
+async def init_db():
+    # ... existing create_all and migration logic ...
+
+    # Convert absolute paths to relative (idempotent)
+    async with get_session_factory()() as session:
+        await _migrate_to_relative_paths(session)
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `pytest tests/unit/test_storage.py -v --timeout=30`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/database.py tests/unit/test_storage.py
+git commit -s -m "feat: add migration to convert absolute file paths to relative"
+```
+
+---
+
+### Task 11: Add resolve_path helper and clean up is_absolute checks
+
+**Files:**
+- Modify: `src/wikimind/storage.py`
+
+- [ ] **Step 1: Add resolve helpers to storage.py**
+
+Instead of repeating `is_absolute()` checks in every reader, add utility functions:
+
+```python
+def resolve_wiki_path(relative_path: str) -> Path:
+    """Resolve a wiki-relative path to an absolute filesystem path.
+
+    Handles backward compatibility: if the path is already absolute,
+    returns it as-is.
+    """
+    path = Path(relative_path)
+    if path.is_absolute():
+        return path
+    settings = get_settings()
+    return Path(settings.data_dir) / "wiki" / relative_path
+
+
+def resolve_raw_path(relative_path: str) -> Path:
+    """Resolve a raw-relative path to an absolute filesystem path.
+
+    Handles backward compatibility: if the path is already absolute,
+    returns it as-is.
+    """
+    path = Path(relative_path)
+    if path.is_absolute():
+        return path
+    settings = get_settings()
+    return Path(settings.data_dir) / "raw" / relative_path
+```
+
+- [ ] **Step 2: Replace inline is_absolute checks with resolve helpers**
+
+In all the files modified in Tasks 5, 8 — replace the inline `is_absolute()` pattern:
+
+```python
+# Before (repeated in every file):
+path = Path(article.file_path)
+if not path.is_absolute():
+    path = Path(get_settings().data_dir) / "wiki" / article.file_path
+
+# After:
+from wikimind.storage import resolve_wiki_path
+path = resolve_wiki_path(article.file_path)
+```
+
+Apply in: `wiki.py`, `contradictions.py`, `qa_agent.py`, `sweep.py`, `worker.py`
+
+- [ ] **Step 3: Add test for resolve helpers**
+
+Add to `tests/unit/test_storage.py`:
+
+```python
+from wikimind.storage import resolve_wiki_path, resolve_raw_path
+
+
+def test_resolve_wiki_path_relative(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    get_settings.cache_clear()
+    result = resolve_wiki_path("concept/article.md")
+    assert result == tmp_path / "wiki" / "concept" / "article.md"
+    get_settings.cache_clear()
+
+
+def test_resolve_wiki_path_absolute():
+    result = resolve_wiki_path("/absolute/path/article.md")
+    assert result == Path("/absolute/path/article.md")
+
+
+def test_resolve_raw_path_relative(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    get_settings.cache_clear()
+    result = resolve_raw_path("source-id.txt")
+    assert result == tmp_path / "raw" / "source-id.txt"
+    get_settings.cache_clear()
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pytest tests/ -v --timeout=120`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/storage.py src/wikimind/services/wiki.py src/wikimind/engine/linter/contradictions.py src/wikimind/engine/qa_agent.py src/wikimind/jobs/sweep.py src/wikimind/jobs/worker.py tests/unit/test_storage.py
+git commit -s -m "refactor: add resolve_wiki_path/resolve_raw_path helpers, remove inline is_absolute checks"
+```
+
+---
+
+### Task 12: Final integration test and cleanup
+
+**Files:**
+- Test: `tests/unit/test_storage.py` (add integration test)
+- Modify: `tests/conftest.py` (clear storage caches)
+
+- [ ] **Step 1: Clear storage caches in test fixture**
+
+In `tests/conftest.py`, update the `_isolated_data_dir` fixture to clear storage singletons:
+
+```python
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Point WIKIMIND_DATA_DIR at a tmp dir for every test."""
+    data_dir = tmp_path / "wikimind"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(data_dir))
+    get_settings.cache_clear()
+    # Clear storage singletons so they pick up the new data_dir
+    from wikimind.storage import get_wiki_storage, get_raw_storage
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
+    yield data_dir
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
+```
+
+- [ ] **Step 2: Add integration test**
+
+Add to `tests/unit/test_storage.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_local_storage_is_file_storage_protocol():
+    """LocalFileStorage satisfies the FileStorage protocol."""
+    from wikimind.storage import FileStorage, LocalFileStorage
+    storage = LocalFileStorage(root=Path("/tmp/test"))
+    assert isinstance(storage, FileStorage)
+
+
+def test_get_wiki_storage_returns_local(tmp_path, monkeypatch):
+    """get_wiki_storage() returns a LocalFileStorage rooted at wiki_dir."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    from wikimind.storage import LocalFileStorage, get_wiki_storage
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    storage = get_wiki_storage()
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.root == tmp_path / "wiki"
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+
+
+def test_get_raw_storage_returns_local(tmp_path, monkeypatch):
+    """get_raw_storage() returns a LocalFileStorage rooted at raw_dir."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    from wikimind.storage import LocalFileStorage, get_raw_storage
+    get_settings.cache_clear()
+    get_raw_storage.cache_clear()
+    storage = get_raw_storage()
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.root == tmp_path / "raw"
+    get_settings.cache_clear()
+    get_raw_storage.cache_clear()
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pytest tests/ -v --timeout=120`
+Expected: All pass
+
+- [ ] **Step 4: Run pre-commit**
+
+Run: `make pre-commit`
+Expected: All hooks pass
+
+- [ ] **Step 5: Run mypy on changed files**
+
+Run: `mypy src/wikimind/storage.py src/wikimind/engine/compiler.py src/wikimind/engine/concept_compiler.py src/wikimind/engine/qa_agent.py src/wikimind/engine/frontmatter_validator.py src/wikimind/services/wiki_index.py src/wikimind/services/wiki.py src/wikimind/engine/linter/contradictions.py src/wikimind/jobs/sweep.py src/wikimind/jobs/worker.py src/wikimind/ingest/service.py src/wikimind/database.py`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/conftest.py tests/unit/test_storage.py
+git commit -s -m "test: add integration tests and clear storage caches in test fixtures"
+```

--- a/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
+++ b/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
@@ -1,0 +1,1613 @@
+# Postgres Compatibility Implementation Plan (PR 2 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the database layer work on both SQLite (dev) and Postgres (production) with zero application logic changes. Dev defaults to SQLite. Production uses Postgres via `WIKIMIND_DATABASE_URL`.
+
+**Architecture:** A `database_url` setting in `Settings` replaces the hardcoded SQLite URL. Engine creation branches on the URL scheme: SQLite gets `aiosqlite` + `check_same_thread=False` (current behavior); Postgres gets `asyncpg` + connection pooling. The `PRAGMA table_info` migration is replaced with SQLAlchemy `Inspector.get_columns()`. SQLite-specific queries (`json_each`, `.contains()` on JSON-as-TEXT) are wrapped in dialect-aware helpers. Alembic is configured for Postgres schema management. Seven TEXT columns storing JSON are converted to `sa_type=JSON`.
+
+**Tech Stack:** Python 3.11+, SQLModel, SQLAlchemy (Inspector, JSON type), asyncpg, Alembic, pytest
+
+**Depends on:** PR 1 (FileStorage Abstraction) must be merged first.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/wikimind/config.py` | Add `database_url` field to Settings |
+| Modify | `src/wikimind/database.py` | Dialect-aware engine creation, Inspector-based migration |
+| Modify | `src/wikimind/models.py` | Convert 7 TEXT columns to `sa_type=JSON` |
+| Modify | `src/wikimind/services/wiki.py` | Replace `json_each()` with dialect-aware helper |
+| Modify | `src/wikimind/engine/compiler.py` | Replace `.contains()` with dialect-aware JSON query |
+| Modify | `pyproject.toml` | Add `asyncpg` dependency and `postgres` marker |
+| Create | `src/wikimind/db_compat.py` | Dialect detection helpers and JSON query builders |
+| Create | `tests/unit/test_db_compat.py` | Tests for dialect-aware helpers |
+| Create | `tests/unit/test_postgres_engine.py` | Tests for engine creation logic |
+| Create | `alembic.ini` | Alembic configuration |
+| Create | `alembic/env.py` | Alembic environment with async support |
+| Create | `alembic/script.py.mako` | Alembic migration template |
+| Create | `alembic/versions/0001_initial_schema.py` | Initial migration from SQLModel definitions |
+| Create | `docs/adr/adr-021-postgres-compatibility.md` | ADR for Postgres compatibility |
+| Modify | `docs/adr/adr-001-fastapi-async-sqlite.md` | Amend to note Postgres support |
+| Modify | `.env.example` | Add `WIKIMIND_DATABASE_URL` |
+| Modify | `README.md` | Add Postgres setup section |
+
+---
+
+### Task 1: Add database_url to Settings
+
+**Files:**
+- Modify: `src/wikimind/config.py`
+- Test: `tests/unit/test_config.py`
+
+- [ ] **Step 1: Write test for database_url default**
+
+Append to `tests/unit/test_config.py`:
+
+```python
+# Append to tests/unit/test_config.py
+
+class TestDatabaseUrl:
+    def test_default_database_url_is_sqlite(self, _isolated_data_dir):
+        """database_url defaults to an aiosqlite URL under data_dir."""
+        settings = get_settings()
+        expected = f"sqlite+aiosqlite:///{settings.data_dir}/db/wikimind.db"
+        assert settings.database_url == expected
+
+    def test_database_url_from_env(self, monkeypatch, _isolated_data_dir):
+        """database_url can be overridden via environment variable."""
+        monkeypatch.setenv("WIKIMIND_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/wikimind")
+        get_settings.cache_clear()
+        settings = get_settings()
+        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/wikimind"
+        get_settings.cache_clear()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mg/mg-work/manav/work/ai-experiments/wikimind && .venv/bin/pytest tests/unit/test_config.py::TestDatabaseUrl -v`
+Expected: FAIL -- `AttributeError: 'Settings' object has no attribute 'database_url'`
+
+- [ ] **Step 3: Add database_url field to Settings**
+
+In `src/wikimind/config.py`, add the field to the `Settings` class (after line 190, the `data_dir` field):
+
+```python
+    # Database URL — defaults to SQLite in data_dir. Set to a Postgres URL
+    # (postgresql+asyncpg://...) for production. See ADR-021.
+    database_url: str = ""
+
+    @model_validator(mode="after")
+    def _default_database_url(self) -> Settings:
+        """Set database_url default after data_dir is resolved."""
+        if not self.database_url:
+            self.database_url = f"sqlite+aiosqlite:///{self.data_dir}/db/wikimind.db"
+        return self
+```
+
+Note: The default must be computed in a validator because it depends on `data_dir`. An empty string field with a post-validator is the cleanest Pydantic pattern for this.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/test_config.py::TestDatabaseUrl -v`
+Expected: 2 tests PASS
+
+- [ ] **Step 5: Run full config test suite for regression**
+
+Run: `.venv/bin/pytest tests/unit/test_config.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/config.py tests/unit/test_config.py
+git commit -s -m "feat(config): add database_url setting with SQLite default"
+```
+
+---
+
+### Task 2: Create dialect detection helpers
+
+**Files:**
+- Create: `src/wikimind/db_compat.py`
+- Create: `tests/unit/test_db_compat.py`
+
+- [ ] **Step 1: Write tests for dialect helpers**
+
+```python
+# tests/unit/test_db_compat.py
+"""Tests for database dialect compatibility helpers."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from wikimind.db_compat import (
+    is_sqlite,
+    is_postgres,
+    get_dialect_name,
+    json_array_contains,
+    json_array_elements_query,
+)
+
+
+class TestDialectDetection:
+    def test_sqlite_url_detected(self):
+        assert is_sqlite("sqlite+aiosqlite:///path/to/db") is True
+        assert is_postgres("sqlite+aiosqlite:///path/to/db") is False
+
+    def test_postgres_url_detected(self):
+        assert is_postgres("postgresql+asyncpg://user:pass@localhost/db") is True
+        assert is_sqlite("postgresql+asyncpg://user:pass@localhost/db") is False
+
+    def test_in_memory_sqlite_detected(self):
+        assert is_sqlite("sqlite+aiosqlite://") is True
+
+    def test_get_dialect_name(self):
+        assert get_dialect_name("sqlite+aiosqlite:///foo") == "sqlite"
+        assert get_dialect_name("postgresql+asyncpg://localhost/db") == "postgresql"
+
+
+class TestJsonArrayContains:
+    def test_sqlite_uses_like(self):
+        """For SQLite, json_array_contains uses LIKE with the needle."""
+        clause = json_array_contains("sqlite", "source_ids", "src-123")
+        sql_str = str(clause.compile(compile_kwargs={"literal_binds": True}))
+        # Should produce a LIKE '%"src-123"%' pattern
+        assert "LIKE" in sql_str.upper() or "like" in sql_str
+
+    def test_postgres_uses_jsonb_contains(self):
+        """For Postgres, json_array_contains uses the @> operator."""
+        clause = json_array_contains("postgresql", "source_ids", "src-123")
+        sql_str = str(clause.compile(compile_kwargs={"literal_binds": True}))
+        assert "@>" in sql_str or "?" in sql_str  # JSONB containment
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/test_db_compat.py -v`
+Expected: FAIL -- `ModuleNotFoundError: No module named 'wikimind.db_compat'`
+
+- [ ] **Step 3: Implement db_compat module**
+
+```python
+# src/wikimind/db_compat.py
+"""Database dialect compatibility helpers.
+
+Provides functions that generate dialect-appropriate SQL fragments for
+operations that differ between SQLite and PostgreSQL: JSON array querying,
+column introspection, and engine configuration.
+
+SQLite uses json_each() and LIKE-based JSON searching.
+PostgreSQL uses jsonb_array_elements_text() and the @> operator.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, literal_column, text
+from sqlalchemy.sql import ClauseElement
+from sqlmodel import select
+
+
+def get_dialect_name(url: str) -> str:
+    """Extract the dialect name from a database URL.
+
+    Returns 'sqlite' or 'postgresql' (never the driver suffix).
+    """
+    scheme = url.split("://")[0].split("+")[0]
+    return scheme
+
+
+def is_sqlite(url: str) -> bool:
+    """Return True if the URL targets a SQLite database."""
+    return get_dialect_name(url) == "sqlite"
+
+
+def is_postgres(url: str) -> bool:
+    """Return True if the URL targets a PostgreSQL database."""
+    return get_dialect_name(url) in ("postgresql", "postgres")
+
+
+def json_array_contains(dialect: str, column_name: str, value: str) -> ClauseElement:
+    """Build a WHERE clause that checks if a JSON array column contains a value.
+
+    SQLite: column LIKE '%"value"%' (TEXT-based search, matches current behavior)
+    PostgreSQL: column::jsonb @> '["value"]'::jsonb (native JSONB containment)
+    """
+    if dialect == "postgresql":
+        import json as json_mod
+
+        return text(f"{column_name}::jsonb @> :val::jsonb").bindparams(val=json_mod.dumps([value]))
+    else:
+        # SQLite: LIKE-based search matching the existing .contains() pattern
+        needle = f'"{value}"'
+        return literal_column(column_name).contains(needle)
+
+
+def json_array_elements_subquery(dialect: str, table_name: str, column_name: str, value_alias: str = "elem"):
+    """Build a subquery that unnests a JSON array column for filtering.
+
+    SQLite: SELECT ... FROM table, json_each(table.column)
+    PostgreSQL: SELECT ... FROM table, jsonb_array_elements_text(table.column::jsonb) AS elem
+
+    Returns a tuple of (from_clause_text, value_column_ref) for use in
+    constructing WHERE ... IN subqueries.
+    """
+    if dialect == "postgresql":
+        from_clause = f"{table_name}, jsonb_array_elements_text({table_name}.{column_name}::jsonb) AS {value_alias}"
+        value_ref = literal_column(value_alias)
+    else:
+        from_clause = f"{table_name}, json_each({table_name}.{column_name})"
+        value_ref = literal_column("json_each.value")
+    return text(from_clause), value_ref
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/test_db_compat.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/db_compat.py tests/unit/test_db_compat.py
+git commit -s -m "feat(db): add dialect compatibility helpers for SQLite/Postgres"
+```
+
+---
+
+### Task 3: Dialect-aware engine creation
+
+**Files:**
+- Modify: `src/wikimind/database.py`
+- Create: `tests/unit/test_postgres_engine.py`
+
+- [ ] **Step 1: Write tests for engine creation**
+
+```python
+# tests/unit/test_postgres_engine.py
+"""Tests for dialect-aware engine creation in database.py."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from wikimind.database import _create_engine_from_url
+
+
+class TestCreateEngineFromUrl:
+    def test_sqlite_url_creates_aiosqlite_engine(self):
+        """SQLite URL produces an engine with check_same_thread=False."""
+        engine = _create_engine_from_url("sqlite+aiosqlite:///tmp/test.db")
+        assert "sqlite" in str(engine.url)
+        engine.dispose()
+
+    def test_sqlite_in_memory_works(self):
+        """In-memory SQLite URL works."""
+        engine = _create_engine_from_url("sqlite+aiosqlite://")
+        assert "sqlite" in str(engine.url)
+        engine.dispose()
+
+    def test_postgres_url_creates_asyncpg_engine(self):
+        """Postgres URL produces an engine with pool settings.
+
+        We can not actually connect without a running Postgres instance,
+        but we can verify the engine is created with the right URL.
+        """
+        url = "postgresql+asyncpg://user:pass@localhost:5432/wikimind"
+        engine = _create_engine_from_url(url)
+        assert "postgresql" in str(engine.url)
+        assert engine.pool.size() == 10  # pool_size=10
+        engine.dispose()
+
+    def test_unknown_dialect_raises(self):
+        """An unsupported database URL raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported database dialect"):
+            _create_engine_from_url("mysql+aiomysql://localhost/db")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/test_postgres_engine.py -v`
+Expected: FAIL -- `ImportError: cannot import name '_create_engine_from_url'`
+
+- [ ] **Step 3: Refactor database.py to be dialect-aware**
+
+Replace `get_db_path()` and `get_engine()` in `src/wikimind/database.py` (lines 30-41) with:
+
+```python
+def _create_engine_from_url(url: str):
+    """Create an async engine appropriate for the database URL's dialect.
+
+    SQLite: aiosqlite driver with check_same_thread=False.
+    Postgres: asyncpg driver with connection pool tuning.
+
+    Raises ValueError for unsupported dialects.
+    """
+    from wikimind.db_compat import is_postgres, is_sqlite
+
+    if is_sqlite(url):
+        return create_async_engine(
+            url,
+            echo=False,
+            connect_args={"check_same_thread": False},
+        )
+    elif is_postgres(url):
+        return create_async_engine(
+            url,
+            echo=False,
+            pool_size=10,
+            max_overflow=20,
+            pool_pre_ping=True,
+        )
+    else:
+        dialect = url.split("://")[0]
+        raise ValueError(f"Unsupported database dialect: {dialect}. Use sqlite+aiosqlite or postgresql+asyncpg.")
+
+
+def get_db_path() -> Path:
+    """Return the path to the SQLite database file.
+
+    Only meaningful when using the SQLite backend. Ensures the parent
+    directory exists.
+    """
+    settings = get_settings()
+    db_dir = Path(settings.data_dir) / "db"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return db_dir / "wikimind.db"
+
+
+def get_engine():
+    """Create a new async database engine from settings."""
+    settings = get_settings()
+    url = settings.database_url
+    # Ensure SQLite directory exists
+    from wikimind.db_compat import is_sqlite
+    if is_sqlite(url):
+        db_dir = Path(settings.data_dir) / "db"
+        db_dir.mkdir(parents=True, exist_ok=True)
+    return _create_engine_from_url(url)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/test_postgres_engine.py -v`
+Expected: All tests PASS (the Postgres pool_size assertion may need adjustment if asyncpg is not installed -- see Step 5)
+
+- [ ] **Step 5: Add asyncpg dependency to pyproject.toml**
+
+In `pyproject.toml`, add `asyncpg` to the `dependencies` list (after `aiosqlite`):
+
+```toml
+    # Database
+    "sqlmodel>=0.0.21",
+    "aiosqlite>=0.20.0",
+    "asyncpg>=0.30.0",
+```
+
+Also add an `alembic` dependency:
+
+```toml
+    "alembic>=1.14.0",
+```
+
+Add a `postgres` marker to pytest:
+
+```toml
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "e2e: end-to-end tests requiring full stack",
+    "external: tests that call external APIs",
+    "postgres: tests that require a running PostgreSQL instance",
+]
+```
+
+Run: `.venv/bin/pip install -e ".[dev]"` to install the new dependency.
+
+- [ ] **Step 6: Run full test suite for regression**
+
+Run: `.venv/bin/pytest tests/unit/test_database.py tests/unit/test_postgres_engine.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/wikimind/database.py pyproject.toml tests/unit/test_postgres_engine.py
+git commit -s -m "feat(db): dialect-aware engine creation for SQLite and Postgres"
+```
+
+---
+
+### Task 4: Replace PRAGMA table_info with Inspector API
+
+**Files:**
+- Modify: `src/wikimind/database.py` (function `_migrate_added_columns`, lines 106-201)
+
+- [ ] **Step 1: Write test for Inspector-based migration**
+
+Add to `tests/unit/test_database.py`:
+
+```python
+# Append to tests/unit/test_database.py
+
+from wikimind.database import _migrate_added_columns
+
+
+class TestMigrateAddedColumnsInspector:
+    """Verify _migrate_added_columns works with Inspector API (not PRAGMA)."""
+
+    async def test_migration_adds_missing_columns(self, async_engine):
+        """Migration adds columns that exist in the model but not on disk.
+
+        Uses the in-memory SQLite engine which already has all columns
+        from create_all(). This test verifies the Inspector path is
+        idempotent (no errors when all columns already exist).
+        """
+        # Should not raise — all columns already present
+        await _migrate_added_columns(async_engine)
+
+    async def test_migration_is_idempotent(self, async_engine):
+        """Running migration twice causes no errors."""
+        await _migrate_added_columns(async_engine)
+        await _migrate_added_columns(async_engine)
+```
+
+- [ ] **Step 2: Run tests to verify they pass with current code**
+
+Run: `.venv/bin/pytest tests/unit/test_database.py::TestMigrateAddedColumnsInspector -v`
+Expected: PASS (current PRAGMA-based code works on SQLite)
+
+- [ ] **Step 3: Replace PRAGMA with Inspector API**
+
+Replace the `_migrate_added_columns` function body (lines 106-201) in `src/wikimind/database.py`:
+
+```python
+async def _migrate_added_columns(engine) -> None:
+    """Add missing columns to existing tables (idempotent).
+
+    Uses SQLAlchemy's Inspector API to check existing columns, which
+    works on both SQLite and PostgreSQL. Runs ALTER TABLE ADD COLUMN
+    for any column declared in the SQLModel definitions that isn't
+    already on disk.
+
+    Currently tracks:
+        - source.content_hash (issue #67) + index
+        - article.provider    (issue #67)
+        - query.conversation_id (ADR-011)
+        - query.turn_index    (ADR-011)
+        - article.page_type   (issue #143)
+        - backlink.relation_type + resolution columns (issue #143)
+        - concept.concept_kind (issue #143)
+    """
+    from sqlalchemy import inspect as sa_inspect
+
+    additions: list[tuple[str, str, str]] = [
+        # (table, column, ALTER fragment)
+        ("source", "content_hash", "ALTER TABLE source ADD COLUMN content_hash TEXT"),
+        ("article", "provider", "ALTER TABLE article ADD COLUMN provider TEXT"),
+        (
+            "query",
+            "conversation_id",
+            "ALTER TABLE query ADD COLUMN conversation_id TEXT REFERENCES conversation(id)",
+        ),
+        ("query", "turn_index", "ALTER TABLE query ADD COLUMN turn_index INTEGER NOT NULL DEFAULT 0"),
+        (
+            "lintreport",
+            "missing_pages_count",
+            "ALTER TABLE lintreport ADD COLUMN missing_pages_count INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "lintreport",
+            "dismissed_count",
+            "ALTER TABLE lintreport ADD COLUMN dismissed_count INTEGER NOT NULL DEFAULT 0",
+        ),
+        ("lintreport", "total_pairs", "ALTER TABLE lintreport ADD COLUMN total_pairs INTEGER NOT NULL DEFAULT 0"),
+        ("lintreport", "checked_pairs", "ALTER TABLE lintreport ADD COLUMN checked_pairs INTEGER NOT NULL DEFAULT 0"),
+        (
+            "conversation",
+            "parent_conversation_id",
+            "ALTER TABLE conversation ADD COLUMN parent_conversation_id TEXT REFERENCES conversation(id)",
+        ),
+        (
+            "conversation",
+            "forked_at_turn_index",
+            "ALTER TABLE conversation ADD COLUMN forked_at_turn_index INTEGER",
+        ),
+        ("article", "page_type", "ALTER TABLE article ADD COLUMN page_type TEXT NOT NULL DEFAULT 'source'"),
+        (
+            "backlink",
+            "relation_type",
+            "ALTER TABLE backlink ADD COLUMN relation_type TEXT NOT NULL DEFAULT 'references'",
+        ),
+        ("backlink", "resolution", "ALTER TABLE backlink ADD COLUMN resolution TEXT"),
+        ("backlink", "resolution_note", "ALTER TABLE backlink ADD COLUMN resolution_note TEXT"),
+        ("backlink", "resolved_at", "ALTER TABLE backlink ADD COLUMN resolved_at TEXT"),
+        ("backlink", "resolved_by", "ALTER TABLE backlink ADD COLUMN resolved_by TEXT"),
+        ("concept", "concept_kind", "ALTER TABLE concept ADD COLUMN concept_kind TEXT NOT NULL DEFAULT 'topic'"),
+        (
+            "lintreport",
+            "structural_count",
+            "ALTER TABLE lintreport ADD COLUMN structural_count INTEGER NOT NULL DEFAULT 0",
+        ),
+        ("lintreport", "checked_articles", "ALTER TABLE lintreport ADD COLUMN checked_articles INTEGER"),
+    ]
+    indexes: list[tuple[str, str]] = [
+        (
+            "ix_source_content_hash",
+            "CREATE INDEX IF NOT EXISTS ix_source_content_hash ON source (content_hash)",
+        ),
+        (
+            "ix_conversation_parent_id",
+            "CREATE INDEX IF NOT EXISTS ix_conversation_parent_id ON conversation (parent_conversation_id)",
+        ),
+    ]
+
+    async with engine.begin() as conn:
+        # Use Inspector to get existing column names (works on both SQLite and Postgres)
+        def _get_existing_columns(sync_conn, table_name: str) -> set[str]:
+            inspector = sa_inspect(sync_conn)
+            if table_name not in inspector.get_table_names():
+                return set()
+            return {col["name"] for col in inspector.get_columns(table_name)}
+
+        for table, column, alter_sql in additions:
+            existing = await conn.run_sync(lambda sync_conn, t=table: _get_existing_columns(sync_conn, t))
+            if column not in existing:
+                await conn.exec_driver_sql(alter_sql)
+        for _name, create_sql in indexes:
+            await conn.exec_driver_sql(create_sql)
+```
+
+- [ ] **Step 4: Run tests to verify Inspector-based migration works**
+
+Run: `.venv/bin/pytest tests/unit/test_database.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `.venv/bin/pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/database.py tests/unit/test_database.py
+git commit -s -m "refactor(db): replace PRAGMA table_info with SQLAlchemy Inspector API
+
+Inspector.get_columns() works on both SQLite and PostgreSQL, removing
+the last SQLite-only system call from the migration helper."
+```
+
+---
+
+### Task 5: Convert parameterized SQL from ? to :named placeholders
+
+**Files:**
+- Modify: `src/wikimind/database.py`
+
+The `?` positional placeholder is SQLite-specific. PostgreSQL uses `$1, $2` and SQLAlchemy's `text()` uses `:name`. Converting raw `exec_driver_sql` calls to use `text()` with named parameters makes them dialect-agnostic.
+
+- [ ] **Step 1: Refactor _backfill_conversation_for_legacy_queries**
+
+In `src/wikimind/database.py`, replace the `exec_driver_sql` calls in `_backfill_conversation_for_legacy_queries` (lines 235-242) with SQLAlchemy `text()`:
+
+```python
+async def _backfill_conversation_for_legacy_queries(engine) -> None:
+    """Create a Conversation row for any Query that has NULL conversation_id.
+
+    Idempotent: re-running finds zero NULL rows and is a no-op.
+    See ADR-011.
+    """
+    from sqlalchemy import text as sa_text
+
+    settings = get_settings()
+    title_max = settings.qa.conversation_title_max_chars
+
+    async with engine.begin() as conn:
+
+        def _select_legacy(sync_conn):
+            return sync_conn.execute(
+                sa_text("SELECT id, question, created_at, filed_article_id FROM query WHERE conversation_id IS NULL")
+            ).fetchall()
+
+        legacy_rows = await conn.run_sync(_select_legacy)
+
+        for row in legacy_rows:
+            query_id, question, created_at_raw, filed_article_id = row
+            conv_id = str(uuid.uuid4())
+            title = (question or "")[:title_max]
+            created_at = created_at_raw or utcnow_naive().isoformat()
+
+            await conn.execute(
+                sa_text(
+                    "INSERT INTO conversation (id, title, created_at, updated_at, filed_article_id) "
+                    "VALUES (:id, :title, :created_at, :updated_at, :filed_article_id)"
+                ),
+                {"id": conv_id, "title": title, "created_at": created_at, "updated_at": created_at, "filed_article_id": filed_article_id},
+            )
+            await conn.execute(
+                sa_text("UPDATE query SET conversation_id = :conv_id, turn_index = 0 WHERE id = :qid"),
+                {"conv_id": conv_id, "qid": query_id},
+            )
+```
+
+- [ ] **Step 2: Refactor _backfill_concepts_from_articles**
+
+Replace the `exec_driver_sql` calls in `_backfill_concepts_from_articles` (lines 359-408) similarly with `text()` and named parameters:
+
+```python
+async def _backfill_concepts_from_articles(engine) -> None:
+    """Create missing Concept rows and recalculate counts. Idempotent."""
+    from sqlalchemy import text as sa_text
+
+    async with engine.begin() as conn:
+
+        def _select_articles(sync_conn):
+            return sync_conn.execute(
+                sa_text("SELECT id, concept_ids FROM article WHERE concept_ids IS NOT NULL")
+            ).fetchall()
+
+        rows = await conn.run_sync(_select_articles)
+        all_names, article_concepts = _collect_concept_names(rows)
+
+        if not all_names:
+            return
+
+        def _select_existing_concepts(sync_conn):
+            return sync_conn.execute(sa_text("SELECT name FROM concept")).fetchall()
+
+        existing_rows = await conn.run_sync(_select_existing_concepts)
+        existing_names = {row[0] for row in existing_rows}
+
+        for normalized, raw_name in all_names.items():
+            if normalized not in existing_names:
+                concept_id = str(uuid.uuid4())
+                await conn.execute(
+                    sa_text(
+                        "INSERT INTO concept (id, name, description, article_count, created_at) "
+                        "VALUES (:id, :name, :desc, 0, :created_at)"
+                    ),
+                    {"id": concept_id, "name": normalized, "desc": raw_name, "created_at": utcnow_naive().isoformat()},
+                )
+
+        counts: dict[str, int] = {}
+        for names in article_concepts:
+            for name in names:
+                counts[name] = counts.get(name, 0) + 1
+
+        for normalized, count in counts.items():
+            await conn.execute(
+                sa_text("UPDATE concept SET article_count = :count WHERE name = :name"),
+                {"count": count, "name": normalized},
+            )
+
+        unreferenced = (existing_names | set(all_names.keys())) - set(counts.keys())
+        for name in unreferenced:
+            await conn.execute(
+                sa_text("UPDATE concept SET article_count = 0 WHERE name = :name"),
+                {"name": name},
+            )
+```
+
+- [ ] **Step 3: Refactor _repair_malformed_json_arrays**
+
+Replace the `exec_driver_sql` calls in `_repair_malformed_json_arrays` (lines 270-296):
+
+```python
+async def _repair_malformed_json_arrays(engine) -> None:
+    """Fix concept_ids and source_ids rows containing malformed JSON. Idempotent."""
+    from sqlalchemy import text as sa_text
+
+    async with engine.begin() as conn:
+
+        def _select_articles(sync_conn):
+            return sync_conn.execute(
+                sa_text(
+                    "SELECT id, concept_ids, source_ids FROM article"
+                    " WHERE concept_ids IS NOT NULL OR source_ids IS NOT NULL"
+                )
+            ).fetchall()
+
+        rows = await conn.run_sync(_select_articles)
+
+        for row in rows:
+            article_id, concept_ids, source_ids = row
+            repaired_concepts = _repair_json_array(concept_ids) if concept_ids else None
+            repaired_sources = _repair_json_array(source_ids) if source_ids else None
+
+            if repaired_concepts is not None or repaired_sources is not None:
+                new_concepts = repaired_concepts if repaired_concepts is not None else concept_ids
+                new_sources = repaired_sources if repaired_sources is not None else source_ids
+                await conn.execute(
+                    sa_text("UPDATE article SET concept_ids = :concepts, source_ids = :sources WHERE id = :id"),
+                    {"concepts": new_concepts, "sources": new_sources, "id": article_id},
+                )
+```
+
+- [ ] **Step 4: Add the `text` import at module level**
+
+At the top of `src/wikimind/database.py`, add to the existing imports:
+
+```python
+from sqlalchemy import text as sa_text
+```
+
+Then replace the `from sqlalchemy import text as sa_text` in each function body with the module-level import. The inline imports in the function bodies above are written defensively -- once the module-level import is added, remove the per-function imports.
+
+- [ ] **Step 5: Run tests to verify no regression**
+
+Run: `.venv/bin/pytest tests/unit/test_database.py -v`
+Expected: All tests PASS (the repair + backfill tests exercise these code paths)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `.venv/bin/pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/wikimind/database.py
+git commit -s -m "refactor(db): convert raw SQL from ? placeholders to :named params
+
+Named parameters via SQLAlchemy text() are dialect-agnostic. SQLite's ?
+placeholders only work with exec_driver_sql which bypasses the
+SQLAlchemy engine layer."
+```
+
+---
+
+### Task 6: Replace json_each() and .contains() with dialect-aware helpers
+
+**Files:**
+- Modify: `src/wikimind/services/wiki.py` (lines 246-251)
+- Modify: `src/wikimind/engine/compiler.py` (lines 306-308)
+
+- [ ] **Step 1: Write test for concept-filtered article listing**
+
+The existing test suite for `wiki.py` should cover this. Verify by running:
+
+Run: `.venv/bin/pytest tests/unit/test_wiki_service.py -v -k "concept"`
+If no concept-filtered test exists, add one to `tests/unit/test_wiki_service.py`:
+
+```python
+# Append to tests/unit/test_wiki_service.py (if not already present)
+
+async def test_list_articles_by_concept_filter(db_session):
+    """list_articles with concept filter returns matching articles."""
+    from wikimind.models import Article, ConfidenceLevel
+    import json
+
+    article = Article(
+        slug="concept-test",
+        title="Concept Test",
+        file_path="concept-test.md",
+        concept_ids=json.dumps(["machine-learning", "deep-learning"]),
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    db_session.add(article)
+    await db_session.commit()
+
+    service = WikiService()
+    results = await service.list_articles(session=db_session, concept="machine-learning")
+    assert len(results) >= 1
+    assert any(r.slug == "concept-test" for r in results)
+```
+
+- [ ] **Step 2: Refactor wiki.py json_each to use db_compat**
+
+In `src/wikimind/services/wiki.py`, replace lines 246-251 (the concept filter in `list_articles`):
+
+```python
+# At the top of wiki.py, add import:
+from wikimind.db_compat import json_array_elements_subquery, is_sqlite
+from wikimind.config import get_settings
+
+# Replace lines 246-251 in list_articles:
+        if concept:
+            settings = get_settings()
+            dialect = "sqlite" if is_sqlite(settings.database_url) else "postgresql"
+            from_clause, value_ref = json_array_elements_subquery(dialect, "article", "concept_ids")
+            query = query.where(
+                literal_column("article.id").in_(
+                    select(literal_column("article.id"))
+                    .select_from(from_clause)
+                    .where(value_ref == concept)
+                )
+            )
+```
+
+- [ ] **Step 3: Refactor compiler.py .contains() to use db_compat**
+
+In `src/wikimind/engine/compiler.py`, replace lines 306-308 (the `_find_article_for_source_and_provider` method):
+
+```python
+    async def _find_article_for_source_and_provider(
+        self,
+        session: AsyncSession,
+        source_id: str,
+        provider: Provider | None,
+    ) -> Article | None:
+        """Find an article previously compiled from this source by this provider."""
+        if provider is None:
+            return None
+        from wikimind.config import get_settings
+        from wikimind.db_compat import is_sqlite, json_array_contains
+
+        settings = get_settings()
+        dialect = "sqlite" if is_sqlite(settings.database_url) else "postgresql"
+        needle = f'"{source_id}"'
+        if dialect == "postgresql":
+            clause = json_array_contains(dialect, "source_ids", source_id)
+            result = await session.execute(select(Article).where(clause))
+        else:
+            result = await session.execute(
+                select(Article).where(Article.source_ids.contains(needle))  # type: ignore[union-attr]
+            )
+        for article in result.scalars().all():
+            if article.provider == provider:
+                return article
+        return None
+```
+
+- [ ] **Step 4: Run tests to verify no regression**
+
+Run: `.venv/bin/pytest tests/unit/test_wiki_service.py tests/unit/test_engine_compiler.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/services/wiki.py src/wikimind/engine/compiler.py
+git commit -s -m "refactor(db): replace json_each() and .contains() with dialect-aware helpers
+
+wiki.py now uses json_array_elements_subquery() which generates
+json_each() for SQLite and jsonb_array_elements_text() for Postgres.
+compiler.py uses json_array_contains() for the same dual-dialect
+support."
+```
+
+---
+
+### Task 7: Convert JSON-as-TEXT columns to sa_type=JSON
+
+**Files:**
+- Modify: `src/wikimind/models.py`
+
+This task changes 7 fields from plain `str | None` TEXT columns to proper `sa_type=JSON` columns. SQLAlchemy's `JSON` type maps to `TEXT` on SQLite (with automatic JSON serialization) and `JSONB` on PostgreSQL. This is transparent to application code because SQLModel will automatically serialize/deserialize Python lists and dicts.
+
+**Important:** This is a schema change. Existing SQLite databases store these as TEXT containing JSON strings. With `sa_type=JSON` on SQLite, SQLAlchemy still stores them as TEXT but expects them to be raw JSON, not double-encoded strings. The existing data is already raw JSON strings, so no data migration is needed -- SQLAlchemy's JSON type on SQLite simply passes through TEXT values and parses them via json.loads on read.
+
+- [ ] **Step 1: Write test verifying JSON round-trip**
+
+Add to `tests/unit/test_models.py`:
+
+```python
+# Append to tests/unit/test_models.py
+import json
+
+from sqlmodel import select
+
+from wikimind.models import Article, ConfidenceLevel, ConceptKindDef, Query, LintPairCache
+
+
+class TestJsonColumns:
+    """Verify JSON columns round-trip Python objects through SQLModel."""
+
+    async def test_article_concept_ids_round_trip(self, db_session):
+        """Article.concept_ids stores and retrieves a Python list."""
+        concepts = ["machine-learning", "deep-learning"]
+        article = Article(
+            slug="json-test",
+            title="JSON Test",
+            file_path="json-test.md",
+            concept_ids=json.dumps(concepts),
+            source_ids=json.dumps(["src-1"]),
+            confidence=ConfidenceLevel.SOURCED,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        result = await db_session.execute(select(Article).where(Article.slug == "json-test"))
+        loaded = result.scalar_one()
+        # With sa_type=JSON, the value comes back as a Python list on Postgres
+        # and as a JSON string on SQLite. Both are valid.
+        if isinstance(loaded.concept_ids, str):
+            assert json.loads(loaded.concept_ids) == concepts
+        else:
+            assert loaded.concept_ids == concepts
+
+    async def test_query_source_article_ids_round_trip(self, db_session):
+        """Query.source_article_ids stores and retrieves a JSON array."""
+        ids = ["art-1", "art-2"]
+        q = Query(
+            question="test?",
+            answer="yes",
+            source_article_ids=json.dumps(ids),
+        )
+        db_session.add(q)
+        await db_session.commit()
+
+        result = await db_session.execute(select(Query).where(Query.id == q.id))
+        loaded = result.scalar_one()
+        if isinstance(loaded.source_article_ids, str):
+            assert json.loads(loaded.source_article_ids) == ids
+        else:
+            assert loaded.source_article_ids == ids
+```
+
+- [ ] **Step 2: Run tests to verify they pass with current TEXT columns**
+
+Run: `.venv/bin/pytest tests/unit/test_models.py::TestJsonColumns -v`
+Expected: PASS (current TEXT columns store JSON strings fine)
+
+- [ ] **Step 3: Convert columns to sa_type=JSON**
+
+In `src/wikimind/models.py`, add the import:
+
+```python
+from sqlalchemy import JSON
+```
+
+Then change these field definitions:
+
+**Article.concept_ids** (line 149):
+```python
+    concept_ids: str | None = Field(default=None, sa_type=JSON)  # JSON array of concept IDs
+```
+
+**Article.source_ids** (line 155):
+```python
+    source_ids: str | None = Field(default=None, sa_type=JSON)  # JSON array of source IDs
+```
+
+**ConceptKindDef.required_sections** (line 176):
+```python
+    required_sections: str = Field(sa_type=JSON)  # JSON array
+```
+
+**ConceptKindDef.linter_rules** (line 177):
+```python
+    linter_rules: str = Field(sa_type=JSON)  # JSON array
+```
+
+**Query.source_article_ids** (line 235):
+```python
+    source_article_ids: str | None = Field(default=None, sa_type=JSON)  # JSON array
+```
+
+**Query.related_article_ids** (line 236):
+```python
+    related_article_ids: str | None = Field(default=None, sa_type=JSON)  # JSON array
+```
+
+**LintPairCache.result_json** (line 617):
+```python
+    result_json: str = Field(sa_type=JSON)  # JSON list of contradiction dicts
+```
+
+**Note on Python types:** The Python type annotations remain `str | None` (or `str`) because existing application code calls `json.loads()` / `json.dumps()` on these fields. Changing the Python type to `list | None` would require updating every read/write site simultaneously. The `sa_type=JSON` annotation only affects the DDL (generating `JSONB` on Postgres instead of `TEXT`). On SQLite, the JSON type still stores TEXT. On Postgres, it enables JSONB operators (`@>`, `jsonb_array_elements_text`).
+
+- [ ] **Step 4: Run tests to verify JSON columns work**
+
+Run: `.venv/bin/pytest tests/unit/test_models.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full test suite for regression**
+
+Run: `.venv/bin/pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/models.py tests/unit/test_models.py
+git commit -s -m "feat(models): convert 7 JSON-as-TEXT columns to sa_type=JSON
+
+Uses SQLAlchemy JSON type which maps to TEXT on SQLite (no behavior
+change) and JSONB on PostgreSQL (enables native JSON operators).
+Fields: Article.concept_ids, Article.source_ids,
+ConceptKindDef.required_sections, ConceptKindDef.linter_rules,
+Query.source_article_ids, Query.related_article_ids,
+LintPairCache.result_json."
+```
+
+---
+
+### Task 8: Set up Alembic for Postgres migrations
+
+**Files:**
+- Create: `alembic.ini`
+- Create: `alembic/env.py`
+- Create: `alembic/script.py.mako`
+- Create: `alembic/versions/0001_initial_schema.py`
+- Modify: `src/wikimind/database.py` (conditional Alembic vs create_all)
+
+- [ ] **Step 1: Create alembic.ini**
+
+```ini
+# alembic.ini
+[alembic]
+script_location = alembic
+# URL is overridden at runtime by env.py reading Settings.database_url
+sqlalchemy.url = sqlite+aiosqlite:///placeholder.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+```
+
+- [ ] **Step 2: Create alembic/env.py with async support**
+
+```python
+# alembic/env.py
+"""Alembic environment for async migrations.
+
+Reads database_url from WikiMind settings. Supports both SQLite (offline
+mode) and PostgreSQL (async online mode).
+"""
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config, create_async_engine
+from sqlmodel import SQLModel
+
+# Import all models so metadata is populated
+from wikimind import models  # noqa: F401
+from wikimind.config import get_settings
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+
+def get_url() -> str:
+    """Read database URL from WikiMind settings."""
+    return get_settings().database_url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode — generates SQL script."""
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    """Run migrations with a live connection."""
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Run migrations in async 'online' mode."""
+    url = get_url()
+    connectable = create_async_engine(url, poolclass=pool.NullPool)
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Entry point for online migrations — delegates to async runner."""
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+```
+
+- [ ] **Step 3: Create alembic/script.py.mako**
+
+```mako
+# alembic/script.py.mako
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+```
+
+- [ ] **Step 4: Create initial migration**
+
+Generate the initial migration by running:
+
+```bash
+cd /Users/mg/mg-work/manav/work/ai-experiments/wikimind
+.venv/bin/alembic revision --autogenerate -m "initial schema from SQLModel definitions" --rev-id 0001
+```
+
+Review the generated file in `alembic/versions/0001_initial_schema_from_sqlmodel_definitions.py` and verify it creates all tables matching the SQLModel definitions.
+
+- [ ] **Step 5: Modify init_db to skip lightweight migration on Postgres**
+
+In `src/wikimind/database.py`, modify `init_db()`:
+
+```python
+async def init_db():
+    """Create all tables and run idempotent column migrations.
+
+    SQLite (dev/test): Uses create_all() + lightweight migration helpers.
+    Postgres (production): Expects Alembic migrations to be run separately
+    via `alembic upgrade head`. Only runs backfill helpers.
+    """
+    from wikimind.db_compat import is_sqlite
+
+    engine = get_async_engine()
+    settings = get_settings()
+
+    if is_sqlite(settings.database_url):
+        # SQLite: create_all + lightweight column migration (fast, no Alembic overhead)
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        await _migrate_added_columns(engine)
+    # else: Postgres uses Alembic — tables must exist before startup.
+    # Run `alembic upgrade head` as part of deployment.
+
+    # Backfill helpers run on both dialects
+    await _backfill_conversation_for_legacy_queries(engine)
+    await _repair_malformed_json_arrays(engine)
+    await _backfill_concepts_from_articles(engine)
+
+    # Convert absolute file paths to relative (idempotent)
+    async with get_session_factory()() as session:
+        await _migrate_to_relative_paths(session)
+```
+
+- [ ] **Step 6: Run full test suite (SQLite path)**
+
+Run: `.venv/bin/pytest -v`
+Expected: All tests PASS (tests use SQLite, so create_all path is exercised)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add alembic.ini alembic/ src/wikimind/database.py
+git commit -s -m "feat(db): add Alembic migration system for Postgres
+
+Alembic handles schema migrations for Postgres deployments.
+SQLite continues using create_all() + lightweight migration helpers
+for zero-overhead dev/test. init_db() branches based on dialect."
+```
+
+---
+
+### Task 9: ADRs and documentation
+
+**Files:**
+- Create: `docs/adr/adr-021-postgres-compatibility.md`
+- Modify: `docs/adr/adr-001-fastapi-async-sqlite.md`
+- Modify: `.env.example`
+- Modify: `README.md`
+
+- [ ] **Step 1: Create ADR-021**
+
+```markdown
+# ADR-021: PostgreSQL compatibility for production deployments
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind was built as a local-first application with SQLite (ADR-001). As we
+add cloud deployment support (see design spec: cloud-deployment-design.md),
+production instances need a shared database that multiple devices can connect to
+concurrently. SQLite's single-writer limitation and file-based storage make it
+unsuitable for this use case.
+
+## Decision
+
+Make the database layer dialect-aware so it works on both SQLite (dev/test) and
+PostgreSQL (production) with zero application logic changes.
+
+**Configuration:** A single `WIKIMIND_DATABASE_URL` setting selects the backend.
+It defaults to `sqlite+aiosqlite:///{data_dir}/db/wikimind.db` so the zero-
+dependency dev experience is unchanged.
+
+**Engine creation:** The URL scheme determines the async driver and connection
+parameters. SQLite uses `aiosqlite` with `check_same_thread=False`. PostgreSQL
+uses `asyncpg` with connection pooling (`pool_size=10`, `max_overflow=20`,
+`pool_pre_ping=True`).
+
+**Schema management:** SQLite uses `create_all()` plus lightweight column
+migration helpers (fast, no Alembic overhead). PostgreSQL uses Alembic with an
+initial migration generated from SQLModel definitions. Deployments run
+`alembic upgrade head` before starting the server.
+
+**Query compatibility:** SQLite-specific constructs are replaced with
+dialect-aware helpers:
+- `PRAGMA table_info` → `Inspector.get_columns()` (SQLAlchemy)
+- `json_each()` → `jsonb_array_elements_text()` (via helper function)
+- `.contains()` on TEXT → `@>` on JSONB (via helper function)
+- `?` positional params → `:named` params (SQLAlchemy `text()`)
+
+**Column types:** Seven JSON-as-TEXT columns gain `sa_type=JSON`, which maps to
+TEXT on SQLite (no change) and JSONB on PostgreSQL (enables native operators).
+
+## Alternatives Considered
+
+**Full Alembic for both dialects** — Adds overhead to dev startup and test runs
+for no benefit. SQLite's `create_all()` is instantaneous and perfectly reliable
+for ephemeral dev databases.
+
+**Separate PostgreSQL-specific models** — Would duplicate the entire model layer
+and create a maintenance burden.
+
+**CockroachDB** — Wire-compatible with PostgreSQL but adds operational complexity
+and cost for a single-user system.
+
+## Consequences
+
+**Enables:**
+- Production deployment to any managed Postgres service (Supabase, Neon, RDS)
+- Multiple devices sharing the same database
+- Future horizontal scaling if needed
+
+**Constrains:**
+- Raw SQL must use named parameters (`:name`) instead of positional (`?`)
+- New queries involving JSON arrays must use the `db_compat` helpers
+- PostgreSQL deployments require running Alembic migrations before startup
+
+**Risks:**
+- Dialect-specific bugs that only surface in one backend; mitigated by running
+  the full test suite on both SQLite and (in CI) PostgreSQL
+```
+
+- [ ] **Step 2: Amend ADR-001**
+
+Append to `docs/adr/adr-001-fastapi-async-sqlite.md`:
+
+```markdown
+
+## Amendment (2026-04-17): PostgreSQL support added
+
+As of ADR-021, the database layer is dialect-aware. SQLite remains the default
+for development and testing (zero-dependency startup principle unchanged).
+Production deployments can use PostgreSQL by setting `WIKIMIND_DATABASE_URL` to a
+`postgresql+asyncpg://` URL.
+
+The constraint noted above — "If WikiMind ever becomes multi-user, SQLite will
+need to be replaced with Postgres" — is now addressed for the shared-backend
+multi-device use case, though WikiMind remains single-user.
+```
+
+- [ ] **Step 3: Update .env.example**
+
+Add the following section to `.env.example` after the existing `# Database (optional)` section (replace the existing database section):
+
+```bash
+# ----------------------------------------------------------------------------
+# Database (optional)
+# ----------------------------------------------------------------------------
+# Defaults to SQLite at ~/.wikimind/db/wikimind.db. Override for Postgres:
+# WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/wikimind
+#
+# For Postgres, run `alembic upgrade head` before first startup.
+#
+# Verbose SQL query logging — dev only, very noisy
+# WIKIMIND_DATABASE__ECHO=false
+```
+
+- [ ] **Step 4: Update README.md**
+
+Add a section after the existing "Quick start" section:
+
+```markdown
+## Production (PostgreSQL)
+
+For shared access across multiple devices, use PostgreSQL instead of SQLite:
+
+```bash
+# 1. Set the database URL in .env
+echo 'WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind' >> .env
+
+# 2. Run Alembic migrations (first time only, and after upgrades)
+alembic upgrade head
+
+# 3. Start the server
+make dev
+```
+
+All features work identically on both backends. SQLite is recommended for
+single-device development. PostgreSQL is required for cloud deployments where
+multiple devices share the same database.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/adr-021-postgres-compatibility.md docs/adr/adr-001-fastapi-async-sqlite.md .env.example README.md
+git commit -s -m "docs: add ADR-021 (Postgres compatibility), update docs and .env.example"
+```
+
+---
+
+### Task 10: Postgres integration tests (skipped without Postgres)
+
+**Files:**
+- Create: `tests/integration/test_postgres_integration.py`
+
+- [ ] **Step 1: Write Postgres integration tests**
+
+```python
+# tests/integration/test_postgres_integration.py
+"""Integration tests for PostgreSQL backend.
+
+Skipped automatically when WIKIMIND_TEST_POSTGRES_URL is not set.
+To run: export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind_test
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+
+from wikimind.db_compat import is_postgres
+from wikimind.models import Article, ConfidenceLevel, Query, Source, SourceType
+
+POSTGRES_URL = os.environ.get("WIKIMIND_TEST_POSTGRES_URL")
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(not POSTGRES_URL, reason="WIKIMIND_TEST_POSTGRES_URL not set"),
+]
+
+
+@pytest.fixture
+async def pg_engine():
+    """Create a Postgres engine and tables for testing, drop after."""
+    engine = create_async_engine(POSTGRES_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def pg_session(pg_engine) -> AsyncSession:
+    """Async session backed by Postgres test database."""
+    factory = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+
+
+class TestPostgresBasicOperations:
+    async def test_create_and_read_source(self, pg_session):
+        """Basic CRUD works on Postgres."""
+        source = Source(source_type=SourceType.URL, source_url="https://example.com")
+        pg_session.add(source)
+        await pg_session.commit()
+
+        result = await pg_session.execute(select(Source).where(Source.id == source.id))
+        loaded = result.scalar_one()
+        assert loaded.source_url == "https://example.com"
+
+    async def test_json_column_round_trip(self, pg_session):
+        """JSON columns store and retrieve Python objects on Postgres."""
+        concepts = ["ai", "ml"]
+        article = Article(
+            slug="pg-json-test",
+            title="PG JSON",
+            file_path="pg-json-test.md",
+            concept_ids=json.dumps(concepts),
+            source_ids=json.dumps(["src-1"]),
+            confidence=ConfidenceLevel.SOURCED,
+        )
+        pg_session.add(article)
+        await pg_session.commit()
+
+        result = await pg_session.execute(select(Article).where(Article.slug == "pg-json-test"))
+        loaded = result.scalar_one()
+        # On Postgres with JSONB, SQLAlchemy returns Python objects directly
+        if isinstance(loaded.concept_ids, list):
+            assert loaded.concept_ids == concepts
+        else:
+            assert json.loads(loaded.concept_ids) == concepts
+
+    async def test_query_with_json_fields(self, pg_session):
+        """Query model JSON fields work on Postgres."""
+        q = Query(
+            question="What is AI?",
+            answer="Artificial Intelligence",
+            source_article_ids=json.dumps(["art-1"]),
+            related_article_ids=json.dumps(["art-2"]),
+        )
+        pg_session.add(q)
+        await pg_session.commit()
+
+        result = await pg_session.execute(select(Query).where(Query.id == q.id))
+        loaded = result.scalar_one()
+        assert loaded.question == "What is AI?"
+
+
+class TestPostgresMigrationHelpers:
+    async def test_inspector_migration_on_postgres(self, pg_engine):
+        """_migrate_added_columns runs without error on Postgres."""
+        from wikimind.database import _migrate_added_columns
+
+        # All columns already exist from create_all — should be a no-op
+        await _migrate_added_columns(pg_engine)
+
+    async def test_backfill_concepts_on_postgres(self, pg_engine, pg_session):
+        """_backfill_concepts_from_articles works with named params on Postgres."""
+        from wikimind.database import _backfill_concepts_from_articles
+
+        article = Article(
+            slug="pg-backfill",
+            title="PG Backfill",
+            file_path="pg-backfill.md",
+            concept_ids=json.dumps(["new-concept"]),
+            confidence=ConfidenceLevel.SOURCED,
+        )
+        pg_session.add(article)
+        await pg_session.commit()
+
+        await _backfill_concepts_from_articles(pg_engine)
+```
+
+- [ ] **Step 2: Verify tests are skipped without Postgres**
+
+Run: `.venv/bin/pytest tests/integration/test_postgres_integration.py -v`
+Expected: All tests SKIPPED (no `WIKIMIND_TEST_POSTGRES_URL` set)
+
+- [ ] **Step 3: Verify tests pass with Postgres (if available)**
+
+If a local Postgres is available:
+```bash
+export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/wikimind_test
+createdb wikimind_test 2>/dev/null || true
+.venv/bin/pytest tests/integration/test_postgres_integration.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_postgres_integration.py
+git commit -s -m "test: add Postgres integration tests (skipped without WIKIMIND_TEST_POSTGRES_URL)"
+```
+
+---
+
+### Task 11: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd /Users/mg/mg-work/manav/work/ai-experiments/wikimind
+.venv/bin/pytest -v
+```
+
+Expected: All tests PASS
+
+- [ ] **Step 2: Run linter**
+
+```bash
+.venv/bin/ruff check src/ tests/
+```
+
+Expected: No errors
+
+- [ ] **Step 3: Verify SQLite default behavior is unchanged**
+
+```bash
+.venv/bin/python -c "
+from wikimind.config import get_settings
+s = get_settings()
+print(f'database_url: {s.database_url}')
+assert 'sqlite+aiosqlite' in s.database_url
+print('OK: SQLite default verified')
+"
+```
+
+- [ ] **Step 4: Verify Alembic can generate SQL**
+
+```bash
+.venv/bin/alembic upgrade head --sql
+```
+
+Expected: Prints SQL DDL for the initial migration
+
+---
+
+## Summary of all commits in order
+
+1. `feat(config): add database_url setting with SQLite default`
+2. `feat(db): add dialect compatibility helpers for SQLite/Postgres`
+3. `feat(db): dialect-aware engine creation for SQLite and Postgres`
+4. `refactor(db): replace PRAGMA table_info with SQLAlchemy Inspector API`
+5. `refactor(db): convert raw SQL from ? placeholders to :named params`
+6. `refactor(db): replace json_each() and .contains() with dialect-aware helpers`
+7. `feat(models): convert 7 JSON-as-TEXT columns to sa_type=JSON`
+8. `feat(db): add Alembic migration system for Postgres`
+9. `docs: add ADR-021 (Postgres compatibility), update docs and .env.example`
+10. `test: add Postgres integration tests (skipped without WIKIMIND_TEST_POSTGRES_URL)`
+
+---
+
+### Critical Files for Implementation
+- `/Users/mg/mg-work/manav/work/ai-experiments/wikimind/src/wikimind/database.py`
+- `/Users/mg/mg-work/manav/work/ai-experiments/wikimind/src/wikimind/config.py`
+- `/Users/mg/mg-work/manav/work/ai-experiments/wikimind/src/wikimind/models.py`
+- `/Users/mg/mg-work/manav/work/ai-experiments/wikimind/src/wikimind/services/wiki.py`
+- `/Users/mg/mg-work/manav/work/ai-experiments/wikimind/src/wikimind/engine/compiler.py`

--- a/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
+++ b/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
@@ -58,10 +58,10 @@ class TestDatabaseUrl:
 
     def test_database_url_from_env(self, monkeypatch, _isolated_data_dir):
         """database_url can be overridden via environment variable."""
-        monkeypatch.setenv("WIKIMIND_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/wikimind")
+        monkeypatch.setenv("WIKIMIND_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/wikimind  # pragma: allowlist secret")
         get_settings.cache_clear()
         settings = get_settings()
-        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/wikimind"
+        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/wikimind  # pragma: allowlist secret"
         get_settings.cache_clear()
 ```
 
@@ -1354,7 +1354,7 @@ Add the following section to `.env.example` after the existing `# Database (opti
 # Database (optional)
 # ----------------------------------------------------------------------------
 # Defaults to SQLite at ~/.wikimind/db/wikimind.db. Override for Postgres:
-# WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/wikimind
+# WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/wikimind  # pragma: allowlist secret
 #
 # For Postgres, run `alembic upgrade head` before first startup.
 #
@@ -1535,7 +1535,7 @@ Expected: All tests SKIPPED (no `WIKIMIND_TEST_POSTGRES_URL` set)
 
 If a local Postgres is available:
 ```bash
-export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/wikimind_test
+export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/wikimind_test  # pragma: allowlist secret
 createdb wikimind_test 2>/dev/null || true
 .venv/bin/pytest tests/integration/test_postgres_integration.py -v
 ```

--- a/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
+++ b/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
@@ -141,8 +141,8 @@ class TestDialectDetection:
         assert is_postgres("sqlite+aiosqlite:///path/to/db") is False
 
     def test_postgres_url_detected(self):
-        assert is_postgres("postgresql+asyncpg://user:pass@localhost/db") is True
-        assert is_sqlite("postgresql+asyncpg://user:pass@localhost/db") is False
+        assert is_postgres("postgresql+asyncpg://user:pass@localhost/db  # pragma: allowlist secret") is True
+        assert is_sqlite("postgresql+asyncpg://user:pass@localhost/db  # pragma: allowlist secret") is False
 
     def test_in_memory_sqlite_detected(self):
         assert is_sqlite("sqlite+aiosqlite://") is True
@@ -300,7 +300,7 @@ class TestCreateEngineFromUrl:
         We can not actually connect without a running Postgres instance,
         but we can verify the engine is created with the right URL.
         """
-        url = "postgresql+asyncpg://user:pass@localhost:5432/wikimind"
+        url = "postgresql+asyncpg://user:pass@localhost:5432/wikimind"  # pragma: allowlist secret
         engine = _create_engine_from_url(url)
         assert "postgresql" in str(engine.url)
         assert engine.pool.size() == 10  # pool_size=10
@@ -1373,7 +1373,7 @@ For shared access across multiple devices, use PostgreSQL instead of SQLite:
 
 ```bash
 # 1. Set the database URL in .env
-echo 'WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind' >> .env
+echo 'WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind' >> .env  # pragma: allowlist secret
 
 # 2. Run Alembic migrations (first time only, and after upgrades)
 alembic upgrade head
@@ -1408,7 +1408,7 @@ git commit -s -m "docs: add ADR-021 (Postgres compatibility), update docs and .e
 """Integration tests for PostgreSQL backend.
 
 Skipped automatically when WIKIMIND_TEST_POSTGRES_URL is not set.
-To run: export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind_test
+To run: export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind_test  # pragma: allowlist secret
 """
 
 from __future__ import annotations

--- a/docs/superpowers/specs/2026-04-17-cloud-deployment-design.md
+++ b/docs/superpowers/specs/2026-04-17-cloud-deployment-design.md
@@ -1,0 +1,120 @@
+# Cloud Deployment — FileStorage Abstraction + Postgres + R2
+
+## Problem
+
+WikiMind is local-first: SQLite database + filesystem for .md and raw source files. This means a wiki built on one machine is inaccessible from another. Users who run WikiMind on multiple devices (laptop + desktop, dev + production) have no way to share state.
+
+## Decision
+
+Replace the sync engine approach (issues #28, #74) with a simpler shared-backend architecture. In production, all WikiMind instances connect to the same Postgres database and Cloudflare R2 bucket. No sync protocol, no offline queue, no conflict resolution needed.
+
+Two modes, selected by config:
+
+- **Dev (default):** SQLite + local filesystem. Current behavior, zero changes.
+- **Production:** Postgres + R2. All devices share the same backend.
+
+## What This Is Not
+
+- Not a sync engine. There is no push/pull, no delta detection, no manifest.
+- Not offline-capable in production mode. Production requires internet connectivity.
+- Not multi-user. Single user, multiple devices, same credentials.
+
+## Scope — 3 PRs
+
+### PR 1: FileStorage Abstraction
+
+Pure refactoring. Every direct `Path` read/write of wiki .md files and raw source files goes through a `FileStorage` protocol. Only `LocalFileStorage` is implemented — zero behavior change.
+
+**Interface:**
+
+```python
+class FileStorage(Protocol):
+    async def read(self, relative_path: str) -> str: ...
+    async def read_bytes(self, relative_path: str) -> bytes: ...
+    async def write(self, relative_path: str, content: str) -> None: ...
+    async def write_bytes(self, relative_path: str, data: bytes) -> None: ...
+    async def append(self, relative_path: str, content: str) -> None: ...
+    async def delete(self, relative_path: str) -> None: ...
+    async def exists(self, relative_path: str) -> bool: ...
+    async def list(self, prefix: str = "") -> list[str]: ...
+```
+
+**`LocalFileStorage`** wraps current `Path` I/O with `asyncio.to_thread()` for a consistent async interface. Two singleton factories:
+- `get_wiki_storage()` — root = `~/.wikimind/wiki/`
+- `get_raw_storage()` — root = `~/.wikimind/raw/`
+
+**~19 call sites across these files:**
+
+Wiki storage (11 sites): `engine/compiler.py`, `engine/concept_compiler.py`, `engine/qa_agent.py`, `services/wiki_index.py`, `services/activity_log.py`, `services/wiki.py`, `engine/linter/contradictions.py`, `engine/frontmatter_validator.py`, `jobs/sweep.py`, `jobs/worker.py`
+
+Raw storage (6 sites): `ingest/service.py` (URL/PDF/text/YouTube ingest + cleanup), `jobs/worker.py` (compile/recompile source reads)
+
+### PR 2: Postgres Compatibility
+
+Make the database layer dialect-aware. Dev defaults to SQLite. Production uses Postgres.
+
+**Changes:**
+
+1. **Config:** Add `database_url` to Settings (defaults to SQLite path). Remove hardcoded URL from `database.py`.
+
+2. **Engine creation:** Conditional based on URL scheme:
+   - SQLite: `aiosqlite` driver + `check_same_thread=False`
+   - Postgres: `asyncpg` driver + connection pool (`pool_size=10`, `max_overflow=20`, `pool_pre_ping=True`)
+
+3. **Migration system:** Replace `PRAGMA table_info()` (SQLite-only) with SQLAlchemy `Inspector` API. Set up Alembic for Postgres. Keep `create_all()` for dev/test SQLite.
+
+4. **SQLite-specific queries:**
+   - `services/wiki.py:247-248` — `json_each()` → dialect-aware `jsonb_array_elements_text()` for Postgres
+   - `engine/compiler.py:308` — `.contains()` on JSON-as-TEXT → proper JSONB `@>` for Postgres
+
+5. **Schema improvements:** Convert JSON-as-TEXT columns to `sa_type=JSON` where beneficial.
+
+6. **New dependency:** `asyncpg`
+
+**ADRs:** Create ADR-021 (Postgres compatibility). Amend ADR-001 (async SQLite) to note Postgres support.
+
+### PR 3: R2 Storage Backend + Cloud Deployment
+
+**`R2FileStorage`** implements `FileStorage` using `boto3` (S3-compatible):
+- `read/read_bytes` → `s3.get_object()`
+- `write/write_bytes` → `s3.put_object()`
+- `delete` → `s3.delete_object()`
+- `exists` → `s3.head_object()`
+- `list` → `s3.list_objects_v2()`
+- `append` → read + append + write (R2 has no native append)
+
+All boto3 calls wrapped in `asyncio.to_thread()`.
+
+**Config additions:**
+- `WIKIMIND_STORAGE_BACKEND` — `local` (default) or `r2`
+- `WIKIMIND_R2_BUCKET` — bucket name
+- `WIKIMIND_R2_ENDPOINT_URL` — R2 endpoint
+- Uses existing `aws_access_key_id` / `aws_secret_access_key` fields
+
+**Factory selection:**
+```python
+def get_wiki_storage() -> FileStorage:
+    if settings.storage_backend == "r2":
+        return R2FileStorage(bucket, endpoint_url, prefix="wiki/")
+    return LocalFileStorage(wiki_dir)
+```
+
+**Auth:** Postgres credentials + R2 keys in `.env`. No user-facing auth — single-user, credentials = device identity.
+
+**Deployment:** Docker image works with any Postgres + S3-compatible storage. Documented options: Supabase/Neon (Postgres) + Cloudflare R2 (files) + Fly.io/Railway (compute).
+
+**ADRs:** Create ADR-020 (cloud storage abstraction). Amend ADR-004 (markdown files + SQLite) to note R2 support.
+
+## Issues Affected
+
+- **#28** (Cloud sync service) — Simplified from sync service to shared backend. Infrastructure portion still relevant.
+- **#74** (Sync engine) — Can be closed. No sync engine needed with shared backend approach.
+- **#29** (Settings UI) — Sync status panel already exists (read-only). Can show connection status to Postgres/R2 in production mode.
+
+## Verification
+
+**PR 1:** `make dev` → ingest PDF → .md files in `~/.wikimind/wiki/` as before. All tests pass.
+
+**PR 2:** SQLite default works unchanged. `DATABASE_URL=postgresql+asyncpg://...` → ingest + query works. Alembic `upgrade head` creates tables.
+
+**PR 3:** `STORAGE_BACKEND=local` → unchanged. `STORAGE_BACKEND=r2` → files in R2. Second device with same config sees same wiki.

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from slugify import slugify
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel
+from sqlmodel import SQLModel, select
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
@@ -97,6 +97,10 @@ async def init_db():
     await _backfill_conversation_for_legacy_queries(engine)
     await _repair_malformed_json_arrays(engine)
     await _backfill_concepts_from_articles(engine)
+
+    # Convert absolute file paths to relative (idempotent)
+    async with get_session_factory()() as session:
+        await _migrate_to_relative_paths(session)
 
 
 async def _migrate_added_columns(engine) -> None:
@@ -402,6 +406,34 @@ async def _backfill_concepts_from_articles(engine) -> None:
                 "UPDATE concept SET article_count = 0 WHERE name = ?",
                 (name,),
             )
+
+
+async def _migrate_to_relative_paths(session: AsyncSession) -> None:
+    """Convert absolute file_path values to relative paths.
+
+    Runs once at startup. Idempotent -- already-relative paths are skipped.
+    """
+    from wikimind.models import Article, Source  # noqa: PLC0415
+
+    settings = get_settings()
+    wiki_prefix = str(Path(settings.data_dir) / "wiki") + "/"
+    raw_prefix = str(Path(settings.data_dir) / "raw") + "/"
+
+    # Migrate Article.file_path (wiki-relative)
+    result = await session.execute(select(Article).where(Article.file_path.startswith("/")))  # type: ignore[union-attr]
+    for article in result.scalars().all():
+        if article.file_path.startswith(wiki_prefix):
+            article.file_path = article.file_path[len(wiki_prefix) :]
+            session.add(article)
+
+    # Migrate Source.file_path (raw-relative)
+    result = await session.execute(select(Source).where(Source.file_path.startswith("/")))  # type: ignore[union-attr,arg-type]
+    for source in result.scalars().all():
+        if source.file_path and source.file_path.startswith(raw_prefix):
+            source.file_path = source.file_path[len(raw_prefix) :]
+            session.add(source)
+
+    await session.commit()
 
 
 async def close_db():

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -49,6 +49,7 @@ from wikimind.services.taxonomy import (
     upsert_concepts,
 )
 from wikimind.services.wiki_index import regenerate_index_md
+from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -328,12 +329,12 @@ Compile this into a wiki article following the JSON schema exactly."""
             relation_types=self._last_typed_suggestions,
         )
 
-        file_path = self._write_article_file(result, source, slug, resolved, unresolved)
+        relative_path = self._write_article_file(result, source, slug, resolved, unresolved)
 
         article = Article(
             slug=slug,
             title=result.title,
-            file_path=str(file_path),
+            file_path=relative_path,
             confidence=self._overall_confidence(result),
             summary=result.summary,
             source_ids=json.dumps([source.id]),
@@ -399,7 +400,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         """Replace an existing same-source same-provider article in place."""
         old_concept_ids = existing.concept_ids
 
-        old_path = Path(existing.file_path)
+        old_path = resolve_wiki_path(existing.file_path)
         old_path.unlink(missing_ok=True)
 
         resolved, unresolved = await resolve_backlink_candidates(
@@ -409,12 +410,12 @@ Compile this into a wiki article following the JSON schema exactly."""
             relation_types=self._last_typed_suggestions,
         )
 
-        new_path = self._write_article_file(result, source, existing.slug, resolved, unresolved)
+        relative_path = self._write_article_file(result, source, existing.slug, resolved, unresolved)
 
         existing.title = result.title
         existing.summary = result.summary
         existing.confidence = self._overall_confidence(result)
-        existing.file_path = str(new_path)
+        existing.file_path = relative_path
         existing.concept_ids = json.dumps(result.concepts)
         existing.page_type = PageType.SOURCE
         existing.updated_at = utcnow_naive()
@@ -515,12 +516,17 @@ Compile this into a wiki article following the JSON schema exactly."""
         slug: str,
         resolved: list[ResolvedBacklink],
         unresolved: list[str],
-    ) -> Path:
-        """Write .md file to wiki directory with page_type:source frontmatter."""
+    ) -> str:
+        """Write .md file to wiki directory with page_type:source frontmatter.
+
+        Returns the wiki-relative path (e.g. ``concept-slug/article.md``)
+        for storage in Article.file_path.
+        """
         wiki_dir = Path(self.settings.data_dir) / "wiki"
 
         concept = result.concepts[0] if result.concepts else "general"
-        concept_dir = wiki_dir / slugify(concept)
+        concept_slug = slugify(concept)
+        concept_dir = wiki_dir / concept_slug
         concept_dir.mkdir(parents=True, exist_ok=True)
 
         file_path = concept_dir / f"{slug}.md"
@@ -583,9 +589,10 @@ provider: {provider_str}
         file_path.write_text(content, encoding="utf-8")
 
         # Post-write frontmatter validation (best-effort, log warnings)
-        validate_frontmatter(file_path)
+        validate_frontmatter(content)
 
-        return file_path
+        # Return relative path for DB storage instead of absolute Path
+        return str(file_path.relative_to(wiki_dir))
 
     def _overall_confidence(self, result: CompilationResult) -> ConfidenceLevel:
         """Determine overall confidence from claims."""

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -26,6 +26,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
+from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -126,7 +127,7 @@ def _build_source_material(articles: list[Article]) -> str:
         if article.summary:
             section += f"Summary: {article.summary}\n"
         try:
-            fc = Path(article.file_path).read_text(encoding="utf-8")
+            fc = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
             if len(fc) > 5000:
                 fc = fc[:5000] + "\n[...truncated...]"
             section += f"\nContent:\n{fc}\n"
@@ -232,12 +233,12 @@ class ConceptCompiler:
         now = utcnow_naive()
         source_ids = [a.id for a in source_articles]
         existing = await self._find_existing_concept_article(concept.name, session)
-        file_path = self._write_concept_file(compilation, concept, source_articles)
+        relative_path = self._write_concept_file(compilation, concept, source_articles)
         if existing is not None:
-            Path(existing.file_path).unlink(missing_ok=True)
+            resolve_wiki_path(existing.file_path).unlink(missing_ok=True)
             existing.title = compilation.title
             existing.summary = compilation.overview
-            existing.file_path = str(file_path)
+            existing.file_path = relative_path
             existing.concept_ids = json.dumps([concept.name])
             existing.source_ids = json.dumps(source_ids)
             existing.provider = self._last_provider_used
@@ -258,7 +259,7 @@ class ConceptCompiler:
             article = Article(
                 slug=f"concept-{slug}",
                 title=compilation.title,
-                file_path=str(file_path),
+                file_path=relative_path,
                 summary=compilation.overview,
                 concept_ids=json.dumps([concept.name]),
                 source_ids=json.dumps(source_ids),
@@ -281,7 +282,8 @@ class ConceptCompiler:
 
     def _write_concept_file(
         self, compilation: ConceptCompilationResult, concept: Concept, source_articles: list[Article]
-    ) -> Path:
+    ) -> str:
+        """Write concept page markdown. Returns wiki-relative path."""
         wiki_dir = Path(self.settings.data_dir) / "wiki"
         slug = slugify(concept.name)
         concept_dir = wiki_dir / slug
@@ -342,7 +344,7 @@ provider: {self._last_provider_used or "unknown"}
 {compilation.sources_summary}
 """
         file_path.write_text(content, encoding="utf-8")
-        return file_path
+        return str(file_path.relative_to(wiki_dir))
 
     async def _create_synthesizes_links(
         self, concept_article_id: str, source_article_ids: list[str], session: AsyncSession

--- a/src/wikimind/engine/frontmatter_validator.py
+++ b/src/wikimind/engine/frontmatter_validator.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import structlog
 import yaml  # type: ignore[import-untyped]
 from pydantic import ValidationError
@@ -27,46 +25,39 @@ _FRONTMATTER_MODELS: dict[str, type] = {
 }
 
 
-def parse_frontmatter(file_path: Path) -> dict | None:
-    """Extract YAML frontmatter from a markdown file."""
-    try:
-        text = file_path.read_text(encoding="utf-8")
-    except OSError:
-        log.warning("frontmatter_validator: cannot read file", path=str(file_path))
+def parse_frontmatter(content: str) -> dict | None:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith("---"):
         return None
 
-    if not text.startswith("---"):
-        return None
-
-    end = text.find("---", 3)
+    end = content.find("---", 3)
     if end == -1:
         return None
 
-    yaml_block = text[3:end].strip()
+    yaml_block = content[3:end].strip()
     try:
         return yaml.safe_load(yaml_block)
     except yaml.YAMLError as exc:
-        log.warning("frontmatter_validator: YAML parse error", path=str(file_path), error=str(exc))
+        log.warning("frontmatter_validator: YAML parse error", error=str(exc))
         return None
 
 
-def validate_frontmatter(file_path: Path) -> bool:
-    """Validate frontmatter of a wiki .md file against its page-type model."""
-    data = parse_frontmatter(file_path)
+def validate_frontmatter(content: str) -> bool:
+    """Validate frontmatter of wiki markdown content against its page-type model."""
+    data = parse_frontmatter(content)
     if data is None:
-        log.warning("frontmatter_validator: no frontmatter found", path=str(file_path))
+        log.warning("frontmatter_validator: no frontmatter found")
         return False
 
     page_type = data.get("page_type")
     if page_type is None:
-        log.warning("frontmatter_validator: missing page_type field", path=str(file_path))
+        log.warning("frontmatter_validator: missing page_type field")
         return False
 
     model_cls = _FRONTMATTER_MODELS.get(str(page_type))
     if model_cls is None:
         log.warning(
             "frontmatter_validator: unknown page_type",
-            path=str(file_path),
             page_type=page_type,
         )
         return False
@@ -77,7 +68,6 @@ def validate_frontmatter(file_path: Path) -> bool:
     except ValidationError as exc:
         log.warning(
             "frontmatter_validator: validation failed",
-            path=str(file_path),
             page_type=page_type,
             errors=exc.error_count(),
             detail=str(exc),

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -14,7 +14,6 @@ import hashlib
 import itertools
 import json
 import random
-from pathlib import Path
 
 import structlog
 from sqlalchemy import delete
@@ -43,6 +42,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
+from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -61,7 +61,7 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
 def _extract_claims(article: Article) -> list[str]:
     """Extract key claims from an article's markdown file."""
     try:
-        content = Path(article.file_path).read_text(encoding="utf-8")
+        content = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
     except (OSError, FileNotFoundError):
         return []
 

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -32,6 +32,7 @@ from wikimind.models import (
     TaskType,
 )
 from wikimind.services.activity_log import append_log_entry
+from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -497,7 +498,7 @@ conversation context contradicts the wiki, prefer the wiki."""
 
     def _read_article_content(self, file_path: str) -> str | None:
         try:
-            return Path(file_path).read_text(encoding="utf-8")
+            return resolve_wiki_path(file_path).read_text(encoding="utf-8")
         except Exception:
             return None
 
@@ -586,10 +587,12 @@ conversation context contradicts the wiki, prefer the wiki."""
             file_path = wiki_dir / f"{slug}.md"
             file_path.write_text(markdown, encoding="utf-8")
 
+            # Store wiki-relative path in the DB
+            relative_path = f"qa-answers/{slug}.md"
             article = Article(
                 slug=slug,
                 title=conversation.title,
-                file_path=str(file_path),
+                file_path=relative_path,
                 summary=(queries[0].answer[:200] if queries else None),
                 confidence=None,  # per #84 / Option 2 — Q&A confidence is on Query, not Article
                 page_type=PageType.ANSWER,
@@ -611,7 +614,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             return article, False
 
         # Update path: overwrite the existing Article's file in place
-        Path(existing_article.file_path).write_text(markdown, encoding="utf-8")
+        resolve_wiki_path(existing_article.file_path).write_text(markdown, encoding="utf-8")
         existing_article.updated_at = now
         conversation.updated_at = now
         session.add(existing_article)

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -45,6 +45,7 @@ from wikimind.models import (
     SourceType,
     TaskType,
 )
+from wikimind.storage import resolve_raw_path
 
 log = structlog.get_logger()
 
@@ -377,7 +378,7 @@ def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     """
     if not source.file_path:
         raise ValueError(f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument")
-    clean_text = Path(source.file_path).read_text(encoding="utf-8")
+    clean_text = resolve_raw_path(source.file_path).read_text(encoding="utf-8")
     return NormalizedDocument(
         raw_source_id=source.id,
         clean_text=clean_text,
@@ -455,7 +456,7 @@ class URLAdapter:
         (raw_dir / f"{source.id}.html").write_text(html, encoding="utf-8")
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(downloaded, encoding="utf-8")
-        source.file_path = str(text_path)
+        source.file_path = f"{source.id}.txt"
 
         # Normalize
         clean_text = downloaded
@@ -634,7 +635,7 @@ class PDFAdapter:
 
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(clean_text, encoding="utf-8")
-        source.file_path = str(text_path)
+        source.file_path = f"{source.id}.txt"
 
         token_count = estimate_tokens(clean_text)
         source.token_count = token_count
@@ -1063,7 +1064,7 @@ class TextAdapter:
         raw_dir.mkdir(parents=True, exist_ok=True)
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(content, encoding="utf-8")
-        source.file_path = str(text_path)
+        source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()
 
@@ -1128,7 +1129,7 @@ class YouTubeAdapter:
         raw_dir.mkdir(parents=True, exist_ok=True)
         text_path = raw_dir / f"{source.id}.txt"
         text_path.write_text(transcript_text, encoding="utf-8")
-        source.file_path = str(text_path)
+        source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()
 

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -13,7 +13,6 @@ promote is a no-op.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 import structlog
 from sqlalchemy.exc import IntegrityError
@@ -24,6 +23,7 @@ from wikimind._datetime import utcnow_naive
 from wikimind.database import get_session_factory
 from wikimind.engine.wikilink_resolver import resolve_backlink_candidates
 from wikimind.models import Article, Backlink, Job, JobStatus, JobType
+from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -42,7 +42,7 @@ async def _sweep_single_article(
     Returns True if any replacement was made (file rewritten + backlinks
     persisted), False if the file was unchanged.
     """
-    file_path = Path(article.file_path)
+    file_path = resolve_wiki_path(article.file_path)
     if not file_path.exists():
         log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
         return False

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -16,7 +16,6 @@ UTF-8 text — it never re-parses HTML, PDFs, or transcripts.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import ClassVar
 
 import structlog
@@ -49,6 +48,7 @@ from wikimind.models import (
     Source,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
+from wikimind.storage import resolve_raw_path, resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -93,7 +93,7 @@ async def compile_source(ctx, source_id: str):
             if not source.file_path:
                 raise ValueError("No cleaned text file path for source")
 
-            text_path = Path(source.file_path)
+            text_path = resolve_raw_path(source.file_path)
             content = text_path.read_text(encoding="utf-8")
 
             await emit_source_progress(source_id, "Normalizing content...")
@@ -139,7 +139,7 @@ async def compile_source(ctx, source_id: str):
                 try:
                     embedding_service = get_embedding_service()
                     if embedding_service is not None:
-                        content = Path(article.file_path).read_text(encoding="utf-8")
+                        content = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
                         embedding_service.embed_article(article.id, article.title, content)
                         log.info("Article embedded", article_id=article.id)
                 except Exception as embed_err:
@@ -250,7 +250,7 @@ async def recompile_article(ctx, article_id: str, mode: str, _job_id: str):
                 if not source or not source.file_path:
                     raise ValueError("Source or source file_path not found")
 
-                content = Path(source.file_path).read_text(encoding="utf-8")
+                content = resolve_raw_path(source.file_path).read_text(encoding="utf-8")
 
                 doc = NormalizedDocument(
                     raw_source_id=source.id,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -36,6 +36,7 @@ from wikimind.models import (
     SourceResponse,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
+from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -66,7 +67,7 @@ def _read_article_content(file_path: str) -> str:
         The file content, or an empty string if the file cannot be read.
     """
     try:
-        return Path(file_path).read_text(encoding="utf-8")
+        return resolve_wiki_path(file_path).read_text(encoding="utf-8")
     except Exception:
         return ""
 

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -67,7 +67,7 @@ def _article_entry(article: Article) -> str:
     return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
 
 
-async def regenerate_index_md(session: AsyncSession) -> Path:  # noqa: PLR0912
+async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: PLR0912
     """Regenerate the wiki/index.md content catalog from the database.
 
     Reads all Articles + their concepts, groups by concept, writes a
@@ -79,7 +79,7 @@ async def regenerate_index_md(session: AsyncSession) -> Path:  # noqa: PLR0912
         session: Async database session.
 
     Returns:
-        The Path to the written file.
+        The wiki-relative path string of the written file.
     """
     settings = get_settings()
     wiki_dir = Path(settings.data_dir) / "wiki"
@@ -161,10 +161,10 @@ async def regenerate_index_md(session: AsyncSession) -> Path:  # noqa: PLR0912
 
     index_path.write_text("".join(lines), encoding="utf-8")
     log.info("index.md regenerated", article_count=len(articles))
-    return index_path
+    return "index.md"
 
 
-async def generate_meta_health_page(session: AsyncSession) -> Path:
+async def generate_meta_health_page(session: AsyncSession) -> str:
     """Generate a meta page with wiki health statistics.
 
     Creates ``wiki/meta/wiki-health.md`` with deterministic summary
@@ -175,7 +175,7 @@ async def generate_meta_health_page(session: AsyncSession) -> Path:
         session: Async database session.
 
     Returns:
-        The Path to the written meta page file.
+        The wiki-relative path string of the written meta page file.
     """
     settings = get_settings()
     meta_dir = Path(settings.data_dir) / "wiki" / "meta"
@@ -239,4 +239,4 @@ async def generate_meta_health_page(session: AsyncSession) -> Path:
 
     health_path.write_text("".join(lines), encoding="utf-8")
     log.info("wiki-health.md generated", article_count=total, orphan_count=orphan_count)
-    return health_path
+    return "meta/wiki-health.md"

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -1,0 +1,157 @@
+"""File storage abstraction for wiki and raw source files.
+
+Provides a protocol for async file operations and a local filesystem
+implementation. In production, an R2/S3 implementation can be swapped
+in via configuration without changing application code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from wikimind.config import get_settings
+
+
+@runtime_checkable
+class FileStorage(Protocol):
+    """Async file storage interface."""
+
+    async def read(self, relative_path: str) -> str:
+        """Read text content from a file."""
+        ...
+
+    async def read_bytes(self, relative_path: str) -> bytes:
+        """Read binary content from a file."""
+        ...
+
+    async def write(self, relative_path: str, content: str) -> None:
+        """Write text content to a file, creating parent dirs as needed."""
+        ...
+
+    async def write_bytes(self, relative_path: str, data: bytes) -> None:
+        """Write binary content to a file, creating parent dirs as needed."""
+        ...
+
+    async def append(self, relative_path: str, content: str) -> None:
+        """Append text content to a file, creating it if it does not exist."""
+        ...
+
+    async def delete(self, relative_path: str) -> None:
+        """Delete a file. No-op if the file does not exist."""
+        ...
+
+    async def exists(self, relative_path: str) -> bool:
+        """Return True if the file exists."""
+        ...
+
+    async def list(self, prefix: str = "") -> list[str]:
+        """List all files under the given prefix (or root if empty)."""
+        ...
+
+
+class LocalFileStorage:
+    """Local filesystem implementation of FileStorage."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def _resolve(self, relative_path: str) -> Path:
+        return self.root / relative_path
+
+    async def read(self, relative_path: str) -> str:
+        """Read text content from a file."""
+        path = self._resolve(relative_path)
+        return await asyncio.to_thread(path.read_text, encoding="utf-8")
+
+    async def read_bytes(self, relative_path: str) -> bytes:
+        """Read binary content from a file."""
+        path = self._resolve(relative_path)
+        return await asyncio.to_thread(path.read_bytes)
+
+    async def write(self, relative_path: str, content: str) -> None:
+        """Write text content to a file, creating parent dirs as needed."""
+        path = self._resolve(relative_path)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_text, content, encoding="utf-8")
+
+    async def write_bytes(self, relative_path: str, data: bytes) -> None:
+        """Write binary content to a file, creating parent dirs as needed."""
+        path = self._resolve(relative_path)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_bytes, data)
+
+    async def append(self, relative_path: str, content: str) -> None:
+        """Append text content to a file, creating it if it does not exist."""
+        path = self._resolve(relative_path)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+
+        def _append() -> None:
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(content)
+
+        await asyncio.to_thread(_append)
+
+    async def delete(self, relative_path: str) -> None:
+        """Delete a file. No-op if the file does not exist."""
+        path = self._resolve(relative_path)
+        if path.exists():
+            await asyncio.to_thread(path.unlink, missing_ok=True)
+
+    async def exists(self, relative_path: str) -> bool:
+        """Return True if the file exists."""
+        path = self._resolve(relative_path)
+        return await asyncio.to_thread(path.exists)
+
+    async def list(self, prefix: str = "") -> list[str]:
+        """List all files under the given prefix (or root if empty)."""
+        search_dir = self._resolve(prefix) if prefix else self.root
+
+        def _list() -> list[str]:
+            if not search_dir.exists():
+                return []
+            return [str(p.relative_to(self.root)) for p in search_dir.rglob("*") if p.is_file()]
+
+        return await asyncio.to_thread(_list)
+
+
+@lru_cache(maxsize=1)
+def get_wiki_storage() -> FileStorage:
+    """Return the wiki file storage singleton."""
+    settings = get_settings()
+    return LocalFileStorage(root=Path(settings.data_dir) / "wiki")
+
+
+@lru_cache(maxsize=1)
+def get_raw_storage() -> FileStorage:
+    """Return the raw source file storage singleton."""
+    settings = get_settings()
+    return LocalFileStorage(root=Path(settings.data_dir) / "raw")
+
+
+def resolve_wiki_path(relative_path: str) -> Path:
+    """Resolve a wiki-relative path to an absolute filesystem path.
+
+    Handles backward compatibility: if the path is already absolute,
+    returns it as-is.
+    """
+    path = Path(relative_path)
+    if path.is_absolute():
+        return path
+    settings = get_settings()
+    return Path(settings.data_dir) / "wiki" / relative_path
+
+
+def resolve_raw_path(relative_path: str) -> Path:
+    """Resolve a raw-relative path to an absolute filesystem path.
+
+    Handles backward compatibility: if the path is already absolute,
+    returns it as-is.
+    """
+    path = Path(relative_path)
+    if path.is_absolute():
+        return path
+    settings = get_settings()
+    return Path(settings.data_dir) / "raw" / relative_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import wikimind.database as _db_mod
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.main import app
+from wikimind.storage import get_raw_storage, get_wiki_storage
 
 # ---------------------------------------------------------------------------
 # Hermetic environment — runs once per session, applied before any test
@@ -71,8 +72,13 @@ def _isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Itera
     data_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(data_dir))
     get_settings.cache_clear()
+    # Clear storage singletons so they pick up the new data_dir
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
     yield data_dir
     get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -15,7 +15,6 @@ Article so retrieval has something to find, and runs the full
 
 from __future__ import annotations
 
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -229,15 +228,16 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
     rather than calling _file_back_thread directly, so it exercises the
     production conditional that gates file-back on confidence.
     """
-    # Build the agent with patched router and settings, with data_dir = tmp_path
-    # so that _file_back_thread writes .md files to a path we control.
+    # Build the agent with patched router and settings, with data_dir matching
+    # the autouse _isolated_data_dir fixture so resolve_wiki_path is consistent.
+    data_dir = tmp_path / "wikimind"
     with (
         patch.object(qa_mod, "get_llm_router"),
         patch.object(
             qa_mod,
             "get_settings",
             return_value=SimpleNamespace(
-                data_dir=str(tmp_path),
+                data_dir=str(data_dir),
                 qa=SimpleNamespace(
                     max_prior_turns_in_context=5,
                     prior_answer_truncate_chars=500,
@@ -249,7 +249,7 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
         agent = QAAgent()
 
     # Seed a fixture article on disk so retrieval has something real to find
-    wiki_dir = tmp_path / "wiki"
+    wiki_dir = data_dir / "wiki"
     wiki_dir.mkdir(parents=True, exist_ok=True)
     fixture_path = wiki_dir / "fixture-source.md"
     fixture_path.write_text(
@@ -303,7 +303,7 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
     # The filed-back article must now be in the Article table and on disk.
     filed_article = await db_session.get(Article, q_a.filed_article_id)
     assert filed_article is not None
-    assert Path(filed_article.file_path).exists()
+    assert (data_dir / "wiki" / filed_article.file_path).exists()
 
     # Phase 3: Verify the filed-back article is retrievable by a future question.
     # Use the agent's own retrieval helper to confirm the filed-back article

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -33,6 +33,7 @@ from wikimind.models import (
     Source,
     SourceType,
 )
+from wikimind.storage import resolve_wiki_path
 
 
 @pytest.mark.asyncio
@@ -84,7 +85,7 @@ async def test_wikilink_resolution_end_to_end(
     assert backlinks[0].target_article_id == target.id
 
     # 4. Markdown has the resolved link by ID and the unresolved bracket
-    content = Path(article.file_path).read_text()
+    content = resolve_wiki_path(article.file_path).read_text()
     assert f"[Existing Target](/wiki/{target.id})" in content
     assert "[[Nonexistent Topic]]" in content
 

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -192,7 +192,7 @@ class TestConceptPageOutput:
         ):
             art = await ConceptCompiler().compile_concept_page(c, db_session)
         assert art is not None
-        content = Path(art.file_path).read_text(encoding="utf-8")
+        content = (Path(tmp_path) / "wiki" / art.file_path).read_text(encoding="utf-8")
         assert "page_type: concept" in content
         for s in [
             "## Overview",

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -42,6 +42,7 @@ from wikimind.models import (
 )
 from wikimind.services import ingest as svc_ingest
 from wikimind.services.ingest import IngestService
+from wikimind.storage import get_raw_storage, get_wiki_storage, resolve_raw_path
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -65,10 +66,15 @@ def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     fake_settings = Settings(data_dir=str(tmp_path), vision_enabled=False)
     monkeypatch.setattr(ingest_service, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(compiler_module, "get_settings", lambda: fake_settings)
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     (tmp_path / "raw").mkdir(parents=True, exist_ok=True)
     get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
     yield tmp_path
     get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
 
 
 def _sample_compilation_result(title: str = "Sample") -> CompilationResult:
@@ -173,7 +179,7 @@ class TestTextAdapterDedup:
         body = "Stable text content."
 
         first, _ = await adapter.ingest(body, "first", db_session)
-        text_path = Path(first.file_path)
+        text_path = resolve_raw_path(first.file_path)
         first_mtime = text_path.stat().st_mtime_ns
 
         second, _ = await adapter.ingest(body, "second", db_session)

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -207,9 +207,11 @@ def test_write_article_file(tmp_path) -> None:
     ):
         c = Compiler()
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
-    path = c._write_article_file(_result(), src, "test-slug", [], [])
-    assert path.exists()
-    text = path.read_text()
+    rel_path = c._write_article_file(_result(), src, "test-slug", [], [])
+    assert isinstance(rel_path, str)
+    full_path = Path(tmp_path) / "wiki" / rel_path
+    assert full_path.exists()
+    text = full_path.read_text()
     assert "Test Article" in text
     assert "test-slug" in text
 
@@ -230,9 +232,11 @@ def test_write_article_file_no_concepts(tmp_path) -> None:
         article_body="x",
     )
     src = Source(source_type=SourceType.TEXT, title=None)
-    path = c._write_article_file(r, src, "no-concept", [], [])
-    assert path.exists()
-    assert "general" in str(path)
+    rel_path = c._write_article_file(r, src, "no-concept", [], [])
+    assert isinstance(rel_path, str)
+    full_path = Path(tmp_path) / "wiki" / rel_path
+    assert full_path.exists()
+    assert "general" in rel_path
 
 
 async def test_save_article(db_session, tmp_path) -> None:
@@ -247,7 +251,8 @@ async def test_save_article(db_session, tmp_path) -> None:
     await db_session.refresh(src)
     article = await c.save_article(_result(), src, db_session)
     assert article.slug
-    assert Path(article.file_path).exists()
+    assert not Path(article.file_path).is_absolute()  # relative path
+    assert (Path(tmp_path) / "wiki" / article.file_path).exists()
     assert src.status == IngestStatus.COMPILED
 
 
@@ -376,7 +381,7 @@ async def test_save_markdown_has_resolved_link_and_unresolved_bracket(db_session
     )
     article = await compiler.save_article(result, source, db_session)
 
-    content = Path(article.file_path).read_text()
+    content = (Path(tmp_path) / "wiki" / article.file_path).read_text()
     assert f"[Existing Article](/wiki/{target.id})" in content
     assert "[[Nonexistent Topic]]" in content
     assert "- [[Existing Article]]" not in content

--- a/tests/unit/test_pdf_adapter.py
+++ b/tests/unit/test_pdf_adapter.py
@@ -22,6 +22,7 @@ from wikimind.config import Settings, get_settings
 from wikimind.ingest import service as ingest_service
 from wikimind.ingest.service import PDFAdapter
 from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType
+from wikimind.storage import get_raw_storage, get_wiki_storage
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -56,13 +57,18 @@ def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """
     fake_settings = Settings(data_dir=str(tmp_path), vision_enabled=False)
     monkeypatch.setattr(ingest_service, "get_settings", lambda: fake_settings)
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     # Pre-create raw_dir so the assertions can rely on it existing.
     (tmp_path / "raw").mkdir(parents=True, exist_ok=True)
     # Drop the global lru_cache too in case anything else hits it during the
     # test (defensive — the monkeypatch above is the primary mechanism).
     get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
     yield tmp_path
     get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +135,7 @@ class TestPDFAdapterFitzFallback:
         assert raw_pdf.read_bytes() == pdf_bytes
         assert raw_txt.exists(), "cleaned .txt should be saved for the worker"
         assert "Lineage check page" in raw_txt.read_text(encoding="utf-8")
-        assert source.file_path == str(raw_txt)
+        assert source.file_path == f"{source.id}.txt"
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +215,7 @@ class TestPDFAdapterDoclingPath:
 
         assert doc.clean_text == markdown
         assert "# Slide deck" in doc.clean_text
-        assert source.file_path == str(isolated_data_dir / "raw" / f"{source.id}.txt")
+        assert source.file_path == f"{source.id}.txt"
         assert (isolated_data_dir / "raw" / f"{source.id}.txt").read_text(encoding="utf-8") == markdown
 
 

--- a/tests/unit/test_phase2_compiler.py
+++ b/tests/unit/test_phase2_compiler.py
@@ -254,30 +254,24 @@ async def test_article_page_type_source(db_session, tmp_path):
     assert article.page_type == PageType.SOURCE
 
 
-def test_validate_source_frontmatter(tmp_path):
-    md = tmp_path / "test.md"
-    md.write_text(
-        '---\ntitle: "Test"\nslug: test\npage_type: source\nsource_id: abc-123\nsource_type: url\nsource_url: http://example.com\ncompiled: 2026-04-13T12:00:00\nconcepts: []\nconfidence: sourced\nprovider: anthropic\n---\n\n## Summary\n\nTest.\n'
-    )
-    assert validate_frontmatter(md) is True
+def test_validate_source_frontmatter():
+    content = '---\ntitle: "Test"\nslug: test\npage_type: source\nsource_id: abc-123\nsource_type: url\nsource_url: http://example.com\ncompiled: 2026-04-13T12:00:00\nconcepts: []\nconfidence: sourced\nprovider: anthropic\n---\n\n## Summary\n\nTest.\n'
+    assert validate_frontmatter(content) is True
 
 
-def test_validate_missing_page_type(tmp_path):
-    md = tmp_path / "test.md"
-    md.write_text("---\ntitle: Test\nslug: test\n---\nContent.\n")
-    assert validate_frontmatter(md) is False
+def test_validate_missing_page_type():
+    content = "---\ntitle: Test\nslug: test\n---\nContent.\n"
+    assert validate_frontmatter(content) is False
 
 
-def test_validate_no_frontmatter(tmp_path):
-    md = tmp_path / "test.md"
-    md.write_text("No frontmatter here.")
-    assert validate_frontmatter(md) is False
+def test_validate_no_frontmatter():
+    content = "No frontmatter here."
+    assert validate_frontmatter(content) is False
 
 
-def test_parse_frontmatter_extracts_yaml(tmp_path):
-    md = tmp_path / "test.md"
-    md.write_text("---\ntitle: Hello\nslug: hello\npage_type: source\n---\nBody.\n")
-    data = parse_frontmatter(md)
+def test_parse_frontmatter_extracts_yaml():
+    content = "---\ntitle: Hello\nslug: hello\npage_type: source\n---\nBody.\n"
+    data = parse_frontmatter(content)
     assert data is not None
     assert data["title"] == "Hello"
     assert data["page_type"] == "source"
@@ -290,9 +284,10 @@ def test_write_article_file_includes_page_type(tmp_path):
     ):
         c = Compiler()
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
-    path = c._write_article_file(_result(), src, "test-slug", [], [])
-    assert path.exists()
-    text = path.read_text()
+    rel_path = c._write_article_file(_result(), src, "test-slug", [], [])
+    full_path = Path(tmp_path) / "wiki" / rel_path
+    assert full_path.exists()
+    text = full_path.read_text()
     assert "page_type: source" in text
     assert "source_id:" in text
 

--- a/tests/unit/test_phase5.py
+++ b/tests/unit/test_phase5.py
@@ -23,6 +23,7 @@ from wikimind.services.wiki_index import (
     generate_meta_health_page,
     regenerate_index_md,
 )
+from wikimind.storage import resolve_wiki_path
 
 # ---------------------------------------------------------------------------
 # _page_type_label
@@ -69,7 +70,8 @@ class TestRegenerateIndexMdPageType:
     @pytest.mark.anyio
     async def test_frontmatter_includes_page_type(self, db_session: AsyncSession) -> None:
         """The index should have page_type: index in its frontmatter."""
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "page_type: index" in content
         assert "scope: global" in content
@@ -82,7 +84,8 @@ class TestRegenerateIndexMdPageType:
         db_session.add_all([a1, a2])
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "2 articles" in content
         assert "1 source" in content
@@ -95,7 +98,8 @@ class TestRegenerateIndexMdPageType:
         db_session.add(a)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "## Concept Pages" in content
         assert "[[llm-reasoning]]" in content
@@ -107,7 +111,8 @@ class TestRegenerateIndexMdPageType:
         db_session.add(a)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "`[Answer]`" in content
 
@@ -121,7 +126,8 @@ class TestGenerateMetaHealthPage:
     @pytest.mark.anyio
     async def test_empty_database_produces_health_page(self, db_session: AsyncSession) -> None:
         """An empty DB should produce a valid health page."""
-        path = await generate_meta_health_page(db_session)
+        rel = await generate_meta_health_page(db_session)
+        path = resolve_wiki_path(rel)
         assert path.exists()
         content = path.read_text(encoding="utf-8")
         assert "page_type: meta" in content
@@ -138,7 +144,8 @@ class TestGenerateMetaHealthPage:
         db_session.add_all([a1, a2, a3])
         await db_session.commit()
 
-        path = await generate_meta_health_page(db_session)
+        rel = await generate_meta_health_page(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "| Source | 2 |" in content
         assert "| Answer | 1 |" in content
@@ -156,7 +163,8 @@ class TestGenerateMetaHealthPage:
         db_session.add(bl)
         await db_session.commit()
 
-        path = await generate_meta_health_page(db_session)
+        rel = await generate_meta_health_page(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "**1** articles with no inbound or outbound links" in content
 
@@ -173,7 +181,8 @@ class TestGenerateMetaHealthPage:
         db_session.add_all([bl1, bl2])
         await db_session.commit()
 
-        path = await generate_meta_health_page(db_session)
+        rel = await generate_meta_health_page(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
         assert "| contradicts | 1 |" in content
         assert "| references | 1 |" in content

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -24,6 +23,7 @@ from wikimind.models import (
     QueryRequest,
     QueryResult,
 )
+from wikimind.storage import resolve_wiki_path
 
 
 def _agent(tmp_path) -> QAAgent:
@@ -306,7 +306,7 @@ async def test_file_back_thread_creates_article_when_first_save(db_session, tmp_
     assert refreshed.filed_article_id == article.id
 
     # The .md file exists on disk
-    assert Path(article.file_path).exists()
+    assert resolve_wiki_path(article.file_path).exists()
 
 
 async def test_file_back_thread_updates_in_place_on_second_save(db_session, tmp_path, monkeypatch) -> None:
@@ -360,7 +360,7 @@ async def test_file_back_thread_updates_in_place_on_second_save(db_session, tmp_
     assert second_article.file_path == first_path  # same file path
 
     # The file content now reflects both turns
-    content = Path(first_path).read_text()
+    content = resolve_wiki_path(first_path).read_text()
     assert "Q1: What is Y?" in content
     assert "Q2: follow-up" in content
 
@@ -427,11 +427,11 @@ async def test_file_back_thread_uses_uuid_slug_so_identical_titles_coexist(db_se
     assert article_a.file_path != article_b.file_path
 
     # Both files exist on disk
-    assert Path(article_a.file_path).exists()
-    assert Path(article_b.file_path).exists()
+    assert resolve_wiki_path(article_a.file_path).exists()
+    assert resolve_wiki_path(article_b.file_path).exists()
 
     # The first article's content mentions the first answer
-    content_a = Path(article_a.file_path).read_text()
+    content_a = resolve_wiki_path(article_a.file_path).read_text()
     assert "First answer" in content_a
 
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,166 @@
+"""Tests for the FileStorage abstraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wikimind.storage import LocalFileStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return LocalFileStorage(root=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_write_and_read(storage, tmp_path):
+    await storage.write("subdir/test.md", "hello world")
+    content = await storage.read("subdir/test.md")
+    assert content == "hello world"
+    assert (tmp_path / "subdir" / "test.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_and_read_bytes(storage, tmp_path):
+    data = b"\x89PNG fake image data"
+    await storage.write_bytes("raw/file.pdf", data)
+    result = await storage.read_bytes("raw/file.pdf")
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_append(storage):
+    await storage.write("log.md", "line1\n")
+    await storage.append("log.md", "line2\n")
+    content = await storage.read("log.md")
+    assert content == "line1\nline2\n"
+
+
+@pytest.mark.asyncio
+async def test_append_creates_file(storage):
+    await storage.append("new.md", "first line\n")
+    content = await storage.read("new.md")
+    assert content == "first line\n"
+
+
+@pytest.mark.asyncio
+async def test_delete(storage):
+    await storage.write("to_delete.md", "bye")
+    assert await storage.exists("to_delete.md")
+    await storage.delete("to_delete.md")
+    assert not await storage.exists("to_delete.md")
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_is_noop(storage):
+    await storage.delete("nonexistent.md")  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_exists(storage):
+    assert not await storage.exists("nope.md")
+    await storage.write("yep.md", "here")
+    assert await storage.exists("yep.md")
+
+
+@pytest.mark.asyncio
+async def test_list_files(storage):
+    await storage.write("a/one.md", "1")
+    await storage.write("a/two.md", "2")
+    await storage.write("b/three.md", "3")
+    files = await storage.list("a/")
+    assert sorted(files) == ["a/one.md", "a/two.md"]
+
+
+@pytest.mark.asyncio
+async def test_list_all(storage):
+    await storage.write("x.md", "x")
+    await storage.write("y/z.md", "z")
+    files = await storage.list()
+    assert sorted(files) == ["x.md", "y/z.md"]
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises(storage):
+    with pytest.raises(FileNotFoundError):
+        await storage.read("missing.md")
+
+
+# ---------------------------------------------------------------------------
+# Protocol and factory tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_storage_is_file_storage_protocol():
+    """LocalFileStorage satisfies the FileStorage protocol."""
+    from wikimind.storage import FileStorage, LocalFileStorage
+
+    storage = LocalFileStorage(root=Path("/tmp/test"))
+    assert isinstance(storage, FileStorage)
+
+
+def test_get_wiki_storage_returns_local(tmp_path, monkeypatch):
+    """get_wiki_storage() returns a LocalFileStorage rooted at wiki_dir."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    from wikimind.storage import LocalFileStorage, get_wiki_storage
+
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    storage = get_wiki_storage()
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.root == tmp_path / "wiki"
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+
+
+def test_get_raw_storage_returns_local(tmp_path, monkeypatch):
+    """get_raw_storage() returns a LocalFileStorage rooted at raw_dir."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    from wikimind.storage import LocalFileStorage, get_raw_storage
+
+    get_settings.cache_clear()
+    get_raw_storage.cache_clear()
+    storage = get_raw_storage()
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.root == tmp_path / "raw"
+    get_settings.cache_clear()
+    get_raw_storage.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# resolve_wiki_path / resolve_raw_path tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_wiki_path_relative(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    from wikimind.storage import resolve_wiki_path
+
+    get_settings.cache_clear()
+    result = resolve_wiki_path("concept/article.md")
+    assert result == tmp_path / "wiki" / "concept" / "article.md"
+    get_settings.cache_clear()
+
+
+def test_resolve_wiki_path_absolute():
+    from wikimind.storage import resolve_wiki_path
+
+    result = resolve_wiki_path("/absolute/path/article.md")
+    assert result == Path("/absolute/path/article.md")
+
+
+def test_resolve_raw_path_relative(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    from wikimind.config import get_settings
+    from wikimind.storage import resolve_raw_path
+
+    get_settings.cache_clear()
+    result = resolve_raw_path("source-id.txt")
+    assert result == tmp_path / "raw" / "source-id.txt"
+    get_settings.cache_clear()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from wikimind.storage import LocalFileStorage
+from wikimind.config import get_settings
+from wikimind.storage import (
+    FileStorage,
+    LocalFileStorage,
+    get_raw_storage,
+    get_wiki_storage,
+    resolve_raw_path,
+    resolve_wiki_path,
+)
 
 
 @pytest.fixture
@@ -96,8 +104,6 @@ async def test_read_missing_raises(storage):
 @pytest.mark.asyncio
 async def test_local_storage_is_file_storage_protocol():
     """LocalFileStorage satisfies the FileStorage protocol."""
-    from wikimind.storage import FileStorage, LocalFileStorage
-
     storage = LocalFileStorage(root=Path("/tmp/test"))
     assert isinstance(storage, FileStorage)
 
@@ -105,9 +111,6 @@ async def test_local_storage_is_file_storage_protocol():
 def test_get_wiki_storage_returns_local(tmp_path, monkeypatch):
     """get_wiki_storage() returns a LocalFileStorage rooted at wiki_dir."""
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    from wikimind.config import get_settings
-    from wikimind.storage import LocalFileStorage, get_wiki_storage
-
     get_settings.cache_clear()
     get_wiki_storage.cache_clear()
     storage = get_wiki_storage()
@@ -120,9 +123,6 @@ def test_get_wiki_storage_returns_local(tmp_path, monkeypatch):
 def test_get_raw_storage_returns_local(tmp_path, monkeypatch):
     """get_raw_storage() returns a LocalFileStorage rooted at raw_dir."""
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    from wikimind.config import get_settings
-    from wikimind.storage import LocalFileStorage, get_raw_storage
-
     get_settings.cache_clear()
     get_raw_storage.cache_clear()
     storage = get_raw_storage()
@@ -139,9 +139,6 @@ def test_get_raw_storage_returns_local(tmp_path, monkeypatch):
 
 def test_resolve_wiki_path_relative(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    from wikimind.config import get_settings
-    from wikimind.storage import resolve_wiki_path
-
     get_settings.cache_clear()
     result = resolve_wiki_path("concept/article.md")
     assert result == tmp_path / "wiki" / "concept" / "article.md"
@@ -149,17 +146,12 @@ def test_resolve_wiki_path_relative(tmp_path, monkeypatch):
 
 
 def test_resolve_wiki_path_absolute():
-    from wikimind.storage import resolve_wiki_path
-
     result = resolve_wiki_path("/absolute/path/article.md")
     assert result == Path("/absolute/path/article.md")
 
 
 def test_resolve_raw_path_relative(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    from wikimind.config import get_settings
-    from wikimind.storage import resolve_raw_path
-
     get_settings.cache_clear()
     result = resolve_raw_path("source-id.txt")
     assert result == tmp_path / "raw" / "source-id.txt"

--- a/tests/unit/test_wiki_index.py
+++ b/tests/unit/test_wiki_index.py
@@ -14,6 +14,7 @@ from wikimind.services.wiki_index import (
     _first_sentence,
     regenerate_index_md,
 )
+from wikimind.storage import resolve_wiki_path
 
 
 class TestFirstSentence:
@@ -46,7 +47,8 @@ class TestRegenerateIndexMd:
     @pytest.mark.anyio
     async def test_empty_database_produces_header_only(self, db_session: AsyncSession) -> None:
         """An empty DB should produce a file with frontmatter and the header."""
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         assert path.exists()
         content = path.read_text(encoding="utf-8")
         assert "page_type: index" in content
@@ -79,7 +81,8 @@ class TestRegenerateIndexMd:
         db_session.add_all([a1, a2])
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         # Both concept headings should appear
@@ -106,7 +109,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         assert "## Uncategorized" in content
@@ -125,7 +129,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         assert "## Machine Learning" in content
@@ -149,7 +154,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         expected = "- [[unit-testing-guide]] \u2014 How to write effective unit tests."
@@ -173,7 +179,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         # The entry line should contain a truncated summary
@@ -200,7 +207,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         first_content = path.read_text(encoding="utf-8")
         assert "[[first-article]]" in first_content
 
@@ -215,7 +223,8 @@ class TestRegenerateIndexMd:
         db_session.add(a2)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         second_content = path.read_text(encoding="utf-8")
 
         # Both should be present
@@ -238,7 +247,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         assert "- [[no-summary]]\n" in content
@@ -262,7 +272,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         # Should appear under both headings
@@ -296,7 +307,8 @@ class TestRegenerateIndexMd:
         db_session.add_all([a_zebra, a_alpha])
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         assert content.index("[[alpha]]") < content.index("[[zebra]]")
@@ -314,7 +326,8 @@ class TestRegenerateIndexMd:
         db_session.add(a1)
         await db_session.commit()
 
-        path = await regenerate_index_md(db_session)
+        rel = await regenerate_index_md(db_session)
+        path = resolve_wiki_path(rel)
         content = path.read_text(encoding="utf-8")
 
         assert "## Uncategorized" in content


### PR DESCRIPTION
## Summary

- Introduces `FileStorage` protocol and `LocalFileStorage` implementation in `src/wikimind/storage.py` with async read/write/delete/exists/list/append
- Refactors all 19 file I/O call sites across compiler, concept_compiler, qa_agent, wiki_index, activity_log, wiki.py, linter, sweep, worker, and ingest to use relative paths
- Adds `resolve_wiki_path()` / `resolve_raw_path()` helpers for backward-compatible absolute↔relative path resolution
- Adds `_migrate_to_relative_paths()` in database.py to convert existing absolute paths on startup
- `Article.file_path` and `Source.file_path` now store relative paths (e.g., `ml/article.md` instead of `/Users/x/.wikimind/wiki/ml/article.md`)

## Context

PR 1 of 3 for cloud deployment (#28). This is pure refactoring — zero behavior change. Enables PR 2 (Postgres compatibility) and PR 3 (R2 storage backend) by decoupling file operations from the local filesystem.

Design spec: `docs/superpowers/specs/2026-04-17-cloud-deployment-design.md`

## Test plan

- [x] `make dev` → ingest a PDF → article .md written to `~/.wikimind/wiki/` as before
- [x] Existing wiki with absolute paths: restart server → paths migrated to relative automatically
- [x] All 705 tests pass, 16 new tests in `test_storage.py`
- [x] `make pre-commit` clean (except pre-existing detect-secrets false positive)