### PR TITLE
feat: add OAuth2 authentication with Google and GitHub (Multi-user PR 1/5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,23 @@
 # WIKIMIND_DATABASE__ECHO=false
 
 # ----------------------------------------------------------------------------
+# Authentication (OAuth2 / SSO)
+# ----------------------------------------------------------------------------
+# Set WIKIMIND_AUTH__ENABLED=true to require login. When disabled (default),
+# WikiMind runs in single-user mode with no authentication.
+# WIKIMIND_AUTH__ENABLED=false
+# WIKIMIND_AUTH__JWT_SECRET_KEY=change-me-to-a-random-string
+# WIKIMIND_AUTH__JWT_EXPIRY_MINUTES=1440
+#
+# Google OAuth2 (https://console.cloud.google.com/apis/credentials)
+# WIKIMIND_AUTH__GOOGLE_CLIENT_ID=...
+# WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
+#
+# GitHub OAuth2 (https://github.com/settings/developers)
+# WIKIMIND_AUTH__GITHUB_CLIENT_ID=...
+# WIKIMIND_AUTH__GITHUB_CLIENT_SECRET=...
+
+# ----------------------------------------------------------------------------
 # Logging (optional)
 # ----------------------------------------------------------------------------
 # LOG_LEVEL=INFO

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,14 +156,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 386
+        "line_number": 400
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 410
+        "line_number": 424
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -194,5 +194,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-17T22:07:28Z"
+  "generated_at": "2026-04-18T19:25:06Z"
 }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ All features work identically on both backends. SQLite is recommended for
 single-device development. PostgreSQL is required for cloud deployments where
 multiple devices share the same database.
 
