### PR TITLE
refactor: split LLM providers into separate files, migrate Google to genai SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # LLM providers
     "anthropic>=0.40.0",
     "openai>=1.54.3",
-    "google-generativeai>=0.8.3",
+    "google-genai>=1.0.0",
     "ollama>=0.3.3",
 
     # Document processing (docling is in [pdf] extra — see below)

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -7,19 +7,13 @@ Handles selection, fallback, cost tracking, and token budgeting.
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
-import anthropic
-import google.generativeai as genai
-import ollama
-import openai
 import structlog
-from google.generativeai.types import GenerationConfig
 from sqlalchemy import func
 from sqlmodel import select
 
@@ -33,7 +27,7 @@ log = structlog.get_logger()
 
 
 # ---------------------------------------------------------------------------
-# Pricing (USD per 1M tokens) — update as providers change pricing
+# Pricing (USD per 1M tokens) -- update as providers change pricing
 # ---------------------------------------------------------------------------
 
 PRICING = {
@@ -49,22 +43,23 @@ PRICING = {
         "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
     },
     Provider.OLLAMA: {
-        "*": {"input": 0.0, "output": 0.0},  # Free — local
+        "*": {"input": 0.0, "output": 0.0},  # Free -- local
     },
     Provider.MOCK: {
-        "*": {"input": 0.0, "output": 0.0},  # Free — deterministic
+        "*": {"input": 0.0, "output": 0.0},  # Free -- deterministic
     },
 }
 
 
 def _calc_cost(provider: Provider, model: str, input_tokens: int, output_tokens: int) -> float:
+    """Calculate the USD cost of an LLM call based on token counts."""
     provider_pricing = PRICING.get(provider, {})
     model_pricing = provider_pricing.get(model) or provider_pricing.get("*", {"input": 0, "output": 0})
     return (input_tokens * model_pricing["input"] + output_tokens * model_pricing["output"]) / 1_000_000
 
 
 # ---------------------------------------------------------------------------
-# StreamSession — wraps a streaming LLM response
+# StreamSession -- wraps a streaming LLM response
 # ---------------------------------------------------------------------------
 
 
@@ -84,720 +79,21 @@ class StreamSession:
 
 
 # ---------------------------------------------------------------------------
-# Provider implementations
+# Provider imports -- each provider lives in its own file under providers/
 # ---------------------------------------------------------------------------
 
