### PR TITLE
feat: add R2/S3 cloud storage backend (PR 3/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,16 @@
 # ------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# AWS / R2 Sync (optional, future use)
+# Storage Backend (optional — default is local filesystem)
+# ----------------------------------------------------------------------------
+# Set to "r2" for Cloudflare R2 (or any S3-compatible store). Requires
+# bucket, endpoint, and AWS credentials below. See ADR-020.
+# WIKIMIND_STORAGE_BACKEND=local
+# WIKIMIND_R2_BUCKET=my-wikimind-bucket
+# WIKIMIND_R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+
+# ----------------------------------------------------------------------------
+# AWS / R2 Credentials (required when storage_backend=r2 or sync is enabled)
 # ----------------------------------------------------------------------------
 # WIKIMIND_AWS_ACCESS_KEY_ID=...
 # WIKIMIND_AWS_SECRET_ACCESS_KEY=...

--- a/.env.example
+++ b/.env.example
@@ -77,8 +77,8 @@
 # ----------------------------------------------------------------------------
 # Storage Backend (optional — default is local filesystem)
 # ----------------------------------------------------------------------------
-# Set to "r2" for Cloudflare R2 (or any S3-compatible store). Requires
-# bucket, endpoint, and AWS credentials below. See ADR-020.
+# Set to "r2" for Cloudflare R2 (or any S3-compatible store like MinIO).
+# Requires bucket, endpoint, and AWS credentials below. See ADR-020.
 # WIKIMIND_STORAGE_BACKEND=local
 # WIKIMIND_R2_BUCKET=my-wikimind-bucket
 # WIKIMIND_R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
@@ -88,6 +88,18 @@
 # ----------------------------------------------------------------------------
 # WIKIMIND_AWS_ACCESS_KEY_ID=...
 # WIKIMIND_AWS_SECRET_ACCESS_KEY=...
+
+# ----------------------------------------------------------------------------
+# Cloud Dev Infrastructure (used by `make dev-cloud` / docker-compose.cloud.yml)
+# ----------------------------------------------------------------------------
+# Override defaults for the local Postgres + MinIO containers.
+# These are NOT needed for production — use WIKIMIND_DATABASE_URL and R2 vars above.
+# WIKIMIND_PG_USER=postgres
+# WIKIMIND_PG_PASS=wikimind
+# WIKIMIND_PG_PORT=5433
+# WIKIMIND_PG_DB=wikimind
+# WIKIMIND_MINIO_PORT=9000
+# WIKIMIND_MINIO_CONSOLE_PORT=9001
 
 # ----------------------------------------------------------------------------
 # Server (optional)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,72 +127,22 @@
     }
   ],
   "results": {
-    "docs/superpowers/plans/2026-04-17-postgres-compatibility.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/superpowers/plans/2026-04-17-postgres-compatibility.md",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 61
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/superpowers/plans/2026-04-17-postgres-compatibility.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 1357
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/superpowers/plans/2026-04-17-postgres-compatibility.md",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 1538
-      }
-    ],
     "src/wikimind/config.py": [
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 386
+        "line_number": 379
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 410
-      }
-    ],
-    "tests/integration/test_postgres_integration.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/integration/test_postgres_integration.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 4
-      }
-    ],
-    "tests/unit/test_db_compat.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/unit/test_db_compat.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "tests/unit/test_postgres_engine.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/unit/test_postgres_engine.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 29
+        "line_number": 403
       }
     ]
   },
-  "generated_at": "2026-04-17T22:07:28Z"
+  "generated_at": "2026-04-17T20:01:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,22 +127,58 @@
     }
   ],
   "results": {
+    "README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "README.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 130
+      }
+    ],
     "src/wikimind/config.py": [
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 379
+        "line_number": 391
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 403
+        "line_number": 415
+      }
+    ],
+    "tests/integration/test_postgres_integration.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/integration/test_postgres_integration.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "tests/unit/test_db_compat.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/unit/test_db_compat.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/unit/test_postgres_engine.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/unit/test_postgres_engine.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 29
       }
     ]
   },
-  "generated_at": "2026-04-17T20:01:33Z"
+  "generated_at": "2026-04-18T00:52:58Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -96,21 +96,40 @@ dev: check-venv ## Run fast-reload dev server on :7842 (uvicorn)
 serve: ## Run production server on :7842 (gunicorn)
 	$(BIN)/gunicorn wikimind.main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 127.0.0.1:7842
 