+## Multi-User Mode
+
+WikiMind supports optional multi-user mode with OAuth2 authentication (Google, GitHub).
+
+### Enable Authentication
+
+Set these in your `.env`:
+
+```env
+WIKIMIND_AUTH__ENABLED=true
+WIKIMIND_AUTH__JWT_SECRET_KEY=your-random-secret-here
+WIKIMIND_AUTH__GOOGLE_CLIENT_ID=...
+WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
+# and/or GitHub credentials
+```
+
+When disabled (default), WikiMind runs in single-user mode with no login required.
+
 ## Architecture
 
 ```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ considered, and the consequences.
 | [018](adr-018-batched-contradiction-detection.md) | Batched Contradiction Detection | Unknown |
 | [019](adr-019-runtime-user-preferences.md) | Runtime User Preferences via DB Override Table | Accepted |
 | [021](adr-021-postgres-compatibility.md) | PostgreSQL compatibility for production deployments | Accepted |
+| [022](adr-022-multi-user-authentication.md) | Multi-User Authentication via OAuth2 | Accepted |
 
 ## ADR Format
 

--- a/docs/adr/adr-022-multi-user-authentication.md
+++ b/docs/adr/adr-022-multi-user-authentication.md
@@ -1,0 +1,41 @@
+# ADR-022: Multi-User Authentication via OAuth2
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind was designed as a single-user personal knowledge OS. To support multiple
+users on a shared server deployment, we need authentication and identity
+management. The system must remain backward compatible — when auth is disabled,
+it works exactly as before.
+
+## Decision
+
+- **OAuth2/SSO** with Google and GitHub as identity providers
+- **JWT tokens** for session management (stateless, no server-side sessions)
+- **Opt-in via config** — `WIKIMIND_AUTH__ENABLED=false` by default
+- **PyJWT** for token encoding/decoding (lightweight, no framework dependency)
+- Auth middleware skips exempt paths (`/health`, `/docs`, `/auth/*`)
+- User model stores provider identity (email, name, avatar) — no passwords stored
+
+### Alternatives Considered
+
+**API keys per user** — simpler but poor UX for a web app (no login flow).
+
+**Managed auth (Auth0, Clerk)** — less code but adds external dependency and cost.
+
+**JWT with email/password** — requires password hashing, email verification, reset
+flows.
+
+## Consequences
+
+**Enables:**
+- Multi-user deployments on a shared server
+- Per-user data isolation (PR 2) depends on user identity from this PR
+
+**Constrains:**
+- New `User` table and `AuthConfig` in Settings
+- All routes remain accessible without auth when disabled (backward compatible)
+- Frontend must handle token storage and injection (PR 5)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1125,6 +1125,81 @@ paths:
           content:
             application/json:
               schema: {}
+  /auth/login/{provider}:
+    get:
+      tags:
+      - Auth
+      summary: Login
+      description: Redirect to OAuth2 provider's authorize URL.
+      operationId: login_auth_login__provider__get
+      parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Provider
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/callback:
+    get:
+      tags:
+      - Auth
+      summary: Auth Callback
+      description: Handle OAuth2 callback — exchange code for token, upsert user,
+        return JWT.
+      operationId: auth_callback_auth_callback_get
+      parameters:
+      - name: code
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Code
+      - name: state
+        in: query
+        required: true
+        schema:
+          type: string
+          title: State
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/me:
+    get:
+      tags:
+      - Auth
+      summary: Me
+      description: Return current user profile.
+      operationId: me_auth_me_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Me Auth Me Get
   /health:
     get:
       summary: Health

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 
     # Security / keychain
     "keyring>=25.4.1",
+    "PyJWT>=2.8.0",
 
     # Sync
     "boto3>=1.35.49",

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -197,15 +197,16 @@ async def login(provider: str, request: Request) -> RedirectResponse:
 
 
 @router.get("/callback", name="auth_callback")
-async def callback(code: str, state: str, session: AsyncSession = Depends(get_session)) -> RedirectResponse:
+async def callback(
+    code: str, state: str, request: Request, session: AsyncSession = Depends(get_session)
+) -> RedirectResponse:
     """Handle OAuth2 callback — exchange code for token, upsert user, return JWT."""
     settings = get_settings()
     provider = state
-    callback_url = ""  # Not needed for token exchange on GitHub
+    # Google requires the exact redirect_uri used in the authorize request
+    callback_url = str(request.url_for("auth_callback"))
 
     if provider == "google":
-        # Google requires redirect_uri in token exchange
-        # We reconstruct it — in practice the request URL is the callback URL
         token_resp = await _exchange_google_token(code, settings, callback_url)
         user_info = await _fetch_google_userinfo(token_resp["access_token"])
     elif provider == "github":

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -1,0 +1,236 @@
+"""OAuth2 authentication routes — Google and GitHub login flows.
+
+Provides ``/auth/login/{provider}`` to redirect users to the OAuth2
+provider's authorization page, ``/auth/callback`` to handle the code
+exchange and JWT issuance, and ``/auth/me`` to return the current
+user's profile.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from wikimind.config import Settings, get_settings
+from wikimind.database import get_session
+from wikimind.models import User
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 token exchange helpers
+# ---------------------------------------------------------------------------
+
+
+async def _exchange_google_token(code: str, settings: Settings, redirect_uri: str) -> dict:
+    """Exchange a Google authorization code for an access token."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://oauth2.googleapis.com/token",
+            data={
+                "code": code,
+                "client_id": settings.auth.google_client_id,
+                "client_secret": settings.auth.google_client_secret,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _exchange_github_token(code: str, settings: Settings) -> dict:
+    """Exchange a GitHub authorization code for an access token."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://github.com/login/oauth/access_token",
+            json={
+                "client_id": settings.auth.github_client_id,
+                "client_secret": settings.auth.github_client_secret,
+                "code": code,
+            },
+            headers={"Accept": "application/json"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 user-info helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_google_userinfo(access_token: str) -> dict:
+    """Fetch the authenticated user's profile from Google."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            "https://www.googleapis.com/oauth2/v2/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _fetch_github_userinfo(access_token: str) -> dict:
+    """Fetch the authenticated user's profile from GitHub.
+
+    GitHub's ``/user`` endpoint may not include a public email, so we
+    also hit ``/user/emails`` and pick the primary verified address.
+    """
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        user_resp = await client.get("https://api.github.com/user", headers=headers)
+        user_resp.raise_for_status()
+        user_data = user_resp.json()
+
+        if not user_data.get("email"):
+            email_resp = await client.get("https://api.github.com/user/emails", headers=headers)
+            email_resp.raise_for_status()
+            emails = email_resp.json()
+            primary = next((e for e in emails if e.get("primary") and e.get("verified")), None)
+            if primary:
+                user_data["email"] = primary["email"]
+
+        return user_data
+
+
+# ---------------------------------------------------------------------------
+# User upsert + JWT creation
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_user(session: AsyncSession, provider: str, user_info: dict) -> User:
+    """Find or create a user by (auth_provider, auth_provider_id)."""
+    if provider == "google":
+        provider_id = str(user_info["id"])
+        email = user_info["email"]
+        name = user_info.get("name")
+        avatar_url = user_info.get("picture")
+    else:
+        provider_id = str(user_info["id"])
+        email = user_info["email"]
+        name = user_info.get("name") or user_info.get("login")
+        avatar_url = user_info.get("avatar_url")
+
+    result = await session.execute(
+        select(User).where(User.auth_provider == provider, User.auth_provider_id == provider_id)
+    )
+    user = result.scalar_one_or_none()
+
+    if user:
+        user.email = email
+        user.name = name
+        user.avatar_url = avatar_url
+        user.updated_at = datetime.now(UTC).replace(tzinfo=None)
+        session.add(user)
+    else:
+        user = User(
+            email=email,
+            name=name,
+            avatar_url=avatar_url,
+            auth_provider=provider,
+            auth_provider_id=provider_id,
+        )
+        session.add(user)
+
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+def _create_jwt(user: User, settings: Settings) -> str:
+    """Create a signed JWT for the given user."""
+    now = datetime.now(UTC)
+    payload = {
+        "sub": user.id,
+        "email": user.email,
+        "exp": now + timedelta(minutes=settings.auth.jwt_expiry_minutes),
+        "iat": now,
+    }
+    return jwt.encode(
+        payload,
+        settings.auth.jwt_secret_key,
+        algorithm=settings.auth.jwt_algorithm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------
+
+
+@router.get("/login/{provider}")
+async def login(provider: str, request: Request) -> RedirectResponse:
+    """Redirect to OAuth2 provider's authorize URL."""
+    settings = get_settings()
+    callback_url = str(request.url_for("auth_callback"))
+
+    if provider == "google":
+        authorize_url = (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+            f"?client_id={settings.auth.google_client_id}"
+            f"&redirect_uri={callback_url}"
+            "&response_type=code"
+            "&scope=openid email profile"
+            f"&state={provider}"
+        )
+    elif provider == "github":
+        authorize_url = (
+            "https://github.com/login/oauth/authorize"
+            f"?client_id={settings.auth.github_client_id}"
+            f"&redirect_uri={callback_url}"
+            "&scope=user:email"
+            f"&state={provider}"
+        )
+    else:
+        raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
+
+    return RedirectResponse(url=authorize_url)
+
+
+@router.get("/callback", name="auth_callback")
+async def callback(code: str, state: str, session: AsyncSession = Depends(get_session)) -> RedirectResponse:
+    """Handle OAuth2 callback — exchange code for token, upsert user, return JWT."""
+    settings = get_settings()
+    provider = state
+    callback_url = ""  # Not needed for token exchange on GitHub
+
+    if provider == "google":
+        # Google requires redirect_uri in token exchange
+        # We reconstruct it — in practice the request URL is the callback URL
+        token_resp = await _exchange_google_token(code, settings, callback_url)
+        user_info = await _fetch_google_userinfo(token_resp["access_token"])
+    elif provider == "github":
+        token_resp = await _exchange_github_token(code, settings)
+        user_info = await _fetch_github_userinfo(token_resp["access_token"])
+    else:
+        raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
+
+    user = await _upsert_user(session, provider, user_info)
+    jwt_token = _create_jwt(user, settings)
+
+    return RedirectResponse(url=f"/?token={jwt_token}")
+
+
+@router.get("/me")
+async def me(request: Request, session: AsyncSession = Depends(get_session)) -> dict:
+    """Return current user profile."""
+    if not request.state.user_id:
+        raise HTTPException(status_code=401)
+    user = await session.get(User, request.state.user_id)
+    if not user:
+        raise HTTPException(status_code=404)
+    return {
+        "id": user.id,
+        "email": user.email,
+        "name": user.name,
+        "avatar_url": user.avatar_url,
+    }

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -120,13 +120,19 @@ async def _upsert_user(session: AsyncSession, provider: str, user_info: dict) ->
         name = user_info.get("name") or user_info.get("login")
         avatar_url = user_info.get("avatar_url")
 
+    # Look up by provider identity first, then fall back to email.
+    # This handles the case where a user logs in with Google first and
+    # GitHub second using the same email — they get the same User record.
     result = await session.execute(
         select(User).where(User.auth_provider == provider, User.auth_provider_id == provider_id)
     )
     user = result.scalar_one_or_none()
 
+    if not user and email:
+        result = await session.execute(select(User).where(User.email == email))
+        user = result.scalar_one_or_none()
+
     if user:
-        user.email = email
         user.name = name
         user.avatar_url = avatar_url
         user.updated_at = datetime.now(UTC).replace(tzinfo=None)

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -166,6 +166,19 @@ class EmbeddingConfig(BaseModel):
     min_similarity_score: float = 0.65
 
 
+class AuthConfig(BaseModel):
+    """OAuth2 authentication configuration."""
+
+    enabled: bool = False
+    jwt_secret_key: str = ""
+    jwt_algorithm: str = "HS256"
+    jwt_expiry_minutes: int = 1440  # 24 hours
+    google_client_id: str | None = None
+    google_client_secret: str | None = None
+    github_client_id: str | None = None
+    github_client_secret: str | None = None
+
+
 # Mapping from provider name → (Settings field for SecretStr key, raw env var name).
 # Used by both `get_api_key` and the auto-enable validator below.
 _PROVIDER_KEY_FIELDS: dict[str, tuple[str, str]] = {
@@ -212,6 +225,7 @@ class Settings(BaseSettings):
     taxonomy: TaxonomyConfig = Field(default_factory=TaxonomyConfig)
     linter: LinterConfig = Field(default_factory=LinterConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
+    auth: AuthConfig = Field(default_factory=AuthConfig)
 
     # PDF extraction: number of pages per Docling batch (issue #117).
     # Smaller values give more frequent progress updates at the cost of

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -15,12 +15,13 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlmodel import select
 
-from wikimind.api.routes import ingest, jobs, lint, query, wiki, ws
+from wikimind.api.routes import auth, ingest, jobs, lint, query, wiki, ws
 from wikimind.api.routes import settings as settings_router
 from wikimind.config import get_settings
 from wikimind.database import close_db, get_session_factory, init_db
 from wikimind.errors import WikiMindError
 from wikimind.ingest.service import _DOCLING_AVAILABLE, _get_docling_converter
+from wikimind.middleware.auth import AuthMiddleware
 from wikimind.middleware.correlation import CorrelationIdMiddleware
 from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
@@ -85,10 +86,11 @@ app = FastAPI(
 
 # ---------------------------------------------------------------------------
 # Middleware stack — evaluated bottom-to-top.
-# Request flow: Correlation → Logging → SecurityHeaders → ErrorHandling → CORS → routes
+# Request flow: Correlation → Logging → Auth → SecurityHeaders → ErrorHandling → CORS → routes
 # ---------------------------------------------------------------------------
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(ErrorHandlingMiddleware)
+app.add_middleware(AuthMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 
@@ -118,6 +120,7 @@ app.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
 app.include_router(lint.router, prefix="/lint", tags=["Lint"])
 app.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
 app.include_router(ws.router, tags=["WebSocket"])
+app.include_router(auth.router, prefix="/auth", tags=["Auth"])
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/middleware/__init__.py
+++ b/src/wikimind/middleware/__init__.py
@@ -1,10 +1,11 @@
 """Middleware stack for the WikiMind gateway.
 
-Provides security headers, error handling, and other cross-cutting
-concerns applied to every HTTP request.
+Provides security headers, error handling, authentication, and other
+cross-cutting concerns applied to every HTTP request.
 """
 
+from wikimind.middleware.auth import AuthMiddleware
 from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.security_headers import SecurityHeadersMiddleware
 
-__all__ = ["ErrorHandlingMiddleware", "SecurityHeadersMiddleware"]
+__all__ = ["AuthMiddleware", "ErrorHandlingMiddleware", "SecurityHeadersMiddleware"]

--- a/src/wikimind/middleware/auth.py
+++ b/src/wikimind/middleware/auth.py
@@ -1,0 +1,83 @@
+"""JWT authentication middleware for OAuth2-protected endpoints.
+
+When ``settings.auth.enabled`` is False (default), the middleware is a
+pass-through — every request proceeds with ``request.state.user_id = None``,
+preserving backward-compatible single-user mode.
+
+When enabled, the middleware extracts a JWT from the ``Authorization: Bearer``
+header, decodes it, and sets ``request.state.user_id`` and
+``request.state.user_email`` for downstream route handlers. Exempt paths
+(health check, docs, auth routes) are never challenged.
+"""
+
+import jwt
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from wikimind.config import get_settings
+
+EXEMPT_PATHS = {"/health", "/docs", "/openapi.json", "/redoc"}
+EXEMPT_PREFIXES = ("/auth/login/", "/auth/callback")
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Enforce JWT authentication when auth is enabled."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Validate JWT token or pass through when auth is disabled."""
+        settings = get_settings()
+
+        if not settings.auth.enabled:
+            request.state.user_id = None
+            request.state.user_email = None
+            return await call_next(request)
+
+        path = request.url.path
+        if path in EXEMPT_PATHS or any(path.startswith(p) for p in EXEMPT_PREFIXES):
+            request.state.user_id = None
+            request.state.user_email = None
+            return await call_next(request)
+
+        token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+        if not token:
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Missing authentication token",
+                    }
+                },
+            )
+
+        try:
+            payload = jwt.decode(
+                token,
+                settings.auth.jwt_secret_key,
+                algorithms=[settings.auth.jwt_algorithm],
+            )
+            request.state.user_id = payload["sub"]
+            request.state.user_email = payload.get("email")
+        except jwt.ExpiredSignatureError:
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired",
+                    }
+                },
+            )
+        except jwt.InvalidTokenError:
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid token",
+                    }
+                },
+            )
+
+        return await call_next(request)

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -118,6 +118,19 @@ class TaskType(StrEnum):
 # ---------------------------------------------------------------------------
 
 
+class User(SQLModel, table=True):
+    """Authenticated user account."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    email: str = Field(index=True, unique=True)
+    name: str | None = None
+    avatar_url: str | None = None
+    auth_provider: str  # "google" | "github"
+    auth_provider_id: str  # provider's unique user ID
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    updated_at: datetime = Field(default_factory=utcnow_naive)
+
+
 class Source(SQLModel, table=True):
     """Raw ingested source — before compilation."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,12 @@ def _hermetic_env() -> Iterator[None]:
         "WIKIMIND_ANTHROPIC_API_KEY",
         "WIKIMIND_OPENAI_API_KEY",
         "WIKIMIND_GOOGLE_API_KEY",
+        "WIKIMIND_AUTH__ENABLED",
+        "WIKIMIND_AUTH__JWT_SECRET_KEY",
+        "WIKIMIND_AUTH__GOOGLE_CLIENT_ID",
+        "WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET",
+        "WIKIMIND_AUTH__GITHUB_CLIENT_ID",
+        "WIKIMIND_AUTH__GITHUB_CLIENT_SECRET",
     ]
     saved = {k: os.environ.pop(k, None) for k in scrubbed}
     try:
@@ -71,6 +77,8 @@ def _isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Itera
     data_dir = tmp_path / "wikimind"
     data_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(data_dir))
+    # Force auth disabled — .env may have WIKIMIND_AUTH__ENABLED=true for local dev
+    monkeypatch.setenv("WIKIMIND_AUTH__ENABLED", "false")
     get_settings.cache_clear()
     # Clear storage singletons so they pick up the new data_dir
     get_wiki_storage.cache_clear()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -18,7 +18,7 @@ from wikimind.models import User
 def test_create_jwt_contains_expected_claims():
     """JWT payload should contain sub, email, iat, and exp claims."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"
+    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
     settings.auth.jwt_algorithm = "HS256"
     settings.auth.jwt_expiry_minutes = 60
 
@@ -41,7 +41,7 @@ def test_create_jwt_contains_expected_claims():
 def test_create_jwt_expiry():
     """JWT should expire after the configured number of minutes."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"
+    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
     settings.auth.jwt_algorithm = "HS256"
     settings.auth.jwt_expiry_minutes = 30
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,277 @@
+"""Tests for OAuth2 authentication — JWT helpers, middleware, and /auth/me."""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from wikimind.api.routes.auth import _create_jwt, _upsert_user
+from wikimind.config import get_settings
+from wikimind.models import User
+
+# ---------------------------------------------------------------------------
+# JWT creation / decoding
+# ---------------------------------------------------------------------------
+
+
+def test_create_jwt_contains_expected_claims():
+    """JWT payload should contain sub, email, iat, and exp claims."""
+    settings = get_settings()
+    settings.auth.jwt_secret_key = "test-secret"
+    settings.auth.jwt_algorithm = "HS256"
+    settings.auth.jwt_expiry_minutes = 60
+
+    user = User(
+        id="user-1",
+        email="alice@example.com",
+        auth_provider="google",
+        auth_provider_id="g-123",
+    )
+
+    token = _create_jwt(user, settings)
+    payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
+
+    assert payload["sub"] == "user-1"
+    assert payload["email"] == "alice@example.com"
+    assert "exp" in payload
+    assert "iat" in payload
+
+
+def test_create_jwt_expiry():
+    """JWT should expire after the configured number of minutes."""
+    settings = get_settings()
+    settings.auth.jwt_secret_key = "test-secret"
+    settings.auth.jwt_algorithm = "HS256"
+    settings.auth.jwt_expiry_minutes = 30
+
+    user = User(
+        id="user-1",
+        email="alice@example.com",
+        auth_provider="github",
+        auth_provider_id="gh-456",
+    )
+
+    token = _create_jwt(user, settings)
+    payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
+
+    now = datetime.now(UTC)
+    exp = datetime.fromtimestamp(payload["exp"], tz=UTC)
+    # Expiry should be ~30 minutes from now (within a 5-second tolerance)
+    assert abs((exp - now).total_seconds() - 1800) < 5
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware — pass-through when disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_middleware_passthrough_when_disabled(client):
+    """When auth.enabled=False, all requests pass through without a token."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_middleware_sets_user_id_none_when_disabled(client):
+    """When auth.enabled=False, request.state.user_id should be None."""
+    # The /health endpoint succeeds without auth — that proves the middleware passed through
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware — enabled mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_middleware_returns_401_when_no_token(client, monkeypatch):
+    """When auth is enabled, missing token should return 401."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    response = await client.get("/wiki/articles")
+    assert response.status_code == 401
+    body = response.json()
+    assert body["error"]["code"] == "UNAUTHORIZED"
+
+
+@pytest.mark.asyncio
+async def test_middleware_returns_401_when_token_expired(client, monkeypatch):
+    """An expired JWT should return a TOKEN_EXPIRED error."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    expired_payload = {
+        "sub": "user-1",
+        "email": "alice@example.com",
+        "exp": datetime.now(UTC) - timedelta(hours=1),
+        "iat": datetime.now(UTC) - timedelta(hours=2),
+    }
+    expired_token = jwt.encode(expired_payload, "test-secret", algorithm="HS256")
+
+    response = await client.get(
+        "/wiki/articles",
+        headers={"Authorization": f"Bearer {expired_token}"},
+    )
+    assert response.status_code == 401
+    body = response.json()
+    assert body["error"]["code"] == "TOKEN_EXPIRED"
+
+
+@pytest.mark.asyncio
+async def test_middleware_returns_401_when_token_invalid(client, monkeypatch):
+    """A token signed with the wrong key should return INVALID_TOKEN."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    bad_token = jwt.encode(
+        {"sub": "user-1", "email": "a@b.com", "exp": datetime.now(UTC) + timedelta(hours=1)},
+        "wrong-secret",
+        algorithm="HS256",
+    )
+
+    response = await client.get(
+        "/wiki/articles",
+        headers={"Authorization": f"Bearer {bad_token}"},
+    )
+    assert response.status_code == 401
+    body = response.json()
+    assert body["error"]["code"] == "INVALID_TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_with_valid_token(client, monkeypatch):
+    """A valid JWT should allow the request through."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    valid_token = jwt.encode(
+        {
+            "sub": "user-1",
+            "email": "alice@example.com",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    response = await client.get(
+        "/health",
+        headers={"Authorization": f"Bearer {valid_token}"},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_exempt_paths(client, monkeypatch):
+    """Exempt paths should not require authentication even when auth is enabled."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    # /health is exempt
+    response = await client.get("/health")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /auth/me
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_me_returns_user_profile(client, db_session: AsyncSession, monkeypatch):
+    """GET /auth/me should return the authenticated user's profile."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    # Create a user directly in the DB
+    user = User(
+        id="user-42",
+        email="alice@example.com",
+        name="Alice",
+        avatar_url="https://example.com/avatar.png",
+        auth_provider="google",
+        auth_provider_id="g-999",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = jwt.encode(
+        {
+            "sub": "user-42",
+            "email": "alice@example.com",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    response = await client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "user-42"
+    assert body["email"] == "alice@example.com"
+    assert body["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_auth_me_returns_401_when_no_user(client, monkeypatch):
+    """GET /auth/me without auth should return 401."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", False)
+
+    response = await client.get("/auth/me")
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# User upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_user_creates_new_user(db_session: AsyncSession):
+    """First login should create a new User record."""
+    user_info = {
+        "id": "google-id-1",
+        "email": "new@example.com",
+        "name": "New User",
+        "picture": "https://example.com/pic.jpg",
+    }
+    user = await _upsert_user(db_session, "google", user_info)
+    assert user.email == "new@example.com"
+    assert user.auth_provider == "google"
+    assert user.auth_provider_id == "google-id-1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_user_updates_existing_user(db_session: AsyncSession):
+    """Re-login should update the existing User record."""
+    user_info = {
+        "id": "google-id-2",
+        "email": "existing@example.com",
+        "name": "Old Name",
+        "picture": None,
+    }
+    user1 = await _upsert_user(db_session, "google", user_info)
+
+    user_info["name"] = "New Name"
+    user_info["picture"] = "https://example.com/new.jpg"
+    user2 = await _upsert_user(db_session, "google", user_info)
+
+    assert user1.id == user2.id
+    assert user2.name == "New Name"
+    assert user2.avatar_url == "https://example.com/new.jpg"


### PR DESCRIPTION
## Summary

First PR in the multi-user epic. Adds OAuth2 authentication infrastructure with Google and GitHub SSO support. **Fully backward compatible** — when `WIKIMIND_AUTH__ENABLED=false` (default), everything works exactly as before with no auth required.

- Add `User` model (id, email, name, avatar_url, auth_provider, auth_provider_id)
- Add `AuthConfig` to Settings (JWT secret, expiry, Google/GitHub OAuth2 credentials)
- Add `AuthMiddleware` — validates JWT Bearer tokens when auth is enabled, pass-through when disabled
- Add OAuth2 routes: `/auth/login/{provider}`, `/auth/callback`, `/auth/me`
- 13 unit tests covering JWT, middleware, upsert, and profile endpoint

### Auth Flow
1. Frontend redirects to `/auth/login/google` (or `/github`)
2. Server redirects to provider's OAuth2 authorize URL
3. Provider redirects back to `/auth/callback?code=...`
4. Server exchanges code for token, fetches user profile, upserts User, issues JWT
5. Frontend stores JWT, sends via `Authorization: Bearer <token>`

### Dependency Chain
This is PR 1/5 of the multi-user epic:
1. **User + OAuth2 Auth** (this PR)
2. Data Isolation (user_id FK on all tables)
3. Per-User Storage Namespacing
4. Per-User Background Jobs + WebSocket Scoping
5. Frontend Auth UI

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (738 pass, 1 pre-existing failure in test_postgres_engine)
- [x] With `WIKIMIND_AUTH__ENABLED=false` (default): all existing functionality works unchanged
- [x] With auth enabled: unauthenticated requests to non-exempt paths return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)