-
-class AnthropicProvider:
-    """Anthropic LLM provider."""
-
-    def __init__(self):
-        api_key = get_api_key("anthropic")
-        if not api_key:
-            raise ValueError("Anthropic API key not configured")
-        self.client = anthropic.AsyncAnthropic(api_key=api_key)
-
-    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
-        """Complete a request using Anthropic."""
-        start = time.monotonic()
-
-        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]
-
-        response = await self.client.messages.create(
-            model=model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            system=request.system,
-            messages=messages,  # type: ignore[arg-type]
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.content[0].text  # type: ignore[union-attr]
-        input_tokens = response.usage.input_tokens
-        output_tokens = response.usage.output_tokens
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.ANTHROPIC,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.ANTHROPIC, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def complete_multimodal(
-        self,
-        system: str,
-        content_parts: list[dict[str, Any]],
-        model: str,
-        max_tokens: int = 4096,
-        temperature: float = 0.3,
-    ) -> CompletionResponse:
-        """Complete a multimodal request with text and images using Anthropic.
-
-        Args:
-            system: System prompt.
-            content_parts: List of content blocks. Each block is either
-                ``{"type": "text", "text": "..."}`` or
-                ``{"type": "image", "source": {"type": "base64",
-                "media_type": "image/png", "data": "..."}}``.
-            model: Model name to use.
-            max_tokens: Maximum output tokens.
-            temperature: Sampling temperature.
-
-        Returns:
-            CompletionResponse with the LLM's text output.
-        """
-        start = time.monotonic()
-
-        response = await self.client.messages.create(
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            system=system,
-            messages=[{"role": "user", "content": content_parts}],  # type: ignore[arg-type,typeddict-item]
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.content[0].text  # type: ignore[union-attr]
-        input_tokens = response.usage.input_tokens
-        output_tokens = response.usage.output_tokens
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.ANTHROPIC,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.ANTHROPIC, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
-        """Stream a completion request using Anthropic."""
-        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]
-        start = time.monotonic()
-
-        async def _generate() -> AsyncIterator[str]:
-            async with self.client.messages.stream(
-                model=model,
-                max_tokens=request.max_tokens,
-                temperature=request.temperature,
-                system=request.system,
-                messages=messages,  # type: ignore[arg-type]
-            ) as stream_ctx:
-                async for text in stream_ctx.text_stream:
-                    yield text
-
-                final = await stream_ctx.get_final_message()
-                latency_ms = int((time.monotonic() - start) * 1000)
-                input_tokens = final.usage.input_tokens
-                output_tokens = final.usage.output_tokens
-                full_text = "".join(getattr(block, "text", "") for block in final.content)
-                session.result = CompletionResponse(
-                    content=full_text,
-                    provider_used=Provider.ANTHROPIC,
-                    model_used=model,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    cost_usd=_calc_cost(Provider.ANTHROPIC, model, input_tokens, output_tokens),
-                    latency_ms=latency_ms,
-                )
-
-        session = StreamSession(_chunks=_generate())
-        return session
-
-
-class OpenAIProvider:
-    """OpenAI LLM provider."""
-
-    def __init__(self):
-        api_key = get_api_key("openai")
-        if not api_key:
-            raise ValueError("OpenAI API key not configured")
-        self.client = openai.AsyncOpenAI(api_key=api_key)
-
-    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
-        """Complete a request using OpenAI."""
-        start = time.monotonic()
-
-        messages = [{"role": "system", "content": request.system}]
-        messages.extend(request.messages)
-
-        kwargs: dict[str, object] = dict(
-            model=model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            messages=messages,
-        )
-        if request.response_format == "json":
-            kwargs["response_format"] = {"type": "json_object"}
-
-        response = await self.client.chat.completions.create(**kwargs)  # type: ignore[call-overload]
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.choices[0].message.content
-        input_tokens = response.usage.prompt_tokens
-        output_tokens = response.usage.completion_tokens
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.OPENAI,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def complete_multimodal(
-        self,
-        system: str,
-        content_parts: list[dict[str, Any]],
-        model: str,
-        max_tokens: int = 4096,
-        temperature: float = 0.3,
-    ) -> CompletionResponse:
-        """Complete a multimodal request with text and images using OpenAI.
-
-        Translates the Anthropic-style content blocks to OpenAI's
-        ``image_url`` format before calling the API.
-
-        Args:
-            system: System prompt.
-            content_parts: List of content blocks in Anthropic format.
-            model: Model name to use.
-            max_tokens: Maximum output tokens.
-            temperature: Sampling temperature.
-
-        Returns:
-            CompletionResponse with the LLM's text output.
-        """
-        start = time.monotonic()
-
-        # Translate Anthropic content blocks to OpenAI format
-        openai_parts: list[dict[str, Any]] = []
-        for part in content_parts:
-            if part["type"] == "text":
-                openai_parts.append({"type": "text", "text": part["text"]})
-            elif part["type"] == "image":
-                media_type = part["source"]["media_type"]
-                data = part["source"]["data"]
-                openai_parts.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:{media_type};base64,{data}"},
-                    }
-                )
-
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": openai_parts},
-        ]
-
-        response = await self.client.chat.completions.create(
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=messages,  # type: ignore[arg-type]
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.choices[0].message.content
-        input_tokens = response.usage.prompt_tokens if response.usage else 0
-        output_tokens = response.usage.completion_tokens if response.usage else 0
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.OPENAI,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
-        """Stream a completion request using OpenAI."""
-        messages: list[dict[str, str]] = [{"role": "system", "content": request.system}]
-        messages.extend(request.messages)
-        start = time.monotonic()
-
-        kwargs: dict[str, object] = dict(
-            model=model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            messages=messages,
-            stream=True,
-            stream_options={"include_usage": True},
-        )
-        if request.response_format == "json":
-            kwargs["response_format"] = {"type": "json_object"}
-
-        async def _generate() -> AsyncIterator[str]:
-            full_text_parts: list[str] = []
-            input_tokens = 0
-            output_tokens = 0
-            response_stream = await self.client.chat.completions.create(
-                **kwargs  # type: ignore[call-overload]
-            )
-            async for chunk in response_stream:  # type: ignore[union-attr]
-                if chunk.usage:
-                    input_tokens = chunk.usage.prompt_tokens or 0
-                    output_tokens = chunk.usage.completion_tokens or 0
-                if chunk.choices and chunk.choices[0].delta.content:
-                    text = chunk.choices[0].delta.content
-                    full_text_parts.append(text)
-                    yield text
-
-            latency_ms = int((time.monotonic() - start) * 1000)
-            session.result = CompletionResponse(
-                content="".join(full_text_parts),
-                provider_used=Provider.OPENAI,
-                model_used=model,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
-                latency_ms=latency_ms,
-            )
-
-        session = StreamSession(_chunks=_generate())
-        return session
-
-
-class OllamaProvider:
-    """Ollama local LLM provider."""
-
-    def __init__(self, base_url: str):
-        self.client = ollama.AsyncClient(host=base_url)
-
-    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
-        """Complete a request using Ollama."""
-        start = time.monotonic()
-
-        messages = [{"role": "system", "content": request.system}]
-        messages.extend(request.messages)
-
-        response = await self.client.chat(
-            model=model,
-            messages=messages,
-            options={"temperature": request.temperature},
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response["message"]["content"]
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.OLLAMA,
-            model_used=model,
-            input_tokens=0,
-            output_tokens=0,
-            cost_usd=0.0,
-            latency_ms=latency_ms,
-        )
-
-    async def complete_multimodal(
-        self,
-        system: str,
-        content_parts: list[dict[str, Any]],
-        model: str,
-        max_tokens: int = 4096,
-        temperature: float = 0.3,
-    ) -> CompletionResponse:
-        """Complete a multimodal request using Ollama.
-
-        Ollama accepts images as base64 strings in the ``images`` field
-        of a message.
-
-        Args:
-            system: System prompt.
-            content_parts: List of content blocks in Anthropic format.
-            model: Model name to use.
-            max_tokens: Maximum output tokens.
-            temperature: Sampling temperature.
-
-        Returns:
-            CompletionResponse with the LLM's text output.
-        """
-        start = time.monotonic()
-
-        # Extract text and images from content parts
-        text_parts: list[str] = []
-        images: list[str] = []
-        for part in content_parts:
-            if part["type"] == "text":
-                text_parts.append(part["text"])
-            elif part["type"] == "image":
-                images.append(part["source"]["data"])
-
-        user_content = "\n".join(text_parts) if text_parts else "Describe these images."
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user_content, "images": images},
-        ]
-
-        response = await self.client.chat(
-            model=model,
-            messages=messages,  # type: ignore[arg-type]
-            options={"temperature": temperature},
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response["message"]["content"]
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.OLLAMA,
-            model_used=model,
-            input_tokens=0,
-            output_tokens=0,
-            cost_usd=0.0,
-            latency_ms=latency_ms,
-        )
-
-    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
-        """Stream a completion request using Ollama."""
-        messages: list[dict[str, str]] = [{"role": "system", "content": request.system}]
-        messages.extend(request.messages)
-        start = time.monotonic()
-
-        async def _generate() -> AsyncIterator[str]:
-            full_text_parts: list[str] = []
-            response_stream = await self.client.chat(
-                model=model,
-                messages=messages,
-                options={"temperature": request.temperature},
-                stream=True,
-            )
-            async for chunk in response_stream:  # type: ignore[union-attr]
-                text = chunk["message"]["content"]
-                if text:
-                    full_text_parts.append(text)
-                    yield text
-
-            latency_ms = int((time.monotonic() - start) * 1000)
-            session.result = CompletionResponse(
-                content="".join(full_text_parts),
-                provider_used=Provider.OLLAMA,
-                model_used=model,
-                input_tokens=0,
-                output_tokens=0,
-                cost_usd=0.0,
-                latency_ms=latency_ms,
-            )
-
-        session = StreamSession(_chunks=_generate())
-        return session
-
-
-class GoogleProvider:
-    """Google Gemini LLM provider."""
-
-    def __init__(self) -> None:
-        api_key = get_api_key("google")
-        if not api_key:
-            raise ValueError("Google API key not configured")
-        genai.configure(api_key=api_key)
-
-    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
-        """Complete a request using Google Gemini."""
-        start = time.monotonic()
-
-        gen_model = genai.GenerativeModel(model, system_instruction=request.system)
-
-        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
-
-        gen_cfg_kwargs: dict[str, Any] = {
-            "max_output_tokens": request.max_tokens,
-            "temperature": request.temperature,
-        }
-        if request.response_format == "json":
-            gen_cfg_kwargs["response_mime_type"] = "application/json"
-
-        response = await gen_model.generate_content_async(
-            contents,
-            generation_config=GenerationConfig(**gen_cfg_kwargs),
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.text
-        usage = response.usage_metadata
-        input_tokens = usage.prompt_token_count if usage else 0
-        output_tokens = usage.candidates_token_count if usage else 0
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.GOOGLE,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def complete_multimodal(
-        self,
-        system: str,
-        content_parts: list[dict[str, Any]],
-        model: str,
-        max_tokens: int = 4096,
-        temperature: float = 0.3,
-    ) -> CompletionResponse:
-        """Complete a multimodal request with text and images using Google Gemini.
-
-        Translates the Anthropic-style content blocks to Google's inline
-        data format before calling the API.
-
-        Args:
-            system: System prompt.
-            content_parts: List of content blocks in Anthropic format.
-            model: Model name to use.
-            max_tokens: Maximum output tokens.
-            temperature: Sampling temperature.
-
-        Returns:
-            CompletionResponse with the LLM's text output.
-        """
-        start = time.monotonic()
-
-        gen_model = genai.GenerativeModel(model, system_instruction=system)
-
-        # Translate Anthropic content blocks to Google format
-        google_parts: list[str | dict[str, str | bytes]] = []
-        for part in content_parts:
-            if part["type"] == "text":
-                google_parts.append(part["text"])
-            elif part["type"] == "image":
-                media_type = part["source"]["media_type"]
-                data_b64 = part["source"]["data"]
-                google_parts.append(
-                    {
-                        "mime_type": media_type,
-                        "data": base64.b64decode(data_b64),
-                    }
-                )
-
-        response = await gen_model.generate_content_async(
-            google_parts,
-            generation_config=GenerationConfig(
-                max_output_tokens=max_tokens,
-                temperature=temperature,
-            ),
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.text
-        usage = response.usage_metadata
-        input_tokens = usage.prompt_token_count if usage else 0
-        output_tokens = usage.candidates_token_count if usage else 0
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.GOOGLE,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
-        """Stream a completion request using Google Gemini."""
-        start = time.monotonic()
-
-        gen_model = genai.GenerativeModel(model, system_instruction=request.system)
-
-        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
-
-        gen_cfg_kwargs: dict[str, Any] = {
-            "max_output_tokens": request.max_tokens,
-            "temperature": request.temperature,
-        }
-        if request.response_format == "json":
-            gen_cfg_kwargs["response_mime_type"] = "application/json"
-
-        async def _generate() -> AsyncIterator[str]:
-            full_text_parts: list[str] = []
-            input_tokens = 0
-            output_tokens = 0
-
-            response = await gen_model.generate_content_async(
-                contents,
-                generation_config=GenerationConfig(**gen_cfg_kwargs),
-                stream=True,
-            )
-            async for chunk in response:
-                text = chunk.text
-                if text:
-                    full_text_parts.append(text)
-                    yield text
-                if chunk.usage_metadata:
-                    if chunk.usage_metadata.prompt_token_count:
-                        input_tokens = chunk.usage_metadata.prompt_token_count
-                    if chunk.usage_metadata.candidates_token_count:
-                        output_tokens = chunk.usage_metadata.candidates_token_count
-
-            latency_ms = int((time.monotonic() - start) * 1000)
-            session.result = CompletionResponse(
-                content="".join(full_text_parts),
-                provider_used=Provider.GOOGLE,
-                model_used=model,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
-                latency_ms=latency_ms,
-            )
-
-        session = StreamSession(_chunks=_generate())
-        return session
-
-
-class MockProvider:
-    """Deterministic mock provider for CI e2e testing.
-
-    Returns canned JSON keyed off the TaskType so callers that expect
-    CompilationResult / QueryResult shapes can parse the response
-    without a real LLM. Zero cost, zero network, fully deterministic.
-
-    Must be explicitly enabled via ``WIKIMIND_LLM__MOCK__ENABLED=true``
-    AND set as the default provider via ``WIKIMIND_LLM__DEFAULT_PROVIDER=mock``
-    to be selected — disabled by default so it cannot silently
-    intercept real traffic.
-    """
-
-    def __init__(self) -> None:
-        # No config needed; all responses are canned
-        pass
-
-    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
-        """Return a deterministic canned response matching the request's task type."""
-        start = time.monotonic()
-        content = self._response_for(request)
-        latency_ms = int((time.monotonic() - start) * 1000)
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.MOCK,
-            model_used=model,
-            input_tokens=0,
-            output_tokens=0,
-            cost_usd=0.0,
-            latency_ms=latency_ms,
-        )
-
-    async def complete_multimodal(
-        self,
-        system: str,
-        content_parts: list[dict[str, Any]],
-        model: str,
-        max_tokens: int = 4096,
-        temperature: float = 0.3,
-    ) -> CompletionResponse:
-        """Return a deterministic description for each image in the request."""
-        start = time.monotonic()
-        # Count images and return one description per image
-        image_count = sum(1 for p in content_parts if p.get("type") == "image")
-        descriptions = [
-            f"[Page {i + 1} description: A visual slide with diagrams and minimal text.]" for i in range(image_count)
-        ]
-        content = "\n\n".join(descriptions) if descriptions else "No images provided."
-        latency_ms = int((time.monotonic() - start) * 1000)
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.MOCK,
-            model_used=model,
-            input_tokens=0,
-            output_tokens=0,
-            cost_usd=0.0,
-            latency_ms=latency_ms,
-        )
-
-    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
-        """Stream a deterministic canned response in small chunks."""
-        content = self._response_for(request)
-        start = time.monotonic()
-        chunk_size = 20
-
-        async def _generate() -> AsyncIterator[str]:
-            for i in range(0, len(content), chunk_size):
-                yield content[i : i + chunk_size]
-
-            latency_ms = int((time.monotonic() - start) * 1000)
-            session.result = CompletionResponse(
-                content=content,
-                provider_used=Provider.MOCK,
-                model_used=model,
-                input_tokens=0,
-                output_tokens=0,
-                cost_usd=0.0,
-                latency_ms=latency_ms,
-            )
-
-        session = StreamSession(_chunks=_generate())
-        return session
-
-    @staticmethod
-    def _response_for(request: CompletionRequest) -> str:
-        """Return a canned response body matching the task's expected shape."""
-        if request.task_type == TaskType.COMPILE:
-            return json.dumps(_MOCK_COMPILE_RESPONSE)
-        if request.task_type == TaskType.QA:
-            return json.dumps(_MOCK_QA_RESPONSE)
-        if request.task_type == TaskType.LINT:
-            return json.dumps(_MOCK_LINT_RESPONSE)
-        # Unknown task type: return an empty JSON object so parse_json_response
-        # doesn't crash. Tests that need specific shapes should add a mock
-        # for their task type.
-        return "{}"
-
-
-# Canned responses used by MockProvider. Defined at module level so tests
-# can import and assert against them directly.
-_MOCK_COMPILE_RESPONSE: dict = {
-    "title": "Mock Article",
-    "summary": "A deterministic summary produced by the mock LLM provider for testing.",
-    "key_claims": [
-        {
-            "claim": "This article was produced by the mock LLM provider.",
-            "confidence": "sourced",
-            "quote": "mock provider",
-        }
-    ],
-    "concepts": ["testing", "mock"],
-    "backlink_suggestions": [],
-    "open_questions": ["What is real?"],
-    "article_body": (
-        "## Mock Article\n\n"
-        "This article was produced by the mock LLM provider for deterministic "
-        "e2e testing.\n\n"
-        "## Details\n\n"
-        "The mock provider returns canned responses regardless of input, "
-        "enabling CI to run the full Ask loop without a real LLM API."
-    ),
-}
-
-_MOCK_QA_RESPONSE: dict = {
-    "answer": (
-        "This is a mock answer from the WikiMind mock LLM provider. "
-        "Your question was received and processed deterministically "
-        "for testing purposes."
-    ),
-    "confidence": "high",
-    "sources": ["Mock Article"],
-    "related_articles": [],
-    "new_article_suggested": None,
-    "follow_up_questions": [],
-}
-
-_MOCK_LINT_RESPONSE: dict = {
-    "contradictions": [],
-    "stale_claims": [],
-    "orphan_articles": [],
-    "missing_pages": [],
-    "data_gaps": [],
-}
-
+from wikimind.engine.providers import (  # noqa: E402
+    AnthropicProvider,
+    GoogleProvider,
+    MockProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
+from wikimind.engine.providers.mock import (  # noqa: E402, F401 -- backward compat re-exports
+    _MOCK_COMPILE_RESPONSE,
+    _MOCK_LINT_RESPONSE,
+    _MOCK_QA_RESPONSE,
+)
 
 # ---------------------------------------------------------------------------
 # Router
@@ -834,6 +130,7 @@ class LLMRouter:
         return order
 
     def _is_provider_available(self, provider: Provider) -> bool:
+        """Check if a provider is enabled and has credentials."""
         cfg = getattr(self.settings.llm, provider.value, None)
         if not cfg or not cfg.enabled:
             return False
@@ -842,6 +139,7 @@ class LLMRouter:
         return bool(get_api_key(provider.value))
 
     async def _get_provider_instance(self, provider: Provider):
+        """Create and return a provider instance."""
         if provider == Provider.ANTHROPIC:
             return AnthropicProvider()
         elif provider == Provider.OPENAI:
@@ -856,10 +154,12 @@ class LLMRouter:
             raise ValueError(f"Provider {provider} not implemented yet")
 
     def _get_model(self, provider: Provider) -> str:
+        """Return the configured model name for a provider."""
         cfg = getattr(self.settings.llm, provider.value, None)
         return cfg.model if cfg else "unknown"
 
     async def _check_budget(self) -> None:
+        """Check monthly budget and emit warnings if thresholds are exceeded."""
         if self._budget_warning_sent and self._budget_exceeded_sent:
             return
 

--- a/src/wikimind/engine/providers/__init__.py
+++ b/src/wikimind/engine/providers/__init__.py
@@ -3,21 +3,21 @@
 from wikimind.engine.providers.anthropic import AnthropicProvider
 from wikimind.engine.providers.google import GoogleProvider
 from wikimind.engine.providers.mock import (
-    MockProvider,
     _MOCK_COMPILE_RESPONSE,
     _MOCK_LINT_RESPONSE,
     _MOCK_QA_RESPONSE,
+    MockProvider,
 )
 from wikimind.engine.providers.ollama import OllamaProvider
 from wikimind.engine.providers.openai import OpenAIProvider
 
 __all__ = [
+    "_MOCK_COMPILE_RESPONSE",
+    "_MOCK_LINT_RESPONSE",
+    "_MOCK_QA_RESPONSE",
     "AnthropicProvider",
     "GoogleProvider",
     "MockProvider",
     "OllamaProvider",
     "OpenAIProvider",
-    "_MOCK_COMPILE_RESPONSE",
-    "_MOCK_QA_RESPONSE",
-    "_MOCK_LINT_RESPONSE",
 ]

--- a/src/wikimind/engine/providers/__init__.py
+++ b/src/wikimind/engine/providers/__init__.py
@@ -1,0 +1,23 @@
+"""LLM provider implementations."""
+
+from wikimind.engine.providers.anthropic import AnthropicProvider
+from wikimind.engine.providers.google import GoogleProvider
+from wikimind.engine.providers.mock import (
+    MockProvider,
+    _MOCK_COMPILE_RESPONSE,
+    _MOCK_LINT_RESPONSE,
+    _MOCK_QA_RESPONSE,
+)
+from wikimind.engine.providers.ollama import OllamaProvider
+from wikimind.engine.providers.openai import OpenAIProvider
+
+__all__ = [
+    "AnthropicProvider",
+    "GoogleProvider",
+    "MockProvider",
+    "OllamaProvider",
+    "OpenAIProvider",
+    "_MOCK_COMPILE_RESPONSE",
+    "_MOCK_QA_RESPONSE",
+    "_MOCK_LINT_RESPONSE",
+]

--- a/src/wikimind/engine/providers/anthropic.py
+++ b/src/wikimind/engine/providers/anthropic.py
@@ -1,0 +1,134 @@
+"""Anthropic LLM provider."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import anthropic
+
+from wikimind.config import get_api_key
+from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.models import CompletionRequest, CompletionResponse, Provider
+
+
+class AnthropicProvider:
+    """Anthropic LLM provider."""
+
+    def __init__(self):
+        api_key = get_api_key("anthropic")
+        if not api_key:
+            raise ValueError("Anthropic API key not configured")
+        self.client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Complete a request using Anthropic."""
+        start = time.monotonic()
+
+        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]
+
+        response = await self.client.messages.create(
+            model=model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            system=request.system,
+            messages=messages,  # type: ignore[arg-type]
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.content[0].text  # type: ignore[union-attr]
+        input_tokens = response.usage.input_tokens
+        output_tokens = response.usage.output_tokens
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.ANTHROPIC,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.ANTHROPIC, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Complete a multimodal request with text and images using Anthropic.
+
+        Args:
+            system: System prompt.
+            content_parts: List of content blocks. Each block is either
+                ``{"type": "text", "text": "..."}`` or
+                ``{"type": "image", "source": {"type": "base64",
+                "media_type": "image/png", "data": "..."}}``.
+            model: Model name to use.
+            max_tokens: Maximum output tokens.
+            temperature: Sampling temperature.
+
+        Returns:
+            CompletionResponse with the LLM's text output.
+        """
+        start = time.monotonic()
+
+        response = await self.client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system,
+            messages=[{"role": "user", "content": content_parts}],  # type: ignore[arg-type,typeddict-item]
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.content[0].text  # type: ignore[union-attr]
+        input_tokens = response.usage.input_tokens
+        output_tokens = response.usage.output_tokens
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.ANTHROPIC,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.ANTHROPIC, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a completion request using Anthropic."""
+        messages = [{"role": m["role"], "content": m["content"]} for m in request.messages]
+        start = time.monotonic()
+
+        async def _generate() -> AsyncIterator[str]:
+            async with self.client.messages.stream(
+                model=model,
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+                system=request.system,
+                messages=messages,  # type: ignore[arg-type]
+            ) as stream_ctx:
+                async for text in stream_ctx.text_stream:
+                    yield text
+
+                final = await stream_ctx.get_final_message()
+                latency_ms = int((time.monotonic() - start) * 1000)
+                input_tokens = final.usage.input_tokens
+                output_tokens = final.usage.output_tokens
+                full_text = "".join(getattr(block, "text", "") for block in final.content)
+                session.result = CompletionResponse(
+                    content=full_text,
+                    provider_used=Provider.ANTHROPIC,
+                    model_used=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cost_usd=_calc_cost(Provider.ANTHROPIC, model, input_tokens, output_tokens),
+                    latency_ms=latency_ms,
+                )
+
+        session = StreamSession(_chunks=_generate())
+        return session

--- a/src/wikimind/engine/providers/google.py
+++ b/src/wikimind/engine/providers/google.py
@@ -1,0 +1,175 @@
+"""Google Gemini LLM provider using the google.genai SDK."""
+
+from __future__ import annotations
+
+import base64
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from google import genai
+from google.genai import types
+
+from wikimind.config import get_api_key
+from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.models import CompletionRequest, CompletionResponse, Provider
+
+
+class GoogleProvider:
+    """Google Gemini LLM provider."""
+
+    def __init__(self) -> None:
+        api_key = get_api_key("google")
+        if not api_key:
+            raise ValueError("Google API key not configured")
+        self.client = genai.Client(api_key=api_key)
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Complete a request using Google Gemini."""
+        start = time.monotonic()
+
+        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
+
+        config_kwargs: dict[str, Any] = {
+            "system_instruction": request.system,
+            "max_output_tokens": request.max_tokens,
+            "temperature": request.temperature,
+        }
+        if request.response_format == "json":
+            config_kwargs["response_mime_type"] = "application/json"
+
+        response = await self.client.aio.models.generate_content(
+            model=model,
+            contents=contents,  # type: ignore[arg-type]
+            config=types.GenerateContentConfig(**config_kwargs),
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.text
+        usage = response.usage_metadata
+        input_tokens = (usage.prompt_token_count or 0) if usage else 0
+        output_tokens = (usage.candidates_token_count or 0) if usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.GOOGLE,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Complete a multimodal request with text and images using Google Gemini.
+
+        Translates the Anthropic-style content blocks to Google's
+        ``types.Part.from_bytes`` format before calling the API.
+
+        Args:
+            system: System prompt.
+            content_parts: List of content blocks in Anthropic format.
+            model: Model name to use.
+            max_tokens: Maximum output tokens.
+            temperature: Sampling temperature.
+
+        Returns:
+            CompletionResponse with the LLM's text output.
+        """
+        start = time.monotonic()
+
+        # Translate Anthropic content blocks to Google format
+        google_parts: list = []
+        for part in content_parts:
+            if part["type"] == "text":
+                google_parts.append(part["text"])
+            elif part["type"] == "image":
+                media_type = part["source"]["media_type"]
+                data_b64 = part["source"]["data"]
+                google_parts.append(
+                    types.Part.from_bytes(
+                        data=base64.b64decode(data_b64),
+                        mime_type=media_type,
+                    )
+                )
+
+        response = await self.client.aio.models.generate_content(
+            model=model,
+            contents=google_parts,
+            config=types.GenerateContentConfig(
+                system_instruction=system,
+                max_output_tokens=max_tokens,
+                temperature=temperature,
+            ),
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.text
+        usage = response.usage_metadata
+        input_tokens = (usage.prompt_token_count or 0) if usage else 0
+        output_tokens = (usage.candidates_token_count or 0) if usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.GOOGLE,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a completion request using Google Gemini."""
+        start = time.monotonic()
+
+        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
+
+        config_kwargs: dict[str, Any] = {
+            "system_instruction": request.system,
+            "max_output_tokens": request.max_tokens,
+            "temperature": request.temperature,
+        }
+        if request.response_format == "json":
+            config_kwargs["response_mime_type"] = "application/json"
+
+        async def _generate() -> AsyncIterator[str]:
+            full_text_parts: list[str] = []
+            input_tokens = 0
+            output_tokens = 0
+
+            async for chunk in await self.client.aio.models.generate_content_stream(
+                model=model,
+                contents=contents,  # type: ignore[arg-type]
+                config=types.GenerateContentConfig(**config_kwargs),
+            ):
+                text = chunk.text
+                if text:
+                    full_text_parts.append(text)
+                    yield text
+                if chunk.usage_metadata:
+                    if chunk.usage_metadata.prompt_token_count:
+                        input_tokens = chunk.usage_metadata.prompt_token_count
+                    if chunk.usage_metadata.candidates_token_count:
+                        output_tokens = chunk.usage_metadata.candidates_token_count
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            session.result = CompletionResponse(
+                content="".join(full_text_parts),
+                provider_used=Provider.GOOGLE,
+                model_used=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=_calc_cost(Provider.GOOGLE, model, input_tokens, output_tokens),
+                latency_ms=latency_ms,
+            )
+
+        session = StreamSession(_chunks=_generate())
+        return session

--- a/src/wikimind/engine/providers/google.py
+++ b/src/wikimind/engine/providers/google.py
@@ -53,7 +53,7 @@ class GoogleProvider:
 
         response = await self.client.aio.models.generate_content(
             model=model,
-            contents=contents,
+            contents=contents,  # type: ignore[arg-type]
             config=types.GenerateContentConfig(**config_kwargs),
         )
 
@@ -170,7 +170,7 @@ class GoogleProvider:
 
             async for chunk in await self.client.aio.models.generate_content_stream(
                 model=model,
-                contents=contents,
+                contents=contents,  # type: ignore[arg-type]
                 config=types.GenerateContentConfig(**config_kwargs),
             ):
                 text = chunk.text

--- a/src/wikimind/engine/providers/google.py
+++ b/src/wikimind/engine/providers/google.py
@@ -28,7 +28,20 @@ class GoogleProvider:
         """Complete a request using Google Gemini."""
         start = time.monotonic()
 
-        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
+        # google.genai accepts plain strings or types.Content objects.
+        # For single-turn: pass the user message as a string.
+        # For multi-turn: build types.Content objects with role mapping.
+        if len(request.messages) == 1:
+            contents: str | list[types.Content] = request.messages[0]["content"]
+        else:
+            role_map = {"user": "user", "assistant": "model"}
+            contents = [
+                types.Content(
+                    role=role_map.get(m["role"], m["role"]),
+                    parts=[types.Part.from_text(text=m["content"])],
+                )
+                for m in request.messages
+            ]
 
         config_kwargs: dict[str, Any] = {
             "system_instruction": request.system,
@@ -40,7 +53,7 @@ class GoogleProvider:
 
         response = await self.client.aio.models.generate_content(
             model=model,
-            contents=contents,  # type: ignore[arg-type]
+            contents=contents,
             config=types.GenerateContentConfig(**config_kwargs),
         )
 
@@ -130,7 +143,17 @@ class GoogleProvider:
         """Stream a completion request using Google Gemini."""
         start = time.monotonic()
 
-        contents = [{"role": m["role"], "parts": [m["content"]]} for m in request.messages]
+        if len(request.messages) == 1:
+            contents: str | list[types.Content] = request.messages[0]["content"]
+        else:
+            role_map = {"user": "user", "assistant": "model"}
+            contents = [
+                types.Content(
+                    role=role_map.get(m["role"], m["role"]),
+                    parts=[types.Part.from_text(text=m["content"])],
+                )
+                for m in request.messages
+            ]
 
         config_kwargs: dict[str, Any] = {
             "system_instruction": request.system,
@@ -147,7 +170,7 @@ class GoogleProvider:
 
             async for chunk in await self.client.aio.models.generate_content_stream(
                 model=model,
-                contents=contents,  # type: ignore[arg-type]
+                contents=contents,
                 config=types.GenerateContentConfig(**config_kwargs),
             ):
                 text = chunk.text

--- a/src/wikimind/engine/providers/mock.py
+++ b/src/wikimind/engine/providers/mock.py
@@ -1,0 +1,156 @@
+"""Deterministic mock LLM provider for CI e2e testing."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from wikimind.engine.llm_router import StreamSession
+from wikimind.models import CompletionRequest, CompletionResponse, Provider, TaskType
+
+
+class MockProvider:
+    """Deterministic mock provider for CI e2e testing.
+
+    Returns canned JSON keyed off the TaskType so callers that expect
+    CompilationResult / QueryResult shapes can parse the response
+    without a real LLM. Zero cost, zero network, fully deterministic.
+
+    Must be explicitly enabled via ``WIKIMIND_LLM__MOCK__ENABLED=true``
+    AND set as the default provider via ``WIKIMIND_LLM__DEFAULT_PROVIDER=mock``
+    to be selected — disabled by default so it cannot silently
+    intercept real traffic.
+    """
+
+    def __init__(self) -> None:
+        # No config needed; all responses are canned
+        pass
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Return a deterministic canned response matching the request's task type."""
+        start = time.monotonic()
+        content = self._response_for(request)
+        latency_ms = int((time.monotonic() - start) * 1000)
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.MOCK,
+            model_used=model,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Return a deterministic description for each image in the request."""
+        start = time.monotonic()
+        # Count images and return one description per image
+        image_count = sum(1 for p in content_parts if p.get("type") == "image")
+        descriptions = [
+            f"[Page {i + 1} description: A visual slide with diagrams and minimal text.]" for i in range(image_count)
+        ]
+        content = "\n\n".join(descriptions) if descriptions else "No images provided."
+        latency_ms = int((time.monotonic() - start) * 1000)
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.MOCK,
+            model_used=model,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a deterministic canned response in small chunks."""
+        content = self._response_for(request)
+        start = time.monotonic()
+        chunk_size = 20
+
+        async def _generate() -> AsyncIterator[str]:
+            for i in range(0, len(content), chunk_size):
+                yield content[i : i + chunk_size]
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            session.result = CompletionResponse(
+                content=content,
+                provider_used=Provider.MOCK,
+                model_used=model,
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.0,
+                latency_ms=latency_ms,
+            )
+
+        session = StreamSession(_chunks=_generate())
+        return session
+
+    @staticmethod
+    def _response_for(request: CompletionRequest) -> str:
+        """Return a canned response body matching the task's expected shape."""
+        if request.task_type == TaskType.COMPILE:
+            return json.dumps(_MOCK_COMPILE_RESPONSE)
+        if request.task_type == TaskType.QA:
+            return json.dumps(_MOCK_QA_RESPONSE)
+        if request.task_type == TaskType.LINT:
+            return json.dumps(_MOCK_LINT_RESPONSE)
+        # Unknown task type: return an empty JSON object so parse_json_response
+        # doesn't crash. Tests that need specific shapes should add a mock
+        # for their task type.
+        return "{}"
+
+
+# Canned responses used by MockProvider. Defined at module level so tests
+# can import and assert against them directly.
+_MOCK_COMPILE_RESPONSE: dict = {
+    "title": "Mock Article",
+    "summary": "A deterministic summary produced by the mock LLM provider for testing.",
+    "key_claims": [
+        {
+            "claim": "This article was produced by the mock LLM provider.",
+            "confidence": "sourced",
+            "quote": "mock provider",
+        }
+    ],
+    "concepts": ["testing", "mock"],
+    "backlink_suggestions": [],
+    "open_questions": ["What is real?"],
+    "article_body": (
+        "## Mock Article\n\n"
+        "This article was produced by the mock LLM provider for deterministic "
+        "e2e testing.\n\n"
+        "## Details\n\n"
+        "The mock provider returns canned responses regardless of input, "
+        "enabling CI to run the full Ask loop without a real LLM API."
+    ),
+}
+
+_MOCK_QA_RESPONSE: dict = {
+    "answer": (
+        "This is a mock answer from the WikiMind mock LLM provider. "
+        "Your question was received and processed deterministically "
+        "for testing purposes."
+    ),
+    "confidence": "high",
+    "sources": ["Mock Article"],
+    "related_articles": [],
+    "new_article_suggested": None,
+    "follow_up_questions": [],
+}
+
+_MOCK_LINT_RESPONSE: dict = {
+    "contradictions": [],
+    "stale_claims": [],
+    "orphan_articles": [],
+    "missing_pages": [],
+    "data_gaps": [],
+}

--- a/src/wikimind/engine/providers/ollama.py
+++ b/src/wikimind/engine/providers/ollama.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import ollama
 
-from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.engine.llm_router import StreamSession
 from wikimind.models import CompletionRequest, CompletionResponse, Provider
 
 

--- a/src/wikimind/engine/providers/ollama.py
+++ b/src/wikimind/engine/providers/ollama.py
@@ -1,0 +1,138 @@
+"""Ollama local LLM provider."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import ollama
+
+from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.models import CompletionRequest, CompletionResponse, Provider
+
+
+class OllamaProvider:
+    """Ollama local LLM provider."""
+
+    def __init__(self, base_url: str):
+        self.client = ollama.AsyncClient(host=base_url)
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Complete a request using Ollama."""
+        start = time.monotonic()
+
+        messages = [{"role": "system", "content": request.system}]
+        messages.extend(request.messages)
+
+        response = await self.client.chat(
+            model=model,
+            messages=messages,
+            options={"temperature": request.temperature},
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response["message"]["content"]
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.OLLAMA,
+            model_used=model,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Complete a multimodal request using Ollama.
+
+        Ollama accepts images as base64 strings in the ``images`` field
+        of a message.
+
+        Args:
+            system: System prompt.
+            content_parts: List of content blocks in Anthropic format.
+            model: Model name to use.
+            max_tokens: Maximum output tokens.
+            temperature: Sampling temperature.
+
+        Returns:
+            CompletionResponse with the LLM's text output.
+        """
+        start = time.monotonic()
+
+        # Extract text and images from content parts
+        text_parts: list[str] = []
+        images: list[str] = []
+        for part in content_parts:
+            if part["type"] == "text":
+                text_parts.append(part["text"])
+            elif part["type"] == "image":
+                images.append(part["source"]["data"])
+
+        user_content = "\n".join(text_parts) if text_parts else "Describe these images."
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_content, "images": images},
+        ]
+
+        response = await self.client.chat(
+            model=model,
+            messages=messages,  # type: ignore[arg-type]
+            options={"temperature": temperature},
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response["message"]["content"]
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.OLLAMA,
+            model_used=model,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a completion request using Ollama."""
+        messages: list[dict[str, str]] = [{"role": "system", "content": request.system}]
+        messages.extend(request.messages)
+        start = time.monotonic()
+
+        async def _generate() -> AsyncIterator[str]:
+            full_text_parts: list[str] = []
+            response_stream = await self.client.chat(
+                model=model,
+                messages=messages,
+                options={"temperature": request.temperature},
+                stream=True,
+            )
+            async for chunk in response_stream:  # type: ignore[union-attr]
+                text = chunk["message"]["content"]
+                if text:
+                    full_text_parts.append(text)
+                    yield text
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            session.result = CompletionResponse(
+                content="".join(full_text_parts),
+                provider_used=Provider.OLLAMA,
+                model_used=model,
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.0,
+                latency_ms=latency_ms,
+            )
+
+        session = StreamSession(_chunks=_generate())
+        return session

--- a/src/wikimind/engine/providers/openai.py
+++ b/src/wikimind/engine/providers/openai.py
@@ -1,0 +1,170 @@
+"""OpenAI LLM provider."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import openai
+
+from wikimind.config import get_api_key
+from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.models import CompletionRequest, CompletionResponse, Provider
+
+
+class OpenAIProvider:
+    """OpenAI LLM provider."""
+
+    def __init__(self):
+        api_key = get_api_key("openai")
+        if not api_key:
+            raise ValueError("OpenAI API key not configured")
+        self.client = openai.AsyncOpenAI(api_key=api_key)
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Complete a request using OpenAI."""
+        start = time.monotonic()
+
+        messages = [{"role": "system", "content": request.system}]
+        messages.extend(request.messages)
+
+        kwargs: dict[str, object] = dict(
+            model=model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            messages=messages,
+        )
+        if request.response_format == "json":
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = await self.client.chat.completions.create(**kwargs)  # type: ignore[call-overload]
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.choices[0].message.content
+        input_tokens = response.usage.prompt_tokens
+        output_tokens = response.usage.completion_tokens
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.OPENAI,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Complete a multimodal request with text and images using OpenAI.
+
+        Translates the Anthropic-style content blocks to OpenAI's
+        ``image_url`` format before calling the API.
+
+        Args:
+            system: System prompt.
+            content_parts: List of content blocks in Anthropic format.
+            model: Model name to use.
+            max_tokens: Maximum output tokens.
+            temperature: Sampling temperature.
+
+        Returns:
+            CompletionResponse with the LLM's text output.
+        """
+        start = time.monotonic()
+
+        # Translate Anthropic content blocks to OpenAI format
+        openai_parts: list[dict[str, Any]] = []
+        for part in content_parts:
+            if part["type"] == "text":
+                openai_parts.append({"type": "text", "text": part["text"]})
+            elif part["type"] == "image":
+                media_type = part["source"]["media_type"]
+                data = part["source"]["data"]
+                openai_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{media_type};base64,{data}"},
+                    }
+                )
+
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": openai_parts},
+        ]
+
+        response = await self.client.chat.completions.create(
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            messages=messages,  # type: ignore[arg-type]
+        )
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.choices[0].message.content
+        input_tokens = response.usage.prompt_tokens if response.usage else 0
+        output_tokens = response.usage.completion_tokens if response.usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=Provider.OPENAI,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a completion request using OpenAI."""
+        messages: list[dict[str, str]] = [{"role": "system", "content": request.system}]
+        messages.extend(request.messages)
+        start = time.monotonic()
+
+        kwargs: dict[str, object] = dict(
+            model=model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            messages=messages,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        if request.response_format == "json":
+            kwargs["response_format"] = {"type": "json_object"}
+
+        async def _generate() -> AsyncIterator[str]:
+            full_text_parts: list[str] = []
+            input_tokens = 0
+            output_tokens = 0
+            response_stream = await self.client.chat.completions.create(
+                **kwargs  # type: ignore[call-overload]
+            )
+            async for chunk in response_stream:  # type: ignore[union-attr]
+                if chunk.usage:
+                    input_tokens = chunk.usage.prompt_tokens or 0
+                    output_tokens = chunk.usage.completion_tokens or 0
+                if chunk.choices and chunk.choices[0].delta.content:
+                    text = chunk.choices[0].delta.content
+                    full_text_parts.append(text)
+                    yield text
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            session.result = CompletionResponse(
+                content="".join(full_text_parts),
+                provider_used=Provider.OPENAI,
+                model_used=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
+                latency_ms=latency_ms,
+            )
+
+        session = StreamSession(_chunks=_generate())
+        return session

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -1,4 +1,4 @@
-"""Tests for the GoogleProvider implementation."""
+"""Tests for the GoogleProvider implementation (google.genai SDK)."""
 
 from __future__ import annotations
 
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from google.genai import types as genai_types
 
-from wikimind.engine import llm_router as llm_router_mod
-from wikimind.engine.llm_router import GoogleProvider, StreamSession, _calc_cost
+from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.engine.providers import google as google_provider_mod
+from wikimind.engine.providers.google import GoogleProvider
 from wikimind.models import CompletionRequest, CompletionResponse, Provider, TaskType
 
 
@@ -31,19 +33,20 @@ def _req(**kw) -> CompletionRequest:
 
 def test_google_provider_missing_key() -> None:
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value=None),
+        patch.object(google_provider_mod, "get_api_key", return_value=None),
         pytest.raises(ValueError, match="Google API key"),
     ):
         GoogleProvider()
 
 
-def test_google_provider_init_configures_genai() -> None:
+def test_google_provider_init_creates_client() -> None:
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="test-key"),
-        patch.object(llm_router_mod.genai, "configure") as mock_configure,
+        patch.object(google_provider_mod, "get_api_key", return_value="test-key"),
+        patch.object(google_provider_mod.genai, "Client") as mock_client_cls,
     ):