-PG_USER ?= postgres
-PG_PASS ?= wikimind
-PG_HOST ?= localhost
-PG_PORT ?= 5433
-PG_DB   ?= wikimind
-PG_URL  := postgresql+asyncpg://$(PG_USER):$(PG_PASS)@$(PG_HOST):$(PG_PORT)/$(PG_DB)
+.PHONY: dev-minio
+dev-minio: check-venv ## Run dev server with MinIO for R2 storage (SQLite DB)
+	docker compose -f docker-compose.cloud.yml up -d --wait minio
+	docker compose -f docker-compose.cloud.yml run --rm minio-init
+	WIKIMIND_STORAGE_BACKEND=r2 \
+	WIKIMIND_R2_BUCKET=$${WIKIMIND_R2_BUCKET:-wikimind} \
+	WIKIMIND_R2_ENDPOINT_URL=http://localhost:$${WIKIMIND_MINIO_PORT:-9000} \
+	WIKIMIND_AWS_ACCESS_KEY_ID=$${WIKIMIND_AWS_ACCESS_KEY_ID:-admin} \
+	WIKIMIND_AWS_SECRET_ACCESS_KEY=$${WIKIMIND_AWS_SECRET_ACCESS_KEY:-admin123} \
+		$(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload \
+			--reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
 
-.PHONY: dev-postgres
-dev-postgres: check-venv ## Run dev server against local Postgres on :5433
-	@docker ps --format '{{.Names}}' | grep -q wikimind-postgres || \
-		(echo "Starting wikimind-postgres on :$(PG_PORT)…" && \
-		docker run -d -p $(PG_PORT):5432 -e POSTGRES_PASSWORD=$(PG_PASS) -e POSTGRES_DB=$(PG_DB) --name wikimind-postgres postgres:16 && \
-		sleep 2)
-	WIKIMIND_DATABASE_URL=$(PG_URL) $(BIN)/python -m alembic upgrade head
-	WIKIMIND_DATABASE_URL=$(PG_URL) $(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
+.PHONY: dev-cloud
+dev-cloud: check-venv ## Run dev server with Postgres + MinIO (full cloud mode)
+	docker compose -f docker-compose.cloud.yml up -d --wait postgres minio
+	docker compose -f docker-compose.cloud.yml run --rm minio-init
+	@if [ -f alembic.ini ]; then \
+		WIKIMIND_DATABASE_URL=postgresql+asyncpg://$${WIKIMIND_PG_USER:-postgres}:$${WIKIMIND_PG_PASS:-wikimind}@localhost:$${WIKIMIND_PG_PORT:-5433}/$${WIKIMIND_PG_DB:-wikimind} \
+			$(BIN)/python -m alembic upgrade head; \
+	else \
+		echo "⚠ alembic.ini not found — skipping migrations (Postgres tables created via create_all)"; \
+	fi
+	WIKIMIND_DATABASE_URL=postgresql+asyncpg://$${WIKIMIND_PG_USER:-postgres}:$${WIKIMIND_PG_PASS:-wikimind}@localhost:$${WIKIMIND_PG_PORT:-5433}/$${WIKIMIND_PG_DB:-wikimind} \
+	WIKIMIND_STORAGE_BACKEND=r2 \
+	WIKIMIND_R2_BUCKET=$${WIKIMIND_R2_BUCKET:-wikimind} \
+	WIKIMIND_R2_ENDPOINT_URL=http://localhost:$${WIKIMIND_MINIO_PORT:-9000} \
+	WIKIMIND_AWS_ACCESS_KEY_ID=$${WIKIMIND_AWS_ACCESS_KEY_ID:-admin} \
+	WIKIMIND_AWS_SECRET_ACCESS_KEY=$${WIKIMIND_AWS_SECRET_ACCESS_KEY:-admin123} \
+		$(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload \
+			--reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
+
+.PHONY: dev-cloud-stop
+dev-cloud-stop: ## Stop and remove Postgres + MinIO containers
+	docker compose -f docker-compose.cloud.yml down
 
 .PHONY: worker
 worker: ## Start ARQ background job worker

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ OPENAI_API_KEY=sk-...
 
 For more advanced configuration (model selection, fallback chain, monthly budget), see `.env.example`.
 
+### Cloud deployment (R2 / S3 storage)
+
+For container-based deployment (Fly.io, Railway, etc.) where the local filesystem is ephemeral, WikiMind can store wiki articles and raw source files in Cloudflare R2 or any S3-compatible object store:
+
+```bash
+# In .env:
+WIKIMIND_STORAGE_BACKEND=r2
+WIKIMIND_R2_BUCKET=my-wikimind-bucket
+WIKIMIND_R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+WIKIMIND_AWS_ACCESS_KEY_ID=...
+WIKIMIND_AWS_SECRET_ACCESS_KEY=...
+```
+
+Files are stored with the same key structure as on disk (`wiki/{concept}/{slug}.md`), so R2 objects can be downloaded and browsed as regular markdown. See [ADR-020](docs/adr/adr-020-cloud-storage-abstraction.md) for design details.
+
 ## Tech stack
 
 | Layer | Technology |

--- a/README.md
+++ b/README.md
@@ -96,12 +96,38 @@ OPENAI_API_KEY=sk-...
 
 For more advanced configuration (model selection, fallback chain, monthly budget), see `.env.example`.
 
-### Cloud deployment (R2 / S3 storage)
+### Deployment modes
 
-For container-based deployment (Fly.io, Railway, etc.) where the local filesystem is ephemeral, WikiMind can store wiki articles and raw source files in Cloudflare R2 or any S3-compatible object store:
+WikiMind supports two deployment modes, selected by configuration:
+
+| Mode | Database | File Storage | Command |
+|------|----------|-------------|---------|
+| **Local** (default) | SQLite | Local filesystem | `make dev` |
+| **Cloud** | Postgres | S3-compatible (R2, MinIO) | `make dev-cloud` |
+
+**Local mode** requires zero configuration — just set an LLM API key and run `make dev`.
+
+**Cloud mode** uses Postgres for the database and any S3-compatible service (Cloudflare R2, MinIO, AWS S3) for file storage. All devices pointing at the same Postgres + S3 share the same wiki.
+
+#### Local cloud development
+
+Test cloud mode locally with Postgres + MinIO (S3-compatible) via Docker:
 
 ```bash
-# In .env:
+make dev-cloud        # starts Postgres + MinIO containers, runs migrations, starts app
+make dev-cloud-stop   # stops and removes containers
+```
+
+Containers are defined in `docker-compose.cloud.yml`. Defaults can be overridden in `.env` (see `.env.example` for `WIKIMIND_PG_*` and `WIKIMIND_MINIO_*` vars).
+
+MinIO console: http://localhost:9001 (admin / admin123)
+
+#### Production cloud deployment
+
+For production (Fly.io, Railway, Supabase, etc.), set in `.env`:
+
+```bash
+WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/wikimind
 WIKIMIND_STORAGE_BACKEND=r2
 WIKIMIND_R2_BUCKET=my-wikimind-bucket
 WIKIMIND_R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
@@ -109,7 +135,7 @@ WIKIMIND_AWS_ACCESS_KEY_ID=...
 WIKIMIND_AWS_SECRET_ACCESS_KEY=...
 ```
 
-Files are stored with the same key structure as on disk (`wiki/{concept}/{slug}.md`), so R2 objects can be downloaded and browsed as regular markdown. See [ADR-020](docs/adr/adr-020-cloud-storage-abstraction.md) for design details.
+Files are stored with the same key structure as on disk (`wiki/{concept}/{slug}.md`). See [ADR-020](docs/adr/adr-020-cloud-storage-abstraction.md) and [ADR-021](docs/adr/adr-021-postgres-compatibility.md) for design details.
 
 ## Tech stack
 
@@ -117,7 +143,8 @@ Files are stored with the same key structure as on disk (`wiki/{concept}/{slug}.
 |---|---|
 | Backend gateway | Python 3.11+ / FastAPI |
 | Job queue | ARQ + asyncio (in-process for dev, ARQ + Redis for prod) |
-| Database | SQLite via SQLModel + aiosqlite |
+| Database | SQLite (dev), Postgres (prod) via SQLModel + aiosqlite/asyncpg |
+| File storage | Local filesystem (dev), S3-compatible / Cloudflare R2 (prod) |
 | LLM providers | Anthropic Claude, OpenAI GPT, Google Gemini, Ollama |
 | PDF extraction | pymupdf (fitz) — default; IBM Docling — opt-in via `[parse-advanced]` |
 | Document ingest | trafilatura (URLs), youtube-transcript-api (YouTube) |

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ Files are stored with the same key structure as on disk (`wiki/{concept}/{slug}.
 |--------|-------------|
 | `make dev` | Run fast-reload dev server on :7842 (uvicorn) |
 | `make serve` | Run production server on :7842 (gunicorn) |
-| `make dev-postgres` | Run dev server against local Postgres on :5433 |
+| `make dev-minio` | Run dev server with MinIO for R2 storage (SQLite DB) |
+| `make dev-cloud` | Run dev server with Postgres + MinIO (full cloud mode) |
+| `make dev-cloud-stop` | Stop and remove Postgres + MinIO containers |
 | `make worker` | Start ARQ background job worker |
 
 ### 🔍 QUALITY

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -1,0 +1,71 @@
+###############################################################################
+# WikiMind Cloud Dev Infrastructure
+#
+# Starts Postgres + MinIO for local cloud-mode development.
+# The WikiMind app itself runs natively with hot-reload (not containerized).
+#
+# Usage:
+#   make dev-cloud        # starts containers + app
+#   make dev-cloud-stop   # stops containers
+#
+# Credentials come from .env (see .env.example for defaults).
+###############################################################################
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: wikimind-postgres
+    restart: unless-stopped
+    ports:
+      - "${WIKIMIND_PG_PORT:-5433}:5432"
+    environment:
+      POSTGRES_USER: ${WIKIMIND_PG_USER:-postgres}
+      POSTGRES_PASSWORD: ${WIKIMIND_PG_PASS:-wikimind}
+      POSTGRES_DB: ${WIKIMIND_PG_DB:-wikimind}
+    volumes:
+      - wikimind-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  minio:
+    image: minio/minio
+    container_name: wikimind-minio
+    restart: unless-stopped
+    ports:
+      - "${WIKIMIND_MINIO_PORT:-9000}:9000"
+      - "${WIKIMIND_MINIO_CONSOLE_PORT:-9001}:9001"
+    environment:
+      MINIO_ROOT_USER: ${WIKIMIND_AWS_ACCESS_KEY_ID:-admin}
+      MINIO_ROOT_PASSWORD: ${WIKIMIND_AWS_SECRET_ACCESS_KEY:-admin123}
+    command: server /data --console-address ":9001"
+    volumes:
+      - wikimind-minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # One-shot container to create the bucket on first run
+  minio-init:
+    image: minio/mc
+    container_name: wikimind-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set wikimind http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
+      mc mb wikimind/$${BUCKET} --ignore-existing;
+      "
+    environment:
+      MINIO_ROOT_USER: ${WIKIMIND_AWS_ACCESS_KEY_ID:-admin}
+      MINIO_ROOT_PASSWORD: ${WIKIMIND_AWS_SECRET_ACCESS_KEY:-admin123}
+      BUCKET: ${WIKIMIND_R2_BUCKET:-wikimind}
+
+volumes:
+  wikimind-pgdata:
+  wikimind-minio-data:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,7 +27,7 @@ considered, and the consequences.
 | [017](adr-017-backlink-enforcer-lint-phase.md) | Backlink enforcer as lint Phase 3 with auto-repair | Accepted |
 | [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
 | [019](adr-019-runtime-user-preferences.md) | Runtime User Preferences via DB Override Table | Accepted |
-| [021](adr-021-postgres-compatibility.md) | PostgreSQL compatibility for production deployments | Accepted |
+| [020](adr-020-cloud-storage-abstraction.md) | Cloud Storage Abstraction (R2/S3 Backend) | Accepted |
 
 ## ADR Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ considered, and the consequences.
 | [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
 | [019](adr-019-runtime-user-preferences.md) | Runtime User Preferences via DB Override Table | Accepted |
 | [020](adr-020-cloud-storage-abstraction.md) | Cloud Storage Abstraction (R2/S3 Backend) | Accepted |
+| [021](adr-021-postgres-compatibility.md) | PostgreSQL compatibility for production deployments | Accepted |
 
 ## ADR Format
 

--- a/docs/adr/adr-004-markdown-files-sqlite-metadata.md
+++ b/docs/adr/adr-004-markdown-files-sqlite-metadata.md
@@ -82,3 +82,12 @@ in. Explicitly rejected by the product vision.
   mid-save could leave the file written but the database not updated (or vice
   versa). Mitigated by writing the file first, then committing the database
   record.
+
+## Amendment (ADR-020): Cloud Storage Support
+
+The storage location for wiki articles is now pluggable via the
+`FileStorage` protocol (`storage.py`). When `storage_backend=r2`, files
+are stored as S3 objects in Cloudflare R2 (or any S3-compatible store)
+with the same key structure (`wiki/{concept}/{slug}.md`). The core
+decision — plain markdown content with SQLite metadata — is unchanged.
+See ADR-020 for details.

--- a/docs/adr/adr-020-cloud-storage-abstraction.md
+++ b/docs/adr/adr-020-cloud-storage-abstraction.md
@@ -1,0 +1,119 @@
+# ADR-020: Cloud Storage Abstraction (R2/S3 Backend)
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind stores wiki articles and raw source files as plain files on disk
+(ADR-004). For cloud deployment (Fly.io, Railway, etc.), ephemeral
+container filesystems lose data on restart. We need a durable storage
+backend that works across container restarts and redeployments.
+
+The PR-1 FileStorage abstraction (protocol in `storage.py`) established
+the interface boundary. This ADR covers the concrete cloud implementation.
+
+## Decision
+
+Add an **R2FileStorage** class (`storage_r2.py`) implementing the
+`FileStorage` protocol using boto3's S3 client, targeting Cloudflare R2
+as the primary object store. The same code works against any S3-compatible
+endpoint (AWS S3, MinIO, Backblaze B2).
+
+### Storage backend selection
+
+A new `storage_backend` setting (`"local"` default, `"r2"` for cloud)
+controls which implementation the factory functions return:
+
+```python
+# config.py
+storage_backend: str = "local"
+r2_bucket: str | None = None
+r2_endpoint_url: str | None = None
+```
+
+### Key design choices
+
+1. **Lazy boto3 import** — `storage_r2.py` is only imported when
+   `storage_backend == "r2"`, so local users never pay the boto3 import
+   cost.
+
+2. **asyncio.to_thread()** — All boto3 calls are synchronous. Wrapping
+   them in `to_thread()` keeps the event loop unblocked, matching the
+   same pattern used by `LocalFileStorage`.
+
+3. **Emulated append** — R2/S3 has no native append operation.
+   `R2FileStorage.append()` performs read → concatenate → write. This is
+   acceptable because append is only used for index files and logs, not
+   hot-path operations.
+
+4. **Prefix-based isolation** — Wiki files use prefix `wiki/`, raw files
+   use prefix `raw/`. A single bucket can serve both by routing through
+   the prefix parameter in the factory function.
+
+5. **Existing AWS credentials** — The `aws_access_key_id` and
+   `aws_secret_access_key` fields already existed in `Settings` for the
+   sync feature. R2 reuses them.
+
+### Configuration
+
+```bash
+WIKIMIND_STORAGE_BACKEND=r2
+WIKIMIND_R2_BUCKET=my-wikimind-bucket
+WIKIMIND_R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+WIKIMIND_AWS_ACCESS_KEY_ID=...
+WIKIMIND_AWS_SECRET_ACCESS_KEY=...
+```
+
+## Alternatives Considered
+
+**Fly.io Volumes** — Persistent volumes tied to a single machine. Simpler
+but does not support multi-region or horizontal scaling. Also adds vendor
+lock-in to Fly.io infrastructure.
+
+**SQLite BLOB storage** — Store file content as BLOBs in the database.
+Loses human-readability and the ability to use external tools. Conflicts
+with ADR-004's core rationale.
+
+**Async S3 library (aiobotocore)** — Would avoid the `to_thread()` wrapper
+but adds a complex dependency with its own event loop management. The
+`to_thread()` approach is simpler, proven in the local backend, and
+sufficient for WikiMind's throughput needs.
+
+**Abstract base class instead of Protocol** — An ABC would enforce the
+interface at class definition time. We chose Protocol because it supports
+structural subtyping (duck typing), avoids inheritance hierarchies, and
+works with `isinstance()` checks via `@runtime_checkable`.
+
+## Consequences
+
+**Enables:**
+- Cloud deployment on Fly.io, Railway, or any container platform
+- Data durability across container restarts and redeployments
+- Multi-region access when using Cloudflare R2's global network
+- Works with any S3-compatible storage (AWS S3, MinIO, Backblaze B2)
+- Local development remains zero-config (default is still filesystem)
+
+**Constrains:**
+- Append operations require a full read-modify-write cycle (acceptable
+  for current usage patterns)
+- `resolve_wiki_path()` and `resolve_raw_path()` still return local `Path`
+  objects — callers that bypass `FileStorage` and access the filesystem
+  directly will not work with R2 (by design — they should be migrated)
+
+**Risks:**
+- Network latency for file operations vs. local disk. Mitigated by the
+  fact that WikiMind's file operations are not on the hot path of user
+  requests (compilation is async, reads are cached in the DB summary).
+- Append race conditions if two workers append simultaneously. Acceptable
+  for single-instance deployments; would need locking for multi-instance.
+
+## Amendment to ADR-004
+
+ADR-004 specified filesystem paths as the storage location for wiki
+articles. This ADR extends that decision: the **content** is still plain
+markdown, but the **storage location** is now pluggable. When using R2,
+files are stored as S3 objects with the same key structure
+(`wiki/{concept}/{slug}.md`). The human-readability guarantee is preserved
+because R2 objects can be downloaded and browsed as regular files.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1365,7 +1365,7 @@ components:
       properties:
         file:
           type: string
-          contentMediaType: application/octet-stream
+          format: binary
           title: File
       type: object
       required:
@@ -2288,11 +2288,6 @@ components:
         type:
           type: string
           title: Error Type
-        input:
-          title: Input
-        ctx:
-          type: object
-          title: Context
       type: object
       required:
       - loc

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1365,7 +1365,7 @@ components:
       properties:
         file:
           type: string
-          format: binary
+          contentMediaType: application/octet-stream
           title: File
       type: object
       required:
@@ -2288,6 +2288,11 @@ components:
         type:
           type: string
           title: Error Type
+        input:
+          title: Input
+        ctx:
+          type: object
+          title: Context
       type: object
       required:
       - loc

--- a/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
+++ b/docs/superpowers/plans/2026-04-17-postgres-compatibility.md
@@ -58,10 +58,10 @@ class TestDatabaseUrl:
 
     def test_database_url_from_env(self, monkeypatch, _isolated_data_dir):
         """database_url can be overridden via environment variable."""
-        monkeypatch.setenv("WIKIMIND_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/wikimind")
+        monkeypatch.setenv("WIKIMIND_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/wikimind")  # pragma: allowlist secret
         get_settings.cache_clear()
         settings = get_settings()
-        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/wikimind"
+        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/wikimind"  # pragma: allowlist secret
         get_settings.cache_clear()
 ```
 
@@ -141,8 +141,8 @@ class TestDialectDetection:
         assert is_postgres("sqlite+aiosqlite:///path/to/db") is False
 
     def test_postgres_url_detected(self):
-        assert is_postgres("postgresql+asyncpg://user:pass@localhost/db") is True
-        assert is_sqlite("postgresql+asyncpg://user:pass@localhost/db") is False
+        assert is_postgres("postgresql+asyncpg://user:pass@localhost/db") is True  # pragma: allowlist secret
+        assert is_sqlite("postgresql+asyncpg://user:pass@localhost/db") is False  # pragma: allowlist secret
 
     def test_in_memory_sqlite_detected(self):
         assert is_sqlite("sqlite+aiosqlite://") is True
@@ -300,7 +300,7 @@ class TestCreateEngineFromUrl:
         We can not actually connect without a running Postgres instance,
         but we can verify the engine is created with the right URL.
         """
-        url = "postgresql+asyncpg://user:pass@localhost:5432/wikimind"
+        url = "postgresql+asyncpg://user:pass@localhost:5432/wikimind"  # pragma: allowlist secret
         engine = _create_engine_from_url(url)
         assert "postgresql" in str(engine.url)
         assert engine.pool.size() == 10  # pool_size=10
@@ -1354,7 +1354,7 @@ Add the following section to `.env.example` after the existing `# Database (opti
 # Database (optional)
 # ----------------------------------------------------------------------------
 # Defaults to SQLite at ~/.wikimind/db/wikimind.db. Override for Postgres:
-# WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/wikimind
+# WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/wikimind  # pragma: allowlist secret
 #
 # For Postgres, run `alembic upgrade head` before first startup.
 #
@@ -1373,7 +1373,7 @@ For shared access across multiple devices, use PostgreSQL instead of SQLite:
 
 ```bash
 # 1. Set the database URL in .env
-echo 'WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind' >> .env
+echo 'WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind' >> .env  # pragma: allowlist secret
 
 # 2. Run Alembic migrations (first time only, and after upgrades)
 alembic upgrade head
@@ -1408,7 +1408,7 @@ git commit -s -m "docs: add ADR-021 (Postgres compatibility), update docs and .e
 """Integration tests for PostgreSQL backend.
 
 Skipped automatically when WIKIMIND_TEST_POSTGRES_URL is not set.
-To run: export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind_test
+To run: export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://user:pass@localhost:5432/wikimind_test  # pragma: allowlist secret
 """
 
 from __future__ import annotations
@@ -1535,7 +1535,7 @@ Expected: All tests SKIPPED (no `WIKIMIND_TEST_POSTGRES_URL` set)
 
 If a local Postgres is available:
 ```bash
-export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/wikimind_test
+export WIKIMIND_TEST_POSTGRES_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/wikimind_test  # pragma: allowlist secret
 createdb wikimind_test 2>/dev/null || true
 .venv/bin/pytest tests/integration/test_postgres_integration.py -v
 ```

--- a/docs/superpowers/plans/2026-04-17-r2-storage-backend.md
+++ b/docs/superpowers/plans/2026-04-17-r2-storage-backend.md
@@ -1,0 +1,37 @@
+# R2 Storage Backend (PR 3 of 3 for Cloud Deployment)
+
+## Status: Implemented
+
+## Summary
+
+Implements `R2FileStorage` — a Cloudflare R2 / S3-compatible backend for
+the `FileStorage` protocol established in PR 1 (FileStorage abstraction).
+
+## Changes
+
+1. **Config** (`src/wikimind/config.py`):
+   - `storage_backend: str = "local"` — `"local"` or `"r2"`
+   - `r2_bucket: str | None` — R2 bucket name
+   - `r2_endpoint_url: str | None` — R2 endpoint URL
+
+2. **R2FileStorage** (`src/wikimind/storage_r2.py`):
+   - Implements all `FileStorage` protocol methods
+   - Uses boto3 S3 client with `asyncio.to_thread()` wrappers
+   - Lazy client creation (no boto3 import until first use)
+   - Append emulated as read + concat + write
+   - `read()` raises `FileNotFoundError` on `NoSuchKey` (matches local)
+
+3. **Factory** (`src/wikimind/storage.py`):
+   - `get_wiki_storage()` / `get_raw_storage()` return `R2FileStorage`
+     when `storage_backend == "r2"`
+   - Lazy import of `R2FileStorage` to avoid pulling boto3 for local users
+
+4. **Tests**:
+   - `tests/unit/test_storage_r2.py` — mock boto3, full method coverage
+   - `tests/integration/test_storage_r2_minio.py` — MinIO Docker, full CRUD
+
+5. **Docs**:
+   - `docs/adr/adr-020-cloud-storage-abstraction.md`
+   - Amendment to ADR-004
+   - `.env.example` updated
+   - `README.md` cloud deployment section

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -194,6 +194,11 @@ class Settings(BaseSettings):
 
     gateway_port: int = 7842
 
+    # Storage backend: "local" (filesystem) or "r2" (Cloudflare R2 / S3-compatible)
+    storage_backend: str = "local"
+    r2_bucket: str | None = None
+    r2_endpoint_url: str | None = None
+
     # Redis URL for the ARQ job queue. When unset, BackgroundCompiler runs
     # compilations in-process (single-user dev mode) and the ARQ worker
     # falls back to localhost (which will fail to connect unless a local

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable
-from pathlib import Path
 
 import structlog
 from slugify import slugify
@@ -50,7 +49,7 @@ from wikimind.services.taxonomy import (
     upsert_concepts,
 )
 from wikimind.services.wiki_index import regenerate_index_md
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import delete_wiki, write_wiki
 
 log = structlog.get_logger()
 
@@ -407,8 +406,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         """Replace an existing same-source same-provider article in place."""
         old_concept_ids = existing.concept_ids
 
-        old_path = resolve_wiki_path(existing.file_path)
-        old_path.unlink(missing_ok=True)
+        delete_wiki(existing.file_path)
 
         resolved, unresolved = await resolve_backlink_candidates(
             result.backlink_suggestions,
@@ -524,19 +522,14 @@ Compile this into a wiki article following the JSON schema exactly."""
         resolved: list[ResolvedBacklink],
         unresolved: list[str],
     ) -> str:
-        """Write .md file to wiki directory with page_type:source frontmatter.
+        """Write .md file to wiki storage with page_type:source frontmatter.
 
         Returns the wiki-relative path (e.g. ``concept-slug/article.md``)
         for storage in Article.file_path.
         """
-        wiki_dir = Path(self.settings.data_dir) / "wiki"
-
         concept = result.concepts[0] if result.concepts else "general"
         concept_slug = slugify(concept)
-        concept_dir = wiki_dir / concept_slug
-        concept_dir.mkdir(parents=True, exist_ok=True)
-
-        file_path = concept_dir / f"{slug}.md"
+        relative_path = f"{concept_slug}/{slug}.md"
 
         related_lines: list[str] = []
         for rb in resolved:
@@ -593,13 +586,12 @@ provider: {provider_str}
 - {source.title or source.source_url or "Uploaded document"} (ingested {source.ingested_at.strftime("%Y-%m-%d")})
 """
 
-        file_path.write_text(content, encoding="utf-8")
+        write_wiki(relative_path, content)
 
         # Post-write frontmatter validation (best-effort, log warnings)
         validate_frontmatter(content)
 
-        # Return relative path for DB storage instead of absolute Path
-        return str(file_path.relative_to(wiki_dir))
+        return relative_path
 
     def _overall_confidence(self, result: CompilationResult) -> ConfidenceLevel:
         """Determine overall confidence from claims."""

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import structlog
 from slugify import slugify
@@ -26,7 +25,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import delete_wiki, read_wiki, write_wiki
 
 log = structlog.get_logger()
 
@@ -127,7 +126,7 @@ def _build_source_material(articles: list[Article]) -> str:
         if article.summary:
             section += f"Summary: {article.summary}\n"
         try:
-            fc = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
+            fc = read_wiki(article.file_path)
             if len(fc) > 5000:
                 fc = fc[:5000] + "\n[...truncated...]"
             section += f"\nContent:\n{fc}\n"
@@ -235,7 +234,7 @@ class ConceptCompiler:
         existing = await self._find_existing_concept_article(concept.name, session)
         relative_path = self._write_concept_file(compilation, concept, source_articles)
         if existing is not None:
-            resolve_wiki_path(existing.file_path).unlink(missing_ok=True)
+            delete_wiki(existing.file_path)
             existing.title = compilation.title
             existing.summary = compilation.overview
             existing.file_path = relative_path
@@ -284,11 +283,8 @@ class ConceptCompiler:
         self, compilation: ConceptCompilationResult, concept: Concept, source_articles: list[Article]
     ) -> str:
         """Write concept page markdown. Returns wiki-relative path."""
-        wiki_dir = Path(self.settings.data_dir) / "wiki"
         slug = slugify(concept.name)
-        concept_dir = wiki_dir / slug
-        concept_dir.mkdir(parents=True, exist_ok=True)
-        file_path = concept_dir / f"{slug}.md"
+        relative_path = f"{slug}/{slug}.md"
         now = utcnow_naive()
         source_ids = [a.id for a in source_articles]
         sources_lines = [f"- [{a.title}](/wiki/{a.id})" for a in source_articles]
@@ -343,8 +339,8 @@ provider: {self._last_provider_used or "unknown"}
 
 {compilation.sources_summary}
 """
-        file_path.write_text(content, encoding="utf-8")
-        return str(file_path.relative_to(wiki_dir))
+        write_wiki(relative_path, content)
+        return relative_path
 
     async def _create_synthesizes_links(
         self, concept_article_id: str, source_article_ids: list[str], session: AsyncSession

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -42,7 +42,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import read_wiki
 
 log = structlog.get_logger()
 
@@ -61,7 +61,7 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
 def _extract_claims(article: Article) -> list[str]:
     """Extract key claims from an article's markdown file."""
     try:
-        content = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
+        content = read_wiki(article.file_path)
     except (OSError, FileNotFoundError):
         return []
 

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from pathlib import Path
 
 import structlog
 from fastapi import HTTPException
@@ -32,7 +31,7 @@ from wikimind.models import (
     TaskType,
 )
 from wikimind.services.activity_log import append_log_entry
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import read_wiki, write_wiki
 
 log = structlog.get_logger()
 
@@ -498,7 +497,7 @@ conversation context contradicts the wiki, prefer the wiki."""
 
     def _read_article_content(self, file_path: str) -> str | None:
         try:
-            return resolve_wiki_path(file_path).read_text(encoding="utf-8")
+            return read_wiki(file_path)
         except Exception:
             return None
 
@@ -579,16 +578,9 @@ conversation context contradicts the wiki, prefer the wiki."""
                 conversation.filed_article_id = None
 
         if existing_article is None:
-            # Create path
-            wiki_dir = Path(self.settings.data_dir) / "wiki" / "qa-answers"
-            wiki_dir.mkdir(parents=True, exist_ok=True)
-
             slug = conversation.id  # UUID — guaranteed unique, no collision possible
-            file_path = wiki_dir / f"{slug}.md"
-            file_path.write_text(markdown, encoding="utf-8")
-
-            # Store wiki-relative path in the DB
             relative_path = f"qa-answers/{slug}.md"
+            write_wiki(relative_path, markdown)
             article = Article(
                 slug=slug,
                 title=conversation.title,
@@ -614,7 +606,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             return article, False
 
         # Update path: overwrite the existing Article's file in place
-        resolve_wiki_path(existing_article.file_path).write_text(markdown, encoding="utf-8")
+        write_wiki(existing_article.file_path, markdown)
         existing_article.updated_at = now
         conversation.updated_at = now
         session.add(existing_article)

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -45,7 +45,7 @@ from wikimind.models import (
     SourceType,
     TaskType,
 )
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import read_raw, resolve_raw_path, write_raw, write_raw_bytes
 
 log = structlog.get_logger()
 
@@ -378,7 +378,7 @@ def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     """
     if not source.file_path:
         raise ValueError(f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument")
-    clean_text = resolve_raw_path(source.file_path).read_text(encoding="utf-8")
+    clean_text = read_raw(source.file_path)
     return NormalizedDocument(
         raw_source_id=source.id,
         clean_text=clean_text,
@@ -450,12 +450,8 @@ class URLAdapter:
 
         # Save clean extracted text (used by the compiler worker) and
         # keep the raw HTML alongside it for reference/reprocessing.
-        settings = get_settings()
-        raw_dir = Path(settings.data_dir) / "raw"
-        raw_dir.mkdir(parents=True, exist_ok=True)
-        (raw_dir / f"{source.id}.html").write_text(html, encoding="utf-8")
-        text_path = raw_dir / f"{source.id}.txt"
-        text_path.write_text(downloaded, encoding="utf-8")
+        write_raw(f"{source.id}.html", html)
+        write_raw(f"{source.id}.txt", downloaded)
         source.file_path = f"{source.id}.txt"
 
         # Normalize
@@ -605,11 +601,10 @@ class PDFAdapter:
         # worker only ever reads the .txt file (see issue #59), so file_path
         # always points at the cleaned text. The raw .pdf is kept for lineage
         # and future re-extraction (e.g. Docling — see issue #57).
-        settings = get_settings()
-        raw_dir = Path(settings.data_dir) / "raw"
-        raw_dir.mkdir(parents=True, exist_ok=True)
-        raw_pdf_path = raw_dir / f"{source.id}.pdf"
-        raw_pdf_path.write_bytes(file_bytes)
+        # Persist the raw PDF via storage (handles both local and R2).
+        write_raw_bytes(f"{source.id}.pdf", file_bytes)
+        # Docling reads from a local filesystem path; resolve for extraction.
+        raw_pdf_path = resolve_raw_path(f"{source.id}.pdf")
 
         # Extract text — prefer Docling for structured output (markdown with
         # heading hierarchy, table-aware), fall back to fitz plain text when
@@ -633,8 +628,7 @@ class PDFAdapter:
         # back into the extracted text.
         clean_text = await self._enhance_with_vision(file_bytes, clean_text, source.id)
 
-        text_path = raw_dir / f"{source.id}.txt"
-        text_path.write_text(clean_text, encoding="utf-8")
+        write_raw(f"{source.id}.txt", clean_text)
         source.file_path = f"{source.id}.txt"
 
         token_count = estimate_tokens(clean_text)
@@ -1059,11 +1053,7 @@ class TextAdapter:
         # Pasted text is already plain text, so the raw and cleaned files are
         # the same .txt file. file_path always points at the .txt the worker
         # reads (see issue #59).
-        settings = get_settings()
-        raw_dir = Path(settings.data_dir) / "raw"
-        raw_dir.mkdir(parents=True, exist_ok=True)
-        text_path = raw_dir / f"{source.id}.txt"
-        text_path.write_text(content, encoding="utf-8")
+        write_raw(f"{source.id}.txt", content)
         source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()
@@ -1124,11 +1114,7 @@ class YouTubeAdapter:
 
         # YouTube transcripts are already plain text, so the raw and cleaned
         # files are the same .txt. There is no separate raw video payload.
-        settings = get_settings()
-        raw_dir = Path(settings.data_dir) / "raw"
-        raw_dir.mkdir(parents=True, exist_ok=True)
-        text_path = raw_dir / f"{source.id}.txt"
-        text_path.write_text(transcript_text, encoding="utf-8")
+        write_raw(f"{source.id}.txt", transcript_text)
         source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -22,7 +22,7 @@ from wikimind._datetime import utcnow_naive
 from wikimind.database import get_session_factory
 from wikimind.engine.wikilink_resolver import resolve_backlink_candidates
 from wikimind.models import Article, Backlink, Job, JobStatus, JobType
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import read_wiki, write_wiki
 
 log = structlog.get_logger()
 
@@ -45,12 +45,11 @@ async def _sweep_single_article(
     Returns True if any replacement was made (file rewritten + backlinks
     persisted), False if the file was unchanged.
     """
-    file_path = resolve_wiki_path(article.file_path)
-    if not file_path.exists():
-        log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
+    try:
+        content = read_wiki(article.file_path)
+    except (OSError, FileNotFoundError):
+        log.warning("sweep: file not found, skipping", article_id=article.id, path=article.file_path)
         return False
-
-    content = file_path.read_text(encoding="utf-8")
 
     # Collect all unique bracket texts
     matches = _WIKILINK_RE.findall(content)
@@ -85,7 +84,7 @@ async def _sweep_single_article(
         return False  # pragma: no cover — defensive; resolved non-empty implies change
 
     # Write the updated file
-    file_path.write_text(new_content, encoding="utf-8")
+    write_wiki(article.file_path, new_content)
 
     # Persist Backlink rows — use get-or-create to handle duplicates
     # gracefully. The selectin eager loading on Article pre-populates the

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -48,7 +48,7 @@ from wikimind.models import (
     Source,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
-from wikimind.storage import resolve_raw_path, resolve_wiki_path
+from wikimind.storage import read_raw, read_wiki
 
 log = structlog.get_logger()
 
@@ -93,8 +93,7 @@ async def compile_source(ctx, source_id: str):
             if not source.file_path:
                 raise ValueError("No cleaned text file path for source")
 
-            text_path = resolve_raw_path(source.file_path)
-            content = text_path.read_text(encoding="utf-8")
+            content = read_raw(source.file_path)
 
             await emit_source_progress(source_id, "Normalizing content...")
 
@@ -139,7 +138,7 @@ async def compile_source(ctx, source_id: str):
                 try:
                     embedding_service = get_embedding_service()
                     if embedding_service is not None:
-                        content = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
+                        content = read_wiki(article.file_path)
                         embedding_service.embed_article(article.id, article.title, content)
                         log.info("Article embedded", article_id=article.id)
                 except Exception as embed_err:
@@ -250,7 +249,7 @@ async def recompile_article(ctx, article_id: str, mode: str, _job_id: str):
                 if not source or not source.file_path:
                     raise ValueError("Source or source file_path not found")
 
-                content = resolve_raw_path(source.file_path).read_text(encoding="utf-8")
+                content = read_raw(source.file_path)
 
                 doc = NormalizedDocument(
                     raw_source_id=source.id,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -37,7 +37,7 @@ from wikimind.models import (
     SourceResponse,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import read_wiki
 
 log = structlog.get_logger()
 
@@ -59,16 +59,16 @@ def _first_concept(concept_ids_json: str | None) -> str | None:
 
 
 def _read_article_content(file_path: str) -> str:
-    """Read article markdown content from disk.
+    """Read article markdown content from storage.
 
     Args:
-        file_path: Absolute path to the article markdown file.
+        file_path: Wiki-relative path to the article markdown file.
 
     Returns:
         The file content, or an empty string if the file cannot be read.
     """
     try:
-        return resolve_wiki_path(file_path).read_text(encoding="utf-8")
+        return read_wiki(file_path)
     except Exception:
         return ""
 

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -10,15 +10,14 @@ from __future__ import annotations
 import contextlib
 import json
 from collections import Counter, defaultdict
-from pathlib import Path
 
 import structlog
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
-from wikimind.config import get_settings
 from wikimind.models import Article, Backlink, Concept, PageType
+from wikimind.storage import write_wiki
 
 log = structlog.get_logger()
 
@@ -81,11 +80,6 @@ async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: PLR0912
     Returns:
         The wiki-relative path string of the written file.
     """
-    settings = get_settings()
-    wiki_dir = Path(settings.data_dir) / "wiki"
-    wiki_dir.mkdir(parents=True, exist_ok=True)
-    index_path = wiki_dir / "index.md"
-
     # Fetch all articles and concepts
     articles_result = await session.execute(select(Article))
     articles: list[Article] = list(articles_result.scalars().all())
@@ -159,7 +153,7 @@ async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: PLR0912
             lines.append(_article_entry(article))
         lines.append("\n")
 
-    index_path.write_text("".join(lines), encoding="utf-8")
+    write_wiki("index.md", "".join(lines))
     log.info("index.md regenerated", article_count=len(articles))
     return "index.md"
 
@@ -177,11 +171,6 @@ async def generate_meta_health_page(session: AsyncSession) -> str:
     Returns:
         The wiki-relative path string of the written meta page file.
     """
-    settings = get_settings()
-    meta_dir = Path(settings.data_dir) / "wiki" / "meta"
-    meta_dir.mkdir(parents=True, exist_ok=True)
-    health_path = meta_dir / "wiki-health.md"
-
     articles_result = await session.execute(select(Article))
     articles: list[Article] = list(articles_result.scalars().all())
 
@@ -237,6 +226,6 @@ async def generate_meta_health_page(session: AsyncSession) -> str:
     lines.append("## Orphan Articles\n\n")
     lines.append(f"**{orphan_count}** articles with no inbound or outbound links.\n")
 
-    health_path.write_text("".join(lines), encoding="utf-8")
+    write_wiki("meta/wiki-health.md", "".join(lines))
     log.info("wiki-health.md generated", article_count=total, orphan_count=orphan_count)
     return "meta/wiki-health.md"

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -241,13 +241,33 @@ def delete_wiki(relative_path: str) -> None:
 
 
 def write_raw(relative_path: str, content: str) -> None:
-    """Write text to raw storage (sync wrapper)."""
+    """Write text to raw storage (sync wrapper).
+
+    When storage_backend is R2, also writes a local copy under
+    ``{data_dir}/raw/`` so that libraries requiring a filesystem path
+    (e.g. Docling, pymupdf) can read the file directly.
+    """
     _run_async(get_raw_storage().write(relative_path, content))
+    settings = get_settings()
+    if settings.storage_backend != "local":
+        local = Path(settings.data_dir) / "raw" / relative_path
+        local.parent.mkdir(parents=True, exist_ok=True)
+        local.write_text(content, encoding="utf-8")
 
 
 def write_raw_bytes(relative_path: str, data: bytes) -> None:
-    """Write bytes to raw storage (sync wrapper)."""
+    """Write bytes to raw storage (sync wrapper).
+
+    When storage_backend is R2, also writes a local copy under
+    ``{data_dir}/raw/`` so that libraries requiring a filesystem path
+    (e.g. Docling, pymupdf) can read the file directly.
+    """
     _run_async(get_raw_storage().write_bytes(relative_path, data))
+    settings = get_settings()
+    if settings.storage_backend != "local":
+        local = Path(settings.data_dir) / "raw" / relative_path
+        local.parent.mkdir(parents=True, exist_ok=True)
+        local.write_bytes(data)
 
 
 def read_raw(relative_path: str) -> str:

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -172,6 +172,9 @@ def resolve_wiki_path(relative_path: str) -> Path:
 
     Handles backward compatibility: if the path is already absolute,
     returns it as-is.
+
+    NOTE: For local storage only. When ``storage_backend=r2``, use the
+    sync helpers (``read_wiki``, ``write_wiki``, etc.) instead.
     """
     path = Path(relative_path)
     if path.is_absolute():
@@ -185,9 +188,73 @@ def resolve_raw_path(relative_path: str) -> Path:
 
     Handles backward compatibility: if the path is already absolute,
     returns it as-is.
+
+    NOTE: For local storage only. When ``storage_backend=r2``, use the
+    sync helpers (``read_raw``, ``write_raw``, etc.) instead.
     """
     path = Path(relative_path)
     if path.is_absolute():
         return path
     settings = get_settings()
     return Path(settings.data_dir) / "raw" / relative_path
+
+
+# ---------------------------------------------------------------------------
+# Sync helpers — bridge sync callers to the async FileStorage backend.
+# These run the async storage method on the current event loop via
+# asyncio.get_event_loop().run_until_complete(), or fall back to
+# asyncio.run() if no loop is running. Safe to call from sync code
+# inside an async application (FastAPI handlers are already in a loop).
+# ---------------------------------------------------------------------------
+
+
+def _run_async(coro):  # noqa: ANN001, ANN202
+    """Run an async coroutine from sync context."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    import concurrent.futures  # noqa: PLC0415
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+def write_wiki(relative_path: str, content: str) -> None:
+    """Write text to wiki storage (sync wrapper)."""
+    _run_async(get_wiki_storage().write(relative_path, content))
+
+
+def write_wiki_bytes(relative_path: str, data: bytes) -> None:
+    """Write bytes to wiki storage (sync wrapper)."""
+    _run_async(get_wiki_storage().write_bytes(relative_path, data))
+
+
+def read_wiki(relative_path: str) -> str:
+    """Read text from wiki storage (sync wrapper)."""
+    return _run_async(get_wiki_storage().read(relative_path))
+
+
+def delete_wiki(relative_path: str) -> None:
+    """Delete a file from wiki storage (sync wrapper)."""
+    _run_async(get_wiki_storage().delete(relative_path))
+
+
+def write_raw(relative_path: str, content: str) -> None:
+    """Write text to raw storage (sync wrapper)."""
+    _run_async(get_raw_storage().write(relative_path, content))
+
+
+def write_raw_bytes(relative_path: str, data: bytes) -> None:
+    """Write bytes to raw storage (sync wrapper)."""
+    _run_async(get_raw_storage().write_bytes(relative_path, data))
+
+
+def read_raw(relative_path: str) -> str:
+    """Read text from raw storage (sync wrapper)."""
+    return _run_async(get_raw_storage().read(relative_path))
+
+
+def delete_raw(relative_path: str) -> None:
+    """Delete a file from raw storage (sync wrapper)."""
+    _run_async(get_raw_storage().delete(relative_path))

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -208,10 +208,10 @@ def resolve_raw_path(relative_path: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def _run_async(coro):  # noqa: ANN001, ANN202
+def _run_async(coro):
     """Run an async coroutine from sync context."""
     try:
-        loop = asyncio.get_running_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(coro)
     import concurrent.futures  # noqa: PLC0415

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -12,7 +12,11 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
+import structlog
+
 from wikimind.config import get_settings
+
+log = structlog.get_logger()
 
 
 @runtime_checkable
@@ -117,10 +121,40 @@ class LocalFileStorage:
         return await asyncio.to_thread(_list)
 
 
+def _make_r2_storage(prefix: str) -> FileStorage:
+    """Create an R2FileStorage instance with the given key prefix.
+
+    Uses lazy import to avoid pulling boto3 when running local.
+    """
+    from wikimind.storage_r2 import R2FileStorage  # noqa: PLC0415
+
+    settings = get_settings()
+    if not settings.r2_bucket:
+        msg = "WIKIMIND_R2_BUCKET must be set when storage_backend=r2"
+        raise ValueError(msg)
+    if not settings.r2_endpoint_url:
+        msg = "WIKIMIND_R2_ENDPOINT_URL must be set when storage_backend=r2"
+        raise ValueError(msg)
+
+    aws_key = settings.aws_access_key_id.get_secret_value() if settings.aws_access_key_id else None
+    aws_secret = settings.aws_secret_access_key.get_secret_value() if settings.aws_secret_access_key else None
+
+    log.info("creating R2 storage", bucket=settings.r2_bucket, prefix=prefix)
+    return R2FileStorage(
+        bucket=settings.r2_bucket,
+        endpoint_url=settings.r2_endpoint_url,
+        prefix=prefix,
+        aws_access_key_id=aws_key,
+        aws_secret_access_key=aws_secret,
+    )
+
+
 @lru_cache(maxsize=1)
 def get_wiki_storage() -> FileStorage:
     """Return the wiki file storage singleton."""
     settings = get_settings()
+    if settings.storage_backend == "r2":
+        return _make_r2_storage(prefix="wiki")
     return LocalFileStorage(root=Path(settings.data_dir) / "wiki")
 
 
@@ -128,6 +162,8 @@ def get_wiki_storage() -> FileStorage:
 def get_raw_storage() -> FileStorage:
     """Return the raw source file storage singleton."""
     settings = get_settings()
+    if settings.storage_backend == "r2":
+        return _make_r2_storage(prefix="raw")
     return LocalFileStorage(root=Path(settings.data_dir) / "raw")
 
 

--- a/src/wikimind/storage_r2.py
+++ b/src/wikimind/storage_r2.py
@@ -1,0 +1,171 @@
+"""Cloudflare R2 / S3-compatible implementation of the FileStorage protocol.
+
+All boto3 calls are blocking and are wrapped in ``asyncio.to_thread()`` so
+they can be called from async FastAPI handlers without blocking the event loop.
+
+The ``append`` operation is emulated as read + append + write because S3/R2
+does not support native append.  The ``delete`` method is a silent no-op when
+the key does not exist, matching ``LocalFileStorage`` semantics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+log = structlog.get_logger()
+
+
+class R2FileStorage:
+    """S3-compatible (Cloudflare R2) file storage backend."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        endpoint_url: str,
+        prefix: str = "",
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+    ) -> None:
+        self.bucket = bucket
+        self.prefix = prefix.rstrip("/") + "/" if prefix else ""
+        self._endpoint_url = endpoint_url
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+        self._client: S3Client | None = None
+
+    def _get_client(self) -> Any:
+        """Lazily create the boto3 S3 client (not thread-safe, but always called inside to_thread)."""
+        if self._client is None:
+            import boto3  # noqa: PLC0415 — lazy import to avoid pulling boto3 when running local
+
+            kwargs: dict[str, Any] = {
+                "service_name": "s3",
+                "endpoint_url": self._endpoint_url,
+            }
+            if self._aws_access_key_id:
+                kwargs["aws_access_key_id"] = self._aws_access_key_id
+            if self._aws_secret_access_key:
+                kwargs["aws_secret_access_key"] = self._aws_secret_access_key
+            self._client = boto3.client(**kwargs)
+        return self._client
+
+    def _key(self, relative_path: str) -> str:
+        """Build the full S3 key from a relative path."""
+        return f"{self.prefix}{relative_path}"
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def read(self, relative_path: str) -> str:
+        """Read text content from R2."""
+        data = await self.read_bytes(relative_path)
+        return data.decode("utf-8")
+
+    async def read_bytes(self, relative_path: str) -> bytes:
+        """Read binary content from R2."""
+
+        def _read() -> bytes:
+            client = self._get_client()
+            try:
+                resp = client.get_object(Bucket=self.bucket, Key=self._key(relative_path))
+                return resp["Body"].read()  # type: ignore[no-any-return]
+            except client.exceptions.NoSuchKey:
+                raise FileNotFoundError(relative_path) from None
+
+        return await asyncio.to_thread(_read)
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def write(self, relative_path: str, content: str) -> None:
+        """Write text content to R2."""
+        await self.write_bytes(relative_path, content.encode("utf-8"))
+
+    async def write_bytes(self, relative_path: str, data: bytes) -> None:
+        """Write binary content to R2."""
+
+        def _write() -> None:
+            client = self._get_client()
+            client.put_object(Bucket=self.bucket, Key=self._key(relative_path), Body=data)
+
+        await asyncio.to_thread(_write)
+
+    # ------------------------------------------------------------------
+    # Append (emulated: read + concat + write)
+    # ------------------------------------------------------------------
+
+    async def append(self, relative_path: str, content: str) -> None:
+        """Append text to an R2 object (emulated via read-modify-write)."""
+        try:
+            existing = await self.read(relative_path)
+        except FileNotFoundError:
+            existing = ""
+        await self.write(relative_path, existing + content)
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    async def delete(self, relative_path: str) -> None:
+        """Delete an object from R2. No-op if the key does not exist."""
+
+        def _delete() -> None:
+            client = self._get_client()
+            # S3 delete_object is idempotent — no error on missing key
+            client.delete_object(Bucket=self.bucket, Key=self._key(relative_path))
+
+        await asyncio.to_thread(_delete)
+
+    # ------------------------------------------------------------------
+    # Exists
+    # ------------------------------------------------------------------
+
+    async def exists(self, relative_path: str) -> bool:
+        """Return True if the key exists in R2."""
+
+        def _exists() -> bool:
+            client = self._get_client()
+            try:
+                client.head_object(Bucket=self.bucket, Key=self._key(relative_path))
+                return True
+            except client.exceptions.ClientError as exc:
+                # head_object raises ClientError with 404 for missing keys
+                code = exc.response.get("Error", {}).get("Code", "")
+                if code in ("404", "NoSuchKey"):
+                    return False
+                raise
+
+        return await asyncio.to_thread(_exists)
+
+    # ------------------------------------------------------------------
+    # List
+    # ------------------------------------------------------------------
+
+    async def list(self, prefix: str = "") -> list[str]:
+        """List all keys under the given prefix, returning relative paths."""
+        full_prefix = self._key(prefix)
+
+        def _list() -> list[str]:
+            client = self._get_client()
+            paginator = client.get_paginator("list_objects_v2")
+            keys: list[str] = []
+            for page in paginator.paginate(Bucket=self.bucket, Prefix=full_prefix):
+                for obj in page.get("Contents", []):
+                    key: str = obj["Key"]
+                    # Strip the storage prefix to return a relative path
+                    if self.prefix and key.startswith(self.prefix):
+                        keys.append(key[len(self.prefix) :])
+                    else:
+                        keys.append(key)
+            return keys
+
+        return await asyncio.to_thread(_list)

--- a/tests/integration/test_storage_r2_minio.py
+++ b/tests/integration/test_storage_r2_minio.py
@@ -1,0 +1,240 @@
+"""Integration tests for R2FileStorage against a real MinIO instance.
+
+These tests require Docker to be available and will spin up a temporary
+MinIO container. They are automatically skipped when Docker is not
+available (e.g. in CI environments without Docker).
+
+To run manually::
+
+    docker run -d --name minio-test -p 9100:9000 \
+        -e MINIO_ROOT_USER=minioadmin \
+        -e MINIO_ROOT_PASSWORD=minioadmin \
+        minio/minio server /data
+
+    pytest tests/integration/test_storage_r2_minio.py -v
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+
+import pytest
+
+# Skip the entire module if Docker is not available
+_has_docker = shutil.which("docker") is not None
+
+
+def _docker_available() -> bool:
+    """Check if Docker daemon is actually running (not just installed)."""
+    if not _has_docker:
+        return False
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+
+MINIO_PORT = 9100
+MINIO_ENDPOINT = f"http://localhost:{MINIO_PORT}"
+MINIO_USER = "minioadmin"
+MINIO_PASSWORD = "minioadmin"
+CONTAINER_NAME = "wikimind-test-minio"
+TEST_BUCKET = "wikimind-test"
+
+
+@pytest.fixture(scope="module")
+def minio_container():
+    """Start a MinIO container for the test module, clean up after."""
+    # Stop any leftover container
+    subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
+
+    # Start MinIO
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            CONTAINER_NAME,
+            "-p",
+            f"{MINIO_PORT}:9000",
+            "-e",
+            f"MINIO_ROOT_USER={MINIO_USER}",
+            "-e",
+            f"MINIO_ROOT_PASSWORD={MINIO_PASSWORD}",
+            "minio/minio",
+            "server",
+            "/data",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Failed to start MinIO container: {result.stderr}")
+
+    # Wait for MinIO to be ready
+    import boto3  # noqa: PLC0415
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=MINIO_ENDPOINT,
+        aws_access_key_id=MINIO_USER,
+        aws_secret_access_key=MINIO_PASSWORD,
+    )
+
+    for _ in range(30):
+        try:
+            client.list_buckets()
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
+        pytest.skip("MinIO did not become ready in time")
+
+    # Create test bucket — ignore if it already exists
+    import contextlib  # noqa: PLC0415
+
+    with contextlib.suppress(client.exceptions.BucketAlreadyOwnedByYou):
+        client.create_bucket(Bucket=TEST_BUCKET)
+
+    yield
+
+    # Cleanup
+    subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
+
+
+@pytest.fixture
+def storage(minio_container):
+    """Create a fresh R2FileStorage pointing at the MinIO test bucket."""
+    from wikimind.storage_r2 import R2FileStorage  # noqa: PLC0415
+
+    return R2FileStorage(
+        bucket=TEST_BUCKET,
+        endpoint_url=MINIO_ENDPOINT,
+        prefix="test",
+        aws_access_key_id=MINIO_USER,
+        aws_secret_access_key=MINIO_PASSWORD,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_bucket(minio_container):
+    """Clean up all objects in the test bucket between tests."""
+    yield
+
+    import boto3  # noqa: PLC0415
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=MINIO_ENDPOINT,
+        aws_access_key_id=MINIO_USER,
+        aws_secret_access_key=MINIO_PASSWORD,
+    )
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=TEST_BUCKET):
+        for obj in page.get("Contents", []):
+            client.delete_object(Bucket=TEST_BUCKET, Key=obj["Key"])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_and_read(storage):
+    await storage.write("concept/article.md", "hello world")
+    content = await storage.read("concept/article.md")
+    assert content == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_and_read_bytes(storage):
+    data = b"\x89PNG fake image data"
+    await storage.write_bytes("raw/file.pdf", data)
+    result = await storage.read_bytes("raw/file.pdf")
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_append(storage):
+    await storage.write("log.md", "line1\n")
+    await storage.append("log.md", "line2\n")
+    content = await storage.read("log.md")
+    assert content == "line1\nline2\n"
+
+
+@pytest.mark.asyncio
+async def test_append_creates_file(storage):
+    await storage.append("new.md", "first line\n")
+    content = await storage.read("new.md")
+    assert content == "first line\n"
+
+
+@pytest.mark.asyncio
+async def test_delete(storage):
+    await storage.write("to_delete.md", "bye")
+    assert await storage.exists("to_delete.md")
+    await storage.delete("to_delete.md")
+    assert not await storage.exists("to_delete.md")
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_is_noop(storage):
+    await storage.delete("nonexistent.md")  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_exists(storage):
+    assert not await storage.exists("nope.md")
+    await storage.write("yep.md", "here")
+    assert await storage.exists("yep.md")
+
+
+@pytest.mark.asyncio
+async def test_list_files(storage):
+    await storage.write("a/one.md", "1")
+    await storage.write("a/two.md", "2")
+    await storage.write("b/three.md", "3")
+    files = await storage.list("a/")
+    assert sorted(files) == ["a/one.md", "a/two.md"]
+
+
+@pytest.mark.asyncio
+async def test_list_all(storage):
+    await storage.write("x.md", "x")
+    await storage.write("y/z.md", "z")
+    files = await storage.list()
+    assert sorted(files) == ["x.md", "y/z.md"]
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises(storage):
+    with pytest.raises(FileNotFoundError):
+        await storage.read("missing.md")
+
+
+@pytest.mark.asyncio
+async def test_full_cycle(storage):
+    """Write, read, exists, list, delete — full CRUD cycle."""
+    await storage.write("cycle/test.md", "content")
+    assert await storage.exists("cycle/test.md")
+    assert await storage.read("cycle/test.md") == "content"
+
+    files = await storage.list("cycle/")
+    assert "cycle/test.md" in files
+
+    await storage.delete("cycle/test.md")
+    assert not await storage.exists("cycle/test.md")

--- a/tests/integration/test_storage_r2_minio.py
+++ b/tests/integration/test_storage_r2_minio.py
@@ -47,7 +47,7 @@ pytestmark = pytest.mark.skipif(not _docker_available(), reason="Docker not avai
 MINIO_PORT = 9100
 MINIO_ENDPOINT = f"http://localhost:{MINIO_PORT}"
 MINIO_USER = "minioadmin"
-MINIO_PASSWORD = "minioadmin"
+MINIO_PASSWORD = "minioadmin"  # pragma: allowlist secret
 CONTAINER_NAME = "wikimind-test-minio"
 TEST_BUCKET = "wikimind-test"
 
@@ -71,7 +71,7 @@ def minio_container():
             "-e",
             f"MINIO_ROOT_USER={MINIO_USER}",
             "-e",
-            f"MINIO_ROOT_PASSWORD={MINIO_PASSWORD}",
+            f"MINIO_ROOT_PASSWORD={MINIO_PASSWORD}",  # pragma: allowlist secret
             "minio/minio",
             "server",
             "/data",
@@ -90,7 +90,7 @@ def minio_container():
         "s3",
         endpoint_url=MINIO_ENDPOINT,
         aws_access_key_id=MINIO_USER,
-        aws_secret_access_key=MINIO_PASSWORD,
+        aws_secret_access_key=MINIO_PASSWORD,  # pragma: allowlist secret
     )
 
     for _ in range(30):
@@ -125,7 +125,7 @@ def storage(minio_container):
         endpoint_url=MINIO_ENDPOINT,
         prefix="test",
         aws_access_key_id=MINIO_USER,
-        aws_secret_access_key=MINIO_PASSWORD,
+        aws_secret_access_key=MINIO_PASSWORD,  # pragma: allowlist secret
     )
 
 
@@ -140,7 +140,7 @@ def _clean_bucket(minio_container):
         "s3",
         endpoint_url=MINIO_ENDPOINT,
         aws_access_key_id=MINIO_USER,
-        aws_secret_access_key=MINIO_PASSWORD,
+        aws_secret_access_key=MINIO_PASSWORD,  # pragma: allowlist secret
     )
     paginator = client.get_paginator("list_objects_v2")
     for page in paginator.paginate(Bucket=TEST_BUCKET):

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -28,6 +27,7 @@ from wikimind.models import (
     Provider,
     RelationType,
 )
+from wikimind.storage import read_wiki, write_wiki
 
 
 def _fake_resp(name="Test"):
@@ -59,14 +59,12 @@ async def _seed_kind(s, name="topic"):
 
 
 async def _mk_art(s, tp, slug, title, concepts, summary="Sum."):
-    d = tp / "wiki" / "test"
-    d.mkdir(parents=True, exist_ok=True)
-    fp = d / f"{slug}.md"
-    fp.write_text(f"# {title}\n{summary}", encoding="utf-8")
+    relative_path = f"test/{slug}.md"
+    write_wiki(relative_path, f"# {title}\n{summary}")
     a = Article(
         slug=slug,
         title=title,
-        file_path=str(fp),
+        file_path=relative_path,
         summary=summary,
         concept_ids=json.dumps(concepts),
         page_type=PageType.SOURCE,
@@ -101,12 +99,9 @@ class TestCollectSourceArticles:
 
     async def test_excludes_concept(self, db_session, tmp_path):
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
-        d = tmp_path / "wiki" / "ml"
-        d.mkdir(parents=True, exist_ok=True)
-        fp = d / "c.md"
-        fp.write_text("# C", encoding="utf-8")
+        write_wiki("ml/c.md", "# C")
         ca = Article(
-            slug="concept-ml", title="ML", file_path=str(fp), concept_ids=json.dumps(["ml"]), page_type=PageType.CONCEPT
+            slug="concept-ml", title="ML", file_path="ml/c.md", concept_ids=json.dumps(["ml"]), page_type=PageType.CONCEPT
         )
         db_session.add(ca)
         await db_session.commit()
@@ -192,7 +187,7 @@ class TestConceptPageOutput:
         ):
             art = await ConceptCompiler().compile_concept_page(c, db_session)
         assert art is not None
-        content = (Path(tmp_path) / "wiki" / art.file_path).read_text(encoding="utf-8")
+        content = read_wiki(art.file_path)
         assert "page_type: concept" in content
         for s in [
             "## Overview",

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -101,7 +101,11 @@ class TestCollectSourceArticles:
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
         write_wiki("ml/c.md", "# C")
         ca = Article(
-            slug="concept-ml", title="ML", file_path="ml/c.md", concept_ids=json.dumps(["ml"]), page_type=PageType.CONCEPT
+            slug="concept-ml",
+            title="ML",
+            file_path="ml/c.md",
+            concept_ids=json.dumps(["ml"]),
+            page_type=PageType.CONCEPT,
         )
         db_session.add(ca)
         await db_session.commit()

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -28,6 +28,7 @@ from wikimind.models import (
     Source,
     SourceType,
 )
+from wikimind.storage import read_wiki
 
 
 def _result(claims: list[CompiledClaim] | None = None, concepts: list[str] | None = None) -> CompilationResult:
@@ -209,9 +210,7 @@ def test_write_article_file(tmp_path) -> None:
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
     rel_path = c._write_article_file(_result(), src, "test-slug", [], [])
     assert isinstance(rel_path, str)
-    full_path = Path(tmp_path) / "wiki" / rel_path
-    assert full_path.exists()
-    text = full_path.read_text()
+    text = read_wiki(rel_path)
     assert "Test Article" in text
     assert "test-slug" in text
 
@@ -234,8 +233,8 @@ def test_write_article_file_no_concepts(tmp_path) -> None:
     src = Source(source_type=SourceType.TEXT, title=None)
     rel_path = c._write_article_file(r, src, "no-concept", [], [])
     assert isinstance(rel_path, str)
-    full_path = Path(tmp_path) / "wiki" / rel_path
-    assert full_path.exists()
+    text = read_wiki(rel_path)
+    assert text  # file exists and has content
     assert "general" in rel_path
 
 
@@ -252,7 +251,8 @@ async def test_save_article(db_session, tmp_path) -> None:
     article = await c.save_article(_result(), src, db_session)
     assert article.slug
     assert not Path(article.file_path).is_absolute()  # relative path
-    assert (Path(tmp_path) / "wiki" / article.file_path).exists()
+    content = read_wiki(article.file_path)
+    assert content  # file exists and has content
     assert src.status == IngestStatus.COMPILED
 
 
@@ -381,7 +381,7 @@ async def test_save_markdown_has_resolved_link_and_unresolved_bracket(db_session
     )
     article = await compiler.save_article(result, source, db_session)
 
-    content = (Path(tmp_path) / "wiki" / article.file_path).read_text()
+    content = read_wiki(article.file_path)
     assert f"[Existing Article](/wiki/{target.id})" in content
     assert "[[Nonexistent Topic]]" in content
     assert "- [[Existing Article]]" not in content

--- a/tests/unit/test_phase2_compiler.py
+++ b/tests/unit/test_phase2_compiler.py
@@ -31,6 +31,7 @@ from wikimind.models import (
     Source,
     SourceType,
 )
+from wikimind.storage import read_wiki
 
 
 def _result(**overrides):
@@ -285,9 +286,8 @@ def test_write_article_file_includes_page_type(tmp_path):
         c = Compiler()
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
     rel_path = c._write_article_file(_result(), src, "test-slug", [], [])
-    full_path = Path(tmp_path) / "wiki" / rel_path
-    assert full_path.exists()
-    text = full_path.read_text()
+    text = read_wiki(rel_path)
+    assert text  # file exists and has content
     assert "page_type: source" in text
     assert "source_id:" in text
 

--- a/tests/unit/test_storage_r2.py
+++ b/tests/unit/test_storage_r2.py
@@ -28,7 +28,7 @@ def _make_storage(
         endpoint_url=endpoint_url,
         prefix=prefix,
         aws_access_key_id="test-key",
-        aws_secret_access_key="test-secret",
+        aws_secret_access_key="test-secret",  # pragma: allowlist secret
     )
 
 
@@ -378,7 +378,7 @@ def test_client_created_with_credentials():
         service_name="s3",
         endpoint_url="https://my-r2.example.com",
         aws_access_key_id="test-key",
-        aws_secret_access_key="test-secret",
+        aws_secret_access_key="test-secret",  # pragma: allowlist secret
     )
 
 
@@ -426,7 +426,7 @@ def test_factory_returns_r2_when_configured(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_R2_BUCKET", "my-bucket")
     monkeypatch.setenv("WIKIMIND_R2_ENDPOINT_URL", "https://r2.example.com")
     monkeypatch.setenv("WIKIMIND_AWS_ACCESS_KEY_ID", "key")
-    monkeypatch.setenv("WIKIMIND_AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("WIKIMIND_AWS_SECRET_ACCESS_KEY", "secret")  # pragma: allowlist secret
     get_settings.cache_clear()
     get_wiki_storage.cache_clear()
     get_raw_storage.cache_clear()

--- a/tests/unit/test_storage_r2.py
+++ b/tests/unit/test_storage_r2.py
@@ -1,0 +1,480 @@
+"""Tests for R2FileStorage with mocked boto3 client."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wikimind.config import get_settings
+from wikimind.storage import FileStorage, get_raw_storage, get_wiki_storage
+from wikimind.storage_r2 import R2FileStorage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(
+    bucket: str = "test-bucket",
+    endpoint_url: str = "https://r2.example.com",
+    prefix: str = "",
+) -> R2FileStorage:
+    """Create an R2FileStorage with default test params."""
+    return R2FileStorage(
+        bucket=bucket,
+        endpoint_url=endpoint_url,
+        prefix=prefix,
+        aws_access_key_id="test-key",
+        aws_secret_access_key="test-secret",
+    )
+
+
+def _mock_client() -> MagicMock:
+    """Create a mock S3 client with standard exception types."""
+    client = MagicMock()
+
+    # NoSuchKey exception class
+    no_such_key = type("NoSuchKey", (Exception,), {})
+    client.exceptions.NoSuchKey = no_such_key
+
+    # ClientError with configurable response
+    class ClientError(Exception):
+        def __init__(self, response: dict[str, Any], operation_name: str = ""):
+            self.response = response
+            super().__init__(f"{operation_name}: {response}")
+
+    client.exceptions.ClientError = ClientError
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_r2_storage_is_file_storage_protocol():
+    """R2FileStorage satisfies the FileStorage runtime protocol."""
+    storage = _make_storage()
+    assert isinstance(storage, FileStorage)
+
+
+# ---------------------------------------------------------------------------
+# Key construction
+# ---------------------------------------------------------------------------
+
+
+def test_key_no_prefix():
+    storage = _make_storage(prefix="")
+    assert storage._key("concept/article.md") == "concept/article.md"
+
+
+def test_key_with_prefix():
+    storage = _make_storage(prefix="wiki")
+    assert storage._key("concept/article.md") == "wiki/concept/article.md"
+
+
+def test_key_with_trailing_slash_prefix():
+    storage = _make_storage(prefix="wiki/")
+    assert storage._key("concept/article.md") == "wiki/concept/article.md"
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_text():
+    storage = _make_storage(prefix="wiki")
+    client = _mock_client()
+    body = MagicMock()
+    body.read.return_value = b"hello world"
+    client.get_object.return_value = {"Body": body}
+    storage._client = client
+
+    result = await storage.read("concept/article.md")
+
+    assert result == "hello world"
+    client.get_object.assert_called_once_with(Bucket="test-bucket", Key="wiki/concept/article.md")
+
+
+@pytest.mark.asyncio
+async def test_read_bytes():
+    storage = _make_storage(prefix="data")
+    client = _mock_client()
+    raw = b"\x89PNG fake"
+    body = MagicMock()
+    body.read.return_value = raw
+    client.get_object.return_value = {"Body": body}
+    storage._client = client
+
+    result = await storage.read_bytes("image.png")
+
+    assert result == raw
+    client.get_object.assert_called_once_with(Bucket="test-bucket", Key="data/image.png")
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises_file_not_found():
+    storage = _make_storage()
+    client = _mock_client()
+    client.get_object.side_effect = client.exceptions.NoSuchKey("not found")
+    storage._client = client
+
+    with pytest.raises(FileNotFoundError, match=r"missing\.md"):
+        await storage.read("missing.md")
+
+
+# ---------------------------------------------------------------------------
+# Write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_text():
+    storage = _make_storage(prefix="wiki")
+    client = _mock_client()
+    storage._client = client
+
+    await storage.write("concept/new.md", "content here")
+
+    client.put_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key="wiki/concept/new.md",
+        Body=b"content here",
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_bytes():
+    storage = _make_storage(prefix="raw")
+    client = _mock_client()
+    storage._client = client
+
+    data = b"\x00\x01\x02"
+    await storage.write_bytes("binary.dat", data)
+
+    client.put_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key="raw/binary.dat",
+        Body=data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Append (emulated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_to_existing():
+    storage = _make_storage()
+    client = _mock_client()
+    body = MagicMock()
+    body.read.return_value = b"line1\n"
+    client.get_object.return_value = {"Body": body}
+    storage._client = client
+
+    await storage.append("log.md", "line2\n")
+
+    # Should have read the existing content then written the combined result
+    client.get_object.assert_called_once()
+    client.put_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key="log.md",
+        Body=b"line1\nline2\n",
+    )
+
+
+@pytest.mark.asyncio
+async def test_append_to_new_file():
+    storage = _make_storage()
+    client = _mock_client()
+    client.get_object.side_effect = client.exceptions.NoSuchKey("not found")
+    storage._client = client
+
+    await storage.append("new.md", "first line\n")
+
+    client.put_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key="new.md",
+        Body=b"first line\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete():
+    storage = _make_storage(prefix="wiki")
+    client = _mock_client()
+    storage._client = client
+
+    await storage.delete("concept/old.md")
+
+    client.delete_object.assert_called_once_with(Bucket="test-bucket", Key="wiki/concept/old.md")
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_is_noop():
+    """delete_object is idempotent in S3 — no error on missing keys."""
+    storage = _make_storage()
+    client = _mock_client()
+    storage._client = client
+
+    await storage.delete("nonexistent.md")
+    client.delete_object.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Exists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exists_true():
+    storage = _make_storage(prefix="wiki")
+    client = _mock_client()
+    client.head_object.return_value = {}
+    storage._client = client
+
+    assert await storage.exists("concept/article.md") is True
+    client.head_object.assert_called_once_with(Bucket="test-bucket", Key="wiki/concept/article.md")
+
+
+@pytest.mark.asyncio
+async def test_exists_false():
+    storage = _make_storage()
+    client = _mock_client()
+    error_response = {"Error": {"Code": "404"}}
+    client.head_object.side_effect = client.exceptions.ClientError(error_response, "HeadObject")
+    storage._client = client
+
+    assert await storage.exists("missing.md") is False
+
+
+@pytest.mark.asyncio
+async def test_exists_no_such_key_code():
+    storage = _make_storage()
+    client = _mock_client()
+    error_response = {"Error": {"Code": "NoSuchKey"}}
+    client.head_object.side_effect = client.exceptions.ClientError(error_response, "HeadObject")
+    storage._client = client
+
+    assert await storage.exists("missing.md") is False
+
+
+@pytest.mark.asyncio
+async def test_exists_unexpected_error_propagates():
+    storage = _make_storage()
+    client = _mock_client()
+    error_response = {"Error": {"Code": "403"}}
+    client.head_object.side_effect = client.exceptions.ClientError(error_response, "HeadObject")
+    storage._client = client
+
+    with pytest.raises(client.exceptions.ClientError):
+        await storage.exists("forbidden.md")
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_with_prefix():
+    storage = _make_storage(prefix="wiki")
+    client = _mock_client()
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"Contents": [{"Key": "wiki/concept/a.md"}, {"Key": "wiki/concept/b.md"}]},
+    ]
+    client.get_paginator.return_value = paginator
+    storage._client = client
+
+    result = await storage.list("concept/")
+
+    assert sorted(result) == ["concept/a.md", "concept/b.md"]
+    paginator.paginate.assert_called_once_with(Bucket="test-bucket", Prefix="wiki/concept/")
+
+
+@pytest.mark.asyncio
+async def test_list_all():
+    storage = _make_storage(prefix="wiki")
+    client = _mock_client()
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"Contents": [{"Key": "wiki/x.md"}, {"Key": "wiki/y/z.md"}]},
+    ]
+    client.get_paginator.return_value = paginator
+    storage._client = client
+
+    result = await storage.list()
+
+    assert sorted(result) == ["x.md", "y/z.md"]
+
+
+@pytest.mark.asyncio
+async def test_list_empty_bucket():
+    storage = _make_storage()
+    client = _mock_client()
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{}]  # No Contents key
+    client.get_paginator.return_value = paginator
+    storage._client = client
+
+    result = await storage.list()
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_paginated():
+    storage = _make_storage(prefix="data")
+    client = _mock_client()
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"Contents": [{"Key": "data/a.txt"}]},
+        {"Contents": [{"Key": "data/b.txt"}, {"Key": "data/c.txt"}]},
+    ]
+    client.get_paginator.return_value = paginator
+    storage._client = client
+
+    result = await storage.list()
+
+    assert sorted(result) == ["a.txt", "b.txt", "c.txt"]
+
+
+# ---------------------------------------------------------------------------
+# Client creation (lazy)
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_client_creation():
+    """Client is not created until the first operation calls _get_client."""
+    storage = _make_storage()
+    assert storage._client is None
+
+
+def test_client_created_with_credentials():
+    """Verify boto3.client is called with the right kwargs."""
+    mock_boto3 = MagicMock()
+    storage = _make_storage(endpoint_url="https://my-r2.example.com")
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        storage._get_client()
+
+    mock_boto3.client.assert_called_once_with(
+        service_name="s3",
+        endpoint_url="https://my-r2.example.com",
+        aws_access_key_id="test-key",
+        aws_secret_access_key="test-secret",
+    )
+
+
+def test_client_created_without_credentials():
+    """Verify boto3.client omits credentials when not provided."""
+    mock_boto3 = MagicMock()
+    storage = R2FileStorage(
+        bucket="test-bucket",
+        endpoint_url="https://r2.example.com",
+    )
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        storage._get_client()
+
+    mock_boto3.client.assert_called_once_with(
+        service_name="s3",
+        endpoint_url="https://r2.example.com",
+    )
+
+
+def test_client_cached():
+    """Verify the client is created only once and then reused."""
+    mock_boto3 = MagicMock()
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+    storage = _make_storage()
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        c1 = storage._get_client()
+        c2 = storage._get_client()
+
+    assert c1 is c2
+    assert mock_boto3.client.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Factory integration (storage.py get_wiki_storage / get_raw_storage)
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_r2_when_configured(tmp_path, monkeypatch):
+    """get_wiki_storage returns R2FileStorage when storage_backend=r2."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WIKIMIND_STORAGE_BACKEND", "r2")
+    monkeypatch.setenv("WIKIMIND_R2_BUCKET", "my-bucket")
+    monkeypatch.setenv("WIKIMIND_R2_ENDPOINT_URL", "https://r2.example.com")
+    monkeypatch.setenv("WIKIMIND_AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("WIKIMIND_AWS_SECRET_ACCESS_KEY", "secret")
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+    get_raw_storage.cache_clear()
+
+    try:
+        wiki = get_wiki_storage()
+        raw = get_raw_storage()
+        assert isinstance(wiki, R2FileStorage)
+        assert isinstance(raw, R2FileStorage)
+        assert wiki.bucket == "my-bucket"
+        assert wiki.prefix == "wiki/"
+        assert raw.prefix == "raw/"
+    finally:
+        get_settings.cache_clear()
+        get_wiki_storage.cache_clear()
+        get_raw_storage.cache_clear()
+
+
+def test_factory_raises_without_bucket(tmp_path, monkeypatch):
+    """get_wiki_storage raises ValueError when r2 backend is missing bucket config."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WIKIMIND_STORAGE_BACKEND", "r2")
+    # No bucket or endpoint set
+    monkeypatch.delenv("WIKIMIND_R2_BUCKET", raising=False)
+    monkeypatch.delenv("WIKIMIND_R2_ENDPOINT_URL", raising=False)
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+
+    try:
+        with pytest.raises(ValueError, match="R2_BUCKET"):
+            get_wiki_storage()
+    finally:
+        get_settings.cache_clear()
+        get_wiki_storage.cache_clear()
+
+
+def test_factory_raises_without_endpoint(tmp_path, monkeypatch):
+    """get_wiki_storage raises ValueError when r2 backend is missing endpoint config."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WIKIMIND_STORAGE_BACKEND", "r2")
+    monkeypatch.setenv("WIKIMIND_R2_BUCKET", "my-bucket")
+    monkeypatch.delenv("WIKIMIND_R2_ENDPOINT_URL", raising=False)
+    get_settings.cache_clear()
+    get_wiki_storage.cache_clear()
+
+    try:
+        with pytest.raises(ValueError, match="R2_ENDPOINT_URL"):
+            get_wiki_storage()
+    finally:
+        get_settings.cache_clear()
+        get_wiki_storage.cache_clear()


### PR DESCRIPTION
## Summary

- Adds `R2FileStorage` class in `src/wikimind/storage_r2.py` implementing the `FileStorage` protocol using boto3 (S3-compatible)
- All boto3 calls wrapped in `asyncio.to_thread()` for async compatibility
- Factories (`get_wiki_storage()`, `get_raw_storage()`) now return R2 or Local based on `WIKIMIND_STORAGE_BACKEND` config
- Lazy import of R2FileStorage — boto3 never imported when running local mode
- 28 new unit tests (mocked boto3) + MinIO integration tests (Docker, auto-skipped if unavailable)

## Config additions

```
WIKIMIND_STORAGE_BACKEND=local  # or "r2"
WIKIMIND_R2_BUCKET=my-bucket
WIKIMIND_R2_ENDPOINT_URL=https://<account>.r2.cloudflarestorage.com
WIKIMIND_AWS_ACCESS_KEY_ID=...
WIKIMIND_AWS_SECRET_ACCESS_KEY=...
```

## Context

PR 3 of 3 for cloud deployment (#28). Depends on PR 1 (FileStorage abstraction, #170).

- ADR-020 created: cloud storage abstraction decision
- ADR-004 amended: files can now live in R2

## Test plan

- [ ] `WIKIMIND_STORAGE_BACKEND=local` (default) → zero behavior change, all existing tests pass
- [ ] `WIKIMIND_STORAGE_BACKEND=r2` with R2 credentials → files stored in R2 bucket
- [ ] MinIO integration: `pytest tests/integration/test_storage_r2_minio.py -v` (requires Docker)
- [ ] Second WikiMind instance with same Postgres + R2 config sees the same wiki