### PR TITLE
feat: production Docker deployment with Postgres + Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,23 @@
 # WIKIMIND_AUTH__GITHUB_CLIENT_SECRET=...
 
 # ----------------------------------------------------------------------------
+# Production Deployment (docker-compose.prod.yml)
+# ----------------------------------------------------------------------------
+# These are read by docker-compose.prod.yml to configure the Postgres
+# container and construct the gateway's DATABASE_URL. Set them in .env
+# before running `make deploy-up`.
+#
+# POSTGRES_USER=wikimind
+# POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD
+# POSTGRES_DB=wikimind
+#
+# Port the gateway listens on (host side)
+# WIKIMIND_PORT=7842
+#
+# Custom image tag (default: wikimind:latest)
+# WIKIMIND_IMAGE=wikimind:latest
+
+# ----------------------------------------------------------------------------
 # Logging (optional)
 # ----------------------------------------------------------------------------
 # LOG_LEVEL=INFO

--- a/.env.make.example
+++ b/.env.make.example
@@ -1,0 +1,3 @@
+# .env.make — Build-time variables for the Makefile.
+# Copy to .env.make and customize. This file is gitignored.
+COMPOSE_CMD=docker compose

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 # Environment
 .env
 .env.local
+.env.make
 
 # WikiMind local data (user data — never commit)
 # ~/.wikimind/ is outside repo, but just in case:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,14 +156,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 422
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 424
+        "line_number": 446
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -194,5 +194,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-18T19:25:06Z"
+  "generated_at": "2026-04-18T20:38:20Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ COPY src ./src
 # Same CVE upgrade as the dev stage — see comment above.
 # Install with [pdf] extra for structured PDF extraction via docling.
 RUN pip install --upgrade pip setuptools wheel \
-    && pip install --extra-index-url ${TORCH_INDEX} ".[pdf]"
+    && pip install --extra-index-url ${TORCH_INDEX} ".[pdf]" gunicorn
 
 # Alembic migrations for Postgres deployments
 COPY alembic.ini ./
@@ -87,7 +87,7 @@ COPY alembic ./alembic
 COPY --from=frontend /app/dist ./static/
 
 # Entrypoint: run migrations (Postgres only), then exec CMD
-COPY docker/entrypoint.sh ./
+COPY docker/entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x docker-entrypoint.sh
 
 # Run as a non-root user in production.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,15 @@ RUN apt-get update \
 WORKDIR /app
 
 # ---------------------------------------------------------------------------
+FROM node:20-alpine AS frontend
+
+WORKDIR /app
+COPY apps/web/package.json apps/web/package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY apps/web/ ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
 FROM base AS dev
 
 # Install the dev extras (tests + lint + pdf) but NOT `search` by default.
@@ -70,6 +79,17 @@ COPY src ./src
 RUN pip install --upgrade pip setuptools wheel \
     && pip install --extra-index-url ${TORCH_INDEX} ".[pdf]"
 
+# Alembic migrations for Postgres deployments
+COPY alembic.ini ./
+COPY alembic ./alembic
+
+# Built frontend from multi-stage build
+COPY --from=frontend /app/dist ./static/
+
+# Entrypoint: run migrations (Postgres only), then exec CMD
+COPY docker/entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
 # Run as a non-root user in production.
 RUN useradd --create-home --uid 1000 wikimind \
     && mkdir -p /home/wikimind/.wikimind \