-        GoogleProvider()
-        mock_configure.assert_called_once_with(api_key="test-key")  # pragma: allowlist secret
+        provider = GoogleProvider()
+        mock_client_cls.assert_called_once_with(api_key="test-key")  # pragma: allowlist secret
+        assert provider.client is mock_client_cls.return_value
 
 
 # ---------------------------------------------------------------------------
@@ -55,19 +58,16 @@ async def test_google_provider_complete() -> None:
     """GoogleProvider.complete() returns a CompletionResponse with token counts."""
     fake_usage = SimpleNamespace(prompt_token_count=15, candidates_token_count=25)
     fake_response = SimpleNamespace(text="hello from gemini", usage_metadata=fake_usage)
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model) as mock_model_cls,
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
     ):
         provider = GoogleProvider()
         resp = await provider.complete(_req(), "gemini-2.0-flash")
-
-        # Verify GenerativeModel was called with correct system instruction
-        mock_model_cls.assert_called_once_with("gemini-2.0-flash", system_instruction="sys")
 
     assert isinstance(resp, CompletionResponse)
     assert resp.content == "hello from gemini"
@@ -77,40 +77,46 @@ async def test_google_provider_complete() -> None:
     assert resp.model_used == "gemini-2.0-flash"
     assert resp.latency_ms >= 0
 
