### PR TITLE
feat: add View Source button to Inbox source cards (#177)

### DIFF
--- a/apps/web/src/api/sources.ts
+++ b/apps/web/src/api/sources.ts
@@ -30,6 +30,12 @@ export function ingestPdf(file: File): Promise<Source> {
   return apiFetch<Source>("/ingest/pdf", { method: "POST", body: form });
 }
 
+export function getSourceContent(
+  sourceId: string,
+): Promise<{ source_id: string; content: string; filename: string }> {
+  return apiFetch(`/ingest/sources/${encodeURIComponent(sourceId)}/content`);
+}
+
 export function deleteSource(sourceId: string): Promise<{ deleted: string }> {
   return apiFetch(`/ingest/sources/${encodeURIComponent(sourceId)}`, {
     method: "DELETE",

--- a/apps/web/src/components/inbox/SourceCard.tsx
+++ b/apps/web/src/components/inbox/SourceCard.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { IngestStatus, Source, SourceType } from "../../types/api";
+import { getSourceContent } from "../../api/sources";
 import { Badge, type BadgeTone } from "../shared/Badge";
 import { Button } from "../shared/Button";
 import { Card } from "../shared/Card";
@@ -50,10 +51,49 @@ function formatTimestamp(iso: string): string {
   }
 }
 
+interface SourceContentModalProps {
+  filename: string;
+  content: string;
+  onClose: () => void;
+}
+
+function SourceContentModal({
+  filename,
+  content,
+  onClose,
+}: SourceContentModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg border border-slate-200 bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <h2 className="truncate text-lg font-semibold text-slate-800">
+            {filename}
+          </h2>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+        <div className="overflow-auto p-6">
+          <pre className="whitespace-pre-wrap break-words font-mono text-sm text-slate-700">
+            {content}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function SourceCard({ source, onRetry, retrying }: SourceCardProps) {
   const statusMessage = useWebSocketStore(
     (s) => s.sourceStatus[source.id] ?? null,
   );
+
+  const [viewState, setViewState] = useState<
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "open"; content: string; filename: string }
+    | { status: "error"; message: string }
+  >({ status: "idle" });
 
   const titleText = useMemo(() => {
     if (source.title && source.title.trim().length > 0) return source.title;
@@ -61,63 +101,104 @@ export function SourceCard({ source, onRetry, retrying }: SourceCardProps) {
     return "Untitled source";
   }, [source.title, source.source_url]);
 
+  const handleViewSource = useCallback(async () => {
+    setViewState({ status: "loading" });
+    try {
+      const result = await getSourceContent(source.id);
+      setViewState({
+        status: "open",
+        content: result.content,
+        filename: result.filename,
+      });
+    } catch {
+      setViewState({ status: "error", message: "Failed to load source content" });
+    }
+  }, [source.id]);
+
   return (
-    <Card className="p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <Badge tone="brand">{TYPE_LABEL[source.source_type]}</Badge>
-            <Badge tone={STATUS_TONE[source.status]}>
-              {source.status === "processing" ? (
-                <>
-                  <Spinner size={10} /> {STATUS_LABEL[source.status]}
-                </>
-              ) : (
-                STATUS_LABEL[source.status]
-              )}
-            </Badge>
+    <>
+      <Card className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <Badge tone="brand">{TYPE_LABEL[source.source_type]}</Badge>
+              <Badge tone={STATUS_TONE[source.status]}>
+                {source.status === "processing" ? (
+                  <>
+                    <Spinner size={10} /> {STATUS_LABEL[source.status]}
+                  </>
+                ) : (
+                  STATUS_LABEL[source.status]
+                )}
+              </Badge>
+            </div>
+            <h3 className="mt-2 truncate text-sm font-semibold text-slate-900">
+              {titleText}
+            </h3>
+            {source.source_url ? (
+              <a
+                href={source.source_url}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-0.5 block truncate text-xs text-brand-600 hover:underline"
+              >
+                {source.source_url}
+              </a>
+            ) : null}
           </div>
-          <h3 className="mt-2 truncate text-sm font-semibold text-slate-900">
-            {titleText}
-          </h3>
-          {source.source_url ? (
-            <a
-              href={source.source_url}
-              target="_blank"
-              rel="noreferrer"
-              className="mt-0.5 block truncate text-xs text-brand-600 hover:underline"
-            >
-              {source.source_url}
-            </a>
-          ) : null}
+          <div className="text-right text-xs text-slate-400">
+            {formatTimestamp(source.ingested_at)}
+          </div>
         </div>
-        <div className="text-right text-xs text-slate-400">
-          {formatTimestamp(source.ingested_at)}
-        </div>
-      </div>
 
-      {source.status === "processing" && statusMessage ? (
-        <p className="mt-2 text-xs text-slate-500">{statusMessage}</p>
-      ) : null}
+        {source.status === "processing" && statusMessage ? (
+          <p className="mt-2 text-xs text-slate-500">{statusMessage}</p>
+        ) : null}
 
-      {source.status === "failed" ? (
-        <div className="mt-3 space-y-2">
-          {source.error_message ? (
-            <p className="text-xs text-rose-700">{source.error_message}</p>
-          ) : null}
-          {onRetry ? (
+        {source.status === "failed" ? (
+          <div className="mt-3 space-y-2">
+            {source.error_message ? (
+              <p className="text-xs text-rose-700">{source.error_message}</p>
+            ) : null}
+            {onRetry ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => onRetry(source.id)}
+                disabled={retrying}
+              >
+                {retrying ? <Spinner size={12} /> : null}
+                Retry compile
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {source.file_path ? (
+          <div className="mt-3">
             <Button
               size="sm"
               variant="secondary"
-              onClick={() => onRetry(source.id)}
-              disabled={retrying}
+              onClick={handleViewSource}
+              disabled={viewState.status === "loading"}
             >
-              {retrying ? <Spinner size={12} /> : null}
-              Retry compile
+              {viewState.status === "loading" ? <Spinner size={12} /> : null}
+              View Source
             </Button>
-          ) : null}
-        </div>
+            {viewState.status === "error" ? (
+              <p className="mt-1 text-xs text-rose-700">{viewState.message}</p>
+            ) : null}
+          </div>
+        ) : null}
+      </Card>
+
+      {viewState.status === "open" ? (
+        <SourceContentModal
+          filename={viewState.filename}
+          content={viewState.content}
+          onClose={() => setViewState({ status: "idle" })}
+        />
       ) : null}
-    </Card>
+    </>
   );
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -189,6 +189,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /ingest/sources/{source_id}/content:
+    get:
+      tags:
+      - Ingest
+      summary: Get Source Content
+      description: Return the extracted text content of an ingested source.
+      operationId: get_source_content_ingest_sources__source_id__content_get
+      parameters:
+      - name: source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Source Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /wiki/contradiction-resolutions:
     get:
       tags:

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -6,6 +6,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind.database import get_session
 from wikimind.models import IngestTextRequest, IngestURLRequest, Source
 from wikimind.services.ingest import IngestService, get_ingest_service
+from wikimind.storage import resolve_raw_path
 
 router = APIRouter()
 
@@ -68,6 +69,25 @@ async def get_source(
 ):
     """Get source by ID."""
     return await service.get_source(source_id, session)
+
+
+@router.get("/sources/{source_id}/content")
+async def get_source_content(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
+):
+    """Return the extracted text content of an ingested source."""
+    source = await service.get_source(source_id, session)
+    if not source.file_path:
+        raise HTTPException(status_code=404, detail="Source has no content file")
+
+    path = resolve_raw_path(source.file_path)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Source file not found on disk")
+
+    content = path.read_text(encoding="utf-8")
+    return {"source_id": source_id, "content": content, "filename": source.file_path}
 
 
 @router.delete("/sources/{source_id}")


### PR DESCRIPTION
## Summary

- Backend: `GET /ingest/sources/{id}/content` endpoint returns the extracted text from raw storage
- Frontend: "View Source" button on each source card opens a modal with scrollable monospace text
- Uses state machine (idle → loading → open/error) for clean UX
- Modal follows existing `ApiKeyModal` pattern (overlay, centered panel, close button)

Closes #177

## Test plan

- [ ] Ingest a URL → source card shows "View Source" button
- [ ] Click "View Source" → modal opens with extracted text content
- [ ] Ingest a PDF → "View Source" shows extracted text
- [ ] Close modal → returns to Inbox
- [ ] Source without file_path → no "View Source" button shown