@@ -81,7 +101,8 @@ ENV WIKIMIND_DATA_DIR=/home/wikimind/.wikimind \
 
 EXPOSE 7842
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD curl -fsS http://127.0.0.1:7842/health || exit 1
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["gunicorn", "wikimind.main:app", "-w", "2", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:7842"]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ BIN := $(VENV)/bin
 PYTHON := $(BIN)/python
 PIP := $(BIN)/pip
 
+# Build-time overrides (container runtime, compose command).
+# Create .env.make from .env.make.example to customize.
+-include .env.make
+COMPOSE_CMD ?= docker compose
+COMPOSE_PROD_FILE ?= docker-compose.prod.yml
+
 # ══════════════════════════════════════════════════════════════════════════════
 
 .PHONY: help
@@ -96,21 +102,11 @@ dev: check-venv ## Run fast-reload dev server on :7842 (uvicorn)
 serve: ## Run production server on :7842 (gunicorn)
 	$(BIN)/gunicorn wikimind.main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 127.0.0.1:7842
 
-PG_USER ?= postgres
-PG_PASS ?= wikimind
-PG_HOST ?= localhost
-PG_PORT ?= 5433
-PG_DB   ?= wikimind
-PG_URL  := postgresql+asyncpg://$(PG_USER):$(PG_PASS)@$(PG_HOST):$(PG_PORT)/$(PG_DB)
-
 .PHONY: dev-postgres
-dev-postgres: check-venv ## Run dev server against local Postgres on :5433
-	@docker ps --format '{{.Names}}' | grep -q wikimind-postgres || \
-		(echo "Starting wikimind-postgres on :$(PG_PORT)…" && \
-		docker run -d -p $(PG_PORT):5432 -e POSTGRES_PASSWORD=$(PG_PASS) -e POSTGRES_DB=$(PG_DB) --name wikimind-postgres postgres:16 && \
-		sleep 2)
-	WIKIMIND_DATABASE_URL=$(PG_URL) $(BIN)/python -m alembic upgrade head
-	WIKIMIND_DATABASE_URL=$(PG_URL) $(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
+dev-postgres: check-venv ## Run dev server against Postgres (set WIKIMIND_DATABASE_URL in .env)
+	@test -n "$${WIKIMIND_DATABASE_URL:-}" || { echo "ERROR: Set WIKIMIND_DATABASE_URL in .env or environment"; exit 1; }
+	$(BIN)/python -m alembic upgrade head
+	$(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
 
 .PHONY: worker
 worker: ## Start ARQ background job worker
@@ -230,6 +226,24 @@ docker-logs: ## Tail logs from all dev stack services
 .PHONY: docker-down
 docker-down: ## Stop and remove the dev stack
 	docker compose down
+
+##@ 🚀 DEPLOY
+
+.PHONY: deploy-up
+deploy-up: ## Build and start the production stack
+	$(COMPOSE_CMD) -f $(COMPOSE_PROD_FILE) up -d --build
+
+.PHONY: deploy-stop
+deploy-stop: ## Stop the production stack
+	$(COMPOSE_CMD) -f $(COMPOSE_PROD_FILE) down
+
+.PHONY: deploy-logs
+deploy-logs: ## Tail logs from the production stack
+	$(COMPOSE_CMD) -f $(COMPOSE_PROD_FILE) logs -f
+
+.PHONY: deploy-ps
+deploy-ps: ## Show production service status
+	$(COMPOSE_CMD) -f $(COMPOSE_PROD_FILE) ps
 
 ##@ 🧪 TESTING
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 |--------|-------------|
 | `make dev` | Run fast-reload dev server on :7842 (uvicorn) |
 | `make serve` | Run production server on :7842 (gunicorn) |
-| `make dev-postgres` | Run dev server against local Postgres on :5433 |
+| `make dev-postgres` | Run dev server against Postgres (set WIKIMIND_DATABASE_URL in .env) |
 | `make worker` | Start ARQ background job worker |
 
 ### 🔍 QUALITY
@@ -201,6 +201,15 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make docker-up-build` | Rebuild the image and start the dev stack in the background |
 | `make docker-logs` | Tail logs from all dev stack services |
 | `make docker-down` | Stop and remove the dev stack |
+
+### 🚀 DEPLOY
+
+| Target | Description |
+|--------|-------------|
+| `make deploy-up` | Build and start the production stack |
+| `make deploy-stop` | Stop the production stack |
+| `make deploy-logs` | Tail logs from the production stack |
+| `make deploy-ps` | Show production service status |
 
 ### 🧪 TESTING
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ npm run dev
 # Opens http://localhost:5173
 ```
 
+### Authentication UI
+
+When multi-user mode is enabled (`WIKIMIND_AUTH__ENABLED=true`), the frontend shows:
+
+- **Login page** (`/login`) — Google and GitHub OAuth2 sign-in buttons
+- **Protected routes** — unauthenticated users are redirected to `/login`
+- **User menu** — avatar, name, and logout button in the sidebar
+
+When auth is disabled (default), no login page is shown and all routes are accessible.
+
 ## Production (PostgreSQL)
 
 For shared access across multiple devices, use PostgreSQL instead of SQLite:

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,8 @@
 import { Navigate, Route, Routes } from "react-router-dom";
+import AuthCallback from "./components/auth/AuthCallback";
+import AuthProvider from "./components/auth/AuthProvider";
+import LoginPage from "./components/auth/LoginPage";
+import ProtectedRoute from "./components/auth/ProtectedRoute";
 import { Layout } from "./components/shared/Layout";
 import { InboxView } from "./components/inbox/InboxView";
 import { WikiExplorerView } from "./components/wiki/WikiExplorerView";
@@ -13,19 +17,32 @@ export function App() {
   useWebSocket();
 
   return (
-    <Layout>
+    <AuthProvider>
       <Routes>
-        <Route path="/" element={<Navigate to="/inbox" replace />} />
-        <Route path="/inbox" element={<InboxView />} />
-        <Route path="/ask" element={<AskView />} />
-        <Route path="/ask/:conversationId" element={<AskView />} />
-        <Route path="/wiki" element={<WikiExplorerView />} />
-        <Route path="/wiki/:slug" element={<WikiExplorerView />} />
-        <Route path="/graph" element={<GraphView />} />
-        <Route path="/health" element={<HealthView />} />
-        <Route path="/settings" element={<SettingsView />} />
-        <Route path="*" element={<Navigate to="/inbox" replace />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route
+          path="*"
+          element={
+            <ProtectedRoute>
+              <Layout>
+                <Routes>
+                  <Route path="/" element={<Navigate to="/inbox" replace />} />
+                  <Route path="/inbox" element={<InboxView />} />
+                  <Route path="/ask" element={<AskView />} />
+                  <Route path="/ask/:conversationId" element={<AskView />} />
+                  <Route path="/wiki" element={<WikiExplorerView />} />
+                  <Route path="/wiki/:slug" element={<WikiExplorerView />} />
+                  <Route path="/graph" element={<GraphView />} />
+                  <Route path="/health" element={<HealthView />} />
+                  <Route path="/settings" element={<SettingsView />} />
+                  <Route path="*" element={<Navigate to="/inbox" replace />} />
+                </Routes>
+              </Layout>
+            </ProtectedRoute>
+          }
+        />
       </Routes>
-    </Layout>
+    </AuthProvider>
   );
 }

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,8 @@
+// Auth API calls for the WikiMind OAuth2 flow.
+
+import type { AuthUser } from "../store/auth";
+import { apiFetch } from "./client";
+
+export function fetchCurrentUser(): Promise<AuthUser> {
+  return apiFetch<AuthUser>("/auth/me");
+}

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -43,10 +43,16 @@ export async function apiFetch<T>(
 ): Promise<T> {
   const { method = "GET", body, query, headers = {}, signal } = options;
 
+  const token = localStorage.getItem("wikimind_token");
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {};
+
   const init: RequestInit = {
     method,
     headers: {
       Accept: "application/json",
+      ...authHeaders,
       ...headers,
     },
     signal,

--- a/apps/web/src/components/auth/AuthCallback.tsx
+++ b/apps/web/src/components/auth/AuthCallback.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "../../store/auth";
+
+export default function AuthCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const setToken = useAuth((s) => s.setToken);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (token) {
+      setToken(token);
+      navigate("/", { replace: true });
+    } else {
+      navigate("/login", { replace: true });
+    }
+  }, [searchParams, setToken, navigate]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <p className="text-zinc-400">Signing in...</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/AuthProvider.tsx
+++ b/apps/web/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "../../store/auth";
+import { fetchCurrentUser } from "../../api/auth";
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const token = useAuth((s) => s.token);
+  const setUser = useAuth((s) => s.setUser);
+  const setAuthDisabled = useAuth((s) => s.setAuthDisabled);
+  const logout = useAuth((s) => s.logout);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      // No token — probe /auth/me to check if auth is even enabled.
+      fetchCurrentUser()
+        .then((user) => {
+          setUser(user);
+          setReady(true);
+        })
+        .catch(() => {
+          // 404 or network error means auth is disabled on the backend.
+          setAuthDisabled(true);
+          setReady(true);
+        });
+      return;
+    }
+
+    // Token exists — validate it.
+    fetchCurrentUser()
+      .then((user) => {
+        setUser(user);
+        setReady(true);
+      })
+      .catch(() => {
+        logout();
+        setReady(true);
+      });
+  }, [token, setUser, setAuthDisabled, logout]);
+
+  if (!ready) {
+    return <div className="min-h-screen bg-zinc-950" />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -1,0 +1,31 @@
+import { getBaseUrl } from "../../api/client";
+
+export default function LoginPage() {
+  const apiBase = getBaseUrl();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-zinc-800 bg-zinc-900 p-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-zinc-100">WikiMind</h1>
+          <p className="mt-1 text-sm text-zinc-400">Sign in to your knowledge wiki</p>
+        </div>
+
+        <div className="space-y-3">
+          <a
+            href={`${apiBase}/auth/login/google`}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2.5 font-medium text-zinc-900 transition-colors hover:bg-zinc-100"
+          >
+            Sign in with Google
+          </a>
+          <a
+            href={`${apiBase}/auth/login/github`}
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2.5 font-medium text-zinc-100 transition-colors hover:bg-zinc-700"
+          >
+            Sign in with GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/ProtectedRoute.tsx
+++ b/apps/web/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../store/auth";
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const isAuthenticated = useAuth((s) => s.isAuthenticated);
+  const authDisabled = useAuth((s) => s.authDisabled);
+
+  if (authDisabled || isAuthenticated) {
+    return <>{children}</>;
+  }
+
+  return <Navigate to="/login" replace />;
+}

--- a/apps/web/src/components/shared/Layout.tsx
+++ b/apps/web/src/components/shared/Layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link, NavLink } from "react-router-dom";
+import { useAuth } from "../../store/auth";
 import { useWebSocketStore } from "../../store/websocket";
 import { Badge } from "./Badge";
 
@@ -17,6 +18,8 @@ const NAV_ITEMS = [
 ];
 
 export function Layout({ children }: LayoutProps) {
+  const user = useAuth((s) => s.user);
+  const logout = useAuth((s) => s.logout);
   const wsState = useWebSocketStore((s) => s.state);
   const toasts = useWebSocketStore((s) => s.toasts);
   const dismissToast = useWebSocketStore((s) => s.dismissToast);
@@ -47,6 +50,25 @@ export function Layout({ children }: LayoutProps) {
             </NavLink>
           ))}
         </nav>
+
+        {user && (
+          <div className="flex items-center gap-2 border-t border-slate-200 px-4 py-3">
+            {user.avatar_url && (
+              <img src={user.avatar_url} alt="" className="h-7 w-7 rounded-full" />
+            )}
+            <span className="truncate text-sm text-slate-600">{user.name || user.email}</span>
+            <button
+              type="button"
+              onClick={() => {
+                logout();
+                window.location.href = "/login";
+              }}
+              className="ml-auto text-xs text-slate-400 hover:text-slate-700"
+            >
+              Logout
+            </button>
+          </div>
+        )}
 
         <div className="border-t border-slate-200 px-4 py-3">
           <ConnectionIndicator state={wsState} />

--- a/apps/web/src/store/auth.ts
+++ b/apps/web/src/store/auth.ts
@@ -1,0 +1,40 @@
+// Zustand store for OAuth2 authentication state.
+//
+// Persists the JWT token in localStorage so sessions survive page reloads.
+
+import { create } from "zustand";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+}
+
+interface AuthState {
+  token: string | null;
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  authDisabled: boolean;
+  setToken: (token: string) => void;
+  setUser: (user: AuthUser) => void;
+  setAuthDisabled: (disabled: boolean) => void;
+  logout: () => void;
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  token: localStorage.getItem("wikimind_token"),
+  user: null,
+  isAuthenticated: !!localStorage.getItem("wikimind_token"),
+  authDisabled: false,
+  setToken: (token) => {
+    localStorage.setItem("wikimind_token", token);
+    set({ token, isAuthenticated: true });
+  },
+  setUser: (user) => set({ user }),
+  setAuthDisabled: (disabled) => set({ authDisabled: disabled }),
+  logout: () => {
+    localStorage.removeItem("wikimind_token");
+    set({ token: null, user: null, isAuthenticated: false });
+  },
+}));