+    # Verify generate_content was called with correct model and config
+    call_kwargs = mock_client.aio.models.generate_content.call_args
+    assert call_kwargs.kwargs["model"] == "gemini-2.0-flash"
+    config = call_kwargs.kwargs["config"]
+    assert config.system_instruction == "sys"
+
 
 async def test_google_provider_complete_json_format() -> None:
     """GoogleProvider.complete() passes response_mime_type for JSON format."""
     fake_usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=10)
     fake_response = SimpleNamespace(text='{"answer": "ok"}', usage_metadata=fake_usage)
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
     ):
         provider = GoogleProvider()
         resp = await provider.complete(_req(response_format="json"), "gemini-2.0-flash")
 
     assert resp.content == '{"answer": "ok"}'
 
-    # Check that generation_config included response_mime_type
-    call_kwargs = fake_model.generate_content_async.call_args
-    gen_config = call_kwargs.kwargs["generation_config"]
-    assert gen_config.response_mime_type == "application/json"
+    # Check that config included response_mime_type
+    call_kwargs = mock_client.aio.models.generate_content.call_args
+    config = call_kwargs.kwargs["config"]
+    assert config.response_mime_type == "application/json"
 
 
 async def test_google_provider_complete_no_usage_metadata() -> None:
     """GoogleProvider.complete() handles missing usage_metadata gracefully."""
     fake_response = SimpleNamespace(text="no usage", usage_metadata=None)
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
     ):
         provider = GoogleProvider()
         resp = await provider.complete(_req(), "gemini-2.0-flash")
