### PR TITLE
feat(web): add OAuth2 login UI with Google and GitHub (Multi-user PR 5/5)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,8 @@
 import { Navigate, Route, Routes } from "react-router-dom";
+import AuthCallback from "./components/auth/AuthCallback";
+import AuthProvider from "./components/auth/AuthProvider";
+import LoginPage from "./components/auth/LoginPage";
+import ProtectedRoute from "./components/auth/ProtectedRoute";
 import { Layout } from "./components/shared/Layout";
 import { InboxView } from "./components/inbox/InboxView";
 import { WikiExplorerView } from "./components/wiki/WikiExplorerView";
@@ -13,19 +17,32 @@ export function App() {
   useWebSocket();
 
   return (
-    <Layout>
+    <AuthProvider>
       <Routes>
-        <Route path="/" element={<Navigate to="/inbox" replace />} />
-        <Route path="/inbox" element={<InboxView />} />
-        <Route path="/ask" element={<AskView />} />
-        <Route path="/ask/:conversationId" element={<AskView />} />
-        <Route path="/wiki" element={<WikiExplorerView />} />
-        <Route path="/wiki/:slug" element={<WikiExplorerView />} />
-        <Route path="/graph" element={<GraphView />} />
-        <Route path="/health" element={<HealthView />} />
-        <Route path="/settings" element={<SettingsView />} />
-        <Route path="*" element={<Navigate to="/inbox" replace />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route
+          path="*"
+          element={
+            <ProtectedRoute>
+              <Layout>
+                <Routes>
+                  <Route path="/" element={<Navigate to="/inbox" replace />} />
+                  <Route path="/inbox" element={<InboxView />} />
+                  <Route path="/ask" element={<AskView />} />
+                  <Route path="/ask/:conversationId" element={<AskView />} />
+                  <Route path="/wiki" element={<WikiExplorerView />} />
+                  <Route path="/wiki/:slug" element={<WikiExplorerView />} />
+                  <Route path="/graph" element={<GraphView />} />
+                  <Route path="/health" element={<HealthView />} />
+                  <Route path="/settings" element={<SettingsView />} />
+                  <Route path="*" element={<Navigate to="/inbox" replace />} />
+                </Routes>
+              </Layout>
+            </ProtectedRoute>
+          }
+        />
       </Routes>
-    </Layout>
+    </AuthProvider>
   );
 }

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,8 @@
+// Auth API calls for the WikiMind OAuth2 flow.
+
+import type { AuthUser } from "../store/auth";
+import { apiFetch } from "./client";
+
+export function fetchCurrentUser(): Promise<AuthUser> {
+  return apiFetch<AuthUser>("/auth/me");
+}

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -43,10 +43,16 @@ export async function apiFetch<T>(
 ): Promise<T> {
   const { method = "GET", body, query, headers = {}, signal } = options;
 
+  const token = localStorage.getItem("wikimind_token");
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {};
+
   const init: RequestInit = {
     method,
     headers: {
       Accept: "application/json",
+      ...authHeaders,
       ...headers,
     },
     signal,

--- a/apps/web/src/components/auth/AuthCallback.tsx
+++ b/apps/web/src/components/auth/AuthCallback.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "../../store/auth";
+
+export default function AuthCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const setToken = useAuth((s) => s.setToken);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (token) {
+      setToken(token);
+      navigate("/", { replace: true });
+    } else {
+      navigate("/login", { replace: true });
+    }
+  }, [searchParams, setToken, navigate]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <p className="text-zinc-400">Signing in...</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/AuthProvider.tsx
+++ b/apps/web/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "../../store/auth";
+import { fetchCurrentUser } from "../../api/auth";
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const token = useAuth((s) => s.token);
+  const setUser = useAuth((s) => s.setUser);
+  const setAuthDisabled = useAuth((s) => s.setAuthDisabled);
+  const logout = useAuth((s) => s.logout);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      // No token — probe /auth/me to check if auth is even enabled.
+      fetchCurrentUser()
+        .then((user) => {
+          setUser(user);
+          setReady(true);
+        })
+        .catch(() => {
+          // 404 or network error means auth is disabled on the backend.
+          setAuthDisabled(true);
+          setReady(true);
+        });
+      return;
+    }
+
+    // Token exists — validate it.
+    fetchCurrentUser()
+      .then((user) => {
+        setUser(user);
+        setReady(true);
+      })
+      .catch(() => {
+        logout();
+        setReady(true);
+      });
+  }, [token, setUser, setAuthDisabled, logout]);
+
+  if (!ready) {
+    return <div className="min-h-screen bg-zinc-950" />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -1,0 +1,31 @@
+import { getBaseUrl } from "../../api/client";
+
+export default function LoginPage() {
+  const apiBase = getBaseUrl();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-zinc-800 bg-zinc-900 p-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-zinc-100">WikiMind</h1>
+          <p className="mt-1 text-sm text-zinc-400">Sign in to your knowledge wiki</p>
+        </div>
+
+        <div className="space-y-3">
+          <a
+            href={`${apiBase}/auth/login/google`}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2.5 font-medium text-zinc-900 transition-colors hover:bg-zinc-100"
+          >
+            Sign in with Google
+          </a>
+          <a
+            href={`${apiBase}/auth/login/github`}
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2.5 font-medium text-zinc-100 transition-colors hover:bg-zinc-700"
+          >
+            Sign in with GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/ProtectedRoute.tsx
+++ b/apps/web/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../store/auth";
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const isAuthenticated = useAuth((s) => s.isAuthenticated);
+  const authDisabled = useAuth((s) => s.authDisabled);
+
+  if (authDisabled || isAuthenticated) {
+    return <>{children}</>;
+  }
+
+  return <Navigate to="/login" replace />;
+}

--- a/apps/web/src/components/shared/Layout.tsx
+++ b/apps/web/src/components/shared/Layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link, NavLink } from "react-router-dom";
+import { useAuth } from "../../store/auth";
 import { useWebSocketStore } from "../../store/websocket";
 import { Badge } from "./Badge";
 