--- a/apps/web/src/store/websocket.ts
+++ b/apps/web/src/store/websocket.ts
@@ -60,7 +60,7 @@ export const useWebSocketStore = create<WebSocketStore>((set) => ({
         next.toasts = [
           {
             id: makeId(),
-            kind: "success",
+            kind: "success" as const,
             title: "Compilation complete",
             detail: event.article_title,
             createdAt: Date.now(),
@@ -73,7 +73,7 @@ export const useWebSocketStore = create<WebSocketStore>((set) => ({
         next.toasts = [
           {
             id: makeId(),
-            kind: "error",
+            kind: "error" as const,
             title: "Compilation failed",
             detail: event.error,
             createdAt: Date.now(),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,165 @@
+# Production stack for WikiMind.
+#
+# All variables sourced from .env or shell environment with sensible defaults.
+# POSTGRES_PASSWORD is required — compose refuses to start without it.
+#
+# Services:
+#   gateway  — FastAPI app (gunicorn) serving API + built frontend
+#   worker   — ARQ background job worker (compilation, sweep)
+#   postgres — PostgreSQL 16 for metadata
+#   redis    — Broker/result store for ARQ background jobs
+#
+# Usage:
+#   make deploy-up       # build and start
+#   make deploy-stop     # stop (preserves data)
+#   make deploy-logs     # tail logs
+
+networks:
+  wikimindnet:
+    driver: bridge
+
+volumes:
+  wikimind-data:
+  wikimind-pgdata:
+  wikimind-redis:
+
+services:
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: prod
+    image: ${WIKIMIND_IMAGE:-wikimind:latest}
+    container_name: wikimind-gateway
+    restart: unless-stopped
+    networks: [wikimindnet]
+    ports:
+      - "${WIKIMIND_PORT:-7842}:7842"
+    environment:
+      WIKIMIND_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-wikimind}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:-wikimind}
+      WIKIMIND_REDIS_URL: redis://redis:6379/0
+      WIKIMIND_DATA_DIR: /home/wikimind/.wikimind
+      WIKIMIND_SERVER__HOST: "0.0.0.0"
+      WIKIMIND_SERVER__PORT: "7842"
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - wikimind-data:/home/wikimind/.wikimind
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7842/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: prod
+    image: ${WIKIMIND_IMAGE:-wikimind:latest}
+    container_name: wikimind-worker
+    restart: unless-stopped
+    networks: [wikimindnet]
+    command: ["python", "-m", "arq", "wikimind.jobs.worker.WorkerSettings"]
+    environment:
+      WIKIMIND_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-wikimind}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:-wikimind}
+      WIKIMIND_REDIS_URL: redis://redis:6379/0
+      WIKIMIND_DATA_DIR: /home/wikimind/.wikimind
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - wikimind-data:/home/wikimind/.wikimind
+    depends_on:
+      gateway:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: wikimind-postgres
+    restart: unless-stopped
+    networks: [wikimindnet]
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=100"
+      - "-c"
+      - "shared_buffers=128MB"
+      - "-c"
+      - "work_mem=4MB"
+      - "-c"
+      - "statement_timeout=60s"
+      - "-c"
+      - "idle_in_transaction_session_timeout=120s"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-wikimind}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      POSTGRES_DB: ${POSTGRES_DB:-wikimind}
+    volumes:
+      - wikimind-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-wikimind}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  redis:
+    image: redis:7-alpine
+    container_name: wikimind-redis
+    restart: unless-stopped
+    networks: [wikimindnet]
+    command:
+      - "redis-server"
+      - "--maxmemory"
+      - "256mb"
+      - "--maxmemory-policy"
+      - "allkeys-lru"
+    volumes:
+      - wikimind-redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 128M

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Alembic migrations when using PostgreSQL.
+# SQLite uses create_all() at startup — no Alembic needed.
+if [[ "${WIKIMIND_DATABASE_URL:-}" == postgresql* ]]; then
+    echo "Running Alembic migrations..."
+    python -m alembic upgrade head
+    echo "Migrations complete."
+fi
+
+# Hand off to CMD (gunicorn in prod, or whatever compose overrides).
+exec "$@"

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@ considered, and the consequences.
 | [019](adr-019-runtime-user-preferences.md) | Runtime User Preferences via DB Override Table | Accepted |
 | [021](adr-021-postgres-compatibility.md) | PostgreSQL compatibility for production deployments | Accepted |
 | [022](adr-022-multi-user-authentication.md) | Multi-User Authentication via OAuth2 | Accepted |
+| [023](adr-023-production-container-architecture.md) | Production Container Architecture | Unknown |
 
 ## ADR Format
 

--- a/docs/adr/adr-023-production-container-architecture.md
+++ b/docs/adr/adr-023-production-container-architecture.md
@@ -1,0 +1,86 @@
+# ADR-023: Production Container Architecture
+
+**Status:** Accepted  
+**Date:** 2026-04-18  
+**Issue:** [#199](https://github.com/manavgup/wikimind/issues/199)
+
+## Context
+
+WikiMind needs a production deployment that bundles the full stack — API server, background worker, database, and cache — into a single `docker compose up` command. The architecture must support two modes: local dev (SQLite, no Redis) and production (Postgres, Redis, multi-worker).
+
+## Decision
+
+### Deployment Modes
+
+```
+Dev (default)                    Production (docker-compose.prod.yml)
+─────────────                    ────────────────────────────────────
+SQLite (local file)              PostgreSQL 16 (container)
+No Redis (in-process jobs)       Redis 7 (container)
+uvicorn --reload                 gunicorn + uvicorn workers
+Vite dev server (:5173)          Built frontend served by FastAPI
+make dev                         make deploy-up
+```
+
+### Production Stack
+
+```mermaid
+graph TB
+    subgraph "docker-compose.prod.yml"
+        subgraph "wikimindnet (bridge)"
+            GW["gateway<br/>gunicorn + FastAPI<br/>:7842"]
+            WK["worker<br/>ARQ job consumer"]
+            PG["postgres:16-alpine<br/>metadata store"]
+            RD["redis:7-alpine<br/>job queue broker"]
+        end
+    end
+
+    USER["Browser / API Client"] -->|":7842"| GW
+    GW -->|"SQL"| PG
+    GW -->|"enqueue jobs"| RD
+    WK -->|"SQL"| PG
+    WK -->|"dequeue jobs"| RD
+    GW -.->|"shared volume"| VOL["wikimind-data<br/>(wiki + raw files)"]
+    WK -.->|"shared volume"| VOL
+```
+
+### Dockerfile Multi-Stage Build
+
+```
+node:20-alpine (frontend)  ──→  npm run build  ──→  /app/dist/
+                                                        │
+python:3.11-slim (base)    ──→  apt-get deps            │
+         │                                              │
+         ├──→  dev stage (editable install, --reload)   │
+         │                                              │
+         └──→  prod stage ──→  pip install .[pdf]  ─────┤
+                               COPY --from=frontend     │
+                               COPY alembic/            │
+                               COPY entrypoint.sh       │
+                               ENTRYPOINT → CMD gunicorn
+```
+
+### Key Design Choices
+
+| Choice | Rationale |
+|--------|-----------|
+| **FastAPI serves frontend** (no nginx) | One container serves API + React SPA. Sufficient for personal/small-team scale. Nginx can be added later if needed. |
+| **Entrypoint runs Alembic** | `docker-entrypoint.sh` runs `alembic upgrade head` on Postgres before starting gunicorn. SQLite uses `create_all()` at startup instead. |
+| **Named bridge network** | `wikimindnet` isolates inter-service traffic. Only the gateway port is published. |
+| **All values env-parameterized** | `docker-compose.prod.yml` uses `${VAR:-default}` syntax throughout. `POSTGRES_PASSWORD` is required via `${...:?}`. Nothing hardcoded. |
+| **Resource limits** | `deploy.resources` on all services prevents runaway containers. Sized for single-user/small-team. |
+| **Fly.io config included** | `fly.toml` provides one-command cloud deployment with auto-stop machines and free TLS. |
+
+### Alternatives Considered
+
+- **nginx reverse proxy** — adds a container + config for caching/TLS. Overkill for this scale; cloud providers (Fly.io, Cloudflare) handle TLS.
+- **PgBouncer connection pooler** — useful at 1000+ connections. WikiMind's `pool_size=10` is sufficient.
+- **Compose profiles** (monitoring, TLS) — modeled after mcp-context-forge. Deferred until needed.
+
+## Consequences
+
+- `make deploy-up` starts the full production stack locally
+- `fly deploy` deploys to Fly.io with managed Postgres
+- Dev mode (`make dev`) is unchanged — no Docker required
+- Frontend is built into the prod image — no separate web server needed
+- Alembic migrations run automatically on every deployment

--- a/docs/superpowers/plans/2026-04-17-production-deployment.md
+++ b/docs/superpowers/plans/2026-04-17-production-deployment.md
@@ -1,0 +1,552 @@
+# Production Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Containerize the full WikiMind stack (gateway + frontend + Postgres + Redis + worker) for production deployment, closing Epic 5.
+
+**Architecture:** The existing Dockerfile gets a frontend build stage. The prod image serves the React frontend via FastAPI's `StaticFiles` — no separate nginx container. A `docker-compose.prod.yml` orchestrates gateway, Postgres 16, Redis 7, and an ARQ worker, all sharing a persistent data volume. Alembic migrations run automatically on startup via an entrypoint script. Deployment docs cover Fly.io and generic Docker.
+
+**Tech Stack:** Docker multi-stage builds, PostgreSQL 16, Redis 7, Alembic, Gunicorn, FastAPI StaticFiles
+
+**Closes:** #199 (production docker-compose), Epic 5 (Sync + Multi-provider)
+
+**Prerequisites on main (already merged):**
+- FileStorage abstraction (PR 1/3, #170)
+- PostgreSQL compatibility (PR 2/3, #174) — `database.py`, `db_compat.py`, `alembic/`
+- Multi-provider LLM + Settings UI + Cost tracking
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `docker/entrypoint.sh` | Run alembic + start gunicorn |
+| Modify | `Dockerfile` | Add frontend build stage, copy dist + alembic to prod |
+| Modify | `src/wikimind/main.py` | Mount frontend dist via StaticFiles (conditional) |
+| Create | `docker-compose.prod.yml` | Full production stack |
+| Modify | `Makefile` | `deploy-local`, `deploy-stop`, `deploy-logs` targets |
+| Modify | `.env.example` | Document production config (DATABASE_URL, REDIS_URL) |
+| Create | `fly.toml` | Fly.io deployment config |
+| Modify | `README.md` | Deployment section |
+
+---
+
+### Task 1: Docker Entrypoint Script
+
+**Files:**
+- Create: `docker/entrypoint.sh`
+
+- [ ] **Step 1: Create the entrypoint script**
+
+```bash
+#!/bin/sh
+set -e
+
+# Run Alembic migrations if using Postgres.
+# SQLite uses create_all() on startup — no Alembic needed.
+if echo "$WIKIMIND_DATABASE_URL" | grep -q "^postgresql"; then
+  echo "Running Alembic migrations..."
+  python -m alembic upgrade head
+  echo "Migrations complete."
+fi
+
+exec "$@"
+```
+
+Write to `docker/entrypoint.sh` and make executable.
+
+- [ ] **Step 2: Verify the script is executable**
+
+Run: `ls -la docker/entrypoint.sh`
+Expected: `-rwxr-xr-x` permissions
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/entrypoint.sh
+git commit -m "feat: add Docker entrypoint with auto-migration for Postgres"
+```
+
+---
+
+### Task 2: Update Dockerfile for Production
+
+**Files:**
+- Modify: `Dockerfile`
+
+The Dockerfile needs two additions:
+1. A `frontend` stage that builds the React app with Node.js
+2. The `prod` stage copies the frontend build + alembic files and uses the entrypoint
+
+- [ ] **Step 1: Add the frontend build stage**
+
+Insert between the `base` and `dev` stages in `Dockerfile`:
+
+```dockerfile
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS frontend
+
+WORKDIR /app
+COPY apps/web/package.json apps/web/package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY apps/web/ ./
+RUN npm run build
+```
+
+- [ ] **Step 2: Update the prod stage**
+
+Modify the `prod` stage to:
+- Copy alembic config and migrations
+- Copy the frontend build from the `frontend` stage
+- Use the entrypoint script
+
+Replace the existing prod stage (from `FROM base AS prod` to end of file) with:
+
+```dockerfile
+# ---------------------------------------------------------------------------
+FROM base AS prod
+
+ARG TORCH_INDEX
+COPY pyproject.toml README.md ./
+COPY src ./src
+# Same CVE upgrade as the dev stage — see comment above.
+# Install with [pdf] extra for structured PDF extraction via docling.
+RUN pip install --upgrade pip setuptools wheel \
+    && pip install --extra-index-url ${TORCH_INDEX} ".[pdf]"
+
+# Alembic migrations for Postgres deployments
+COPY alembic.ini ./
+COPY alembic ./alembic
+
+# Built frontend — served by FastAPI StaticFiles at /
+COPY --from=frontend /app/dist ./frontend
+
+# Entrypoint: run alembic migrations (Postgres only), then exec CMD
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Run as a non-root user in production.
+RUN useradd --create-home --uid 1000 wikimind \
+    && mkdir -p /home/wikimind/.wikimind \
+    && chown -R wikimind:wikimind /home/wikimind /app
+USER wikimind
+
+ENV WIKIMIND_DATA_DIR=/home/wikimind/.wikimind \
+    WIKIMIND_SERVER__HOST=0.0.0.0
+
+EXPOSE 7842
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:7842/health || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["gunicorn", "wikimind.main:app", "-w", "2", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:7842"]
+```
+
+- [ ] **Step 3: Verify Dockerfile builds**
+
+Run: `docker build --target prod -t wikimind-prod:test . 2>&1 | tail -10`
+Expected: Successfully built image
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat: add frontend build stage and entrypoint to Dockerfile prod target"
+```
+
+---
+
+### Task 3: Serve Frontend from FastAPI
+
+**Files:**
+- Modify: `src/wikimind/main.py`
+- Test: verify with `make test`
+
+The frontend dist is at `/app/frontend/` inside the prod container. Mount it via StaticFiles only when it exists (so dev mode with `--reload` is unaffected).
+
+- [ ] **Step 1: Add conditional frontend mount to main.py**
+
+After the existing `/images` mount and router includes, add:
+
+```python
+# Serve the built frontend in production.
+# The dist is copied into the Docker prod image at /app/frontend/.
+# In dev mode this directory does not exist — Vite serves the frontend.
+_frontend_dir = Path(__file__).resolve().parent.parent.parent / "frontend"
+if _frontend_dir.is_dir():
+    app.mount("/", StaticFiles(directory=str(_frontend_dir), html=True), name="frontend")
+```
+
+The `html=True` parameter enables SPA fallback: requests for paths like `/settings` that don't match a static file return `index.html`, allowing React Router to handle client-side routing.
+
+**Important:** This mount MUST be the last `app.mount()` call because `"/"` is a catch-all. All API routers are registered with `include_router` (which uses `APIRouter` prefix matching, not `mount`), so they take priority.
+
+- [ ] **Step 2: Run tests to verify no regression**
+
+Run: `make test`
+Expected: All tests pass — the frontend dir doesn't exist locally, so the mount is skipped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/wikimind/main.py
+git commit -m "feat: serve built frontend via StaticFiles in production"
+```
+
+---
+
+### Task 4: Production Docker Compose
+
+**Files:**
+- Create: `docker-compose.prod.yml`
+
+- [ ] **Step 1: Create docker-compose.prod.yml**
+
+```yaml
+# Production stack for WikiMind.
+#
+# Services:
+#   gateway  — FastAPI app (gunicorn) serving both API and frontend
+#   worker   — ARQ background job worker (compilation, sweep)
+#   postgres — PostgreSQL 16 for metadata
+#   redis    — Broker/result store for ARQ background jobs
+#
+# Bring up:   make deploy-local
+# Tear down:  make deploy-stop
+# Logs:       make deploy-logs
+
+services:
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: prod
+    image: wikimind-prod:latest
+    container_name: wikimind-gateway-prod
+    environment:
+      WIKIMIND_DATABASE_URL: postgresql+asyncpg://wikimind:${POSTGRES_PASSWORD:-wikimind}@postgres:5432/wikimind
+      WIKIMIND_REDIS_URL: redis://redis:6379/0
+      WIKIMIND_DATA_DIR: /home/wikimind/.wikimind
+      WIKIMIND_SERVER__HOST: "0.0.0.0"
+      WIKIMIND_SERVER__PORT: "7842"
+    env_file:
+      - path: .env
+        required: false
+    ports:
+      - "${WIKIMIND_PORT:-7842}:7842"
+    volumes:
+      - wikimind-data:/home/wikimind/.wikimind
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: prod
+    image: wikimind-prod:latest
+    container_name: wikimind-worker-prod
+    command: ["python", "-m", "arq", "wikimind.jobs.worker.WorkerSettings"]
+    environment:
+      WIKIMIND_DATABASE_URL: postgresql+asyncpg://wikimind:${POSTGRES_PASSWORD:-wikimind}@postgres:5432/wikimind
+      WIKIMIND_REDIS_URL: redis://redis:6379/0
+      WIKIMIND_DATA_DIR: /home/wikimind/.wikimind
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - wikimind-data:/home/wikimind/.wikimind
+    depends_on:
+      gateway:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: wikimind-postgres-prod
+    environment:
+      POSTGRES_DB: wikimind
+      POSTGRES_USER: wikimind
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-wikimind}
+    volumes:
+      - wikimind-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U wikimind"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: wikimind-redis-prod
+    volumes:
+      - wikimind-redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  wikimind-data:
+  wikimind-pgdata:
+  wikimind-redis:
+```
+
+- [ ] **Step 2: Verify compose config is valid**
+
+Run: `docker compose -f docker-compose.prod.yml config --quiet`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.prod.yml
+git commit -m "feat: add production docker-compose with Postgres + Redis"
+```
+
+---
+
+### Task 5: Makefile Deploy Targets
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add deploy targets**
+
+Add a new section to the Makefile after the Docker section:
+
+```makefile
+##@ 🚀 DEPLOY
+
+.PHONY: deploy-local
+deploy-local: ## Build and run the full production stack locally
+	docker compose -f docker-compose.prod.yml up -d --build
+
+.PHONY: deploy-stop
+deploy-stop: ## Stop the production stack
+	docker compose -f docker-compose.prod.yml down
+
+.PHONY: deploy-logs
+deploy-logs: ## Tail logs from the production stack
+	docker compose -f docker-compose.prod.yml logs -f
+```
+
+- [ ] **Step 2: Verify targets appear in help**
+
+Run: `make help | grep deploy`
+Expected: Three deploy targets listed
+
+- [ ] **Step 3: Run auto-generated docs**
+
+Run: `make regenerate-docs`
+Expected: README make-targets section updated
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile README.md
+git commit -m "feat: add make deploy-local/stop/logs targets"
+```
+
+---
+
+### Task 6: Fly.io Configuration
+
+**Files:**
+- Create: `fly.toml`
+
+Fly.io is the simplest cloud deployment for WikiMind: one command deploys the entire stack. Fly provides managed Postgres and Redis as add-ons.
+
+- [ ] **Step 1: Create fly.toml**
+
+```toml
+# Fly.io deployment configuration for WikiMind.
+#
+# Prerequisites:
+#   fly auth login
+#   fly apps create wikimind
+#   fly postgres create --name wikimind-db
+#   fly postgres attach wikimind-db
+#   fly redis create --name wikimind-redis
+#
+# Deploy:
+#   fly deploy
+#
+# Set LLM API key:
+#   fly secrets set ANTHROPIC_API_KEY=sk-ant-...
+
+app = "wikimind"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+  [build.args]
+    TORCH_INDEX = "https://download.pytorch.org/whl/cpu"
+
+[env]
+  WIKIMIND_SERVER__HOST = "0.0.0.0"
+  WIKIMIND_SERVER__PORT = "7842"
+
+[http_service]
+  internal_port = 7842
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 100
+    soft_limit = 80
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[checks]
+  [checks.health]
+    type = "http"
+    port = 7842
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add fly.toml
+git commit -m "feat: add Fly.io deployment config"
+```
+
+---
+
+### Task 7: Update .env.example and Docs
+
+**Files:**
+- Modify: `.env.example`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add production config section to .env.example**
+
+Add after the existing Database section:
+
+```env
+# ----------------------------------------------------------------------------
+# Production Database (required for Postgres deployments)
+# ----------------------------------------------------------------------------
+# Override the default SQLite with a PostgreSQL URL for production.
+# See ADR-021 for design. Run `alembic upgrade head` to create tables.
+# WIKIMIND_DATABASE_URL=postgresql+asyncpg://wikimind:password@localhost:5432/wikimind
+```
+
+- [ ] **Step 2: Add deployment section to README.md**
+
+Add a "Deployment" section with:
+- `make deploy-local` quick start
+- Fly.io instructions (3 commands: create app, attach postgres, deploy)
+- Environment variables reference table
+
+- [ ] **Step 3: Run auto-generated docs**
+
+Run: `make regenerate-docs && make check-docs`
+Expected: All docs in sync
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example README.md docs/
+git commit -m "docs: add production deployment guide and config documentation"
+```
+
+---
+
+### Task 8: Smoke Test the Production Stack
+
+- [ ] **Step 1: Build and start the production stack**
+
+Run: `make deploy-local`
+Expected: All 4 containers start (gateway, worker, postgres, redis)
+
+- [ ] **Step 2: Wait for health check**
+
+Run: `curl -sf http://localhost:7842/health`
+Expected: `{"status":"ok","version":"0.1.0"}`
+
+- [ ] **Step 3: Verify frontend is served**
+
+Run: `curl -sf http://localhost:7842/ | head -5`
+Expected: HTML page with React root div
+
+- [ ] **Step 4: Test ingest + compile cycle**
+
+```bash
+curl -sf -X POST http://localhost:7842/ingest/text \
+  -H "Content-Type: application/json" \
+  -d '{"content":"Test article for production deployment verification.","title":"Deploy Test"}'
+```
+
+Expected: Source created, compilation triggers
+
+- [ ] **Step 5: Tear down**
+
+Run: `make deploy-stop`
+Expected: All containers stopped
+
+- [ ] **Step 6: Run make verify**
+
+Run: `make verify`
+Expected: All quality checks pass
+
+---
+
+### Task 9: Epic 5 Cleanup
+
+- [ ] **Step 1: Close PR #171 (R2 storage backend)**
+
+```bash
+gh pr close 171 --comment "Closing in favor of the simpler production deployment approach (#199). R2 storage can be revisited when sync is implemented."
+```
+
+- [ ] **Step 2: Close issue #199**
+
+The PR for this plan will reference and close #199.
+
+- [ ] **Step 3: Update epic #5 body**
+
+Update the checklist to reflect reality:
+- [x] Multi-provider LLM (Anthropic, OpenAI, Google, Ollama)
+- [x] Settings UI with cost tracking
+- [x] Production deployment with Postgres
+- Deferred: #74 (offline-first sync), #28 (cloud sync service)
+
+```bash
+gh issue comment 5 --body "Epic 5 substantially complete:
+- ✅ Multi-provider LLM support (Anthropic, OpenAI, Google, Ollama)
+- ✅ Settings UI with provider config, cost dashboard, budget warnings
+- ✅ Cost tracking per provider per month
+- ✅ Production deployment: docker-compose.prod.yml with Postgres + Redis
+- ✅ Fly.io deployment config
+- ⏸️ Deferred to future epic: #74 (offline-first sync engine), #28 (cloud sync service)
+
+Multi-device access works via shared Postgres deployment — no sync protocol needed for the current use case."
+```
+
+- [ ] **Step 4: Create follow-up issue for sync (optional)**
+
+If you want to track sync separately from Epic 5:
+```bash
+gh issue create --title "[EPIC]: Offline-first sync engine" --body "Extracted from Epic 5. See #74 and #28 for specs." --label "epic"
+```

--- a/docs/superpowers/plans/2026-04-17-production-deployment.md
+++ b/docs/superpowers/plans/2026-04-17-production-deployment.md
@@ -449,7 +449,7 @@ Add after the existing Database section:
 # ----------------------------------------------------------------------------
 # Override the default SQLite with a PostgreSQL URL for production.
 # See ADR-021 for design. Run `alembic upgrade head` to create tables.
-# WIKIMIND_DATABASE_URL=postgresql+asyncpg://wikimind:password@localhost:5432/wikimind
+# WIKIMIND_DATABASE_URL=postgresql+asyncpg://wikimind:PASSWORD@localhost:5432/wikimind  # pragma: allowlist secret
 ```
 
 - [ ] **Step 2: Add deployment section to README.md**

--- a/docs/superpowers/specs/2026-04-18-multi-user-design.md
+++ b/docs/superpowers/specs/2026-04-18-multi-user-design.md
@@ -1,0 +1,375 @@
+# Multi-User WikiMind — Design Spec
+
+## Problem
+
+WikiMind is a single-user personal knowledge OS. Every table, route, storage path, and background job assumes one user. To scale to 100s of users on a shared server, we need authentication, per-user data isolation, scoped file storage, and scoped background jobs.
+
+## Decisions
+
+- **Auth**: OAuth2/SSO via Google and GitHub
+- **Data isolation**: `user_id` FK on all tables, application-level filtering (no RLS)
+- **LLM billing**: BYOK — each user brings their own API keys
+- **File storage**: Per-user namespacing in local/R2 storage (`{user_id}/article-slug.md`)
+- **Backward compatibility**: Existing single-user data migrated to a "default" user
+
+## Architecture Overview
+
+```
+Browser → OAuth2 Login → JWT issued → Authorization header on every request
+                                        ↓
+                              Auth Middleware extracts user_id
+                                        ↓
+                              Route handler filters by user_id
+                                        ↓
+                              Storage namespaced by user_id
+```
+
+No shared LLM keys. No billing system. No Stripe. Each user configures their own Anthropic/OpenAI/Google key in Settings, stored encrypted per-user.
+
+---
+
+## PR 1: User Model + OAuth2 Auth
+
+### New Table: `User`
+
+```python
+class User(SQLModel, table=True):
+    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
+    email: str = Field(index=True, unique=True)
+    name: str | None = None
+    avatar_url: str | None = None
+    auth_provider: str  # "google" | "github"
+    auth_provider_id: str  # provider's user ID
+    created_at: datetime
+    updated_at: datetime
+```
+
+### Config Additions
+
+```python
+class AuthConfig(BaseModel):
+    enabled: bool = False
+    jwt_secret_key: str = ""  # required when enabled
+    jwt_algorithm: str = "HS256"
+    jwt_expiry_minutes: int = 1440  # 24 hours
+    google_client_id: str | None = None
+    google_client_secret: str | None = None
+    github_client_id: str | None = None
+    github_client_secret: str | None = None
+```
+
+Added to Settings as `auth: AuthConfig = Field(default_factory=AuthConfig)`.
+
+### Auth Flow
+
+1. Frontend redirects to `/auth/login/google` (or `/github`)
+2. Server redirects to provider's OAuth2 authorize URL
+3. Provider redirects back to `/auth/callback?code=...&state=...`
+4. Server exchanges code for access token, fetches user profile
+5. Server upserts User row, issues JWT with `{"sub": user_id, "email": email}`
+6. Frontend stores JWT in localStorage, sends via `Authorization: Bearer <token>`
+
+### Auth Middleware
+
+```python
+class AuthMiddleware:
+    async def __call__(self, request, call_next):
+        if not settings.auth.enabled:
+            # Single-user mode — skip auth, set a default user
+            request.state.user = None
+            return await call_next(request)
+
+        token = request.headers.get("Authorization", "").removeprefix("Bearer ")
+        if not token:
+            return JSONResponse(status_code=401, content={"error": "Missing token"})
+
+        payload = jwt.decode(token, settings.auth.jwt_secret_key, ...)
+        request.state.user = User(id=payload["sub"], email=payload["email"])
+        return await call_next(request)
+```
+
+### Routes
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/auth/login/{provider}` | GET | Redirect to OAuth2 provider |
+| `/auth/callback` | GET | Handle OAuth2 callback, issue JWT |
+| `/auth/me` | GET | Return current user profile |
+| `/auth/logout` | POST | Invalidate token (client-side) |
+
+### Backward Compatibility
+
+When `auth.enabled = False` (default), `request.state.user` is `None`. All existing routes continue working without auth. PR 2 will use this to decide whether to filter by user_id.
+
+### New Dependencies
+
+- `PyJWT>=2.8.0` — JWT encoding/decoding
+- `httpx` — already a dependency (used for OAuth2 token exchange)
+
+---
+
+## PR 2: Data Isolation — user_id FK on All Models
+
+### Schema Changes
+
+Add `user_id: str | None = Field(default=None, foreign_key="user.id", index=True)` to:
+
+| Table | Notes |
+|-------|-------|
+| Source | Who ingested this source |
+| Article | Who owns this article (slug unique per user, not globally) |
+| Concept | Per-user concept taxonomy |
+| Backlink | Follows article ownership |
+| Conversation | Who started this conversation |
+| Query | Follows conversation ownership |
+| Job | Whose job |
+| CostLog | Whose LLM spend |
+| UserPreference | Per-user settings (key changes from global to per-user) |
+| LintReport | Per-user lint runs |
+| ContradictionFinding | Per-user |
+| OrphanFinding | Per-user |
+| StructuralFinding | Per-user |
+
+### Unique Constraint Changes
+
+- `Article.slug`: currently globally unique → change to `UniqueConstraint("user_id", "slug")`
+- `Concept.name`: currently globally unique → change to `UniqueConstraint("user_id", "name")`
+
+### FastAPI Dependency: `get_current_user`
+
+```python
+async def get_current_user(request: Request) -> User | None:
+    """Extract current user from request state. Returns None in single-user mode."""
+    return getattr(request.state, "user", None)
+
+def require_user(user: User | None = Depends(get_current_user)) -> User:
+    """Require authentication. Raises 401 if no user."""
+    if user is None:
+        settings = get_settings()
+        if settings.auth.enabled:
+            raise HTTPException(status_code=401, detail="Authentication required")
+    return user
+```
+
+### Route Handler Changes (every route)
+
+Before:
+```python
+@router.get("/articles")
+async def list_articles(session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(Article))
+```
+
+After:
+```python
+@router.get("/articles")
+async def list_articles(
+    session: AsyncSession = Depends(get_session),
+    user: User | None = Depends(get_current_user),
+):
+    stmt = select(Article)
+    if user:
+        stmt = stmt.where(Article.user_id == user.id)
+    result = await session.execute(stmt)
+```
+
+### Alembic Migration
+
+1. Add `user_id` column to all tables (nullable, no FK constraint initially)
+2. Create a "default" User row for existing single-user data
+3. Backfill all existing rows: `UPDATE article SET user_id = '<default-user-id>'`
+4. Add FK constraint and index
+5. For Article: drop old unique index on slug, create composite unique on (user_id, slug)
+6. For Concept: same treatment for name
+
+### Per-User API Keys
+
+Currently, API keys are stored globally in Settings (SecretStr fields) or OS keychain. For multi-user, keys must be per-user:
+
+- Add `UserApiKey` table: `(user_id, provider, encrypted_key)`
+- `get_api_key(provider)` gains a `user_id` parameter
+- Keys encrypted at rest using `auth.jwt_secret_key` or a dedicated encryption key
+- Settings page saves keys per-user, not globally
+
+---
+
+## PR 3: Per-User File Storage Namespacing
+
+### Path Structure
+
+Current:
+```
+~/.wikimind/wiki/article-slug.md
+~/.wikimind/raw/source-id.txt
+```
+
+Multi-user:
+```
+~/.wikimind/wiki/{user_id}/article-slug.md
+~/.wikimind/raw/{user_id}/source-id.txt
+```
+
+### Storage Interface Changes
+
+```python
+def get_wiki_storage(user_id: str | None = None) -> FileStorage:
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki"
+    if user_id:
+        root = root / user_id
+    return LocalFileStorage(root=root)
+```
+
+Same pattern for `get_raw_storage()`.
+
+### R2 Storage (revive PR #171)
+
+Cherry-pick `R2FileStorage` from the `feat/r2-storage-backend` branch. Per-user namespacing via S3 prefix:
+
+```python
+class R2FileStorage:
+    def __init__(self, bucket: str, prefix: str = ""):
+        self.prefix = prefix  # e.g., "wiki/user-123/"
+```
+
+Factory:
+```python
+def get_wiki_storage(user_id: str | None = None) -> FileStorage:
+    settings = get_settings()
+    if settings.storage_backend == "r2":
+        prefix = f"wiki/{user_id}/" if user_id else "wiki/"
+        return R2FileStorage(bucket=settings.r2_bucket, prefix=prefix)
+    else:
+        root = Path(settings.data_dir) / "wiki"
+        if user_id:
+            root = root / user_id
+        return LocalFileStorage(root=root)
+```
+
+### Migration
+
+Alembic migration + startup script:
+1. Create `wiki/{default-user-id}/` directory
+2. Move all existing `wiki/*.md` files into it
+3. Update `Article.file_path` in DB from `slug.md` to `{default-user-id}/slug.md`
+4. Same for `raw/` directory and `Source.file_path`
+
+---
+
+## PR 4: Per-User Background Jobs + WebSocket Scoping
+
+### Job Changes
+
+- `Job.user_id` added (from PR 2)
+- `schedule_compile(source_id, user_id)` — jobs carry user context
+- Worker functions filter by user_id:
+
+```python
+async def compile_source(ctx, source_id: str, user_id: str):
+    async with get_session_factory()() as session:
+        source = await session.get(Source, source_id)
+        if source.user_id != user_id:
+            raise ValueError("Source does not belong to user")
+        # ... compile
+```
+
+### Cron Jobs
+
+```python
+async def lint_all_users(ctx):
+    """Weekly lint — iterate over active users."""
+    async with get_session_factory()() as session:
+        users = await session.execute(select(User))
+        for user in users.scalars():
+            await lint_wiki(ctx, user_id=user.id)
+```
+
+### WebSocket Scoping
+
+Current: single global WebSocket at `/ws` broadcasts to all connections.
+
+Multi-user: connections tagged with user_id.
+
+```python
+# In ws.py
+connections: dict[str, set[WebSocket]] = {}  # user_id → connections
+
+async def broadcast_to_user(user_id: str, event: dict):
+    for ws in connections.get(user_id, set()):
+        await ws.send_json(event)
+```
+
+Worker emits to specific user:
+```python
+emit_compilation_complete(user_id=source.user_id, article_title=...)
+```
+
+---
+
+## PR 5: Frontend Auth UI
+
+### New Components
+
+- `LoginPage.tsx` — Google/GitHub login buttons
+- `AuthProvider.tsx` — React context managing JWT token + user state
+- `useAuth()` hook — `{ user, isAuthenticated, login, logout }`
+- `ProtectedRoute.tsx` — wraps routes, redirects to /login if unauthenticated
+
+### API Client Changes
+
+```typescript
+// api/client.ts
+function apiFetch(url: string, options?: RequestInit) {
+    const token = localStorage.getItem("wikimind_token");
+    const headers = { ...options?.headers };
+    if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+    }
+    return fetch(url, { ...options, headers });
+}
+```
+
+### Layout Changes
+
+- Header: user avatar + dropdown (settings, logout)
+- If not authenticated: redirect to /login
+- Login page: centered card with OAuth buttons
+
+### Routes
+
+```tsx
+<Route path="/login" element={<LoginPage />} />
+<Route path="/auth/callback" element={<AuthCallback />} />
+// All other routes wrapped in <ProtectedRoute>
+```
+
+---
+
+## What's NOT in Scope
+
+- **Billing / Stripe** — users bring their own LLM keys
+- **Admin panel** — no user management UI (manage via DB/API)
+- **Rate limiting per user** — defer until needed
+- **Email notifications** — not needed for v1
+- **RBAC / permissions** — all users are equal; no admin/viewer roles
+- **Multi-tenant org model** — no "teams" or "workspaces"
+- **Real-time collaboration** — each user has their own wiki
+
+---
+
+## Dependency Chain
+
+```
+PR 1: User + OAuth2 Auth
+  ↓
+PR 2: Data Isolation (user_id FK)  ←  depends on User table from PR 1
+  ↓
+PR 3: Storage Namespacing          ←  depends on user_id from PR 2
+  ↓
+PR 4: Jobs + WebSocket Scoping     ←  depends on user_id from PR 2
+  ↓
+PR 5: Frontend Auth UI             ←  depends on auth routes from PR 1
+```
+
+PRs 3 and 4 can be developed in parallel after PR 2 lands.
+PR 5 can start after PR 1 (doesn't need PR 2-4 for the UI itself).

--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,7 @@
 #   fly deploy
 #
 # Set LLM API key:
-#   fly secrets set ANTHROPIC_API_KEY=sk-ant-...
+#   fly secrets set ANTHROPIC_API_KEY=<your-key>
 
 app = "wikimind"
 primary_region = "ord"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,45 @@
+# fly.toml — Fly.io deployment for WikiMind.
+#
+# Prerequisites:
+#   fly auth login
+#   fly apps create wikimind
+#   fly postgres create --name wikimind-db
+#   fly postgres attach wikimind-db
+#
+# Deploy:
+#   fly deploy
+#
+# Set LLM API key:
+#   fly secrets set ANTHROPIC_API_KEY=sk-ant-...
+
+app = "wikimind"
+primary_region = "ord"
+
+[build]
+  dockerfile = "Dockerfile"
+  [build.args]
+    TORCH_INDEX = "https://download.pytorch.org/whl/cpu"
+
+[env]
+  WIKIMIND_SERVER__HOST = "0.0.0.0"
+  WIKIMIND_SERVER__PORT = "7842"
+
+[http_service]
+  internal_port = 7842
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[checks]
+  [checks.health]
+    type = "http"
+    port = 7842
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dependencies = [
     "boto3>=1.35.49",
     "httpx>=0.27.2",
 
+    # Production server
+    "gunicorn>=22.0.0",
+
     # Utilities
     "python-slugify>=8.0.4",
     "python-dateutil>=2.9.0",

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -264,6 +264,28 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def _fallback_database_url(self) -> Settings:
+        """Fall back to the unprefixed DATABASE_URL env var for managed Postgres services.
+
+        Fly.io, Railway, Render, and Heroku set DATABASE_URL automatically
+        when attaching a managed Postgres instance. This validator lets those
+        deployments work without requiring WIKIMIND_DATABASE_URL to be set
+        manually. The scheme is rewritten from postgres:// or postgresql://
+        to postgresql+asyncpg:// for SQLAlchemy async compatibility.
+
+        Only activates when the current database_url is NOT already a Postgres
+        URL (i.e., when it's the SQLite default from _default_database_url).
+        """
+        raw = os.environ.get("DATABASE_URL")
+        if raw and not self.database_url.startswith("postgresql"):
+            if raw.startswith("postgres://"):
+                raw = raw.replace("postgres://", "postgresql+asyncpg://", 1)
+            elif raw.startswith("postgresql://"):
+                raw = raw.replace("postgresql://", "postgresql+asyncpg://", 1)
+            self.database_url = raw
+        return self
+
+    @model_validator(mode="after")
     def _auto_enable_providers_with_keys(self) -> Settings:
         """Auto-enable any provider whose API key is configured.
 

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -122,6 +122,11 @@ app.include_router(settings_router.router, prefix="/settings", tags=["Settings"]
 app.include_router(ws.router, tags=["WebSocket"])
 app.include_router(auth.router, prefix="/auth", tags=["Auth"])
 
+# Serve built frontend in production (Docker image has static/ dir).
+# In dev, Vite on :5173 serves the frontend — this dir won't exist.
+_frontend_dist = Path(__file__).resolve().parent.parent.parent / "static"
+if _frontend_dist.is_dir():
+    app.mount("/", StaticFiles(directory=str(_frontend_dist), html=True), name="frontend")
 
 # ---------------------------------------------------------------------------
 # Exception handlers — catch domain errors raised inside route handlers

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -122,12 +122,6 @@ app.include_router(settings_router.router, prefix="/settings", tags=["Settings"]
 app.include_router(ws.router, tags=["WebSocket"])
 app.include_router(auth.router, prefix="/auth", tags=["Auth"])
 
-# Serve built frontend in production (Docker image has static/ dir).
-# In dev, Vite on :5173 serves the frontend — this dir won't exist.
-_frontend_dist = Path(__file__).resolve().parent.parent.parent / "static"
-if _frontend_dist.is_dir():
-    app.mount("/", StaticFiles(directory=str(_frontend_dist), html=True), name="frontend")
-
 # ---------------------------------------------------------------------------
 # Exception handlers — catch domain errors raised inside route handlers
 # ---------------------------------------------------------------------------
@@ -153,3 +147,14 @@ async def wikimind_error_handler(request: Request, exc: WikiMindError) -> JSONRe
 async def health():
     """Health check — used by Electron to confirm daemon is ready."""
     return {"status": "ok", "version": "0.1.0"}
+
+
+# ---------------------------------------------------------------------------
+# Frontend static files — MUST be last (catch-all "/" mount)
+# ---------------------------------------------------------------------------
+# Serve built frontend in production (Docker image copies dist to /app/static/).
+# In dev, Vite on :5173 serves the frontend — this dir won't exist.
+for _candidate in [Path("/app/static"), Path(__file__).resolve().parent.parent.parent / "static"]:
+    if _candidate.is_dir():
+        app.mount("/", StaticFiles(directory=str(_candidate), html=True), name="frontend")
+        break


### PR DESCRIPTION
## Summary

Closes #199. Substantially completes Epic 5 (Sync + Multi-provider).

WikiMind now has two deployment modes:
- **Dev** (default): SQLite, no Redis, in-process compilation — `make dev`
- **Production**: Postgres + Redis + ARQ worker via `make deploy-up`

Production deployment is modeled after [IBM/mcp-context-forge](https://github.com/IBM/mcp-context-forge) patterns: all values env-parameterized (nothing hardcoded in Makefile), named Docker networks, health checks with `start_period`, `restart: unless-stopped`, resource limits.

### What's new

- **`docker-compose.prod.yml`** — gateway + postgres + redis + worker, all `${VAR:-default}` parameterized, `POSTGRES_PASSWORD` required via `${...:?}` syntax
- **`docker/entrypoint.sh`** — runs Alembic migrations on Postgres before starting gunicorn
- **Dockerfile frontend stage** — builds React app via node:20-alpine, copies dist into prod image
- **FastAPI serves frontend** — `StaticFiles(html=True)` at `/` when `static/` dir exists (prod only)
- **`_fallback_database_url` validator** — reads unprefixed `DATABASE_URL` for Fly.io/Railway compatibility
- **`fly.toml`** — Fly.io deployment config with auto-stop machines
- **Makefile** — `deploy-up`/`deploy-stop`/`deploy-logs`/`deploy-ps` targets; `-include .env.make` for build overrides; PG_* hardcoding removed

### MCF patterns adopted vs skipped

| Adopted | Skipped (with reasoning) |
|---------|--------------------------|
| `${VAR:-default}` parameterization | PgBouncer (single-user scale) |
| Named bridge network | nginx caching proxy (gunicorn serves fine) |
| Health checks + `start_period` | Compose profiles (no monitoring/tls variants needed) |
| `restart: unless-stopped` | sysctls/ulimits tuning (enterprise-only) |
| `deploy.resources` limits | Replicas (single instance sufficient) |
| Entrypoint script pattern | 710-line entrypoint (10 lines suffice) |

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1 pre-existing failure: `test_postgres_url_creates_asyncpg_engine` — asyncpg not in dev venv)
- [x] `make deploy-up` with `POSTGRES_PASSWORD=test` starts all 4 containers
- [x] `curl localhost:7842/health` returns OK
- [x] `curl localhost:7842/` returns React app HTML
- [x] `make deploy-stop` cleanly shuts down

🤖 Generated with [Claude Code](https://claude.com/claude-code)