@@ -128,8 +134,9 @@ async def test_google_provider_complete_multimodal() -> None:
     """GoogleProvider.complete_multimodal() translates Anthropic content blocks."""
     fake_usage = SimpleNamespace(prompt_token_count=100, candidates_token_count=50)
     fake_response = SimpleNamespace(text="I see a diagram", usage_metadata=fake_usage)
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
 
     sample_b64 = base64.b64encode(b"fake-image-data").decode()
 
@@ -146,10 +153,11 @@ async def test_google_provider_complete_multimodal() -> None:
     ]
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
+        patch.object(google_provider_mod.types.Part, "from_bytes") as mock_from_bytes,
     ):
+        mock_from_bytes.return_value = SimpleNamespace(mime_type="image/png")
         provider = GoogleProvider()
         resp = await provider.complete_multimodal(
             system="You are a vision assistant.",
@@ -163,20 +171,25 @@ async def test_google_provider_complete_multimodal() -> None:
     assert resp.input_tokens == 100
     assert resp.output_tokens == 50
 
-    # Verify content format translation
-    call_args = fake_model.generate_content_async.call_args
-    google_parts = call_args.args[0]
+    # Verify types.Part.from_bytes was called for the image
+    mock_from_bytes.assert_called_once_with(
+        data=base64.b64decode(sample_b64),
+        mime_type="image/png",
+    )
+
+    # Verify content format: first is text string, second is the Part
+    call_kwargs = mock_client.aio.models.generate_content.call_args.kwargs
+    google_parts = call_kwargs["contents"]
     assert google_parts[0] == "Describe this image."
-    assert google_parts[1]["mime_type"] == "image/png"
-    assert google_parts[1]["data"] == base64.b64decode(sample_b64)
 
 
 async def test_google_provider_multimodal_text_only() -> None:
     """GoogleProvider.complete_multimodal() works with text-only content."""
     fake_usage = SimpleNamespace(prompt_token_count=10, candidates_token_count=20)
     fake_response = SimpleNamespace(text="text only response", usage_metadata=fake_usage)
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_response)
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
 
     content_parts = [
         {"type": "text", "text": "First part."},
@@ -184,9 +197,8 @@ async def test_google_provider_multimodal_text_only() -> None:
     ]
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
     ):
         provider = GoogleProvider()
         resp = await provider.complete_multimodal(
@@ -198,8 +210,8 @@ async def test_google_provider_multimodal_text_only() -> None:
     assert resp.content == "text only response"
 
     # All parts should be plain strings
-    call_args = fake_model.generate_content_async.call_args
-    google_parts = call_args.args[0]
+    call_kwargs = mock_client.aio.models.generate_content.call_args.kwargs
+    google_parts = call_kwargs["contents"]
     assert google_parts == ["First part.", "Second part."]
 
 
@@ -223,14 +235,12 @@ async def test_google_provider_stream() -> None:
         yield chunk1
         yield chunk2
 
-    fake_async_response = _fake_stream()
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_async_response)
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content_stream = AsyncMock(return_value=_fake_stream())
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
     ):
         provider = GoogleProvider()
         session = await provider.stream(_req(), "gemini-2.0-flash")