@@ -17,6 +18,8 @@ const NAV_ITEMS = [
 ];
 
 export function Layout({ children }: LayoutProps) {
+  const user = useAuth((s) => s.user);
+  const logout = useAuth((s) => s.logout);
   const wsState = useWebSocketStore((s) => s.state);
   const toasts = useWebSocketStore((s) => s.toasts);
   const dismissToast = useWebSocketStore((s) => s.dismissToast);
@@ -47,6 +50,25 @@ export function Layout({ children }: LayoutProps) {
             </NavLink>
           ))}
         </nav>
+
+        {user && (
+          <div className="flex items-center gap-2 border-t border-slate-200 px-4 py-3">
+            {user.avatar_url && (
+              <img src={user.avatar_url} alt="" className="h-7 w-7 rounded-full" />
+            )}
+            <span className="truncate text-sm text-slate-600">{user.name || user.email}</span>
+            <button
+              type="button"
+              onClick={() => {
+                logout();
+                window.location.href = "/login";
+              }}
+              className="ml-auto text-xs text-slate-400 hover:text-slate-700"
+            >
+              Logout
+            </button>
+          </div>
+        )}
 
         <div className="border-t border-slate-200 px-4 py-3">
           <ConnectionIndicator state={wsState} />

--- a/apps/web/src/store/auth.ts
+++ b/apps/web/src/store/auth.ts
@@ -1,0 +1,40 @@
+// Zustand store for OAuth2 authentication state.
+//
+// Persists the JWT token in localStorage so sessions survive page reloads.
+
+import { create } from "zustand";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+}
+
+interface AuthState {
+  token: string | null;
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  authDisabled: boolean;
+  setToken: (token: string) => void;
+  setUser: (user: AuthUser) => void;
+  setAuthDisabled: (disabled: boolean) => void;
+  logout: () => void;
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  token: localStorage.getItem("wikimind_token"),
+  user: null,
+  isAuthenticated: !!localStorage.getItem("wikimind_token"),
+  authDisabled: false,
+  setToken: (token) => {
+    localStorage.setItem("wikimind_token", token);
+    set({ token, isAuthenticated: true });
+  },
+  setUser: (user) => set({ user }),
+  setAuthDisabled: (disabled) => set({ authDisabled: disabled }),
+  logout: () => {
+    localStorage.removeItem("wikimind_token");
+    set({ token: null, user: null, isAuthenticated: false });
+  },
+}));

--- a/apps/web/src/store/websocket.ts
+++ b/apps/web/src/store/websocket.ts
@@ -60,7 +60,7 @@ export const useWebSocketStore = create<WebSocketStore>((set) => ({
         next.toasts = [
           {
             id: makeId(),
-            kind: "success",
+            kind: "success" as const,
             title: "Compilation complete",
             detail: event.article_title,
             createdAt: Date.now(),
@@ -73,7 +73,7 @@ export const useWebSocketStore = create<WebSocketStore>((set) => ({
         next.toasts = [
           {
             id: makeId(),
-            kind: "error",
+            kind: "error" as const,
             title: "Compilation failed",
             detail: event.error,
             createdAt: Date.now(),


### PR DESCRIPTION
## Summary

Frontend authentication UI for the multi-user epic. Adds login page, auth state management, protected routes, and user menu. Works with the backend auth from PR #204.

**When auth is disabled on the backend (default):** The AuthProvider detects this automatically — no login page is shown, app works exactly as before.

### New components
- **LoginPage** — centered dark-themed card with Google/GitHub sign-in buttons
- **AuthCallback** — handles OAuth2 redirect, extracts JWT token from URL
- **AuthProvider** — validates token on mount, detects auth-disabled mode
- **ProtectedRoute** — redirects to /login when unauthenticated (skipped when auth disabled)

### State management
- **auth store** (Zustand) — token, user, isAuthenticated, authDisabled
- Token persisted in localStorage as `wikimind_token`
- Authorization Bearer header auto-injected in API client

### Layout changes
- User avatar, name/email, and logout button in sidebar (only when authenticated)

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] With auth disabled: app loads normally, no login page
- [ ] With auth enabled: unauthenticated users see login page

## Dependencies
- Backend: PR #204 (OAuth2 auth routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)