### PR TITLE
feat: per-user file storage namespacing (Multi-user PR 3/5)

### DIFF
--- a/docs/adr/adr-004-markdown-files-sqlite-metadata.md
+++ b/docs/adr/adr-004-markdown-files-sqlite-metadata.md
@@ -82,3 +82,14 @@ in. Explicitly rejected by the product vision.
   mid-save could leave the file written but the database not updated (or vice
   versa). Mitigated by writing the file first, then committing the database
   record.
+
+## Amendment — Per-User File Namespacing (April 2026)
+
+With multi-user support, file paths are namespaced by user_id:
+
+- **Single-user (default):** `~/.wikimind/wiki/article-slug.md` (unchanged)
+- **Multi-user:** `~/.wikimind/wiki/{user_id}/article-slug.md`
+
+Storage factories (`get_wiki_storage()`, `get_raw_storage()`) accept an optional `user_id` parameter. When provided, the storage root includes a user_id subdirectory. The `resolve_wiki_path()` and `resolve_raw_path()` helpers follow the same pattern.
+
+This namespacing applies to both local filesystem storage and future R2/S3 cloud storage (via S3 key prefix).

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -407,7 +407,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         """Replace an existing same-source same-provider article in place."""
         old_concept_ids = existing.concept_ids
 
-        old_path = resolve_wiki_path(existing.file_path)
+        old_path = resolve_wiki_path(existing.file_path, user_id=source.user_id)
         old_path.unlink(missing_ok=True)
 
         resolved, unresolved = await resolve_backlink_candidates(
@@ -530,6 +530,8 @@ Compile this into a wiki article following the JSON schema exactly."""
         for storage in Article.file_path.
         """
         wiki_dir = Path(self.settings.data_dir) / "wiki"
+        if source.user_id:
+            wiki_dir = wiki_dir / source.user_id
 
         concept = result.concepts[0] if result.concepts else "general"
         concept_slug = slugify(concept)

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -120,14 +120,14 @@ async def _collect_source_articles(concept_name: str, session: AsyncSession) -> 
     return articles
 
 
-def _build_source_material(articles: list[Article]) -> str:
+def _build_source_material(articles: list[Article], user_id: str | None = None) -> str:
     parts: list[str] = []
     for i, article in enumerate(articles, 1):
         section = f"### Source {i}: {article.title}\n"
         if article.summary:
             section += f"Summary: {article.summary}\n"
         try:
-            fc = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
+            fc = resolve_wiki_path(article.file_path, user_id=user_id).read_text(encoding="utf-8")
             if len(fc) > 5000:
                 fc = fc[:5000] + "\n[...truncated...]"
             section += f"\nContent:\n{fc}\n"
@@ -187,7 +187,7 @@ class ConceptCompiler:
         min_sources = self.settings.taxonomy.concept_page_min_sources
         if len(source_articles) < min_sources:
             return None
-        source_material = _build_source_material(source_articles)
+        source_material = _build_source_material(source_articles, user_id=concept.user_id)
         source_ids = [a.id for a in source_articles]
         ct = await _collect_contradictions(source_ids, session)
         contradiction_section = ct if ct else "No known contradictions."
@@ -235,7 +235,7 @@ class ConceptCompiler:
         existing = await self._find_existing_concept_article(concept.name, session)
         relative_path = self._write_concept_file(compilation, concept, source_articles)
         if existing is not None:
-            resolve_wiki_path(existing.file_path).unlink(missing_ok=True)
+            resolve_wiki_path(existing.file_path, user_id=concept.user_id).unlink(missing_ok=True)
             existing.title = compilation.title
             existing.summary = compilation.overview
             existing.file_path = relative_path
@@ -285,6 +285,8 @@ class ConceptCompiler:
     ) -> str:
         """Write concept page markdown. Returns wiki-relative path."""
         wiki_dir = Path(self.settings.data_dir) / "wiki"
+        if concept.user_id:
+            wiki_dir = wiki_dir / concept.user_id
         slug = slugify(concept.name)
         concept_dir = wiki_dir / slug
         concept_dir.mkdir(parents=True, exist_ok=True)

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -61,7 +61,7 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
 def _extract_claims(article: Article) -> list[str]:
     """Extract key claims from an article's markdown file."""
     try:
-        content = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
+        content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text(encoding="utf-8")
     except (OSError, FileNotFoundError):
         return []
 

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -491,7 +491,7 @@ conversation context contradicts the wiki, prefer the wiki."""
 
         relevant = []
         for article in all_articles:
-            content = self._read_article_content(article.file_path)
+            content = self._read_article_content(article.file_path, user_id=user_id)
             if not content:
                 continue
 
@@ -510,9 +510,9 @@ conversation context contradicts the wiki, prefer the wiki."""
         relevant.sort(key=lambda x: x["score"], reverse=True)
         return relevant[:5]
 
-    def _read_article_content(self, file_path: str) -> str | None:
+    def _read_article_content(self, file_path: str, user_id: str | None = None) -> str | None:
         try:
-            return resolve_wiki_path(file_path).read_text(encoding="utf-8")
+            return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
         except Exception:
             return None
 
@@ -596,7 +596,10 @@ conversation context contradicts the wiki, prefer the wiki."""
 
         if existing_article is None:
             # Create path
-            wiki_dir = Path(self.settings.data_dir) / "wiki" / "qa-answers"
+            wiki_dir = Path(self.settings.data_dir) / "wiki"
+            if user_id:
+                wiki_dir = wiki_dir / user_id
+            wiki_dir = wiki_dir / "qa-answers"
             wiki_dir.mkdir(parents=True, exist_ok=True)
 
             slug = conversation.id  # UUID — guaranteed unique, no collision possible
@@ -631,7 +634,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             return article, False
 
         # Update path: overwrite the existing Article's file in place
-        resolve_wiki_path(existing_article.file_path).write_text(markdown, encoding="utf-8")
+        resolve_wiki_path(existing_article.file_path, user_id=user_id).write_text(markdown, encoding="utf-8")
         existing_article.updated_at = now
         conversation.updated_at = now
         session.add(existing_article)

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -378,7 +378,7 @@ def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     """
     if not source.file_path:
         raise ValueError(f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument")
-    clean_text = resolve_raw_path(source.file_path).read_text(encoding="utf-8")
+    clean_text = resolve_raw_path(source.file_path, user_id=source.user_id).read_text(encoding="utf-8")
     return NormalizedDocument(
         raw_source_id=source.id,
         clean_text=clean_text,

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -45,7 +45,7 @@ async def _sweep_single_article(
     Returns True if any replacement was made (file rewritten + backlinks
     persisted), False if the file was unchanged.
     """
-    file_path = resolve_wiki_path(article.file_path)
+    file_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
     if not file_path.exists():
         log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
         return False

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -93,7 +93,7 @@ async def compile_source(ctx, source_id: str):
             if not source.file_path:
                 raise ValueError("No cleaned text file path for source")
 
-            text_path = resolve_raw_path(source.file_path)
+            text_path = resolve_raw_path(source.file_path, user_id=source.user_id)
             content = text_path.read_text(encoding="utf-8")
 
             await emit_source_progress(source_id, "Normalizing content...")
@@ -139,7 +139,9 @@ async def compile_source(ctx, source_id: str):
                 try:
                     embedding_service = get_embedding_service()
                     if embedding_service is not None:
-                        content = resolve_wiki_path(article.file_path).read_text(encoding="utf-8")
+                        content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text(
+                            encoding="utf-8"
+                        )
                         embedding_service.embed_article(article.id, article.title, content)
                         log.info("Article embedded", article_id=article.id)
                 except Exception as embed_err:
@@ -250,7 +252,7 @@ async def recompile_article(ctx, article_id: str, mode: str, _job_id: str):
                 if not source or not source.file_path:
                     raise ValueError("Source or source file_path not found")
 
-                content = resolve_raw_path(source.file_path).read_text(encoding="utf-8")
+                content = resolve_raw_path(source.file_path, user_id=source.user_id).read_text(encoding="utf-8")
 
                 doc = NormalizedDocument(
                     raw_source_id=source.id,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -60,17 +60,18 @@ def _first_concept(concept_ids_json: str | None) -> str | None:
     return items[0] if items else None
 
 
-def _read_article_content(file_path: str) -> str:
+def _read_article_content(file_path: str, user_id: str | None = None) -> str:
     """Read article markdown content from disk.
 
     Args:
         file_path: Absolute path to the article markdown file.
+        user_id: Optional user ID for storage namespacing.
 
     Returns:
         The file content, or an empty string if the file cannot be read.
     """
     try:
-        return resolve_wiki_path(file_path).read_text(encoding="utf-8")
+        return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
     except Exception:
         return ""
 
@@ -343,7 +344,7 @@ class WikiService:
             concepts=concepts,
             backlinks_in=backlinks_in,
             backlinks_out=backlinks_out,
-            content=_read_article_content(article.file_path),
+            content=_read_article_content(article.file_path, user_id=article.user_id),
             sources=[_to_source_response(s) for s in sources],
             created_at=article.created_at,
             updated_at=article.updated_at,
@@ -484,7 +485,7 @@ class WikiService:
         q_lower = q.lower()
         raw_scores: dict[str, int] = {}
         for article in all_articles:
-            content = _read_article_content(article.file_path)
+            content = _read_article_content(article.file_path, user_id=article.user_id)
             if q_lower in article.title.lower() or q_lower in content.lower():
                 score = 10 if q_lower in article.title.lower() else 0
                 score += content.lower().count(q_lower)

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -8,7 +8,6 @@ in via configuration without changing application code.
 from __future__ import annotations
 
 import asyncio
-from functools import lru_cache
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -117,21 +116,25 @@ class LocalFileStorage:
         return await asyncio.to_thread(_list)
 
 
-@lru_cache(maxsize=1)
-def get_wiki_storage() -> FileStorage:
-    """Return the wiki file storage singleton."""
+def get_wiki_storage(user_id: str | None = None) -> FileStorage:
+    """Return wiki file storage, optionally scoped to a user."""
     settings = get_settings()
-    return LocalFileStorage(root=Path(settings.data_dir) / "wiki")
+    root = Path(settings.data_dir) / "wiki"
+    if user_id:
+        root = root / user_id
+    return LocalFileStorage(root=root)
 
 
-@lru_cache(maxsize=1)
-def get_raw_storage() -> FileStorage:
-    """Return the raw source file storage singleton."""
+def get_raw_storage(user_id: str | None = None) -> FileStorage:
+    """Return raw source file storage, optionally scoped to a user."""
     settings = get_settings()
-    return LocalFileStorage(root=Path(settings.data_dir) / "raw")
+    root = Path(settings.data_dir) / "raw"
+    if user_id:
+        root = root / user_id
+    return LocalFileStorage(root=root)
 
 
-def resolve_wiki_path(relative_path: str) -> Path:
+def resolve_wiki_path(relative_path: str, user_id: str | None = None) -> Path:
     """Resolve a wiki-relative path to an absolute filesystem path.
 
     Handles backward compatibility: if the path is already absolute,
@@ -141,10 +144,13 @@ def resolve_wiki_path(relative_path: str) -> Path:
     if path.is_absolute():
         return path
     settings = get_settings()
-    return Path(settings.data_dir) / "wiki" / relative_path
+    root = Path(settings.data_dir) / "wiki"
+    if user_id:
+        root = root / user_id
+    return root / relative_path
 
 
-def resolve_raw_path(relative_path: str) -> Path:
+def resolve_raw_path(relative_path: str, user_id: str | None = None) -> Path:
     """Resolve a raw-relative path to an absolute filesystem path.
 
     Handles backward compatibility: if the path is already absolute,
@@ -154,7 +160,10 @@ def resolve_raw_path(relative_path: str) -> Path:
     if path.is_absolute():
         return path
     settings = get_settings()
-    return Path(settings.data_dir) / "raw" / relative_path
+    root = Path(settings.data_dir) / "raw"
+    if user_id:
+        root = root / user_id
+    return root / relative_path
 
 
 def find_original_sibling(txt_path: Path) -> Path | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ import wikimind.database as _db_mod
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.main import app
-from wikimind.storage import get_raw_storage, get_wiki_storage
 
 # ---------------------------------------------------------------------------
 # Hermetic environment — runs once per session, applied before any test
@@ -80,13 +79,8 @@ def _isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Itera
     # Force auth disabled — .env may have WIKIMIND_AUTH__ENABLED=true for local dev
     monkeypatch.setenv("WIKIMIND_AUTH__ENABLED", "false")
     get_settings.cache_clear()
-    # Clear storage singletons so they pick up the new data_dir
-    get_wiki_storage.cache_clear()
-    get_raw_storage.cache_clear()
     yield data_dir
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
-    get_raw_storage.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -42,7 +42,7 @@ from wikimind.models import (
 )
 from wikimind.services import ingest as svc_ingest
 from wikimind.services.ingest import IngestService
-from wikimind.storage import get_raw_storage, get_wiki_storage, resolve_raw_path
+from wikimind.storage import resolve_raw_path
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -69,12 +69,8 @@ def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     (tmp_path / "raw").mkdir(parents=True, exist_ok=True)
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
-    get_raw_storage.cache_clear()
     yield tmp_path
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
-    get_raw_storage.cache_clear()
 
 
 def _sample_compilation_result(title: str = "Sample") -> CompilationResult:

--- a/tests/unit/test_pdf_adapter.py
+++ b/tests/unit/test_pdf_adapter.py
@@ -22,7 +22,6 @@ from wikimind.config import Settings, get_settings
 from wikimind.ingest import service as ingest_service
 from wikimind.ingest.service import PDFAdapter
 from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType
-from wikimind.storage import get_raw_storage, get_wiki_storage
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -63,12 +62,8 @@ def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # Drop the global lru_cache too in case anything else hits it during the
     # test (defensive — the monkeypatch above is the primary mechanism).
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
-    get_raw_storage.cache_clear()
     yield tmp_path
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
-    get_raw_storage.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -113,24 +113,40 @@ def test_get_wiki_storage_returns_local(tmp_path, monkeypatch):
     """get_wiki_storage() returns a LocalFileStorage rooted at wiki_dir."""
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
     storage = get_wiki_storage()
     assert isinstance(storage, LocalFileStorage)
     assert storage.root == tmp_path / "wiki"
     get_settings.cache_clear()
-    get_wiki_storage.cache_clear()
+
+
+def test_get_wiki_storage_with_user_id(tmp_path, monkeypatch):
+    """get_wiki_storage(user_id=...) returns storage rooted at wiki/{user_id}."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    storage = get_wiki_storage(user_id="user-123")
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.root == tmp_path / "wiki" / "user-123"
+    get_settings.cache_clear()
 
 
 def test_get_raw_storage_returns_local(tmp_path, monkeypatch):
     """get_raw_storage() returns a LocalFileStorage rooted at raw_dir."""
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
-    get_raw_storage.cache_clear()
     storage = get_raw_storage()
     assert isinstance(storage, LocalFileStorage)
     assert storage.root == tmp_path / "raw"
     get_settings.cache_clear()
-    get_raw_storage.cache_clear()
+
+
+def test_get_raw_storage_with_user_id(tmp_path, monkeypatch):
+    """get_raw_storage(user_id=...) returns storage rooted at raw/{user_id}."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    storage = get_raw_storage(user_id="user-456")
+    assert isinstance(storage, LocalFileStorage)
+    assert storage.root == tmp_path / "raw" / "user-456"
+    get_settings.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -151,11 +167,27 @@ def test_resolve_wiki_path_absolute():
     assert result == Path("/absolute/path/article.md")
 
 
+def test_resolve_wiki_path_with_user_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    result = resolve_wiki_path("concept/article.md", user_id="user-abc")
+    assert result == tmp_path / "wiki" / "user-abc" / "concept" / "article.md"
+    get_settings.cache_clear()
+
+
 def test_resolve_raw_path_relative(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
     result = resolve_raw_path("source-id.txt")
     assert result == tmp_path / "raw" / "source-id.txt"
+    get_settings.cache_clear()
+
+
+def test_resolve_raw_path_with_user_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    result = resolve_raw_path("source-id.txt", user_id="user-xyz")
+    assert result == tmp_path / "raw" / "user-xyz" / "source-id.txt"
     get_settings.cache_clear()
 
 


### PR DESCRIPTION
## Summary

Recreated — previous PR #207 was incorrectly auto-merged by GitHub after a rebase.

Third PR in the multi-user epic. Namespaces wiki and raw file storage by user_id.

- **Before:** `~/.wikimind/wiki/article-slug.md`
- **After:** `~/.wikimind/wiki/{user_id}/article-slug.md`
- When `user_id=None`: unchanged flat paths (backward compatible)

### Changes
- `storage.py` — factories accept optional `user_id`, removed `@lru_cache`
- 10 source files pass `user_id` through to storage calls
- 4 new tests for namespaced paths
- ADR-004 amended with per-user namespacing

## Dependencies
- Base: PR #206 (user_id FK on all tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)