@@ -257,14 +267,12 @@ async def test_google_provider_stream_empty_chunks_skipped() -> None:
         yield chunk2
         yield chunk3
 
-    fake_async_response = _fake_stream()
-    fake_model = MagicMock()
-    fake_model.generate_content_async = AsyncMock(return_value=fake_async_response)
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content_stream = AsyncMock(return_value=_fake_stream())
 
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.genai, "configure"),
-        patch.object(llm_router_mod.genai, "GenerativeModel", return_value=fake_model),
+        patch.object(google_provider_mod, "get_api_key", return_value="key"),
+        patch.object(google_provider_mod.genai, "Client", return_value=mock_client),
     ):
         provider = GoogleProvider()
         session = await provider.stream(_req(), "gemini-2.0-flash")
@@ -280,7 +288,7 @@ async def test_google_provider_stream_empty_chunks_skipped() -> None:
 
 
 def test_anthropic_to_google_content_translation() -> None:
-    """Verify Anthropic-style content blocks translate to Google format correctly."""
+    """Verify Anthropic-style content blocks translate to Google format using types.Part.from_bytes."""
     sample_data = base64.b64encode(b"\x89PNG\r\n").decode()
 
     anthropic_parts = [
@@ -297,6 +305,7 @@ def test_anthropic_to_google_content_translation() -> None:
     ]
 
     # Replicate the translation logic from GoogleProvider.complete_multimodal
+    # using the new google.genai types
     google_parts: list = []
     for part in anthropic_parts:
         if part["type"] == "text":
@@ -305,17 +314,15 @@ def test_anthropic_to_google_content_translation() -> None:
             media_type = part["source"]["media_type"]
             data_b64 = part["source"]["data"]
             google_parts.append(
-                {
-                    "mime_type": media_type,
-                    "data": base64.b64decode(data_b64),
-                }
+                genai_types.Part.from_bytes(
+                    data=base64.b64decode(data_b64),
+                    mime_type=media_type,
+                )
             )
 
     assert len(google_parts) == 3
     assert google_parts[0] == "Describe the image"
-    assert isinstance(google_parts[1], dict)
-    assert google_parts[1]["mime_type"] == "image/png"
-    assert google_parts[1]["data"] == b"\x89PNG\r\n"
+    assert hasattr(google_parts[1], "inline_data")
     assert google_parts[2] == "Also this"
 
 

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -22,6 +22,9 @@ from wikimind.engine.llm_router import (
     _calc_cost,
     get_llm_router,
 )
+from wikimind.engine.providers import anthropic as anthropic_provider_mod
+from wikimind.engine.providers import ollama as ollama_provider_mod
+from wikimind.engine.providers import openai as openai_provider_mod
 from wikimind.models import (
     CompilationResult,
     CompletionRequest,
@@ -57,7 +60,7 @@ def test_calc_cost_ollama_wildcard() -> None:
 
 
 def test_anthropic_provider_missing_key() -> None:
-    with patch.object(llm_router_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
+    with patch.object(anthropic_provider_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
         AnthropicProvider()
 
 
@@ -68,8 +71,8 @@ async def test_anthropic_provider_complete() -> None:
     )
     fake_client = SimpleNamespace(messages=SimpleNamespace(create=AsyncMock(return_value=fake_response)))
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.anthropic, "AsyncAnthropic", return_value=fake_client),
+        patch.object(anthropic_provider_mod, "get_api_key", return_value="key"),
+        patch.object(anthropic_provider_mod.anthropic, "AsyncAnthropic", return_value=fake_client),
     ):
         provider = AnthropicProvider()
         resp = await provider.complete(_req(), "claude-sonnet-4-5")
@@ -81,7 +84,7 @@ async def test_anthropic_provider_complete() -> None:
 
 
 def test_openai_provider_missing_key() -> None:
-    with patch.object(llm_router_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
+    with patch.object(openai_provider_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
         OpenAIProvider()
 
 
@@ -94,8 +97,8 @@ async def test_openai_provider_complete_json() -> None:
     create = AsyncMock(return_value=fake_response)
     fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
     with (
-        patch.object(llm_router_mod, "get_api_key", return_value="key"),
-        patch.object(llm_router_mod.openai, "AsyncOpenAI", return_value=fake_client),
+        patch.object(openai_provider_mod, "get_api_key", return_value="key"),
+        patch.object(openai_provider_mod.openai, "AsyncOpenAI", return_value=fake_client),
     ):
         provider = OpenAIProvider()
         resp = await provider.complete(_req(response_format="json"), "gpt-4o-mini")
@@ -108,7 +111,7 @@ async def test_openai_provider_complete_json() -> None:
 
 async def test_ollama_provider_complete() -> None:
     fake_client = SimpleNamespace(chat=AsyncMock(return_value={"message": {"content": "hi"}}))
-    with patch.object(llm_router_mod.ollama, "AsyncClient", return_value=fake_client):
+    with patch.object(ollama_provider_mod.ollama, "AsyncClient", return_value=fake_client):
         provider = OllamaProvider("http://localhost")
         resp = await provider.complete(_req(), "llama3")
     assert resp.content == "hi"


### PR DESCRIPTION
## Summary

- Splits `llm_router.py` (1104 lines) into 6 focused files: `providers/anthropic.py`, `openai.py`, `google.py`, `ollama.py`, `mock.py` + slimmed router (~410 lines)
- Migrates GoogleProvider from deprecated `google.generativeai` to `google.genai` SDK — eliminates `FutureWarning`
- Updates `pyproject.toml`: `google-generativeai>=0.8.3` → `google-genai>=1.0.0`
- All backward-compatible re-exports in `llm_router.py` — zero import changes needed in consuming code
- Rewrites Google provider tests to mock new SDK surface (`genai.Client`, `client.aio.models.generate_content`)

## New file structure

```
src/wikimind/engine/
├── llm_router.py          # Router, pricing, StreamSession (~410 lines)
├── providers/
│   ├── __init__.py        # Re-exports
│   ├── anthropic.py       # AnthropicProvider (unchanged logic)
│   ├── openai.py          # OpenAIProvider (unchanged logic)
│   ├── google.py          # GoogleProvider (NEW google.genai SDK)
│   ├── ollama.py          # OllamaProvider (unchanged logic)
│   └── mock.py            # MockProvider + canned responses
```

## Test plan

- [x] 711 unit tests pass, mypy clean
- [x] `make dev` with `GOOGLE_API_KEY` → no FutureWarning in logs
- [x] Settings page: Google shows "Enabled", "Test" returns OK
- [x] Set Google as default → ingest a doc → logs show `provider=google`
- [x] Anthropic/OpenAI/Ollama providers unchanged — existing workflows unaffected