### PR TITLE
feat: view original source document (PDF, HTML) in-app

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.59.0",
+        "pdfjs-dist": "^5.6.205",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-force-graph-2d": "^1.29.1",
@@ -939,6 +940,256 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.99.tgz",
+      "integrity": "sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-x64": "0.1.99",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.99",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.99",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.99",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.99"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.99.tgz",
+      "integrity": "sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.99.tgz",
+      "integrity": "sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.99.tgz",
+      "integrity": "sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.99.tgz",
+      "integrity": "sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.99.tgz",
+      "integrity": "sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.99.tgz",
+      "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.99.tgz",
+      "integrity": "sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.99.tgz",
+      "integrity": "sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.99.tgz",
+      "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.99.tgz",
+      "integrity": "sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.99.tgz",
+      "integrity": "sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4732,6 +4983,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -4923,6 +5181,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "node_modules/picocolors": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
+    "pdfjs-dist": "^5.6.205",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-force-graph-2d": "^1.29.1",

--- a/apps/web/src/api/sources.ts
+++ b/apps/web/src/api/sources.ts
@@ -1,6 +1,6 @@
 // Endpoints in src/wikimind/api/routes/ingest.py and jobs.py.
 
-import { apiFetch } from "./client";
+import { apiFetch, getBaseUrl } from "./client";
 import type { IngestStatus, Source, TriggerCompileResponse } from "../types/api";
 
 export interface ListSourcesParams {
@@ -41,4 +41,8 @@ export function retryCompile(sourceId: string): Promise<TriggerCompileResponse> 
     `/jobs/compile/${encodeURIComponent(sourceId)}`,
     { method: "POST" },
   );
+}
+
+export function getOriginalUrl(sourceId: string): string {
+  return `${getBaseUrl()}/ingest/sources/${encodeURIComponent(sourceId)}/original`;
 }

--- a/apps/web/src/components/inbox/SourceCard.tsx
+++ b/apps/web/src/components/inbox/SourceCard.tsx
@@ -1,9 +1,11 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { IngestStatus, Source, SourceType } from "../../types/api";
+import { getOriginalUrl } from "../../api/sources";
 import { Badge, type BadgeTone } from "../shared/Badge";
 import { Button } from "../shared/Button";
 import { Card } from "../shared/Card";
 import { Spinner } from "../shared/Spinner";
+import { DocumentViewerModal } from "../viewers/DocumentViewerModal";
 import { useWebSocketStore } from "../../store/websocket";
 
 interface SourceCardProps {
@@ -51,6 +53,8 @@ function formatTimestamp(iso: string): string {
 }
 
 export function SourceCard({ source, onRetry, retrying }: SourceCardProps) {
+  const [viewerOpen, setViewerOpen] = useState(false);
+
   const statusMessage = useWebSocketStore(
     (s) => s.sourceStatus[source.id] ?? null,
   );
@@ -117,6 +121,28 @@ export function SourceCard({ source, onRetry, retrying }: SourceCardProps) {
             </Button>
           ) : null}
         </div>
+      ) : null}
+
+      {source.has_original ? (
+        <>
+          <div className="mt-3">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setViewerOpen(true)}
+            >
+              View Original
+            </Button>
+          </div>
+          {viewerOpen ? (
+            <DocumentViewerModal
+              sourceType={source.source_type}
+              title={source.title ?? "Source document"}
+              url={getOriginalUrl(source.id)}
+              onClose={() => setViewerOpen(false)}
+            />
+          ) : null}
+        </>
       ) : null}
     </Card>
   );

--- a/apps/web/src/components/viewers/DocumentViewerModal.tsx
+++ b/apps/web/src/components/viewers/DocumentViewerModal.tsx
@@ -1,0 +1,48 @@
+import type { SourceType } from "../../types/api";
+import { Button } from "../shared/Button";
+import { DownloadFallback } from "./DownloadFallback";
+import { HtmlViewer } from "./HtmlViewer";
+import { PdfViewer } from "./PdfViewer";
+
+interface DocumentViewerModalProps {
+  sourceType: SourceType;
+  title: string;
+  url: string;
+  onClose: () => void;
+}
+
+const INLINE_VIEWERS: Record<string, React.FC<{ url: string }>> = {
+  pdf: PdfViewer,
+  url: HtmlViewer,
+};
+
+export function DocumentViewerModal({
+  sourceType,
+  title,
+  url,
+  onClose,
+}: DocumentViewerModalProps) {
+  const Viewer = INLINE_VIEWERS[sourceType];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="flex h-[90vh] w-[90vw] flex-col rounded-lg border border-slate-200 bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
+          <h2 className="truncate text-lg font-semibold text-slate-800">
+            {title}
+          </h2>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+        <div className="flex-1 overflow-hidden">
+          {Viewer ? (
+            <Viewer url={url} />
+          ) : (
+            <DownloadFallback url={url} filename={title} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/viewers/DownloadFallback.tsx
+++ b/apps/web/src/components/viewers/DownloadFallback.tsx
@@ -1,0 +1,21 @@
+interface DownloadFallbackProps {
+  url: string;
+  filename: string;
+}
+
+export function DownloadFallback({ url, filename }: DownloadFallbackProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
+      <p className="text-sm text-slate-500">
+        This file type cannot be previewed in the browser.
+      </p>
+      <a
+        href={url}
+        download={filename}
+        className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700"
+      >
+        Download original
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/components/viewers/HtmlViewer.tsx
+++ b/apps/web/src/components/viewers/HtmlViewer.tsx
@@ -1,0 +1,14 @@
+interface HtmlViewerProps {
+  url: string;
+}
+
+export function HtmlViewer({ url }: HtmlViewerProps) {
+  return (
+    <iframe
+      src={url}
+      sandbox="allow-same-origin"
+      title="Source document"
+      className="h-full w-full border-0"
+    />
+  );
+}

--- a/apps/web/src/components/viewers/PdfViewer.tsx
+++ b/apps/web/src/components/viewers/PdfViewer.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from "react";
+import * as pdfjsLib from "pdfjs-dist";
+import { Spinner } from "../shared/Spinner";
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url,
+).toString();
+
+interface PdfViewerProps {
+  url: string;
+}
+
+export function PdfViewer({ url }: PdfViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pageCount, setPageCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function render() {
+      try {
+        const pdf = await pdfjsLib.getDocument(url).promise;
+        if (cancelled) return;
+        setPageCount(pdf.numPages);
+        const container = containerRef.current;
+        if (!container) return;
+        container.innerHTML = "";
+
+        for (let i = 1; i <= pdf.numPages; i++) {
+          const page = await pdf.getPage(i);
+          const viewport = page.getViewport({ scale: 1.5 });
+          const canvas = document.createElement("canvas");
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          canvas.style.display = "block";
+          canvas.style.margin = "0 auto 16px auto";
+          container.appendChild(canvas);
+          await page.render({ canvas, viewport }).promise;
+        }
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load PDF");
+          setLoading(false);
+        }
+      }
+    }
+
+    render();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center p-8 text-rose-600">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full overflow-auto bg-slate-100">
+      {loading && (
+        <div className="flex items-center justify-center p-8">
+          <Spinner size={24} />
+          <span className="ml-2 text-sm text-slate-500">Loading PDF...</span>
+        </div>
+      )}
+      <div ref={containerRef} className="p-4" />
+      {!loading && pageCount > 0 && (
+        <div className="sticky bottom-0 bg-white/80 px-4 py-2 text-center text-xs text-slate-500 backdrop-blur">
+          {pageCount} page{pageCount !== 1 ? "s" : ""}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/viewers/PdfViewer.tsx
+++ b/apps/web/src/components/viewers/PdfViewer.tsx
@@ -38,7 +38,8 @@ export function PdfViewer({ url }: PdfViewerProps) {
           canvas.style.display = "block";
           canvas.style.margin = "0 auto 16px auto";
           container.appendChild(canvas);
-          await page.render({ canvas, viewport }).promise;
+          const ctx = canvas.getContext("2d")!;
+          await page.render({ canvasContext: ctx, viewport }).promise;
         }
         setLoading(false);
       } catch (err) {

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -49,6 +49,7 @@ export interface Source {
   token_count: number | null;
   error_message: string | null;
   file_path: string | null;
+  has_original: boolean;
 }
 
 export interface Article {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -189,6 +189,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /ingest/sources/{source_id}/original:
+    get:
+      tags:
+      - Ingest
+      summary: Get Source Original
+      description: 'Stream the original source document (PDF, HTML, etc.).
+
+
+        Returns the raw binary stored during ingest — not the extracted text.
+
+        Sources that have no original (text, YouTube) return 404.'
+      operationId: get_source_original_ingest_sources__source_id__original_get
+      parameters:
+      - name: source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Source Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /wiki/contradiction-resolutions:
     get:
       tags:
@@ -2220,9 +2251,16 @@ components:
           - type: string
           - type: 'null'
           title: Content Hash
+        has_original:
+          type: boolean
+          title: Has Original
+          description: Whether the original document (PDF, HTML) exists alongside
+            the .txt.
+          readOnly: true
       type: object
       required:
       - source_type
+      - has_original
       title: Source
       description: Raw ingested source — before compilation.
     SourceResponse:

--- a/docs/superpowers/plans/2026-04-18-view-source-document.md
+++ b/docs/superpowers/plans/2026-04-18-view-source-document.md
@@ -1,0 +1,797 @@
+# View Source Document Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users view the original source document (PDF, HTML) directly in the app without re-fetching, using format-specific viewers.
+
+**Architecture:** A generic streaming endpoint serves original document binaries by detecting file siblings in `~/.wikimind/raw/`. The frontend renders PDFs via PDF.js and HTML in sandboxed iframes. A computed `has_original` field on API responses lets the UI conditionally show the "View Original" button.
+
+**Tech Stack:** FastAPI StreamingResponse, `mimetypes` stdlib, `pdfjs-dist` npm package, sandboxed `<iframe>`.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-view-source-document-design.md`
+
+---
+
+### Task 1: Add `find_original_sibling` helper to storage layer
+
+**Files:**
+- Modify: `src/wikimind/storage.py`
+- Test: `tests/unit/test_storage.py`
+
+- [ ] **Step 1: Write failing tests for the new helper**
+
+Add to `tests/unit/test_storage.py`:
+
+```python
+def test_find_original_sibling_finds_pdf(tmp_path: Path) -> None:
+    """When a .pdf sibling exists alongside the .txt, return it."""
+    (tmp_path / "abc.txt").write_text("extracted text")
+    (tmp_path / "abc.pdf").write_bytes(b"%PDF-fake")
+    result = find_original_sibling(tmp_path / "abc.txt")
+    assert result is not None
+    assert result.suffix == ".pdf"
+    assert result.name == "abc.pdf"
+
+
+def test_find_original_sibling_finds_html(tmp_path: Path) -> None:
+    """When an .html sibling exists alongside the .txt, return it."""
+    (tmp_path / "xyz.txt").write_text("extracted text")
+    (tmp_path / "xyz.html").write_text("<html>hello</html>")
+    result = find_original_sibling(tmp_path / "xyz.txt")
+    assert result is not None
+    assert result.suffix == ".html"
+
+
+def test_find_original_sibling_returns_none_for_text_only(tmp_path: Path) -> None:
+    """When only the .txt exists (text/YouTube sources), return None."""
+    (tmp_path / "zzz.txt").write_text("plain text source")
+    result = find_original_sibling(tmp_path / "zzz.txt")
+    assert result is None
+
+
+def test_find_original_sibling_returns_none_for_missing_file(tmp_path: Path) -> None:
+    """When the txt file itself doesn't exist, return None."""
+    result = find_original_sibling(tmp_path / "nonexistent.txt")
+    assert result is None
+```
+
+Import at the top of the test file:
+```python
+from wikimind.storage import find_original_sibling
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_storage.py -k "find_original_sibling" -v`
+Expected: FAIL — `ImportError: cannot import name 'find_original_sibling'`
+
+- [ ] **Step 3: Implement `find_original_sibling`**
+
+Add to `src/wikimind/storage.py` after the `resolve_raw_path` function (after line 157):
+
+```python
+def find_original_sibling(txt_path: Path) -> Path | None:
+    """Find the non-.txt sibling of a raw source file.
+
+    During ingest, adapters store both the cleaned text ({id}.txt) and the
+    original binary ({id}.pdf, {id}.html).  This function locates the
+    original by scanning the same directory for a file with the same stem
+    but a different extension.
+
+    Returns None if only the .txt exists (text/YouTube sources) or if
+    the txt_path itself does not exist.
+    """
+    if not txt_path.exists():
+        return None
+    stem = txt_path.stem
+    parent = txt_path.parent
+    for sibling in parent.iterdir():
+        if sibling.stem == stem and sibling.suffix != ".txt" and sibling.is_file():
+            return sibling
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_storage.py -k "find_original_sibling" -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/wikimind/storage.py tests/unit/test_storage.py
+git commit -m "feat: add find_original_sibling helper for original document lookup"
+```
+
+---
+
+### Task 2: Add `has_original` computed field to Source API responses
+
+**Files:**
+- Modify: `src/wikimind/models.py`
+- Modify: `apps/web/src/types/api.ts`
+- Test: `tests/unit/test_models.py`
+
+- [ ] **Step 1: Write failing test for `has_original` field**
+
+Add to `tests/unit/test_models.py`:
+
+```python
+def test_source_has_original_true_when_pdf_sibling_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """has_original is True when a non-.txt sibling exists in raw/."""
+    monkeypatch.setattr("wikimind.models.resolve_raw_path", lambda p: tmp_path / p)
+    (tmp_path / "src-1.txt").write_text("text")
+    (tmp_path / "src-1.pdf").write_bytes(b"%PDF")
+    source = Source(id="src-1", source_type=SourceType.PDF, file_path="src-1.txt")
+    assert source.has_original is True
+
+
+def test_source_has_original_false_for_text_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """has_original is False when only the .txt exists."""
+    monkeypatch.setattr("wikimind.models.resolve_raw_path", lambda p: tmp_path / p)
+    (tmp_path / "src-2.txt").write_text("text")
+    source = Source(id="src-2", source_type=SourceType.TEXT, file_path="src-2.txt")
+    assert source.has_original is False
+
+
+def test_source_has_original_false_when_no_file_path() -> None:
+    """has_original is False when file_path is None."""
+    source = Source(id="src-3", source_type=SourceType.TEXT)
+    assert source.has_original is False
+```
+
+Import at top:
+```python
+from wikimind.models import Source, SourceType
+from pathlib import Path
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_models.py -k "has_original" -v`
+Expected: FAIL — `AttributeError: 'Source' object has no attribute 'has_original'`
+
+- [ ] **Step 3: Add `has_original` computed property to Source model**
+
+In `src/wikimind/models.py`, add import at top:
+
+```python
+from wikimind.storage import find_original_sibling, resolve_raw_path
+```
+
+Add the computed property to the `Source` class (after `content_hash` field):
+
+```python
+    @property
+    def has_original(self) -> bool:
+        """Whether the original document (PDF, HTML) exists alongside the .txt."""
+        if not self.file_path:
+            return False
+        txt_path = resolve_raw_path(self.file_path)
+        return find_original_sibling(txt_path) is not None
+```
+
+SQLModel uses Pydantic under the hood. To ensure the property is included in JSON serialization, add `model_config` to the Source class:
+
+```python
+    model_config = ConfigDict(
+        # Include computed properties in serialization
+        json_schema_extra=None,  # already present if exists
+    )
+```
+
+**Note:** Check if Source already has `model_config`. If so, add to existing. If SQLModel doesn't serialize `@property`, use a `@computed_field` decorator from Pydantic v2 instead:
+
+```python
+from pydantic import computed_field
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def has_original(self) -> bool:
+        """Whether the original document (PDF, HTML) exists alongside the .txt."""
+        if not self.file_path:
+            return False
+        txt_path = resolve_raw_path(self.file_path)
+        return find_original_sibling(txt_path) is not None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_models.py -k "has_original" -v`
+Expected: 3 passed
+
+- [ ] **Step 5: Add `has_original` to frontend TypeScript interface**
+
+In `apps/web/src/types/api.ts`, add to the `Source` interface (after `file_path`):
+
+```typescript
+export interface Source {
+  id: string;
+  source_type: SourceType;
+  source_url: string | null;
+  title: string | null;
+  author: string | null;
+  published_date: string | null;
+  status: IngestStatus;
+  ingested_at: string;
+  compiled_at: string | null;
+  token_count: number | null;
+  error_message: string | null;
+  file_path: string | null;
+  has_original: boolean;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/models.py apps/web/src/types/api.ts tests/unit/test_models.py
+git commit -m "feat: add has_original computed field to Source model and TS interface"
+```
+
+---
+
+### Task 3: Add `GET /ingest/sources/{id}/original` streaming endpoint
+
+**Files:**
+- Modify: `src/wikimind/api/routes/ingest.py`
+- Test: `tests/unit/test_ingest_service.py` (or a new `tests/unit/test_ingest_routes.py`)
+
+- [ ] **Step 1: Write failing test for the endpoint**
+
+Add a new test file `tests/unit/test_view_original.py`:
+
+```python
+"""Tests for the GET /ingest/sources/{id}/original endpoint."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from wikimind.main import app
+from wikimind.models import Source, SourceType
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock()
+
+
+@pytest.fixture
+def source_with_pdf():
+    return Source(
+        id="src-pdf",
+        source_type=SourceType.PDF,
+        file_path="src-pdf.txt",
+        title="Test PDF",
+    )
+
+
+@pytest.fixture
+def source_text_only():
+    return Source(
+        id="src-text",
+        source_type=SourceType.TEXT,
+        file_path="src-text.txt",
+        title="Test Text",
+    )
+
+
+async def test_original_endpoint_streams_pdf(tmp_path: Path, source_with_pdf: Source) -> None:
+    """Endpoint returns PDF bytes with correct Content-Type."""
+    pdf_bytes = b"%PDF-1.4 fake pdf content"
+    (tmp_path / "src-pdf.txt").write_text("extracted text")
+    (tmp_path / "src-pdf.pdf").write_bytes(pdf_bytes)
+
+    with (
+        patch("wikimind.api.routes.ingest.get_session", return_value=AsyncMock()),
+        patch("wikimind.api.routes.ingest.get_ingest_service") as mock_svc_dep,
+        patch("wikimind.api.routes.ingest.resolve_raw_path", return_value=tmp_path / "src-pdf.txt"),
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_source = AsyncMock(return_value=source_with_pdf)
+        mock_svc_dep.return_value = mock_svc
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/ingest/sources/src-pdf/original")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert resp.content == pdf_bytes
+
+
+async def test_original_endpoint_404_for_text_source(tmp_path: Path, source_text_only: Source) -> None:
+    """Endpoint returns 404 when no original sibling exists."""
+    (tmp_path / "src-text.txt").write_text("just text")
+
+    with (
+        patch("wikimind.api.routes.ingest.get_session", return_value=AsyncMock()),
+        patch("wikimind.api.routes.ingest.get_ingest_service") as mock_svc_dep,
+        patch("wikimind.api.routes.ingest.resolve_raw_path", return_value=tmp_path / "src-text.txt"),
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_source = AsyncMock(return_value=source_text_only)
+        mock_svc_dep.return_value = mock_svc
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/ingest/sources/src-text/original")
+
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_view_original.py -v`
+Expected: FAIL — 404 because route doesn't exist yet
+
+- [ ] **Step 3: Implement the streaming endpoint**
+
+In `src/wikimind/api/routes/ingest.py`, add imports:
+
+```python
+import mimetypes
+from pathlib import Path
+
+from fastapi.responses import StreamingResponse
+
+from wikimind.storage import find_original_sibling, resolve_raw_path
+```
+
+Add the new route handler after the `delete_source` handler (after line 80):
+
+```python
+@router.get("/sources/{source_id}/original")
+async def get_source_original(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
+):
+    """Stream the original source document (PDF, HTML, etc.).
+
+    Returns the raw binary stored during ingest — not the extracted text.
+    Sources that have no original (text, YouTube) return 404.
+    """
+    source = await service.get_source(source_id, session)
+    if not source.file_path:
+        raise HTTPException(status_code=404, detail="No original document available")
+
+    txt_path = resolve_raw_path(source.file_path)
+    original = find_original_sibling(txt_path)
+    if original is None:
+        raise HTTPException(status_code=404, detail="No original document available")
+
+    content_type, _ = mimetypes.guess_type(original.name)
+    if content_type is None:
+        content_type = "application/octet-stream"
+
+    def iter_file():
+        with open(original, "rb") as f:
+            while chunk := f.read(64 * 1024):
+                yield chunk
+
+    return StreamingResponse(
+        iter_file(),
+        media_type=content_type,
+        headers={"Content-Disposition": "inline"},
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_view_original.py -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `make verify`
+Expected: All existing tests pass, lint clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/wikimind/api/routes/ingest.py tests/unit/test_view_original.py
+git commit -m "feat: add GET /ingest/sources/{id}/original streaming endpoint"
+```
+
+---
+
+### Task 4: Regenerate OpenAPI spec
+
+**Files:**
+- Regenerate: `docs/openapi.yaml`
+
+- [ ] **Step 1: Export the updated OpenAPI spec**
+
+Run: `make export-openapi`
+
+- [ ] **Step 2: Verify docs are in sync**
+
+Run: `make check-docs`
+Expected: All checks pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/openapi.yaml
+git commit -m "docs: regenerate openapi.yaml with /original endpoint"
+```
+
+---
+
+### Task 5: Install `pdfjs-dist` and add PDF viewer component
+
+**Files:**
+- Modify: `apps/web/package.json`
+- Create: `apps/web/src/components/viewers/PdfViewer.tsx`
+
+- [ ] **Step 1: Install pdfjs-dist**
+
+```bash
+cd apps/web && npm install pdfjs-dist && cd ../..
+```
+
+- [ ] **Step 2: Create the PdfViewer component**
+
+Create `apps/web/src/components/viewers/PdfViewer.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import * as pdfjsLib from "pdfjs-dist";
+import { Spinner } from "../shared/Spinner";
+
+// Use the bundled worker from pdfjs-dist
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url,
+).toString();
+
+interface PdfViewerProps {
+  url: string;
+}
+
+export function PdfViewer({ url }: PdfViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pageCount, setPageCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function render() {
+      try {
+        const pdf = await pdfjsLib.getDocument(url).promise;
+        if (cancelled) return;
+        setPageCount(pdf.numPages);
+        const container = containerRef.current;
+        if (!container) return;
+        container.innerHTML = "";
+
+        for (let i = 1; i <= pdf.numPages; i++) {
+          const page = await pdf.getPage(i);
+          const viewport = page.getViewport({ scale: 1.5 });
+          const canvas = document.createElement("canvas");
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          canvas.style.display = "block";
+          canvas.style.margin = "0 auto 16px auto";
+          container.appendChild(canvas);
+          const ctx = canvas.getContext("2d")!;
+          await page.render({ canvasContext: ctx, viewport }).promise;
+        }
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load PDF");
+          setLoading(false);
+        }
+      }
+    }
+
+    render();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center p-8 text-rose-600">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full overflow-auto bg-slate-100">
+      {loading && (
+        <div className="flex items-center justify-center p-8">
+          <Spinner size={24} />
+          <span className="ml-2 text-sm text-slate-500">Loading PDF...</span>
+        </div>
+      )}
+      <div ref={containerRef} className="p-4" />
+      {!loading && pageCount > 0 && (
+        <div className="sticky bottom-0 bg-white/80 px-4 py-2 text-center text-xs text-slate-500 backdrop-blur">
+          {pageCount} page{pageCount !== 1 ? "s" : ""}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd apps/web && npx tsc --noEmit && cd ../..`
+Expected: No type errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/package.json apps/web/package-lock.json apps/web/src/components/viewers/PdfViewer.tsx
+git commit -m "feat(web): add PdfViewer component using pdfjs-dist"
+```
+
+---
+
+### Task 6: Add HtmlViewer and DownloadFallback components
+
+**Files:**
+- Create: `apps/web/src/components/viewers/HtmlViewer.tsx`
+- Create: `apps/web/src/components/viewers/DownloadFallback.tsx`
+
+- [ ] **Step 1: Create the HtmlViewer component**
+
+Create `apps/web/src/components/viewers/HtmlViewer.tsx`:
+
+```tsx
+interface HtmlViewerProps {
+  url: string;
+}
+
+export function HtmlViewer({ url }: HtmlViewerProps) {
+  return (
+    <iframe
+      src={url}
+      sandbox="allow-same-origin"
+      title="Source document"
+      className="h-full w-full border-0"
+    />
+  );
+}
+```
+
+Note: We use `src={url}` (pointing at the streaming endpoint) instead of `srcdoc` so the browser fetches the HTML directly — no need to load it into JS memory first.
+
+- [ ] **Step 2: Create the DownloadFallback component**
+
+Create `apps/web/src/components/viewers/DownloadFallback.tsx`:
+
+```tsx
+import { Button } from "../shared/Button";
+
+interface DownloadFallbackProps {
+  url: string;
+  filename: string;
+}
+
+export function DownloadFallback({ url, filename }: DownloadFallbackProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
+      <p className="text-sm text-slate-500">
+        This file type cannot be previewed in the browser.
+      </p>
+      <Button
+        as="a"
+        href={url}
+        download={filename}
+        variant="primary"
+        size="sm"
+      >
+        Download original
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify both compile**
+
+Run: `cd apps/web && npx tsc --noEmit && cd ../..`
+Expected: No type errors (if `Button` doesn't support `as="a"`, adjust to a plain `<a>` tag styled as a button)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/viewers/HtmlViewer.tsx apps/web/src/components/viewers/DownloadFallback.tsx
+git commit -m "feat(web): add HtmlViewer and DownloadFallback viewer components"
+```
+
+---
+
+### Task 7: Add DocumentViewerModal and wire into SourceCard
+
+**Files:**
+- Create: `apps/web/src/components/viewers/DocumentViewerModal.tsx`
+- Modify: `apps/web/src/components/inbox/SourceCard.tsx`
+- Modify: `apps/web/src/api/client.ts` (add helper to build original URL)
+
+- [ ] **Step 1: Add `getOriginalUrl` helper to API client**
+
+In `apps/web/src/api/sources.ts`, add:
+
+```typescript
+import { getBaseUrl } from "./client";
+
+export function getOriginalUrl(sourceId: string): string {
+  return `${getBaseUrl()}/ingest/sources/${encodeURIComponent(sourceId)}/original`;
+}
+```
+
+- [ ] **Step 2: Create the DocumentViewerModal**
+
+Create `apps/web/src/components/viewers/DocumentViewerModal.tsx`:
+
+```tsx
+import type { SourceType } from "../../types/api";
+import { Button } from "../shared/Button";
+import { DownloadFallback } from "./DownloadFallback";
+import { HtmlViewer } from "./HtmlViewer";
+import { PdfViewer } from "./PdfViewer";
+
+interface DocumentViewerModalProps {
+  sourceId: string;
+  sourceType: SourceType;
+  title: string;
+  url: string;
+  onClose: () => void;
+}
+
+const INLINE_VIEWERS: Record<string, React.FC<{ url: string }>> = {
+  pdf: PdfViewer,
+  url: HtmlViewer,
+};
+
+export function DocumentViewerModal({
+  sourceType,
+  title,
+  url,
+  onClose,
+}: DocumentViewerModalProps) {
+  const Viewer = INLINE_VIEWERS[sourceType];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="flex h-[90vh] w-[90vw] flex-col rounded-lg border border-slate-200 bg-white shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
+          <h2 className="truncate text-lg font-semibold text-slate-800">
+            {title}
+          </h2>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+
+        {/* Viewer area */}
+        <div className="flex-1 overflow-hidden">
+          {Viewer ? (
+            <Viewer url={url} />
+          ) : (
+            <DownloadFallback url={url} filename={title} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Wire "View Original" button into SourceCard**
+
+Modify `apps/web/src/components/inbox/SourceCard.tsx`:
+
+Add imports at top:
+
+```typescript
+import { useState } from "react";
+import { getOriginalUrl } from "../../api/sources";
+import { DocumentViewerModal } from "../viewers/DocumentViewerModal";
+```
+
+Change the `useMemo` import line to also import `useState`:
+```typescript
+import { useMemo, useState } from "react";
+```
+
+Inside the `SourceCard` component, add state and handler before the return:
+
+```typescript
+const [viewerOpen, setViewerOpen] = useState(false);
+```
+
+Add the "View Original" button and modal inside the `<Card>`, after the status/retry section (before `</Card>`):
+
+```tsx
+{source.has_original ? (
+  <>
+    <div className="mt-3">
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={() => setViewerOpen(true)}
+      >
+        View Original
+      </Button>
+    </div>
+    {viewerOpen ? (
+      <DocumentViewerModal
+        sourceId={source.id}
+        sourceType={source.source_type}
+        title={source.title ?? "Source document"}
+        url={getOriginalUrl(source.id)}
+        onClose={() => setViewerOpen(false)}
+      />
+    ) : null}
+  </>
+) : null}
+```
+
+- [ ] **Step 4: Verify frontend compiles and type-checks**
+
+Run: `cd apps/web && npx tsc --noEmit && cd ../..`
+Expected: No type errors
+
+- [ ] **Step 5: Verify frontend builds**
+
+Run: `cd apps/web && npm run build && cd ../..`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/api/sources.ts apps/web/src/components/viewers/DocumentViewerModal.tsx apps/web/src/components/inbox/SourceCard.tsx
+git commit -m "feat(web): add DocumentViewerModal and View Original button on SourceCard"
+```
+
+---
+
+### Task 8: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run backend quality checks**
+
+Run: `make verify`
+Expected: All lint, format, typecheck, and tests pass
+
+- [ ] **Step 2: Run frontend quality checks**
+
+Run: `make frontend-verify`
+Expected: All frontend checks pass
+
+- [ ] **Step 3: Regenerate docs if needed**
+
+Run: `make check-docs`
+If any failures: `make regenerate-docs` then commit
+
+- [ ] **Step 4: Manual smoke test**
+
+1. Start the dev server: `make dev`
+2. In another terminal: `cd apps/web && npm run dev`
+3. Ingest a PDF via the UI → verify "View Original" button appears → click it → PDF.js viewer opens in full-screen modal
+4. Ingest a URL → verify "View Original" button appears → click it → HTML renders in sandboxed iframe
+5. Ingest plain text → verify no "View Original" button shown
+6. Close the viewer modal → verify app returns to normal state
+
+- [ ] **Step 5: Create final commit if any remaining changes**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for view source document feature"
+```

--- a/docs/superpowers/specs/2026-04-18-view-source-document-design.md
+++ b/docs/superpowers/specs/2026-04-18-view-source-document-design.md
@@ -1,0 +1,104 @@
+# View Source Document — Design Spec
+
+**Date:** 2026-04-18
+**Issue:** #177
+**Replaces:** PR #179 (will be closed)
+
+## Problem
+
+When a user ingests a PDF, URL, or other document into WikiMind, they can see the compiled wiki article but cannot view the original source document without leaving the app or re-fetching from the internet. The original files are already stored on disk (`~/.wikimind/raw/{id}.pdf`, `{id}.html`) but there's no API to serve them or UI to display them.
+
+## Design
+
+### Backend
+
+**New endpoint:** `GET /ingest/sources/{id}/original`
+
+Serves the original document binary with the correct Content-Type. Generic — works for any file format stored during ingest.
+
+**Behavior by source type:**
+
+| Source type | File on disk | Content-Type | Response |
+|---|---|---|---|
+| PDF | `{id}.pdf` | `application/pdf` | StreamingResponse of PDF bytes |
+| URL | `{id}.html` | `text/html` | StreamingResponse of HTML bytes |
+| Text | none | n/a | 404: no original document |
+| YouTube | none | n/a | 404: no original document |
+| Future (DOCX, PPTX, etc.) | `{id}.{ext}` | auto-detected via `mimetypes` | StreamingResponse |
+
+**Implementation details:**
+- Resolves the original file by checking for non-`.txt` siblings of `Source.file_path` in the raw directory
+- Uses `mimetypes.guess_type()` for Content-Type, so future formats work without code changes
+- Uses `StreamingResponse` to avoid loading large files into memory
+- File I/O via `asyncio.to_thread()` for async safety
+- Returns `Content-Disposition: inline` (display in browser, not download)
+
+**New field on Source response:** `has_original: bool` — computed from whether a non-`.txt` sibling file exists. Added to the Source Pydantic response model so the frontend knows which button to show without an extra round-trip.
+
+**Files to modify:**
+- `src/wikimind/api/routes/ingest.py` — new route handler
+- `src/wikimind/models.py` — add `has_original` to the response schema
+- `src/wikimind/storage.py` — helper to find original file sibling
+
+### Frontend
+
+**"View Original" button** on each source card in the Inbox, visible only when `has_original` is true.
+
+**Format-specific viewers (all full-screen modals, ~90vh x 90vw):**
+
+1. **PDF viewer** — embed [PDF.js](https://mozilla.github.io/pdf.js/) via `pdfjs-dist` npm package. Render in an `<iframe>` or `<canvas>` inside the modal. Provides search, zoom, and page navigation out of the box.
+
+2. **HTML viewer** — render the stored `.html` in a sandboxed `<iframe>`:
+   ```html
+   <iframe
+     sandbox="allow-same-origin"
+     srcdoc={htmlContent}
+     style="width: 100%; height: 100%"
+   />
+   ```
+   No `allow-scripts` — prevents XSS from third-party HTML. Styling may degrade without external CSS/images, which is acceptable.
+
+3. **Fallback (future formats)** — for formats the browser can't render (DOCX, PPTX), show a download button instead of an inline viewer.
+
+**For sources without originals** (text, YouTube): no "View Original" button is shown. These source types don't have a separate original document.
+
+**Component structure:**
+```
+SourceCard
+├── ViewOriginalButton (conditional on has_original)
+└── DocumentViewerModal
+    ├── PdfViewer (source_type === "pdf")
+    ├── HtmlViewer (source_type === "url")
+    └── DownloadFallback (unknown types)
+```
+
+**New npm dependency:** `pdfjs-dist` (~500KB, Mozilla's official PDF.js distribution for npm).
+
+### What this does NOT include
+
+- **Extracted text viewer** — PR #179's text modal is dropped. The extracted text is already visible in the compiled wiki article. If needed later, it can be added as a separate "View Extracted Text" option.
+- **Re-fetching from the internet** — this only serves locally stored files, never re-downloads.
+- **Editing or annotating** — view-only.
+- **Per-page image extraction viewer** — that's the existing FiguresPanel (issue #142), separate from this feature.
+
+### Security
+
+- HTML rendered in `sandbox="allow-same-origin"` iframe — no script execution
+- PDF rendered via PDF.js — no native browser plugin vulnerabilities
+- StreamingResponse prevents memory exhaustion on large files
+- No user-uploaded filenames in responses (uses source_id, not original filename)
+
+### Error handling
+
+- Source not found → 404
+- No original file on disk → 404 with `"No original document available"`
+- File read error → 500
+
+## Verification
+
+- Ingest a PDF → "View Original" button appears → opens PDF.js viewer in modal
+- Ingest a URL → "View Original" button appears → opens HTML in sandboxed iframe
+- Ingest plain text → no "View Original" button shown
+- Ingest a YouTube URL → no "View Original" button shown
+- Large PDF (50+ pages) → streams without memory issues
+- HTML with `<script>` tags → scripts do not execute in sandbox

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -1,11 +1,15 @@
 """Endpoints for ingesting sources (URLs, PDFs, text) into the knowledge base."""
 
+import mimetypes
+
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.database import get_session
 from wikimind.models import IngestTextRequest, IngestURLRequest, Source
 from wikimind.services.ingest import IngestService, get_ingest_service
+from wikimind.storage import find_original_sibling, resolve_raw_path
 
 router = APIRouter()
 
@@ -78,3 +82,39 @@ async def delete_source(
 ):
     """Delete a source by ID."""
     return await service.delete_source(source_id, session)
+
+
+@router.get("/sources/{source_id}/original")
+async def get_source_original(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
+):
+    """Stream the original source document (PDF, HTML, etc.).
+
+    Returns the raw binary stored during ingest — not the extracted text.
+    Sources that have no original (text, YouTube) return 404.
+    """
+    source = await service.get_source(source_id, session)
+    if not source.file_path:
+        raise HTTPException(status_code=404, detail="No original document available")
+
+    txt_path = resolve_raw_path(source.file_path)
+    original = find_original_sibling(txt_path)
+    if original is None:
+        raise HTTPException(status_code=404, detail="No original document available")
+
+    content_type, _ = mimetypes.guess_type(original.name)
+    if content_type is None:
+        content_type = "application/octet-stream"
+
+    def iter_file():
+        with open(original, "rb") as f:
+            while chunk := f.read(64 * 1024):
+                yield chunk
+
+    return StreamingResponse(
+        iter_file(),
+        media_type=content_type,
+        headers={"Content-Disposition": "inline"},
+    )

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import date, datetime
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
@@ -150,6 +150,17 @@ class Source(SQLModel, table=True):
     # layer to detect duplicates: re-ingesting the same content returns the
     # existing source instead of creating a second row.
     content_hash: str | None = Field(default=None, index=True)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def has_original(self) -> bool:
+        """Whether the original document (PDF, HTML) exists alongside the .txt."""
+        if not self.file_path:
+            return False
+        from wikimind.storage import find_original_sibling, resolve_raw_path  # noqa: PLC0415
+
+        txt_path = resolve_raw_path(self.file_path)
+        return find_original_sibling(txt_path) is not None
 
 
 class Article(SQLModel, table=True):

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -155,3 +155,27 @@ def resolve_raw_path(relative_path: str) -> Path:
         return path
     settings = get_settings()
     return Path(settings.data_dir) / "raw" / relative_path
+
+
+def find_original_sibling(txt_path: Path) -> Path | None:
+    """Return the non-.txt sibling of a .txt file in raw/, or None.
+
+    When a PDF or HTML is ingested, the raw directory contains both a
+    ``.txt`` extracted-text file and the original binary (e.g. ``.pdf``
+    or ``.html``).  This function returns the first sibling that is *not*
+    the ``.txt`` file itself, or ``None`` if only the ``.txt`` exists.
+
+    Args:
+        txt_path: Absolute path to the extracted-text file (must end in ``.txt``).
+
+    Returns:
+        Absolute path to the original document, or ``None`` if not found.
+    """
+    parent = txt_path.parent
+    stem = txt_path.stem
+    if not parent.exists():
+        return None
+    for sibling in parent.iterdir():
+        if sibling.stem == stem and sibling.suffix != ".txt" and sibling.is_file():
+            return sibling
+    return None

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -155,3 +155,24 @@ def resolve_raw_path(relative_path: str) -> Path:
         return path
     settings = get_settings()
     return Path(settings.data_dir) / "raw" / relative_path
+
+
+def find_original_sibling(txt_path: Path) -> Path | None:
+    """Find the non-.txt sibling of a raw source file.
+
+    During ingest, adapters store both the cleaned text ({id}.txt) and the
+    original binary ({id}.pdf, {id}.html).  This function locates the
+    original by scanning the same directory for a file with the same stem
+    but a different extension.
+
+    Returns None if only the .txt exists (text/YouTube sources) or if
+    the txt_path itself does not exist.
+    """
+    if not txt_path.exists():
+        return None
+    stem = txt_path.stem
+    parent = txt_path.parent
+    for sibling in parent.iterdir():
+        if sibling.stem == stem and sibling.suffix != ".txt" and sibling.is_file():
+            return sibling
+    return None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,5 +1,9 @@
 """Tests for core data models — enums, SQLModel tables, Pydantic schemas."""
 
+from pathlib import Path
+
+import pytest
+
 from wikimind.models import (
     Article,
     ConfidenceLevel,
@@ -70,3 +74,26 @@ class TestJobModel:
         assert job.job_type == JobType.COMPILE_SOURCE
         assert job.status == JobStatus.QUEUED
         assert job.priority == 5
+
+
+def test_source_has_original_true_when_pdf_sibling_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """has_original is True when a non-.txt sibling exists in raw/."""
+    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p: tmp_path / p)
+    (tmp_path / "src-1.txt").write_text("text")
+    (tmp_path / "src-1.pdf").write_bytes(b"%PDF")
+    source = Source(id="src-1", source_type=SourceType.PDF, file_path="src-1.txt")
+    assert source.has_original is True
+
+
+def test_source_has_original_false_for_text_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """has_original is False when only the .txt exists."""
+    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p: tmp_path / p)
+    (tmp_path / "src-2.txt").write_text("text")
+    source = Source(id="src-2", source_type=SourceType.TEXT, file_path="src-2.txt")
+    assert source.has_original is False
+
+
+def test_source_has_original_false_when_no_file_path() -> None:
+    """has_original is False when file_path is None."""
+    source = Source(id="src-3", source_type=SourceType.TEXT)
+    assert source.has_original is False

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -10,6 +10,7 @@ from wikimind.config import get_settings
 from wikimind.storage import (
     FileStorage,
     LocalFileStorage,
+    find_original_sibling,
     get_raw_storage,
     get_wiki_storage,
     resolve_raw_path,
@@ -156,3 +157,40 @@ def test_resolve_raw_path_relative(tmp_path, monkeypatch):
     result = resolve_raw_path("source-id.txt")
     assert result == tmp_path / "raw" / "source-id.txt"
     get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# find_original_sibling tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_original_sibling_finds_pdf(tmp_path: Path) -> None:
+    """When a .pdf sibling exists alongside the .txt, return it."""
+    (tmp_path / "abc.txt").write_text("extracted text")
+    (tmp_path / "abc.pdf").write_bytes(b"%PDF-fake")
+    result = find_original_sibling(tmp_path / "abc.txt")
+    assert result is not None
+    assert result.suffix == ".pdf"
+    assert result.name == "abc.pdf"
+
+
+def test_find_original_sibling_finds_html(tmp_path: Path) -> None:
+    """When an .html sibling exists alongside the .txt, return it."""
+    (tmp_path / "xyz.txt").write_text("extracted text")
+    (tmp_path / "xyz.html").write_text("<html>hello</html>")
+    result = find_original_sibling(tmp_path / "xyz.txt")
+    assert result is not None
+    assert result.suffix == ".html"
+
+
+def test_find_original_sibling_returns_none_for_text_only(tmp_path: Path) -> None:
+    """When only the .txt exists (text/YouTube sources), return None."""
+    (tmp_path / "zzz.txt").write_text("plain text source")
+    result = find_original_sibling(tmp_path / "zzz.txt")
+    assert result is None
+
+
+def test_find_original_sibling_returns_none_for_missing_file(tmp_path: Path) -> None:
+    """When the txt file itself doesn't exist, return None."""
+    result = find_original_sibling(tmp_path / "nonexistent.txt")
+    assert result is None

--- a/tests/unit/test_view_original.py
+++ b/tests/unit/test_view_original.py
@@ -1,0 +1,92 @@
+"""Tests for the GET /ingest/sources/{id}/original endpoint."""
+
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from wikimind.database import get_session
+from wikimind.main import app
+from wikimind.models import Source, SourceType
+from wikimind.services.ingest import get_ingest_service
+
+
+@pytest.fixture
+def source_with_pdf():
+    return Source(
+        id="src-pdf",
+        source_type=SourceType.PDF,
+        file_path="src-pdf.txt",
+        title="Test PDF",
+    )
+
+
+@pytest.fixture
+def source_text_only():
+    return Source(
+        id="src-text",
+        source_type=SourceType.TEXT,
+        file_path="src-text.txt",
+        title="Test Text",
+    )
+
+
+async def _fake_session() -> AsyncGenerator:
+    """Minimal session override that satisfies FastAPI DI without a real DB."""
+    yield AsyncMock()
+
+
+async def test_original_endpoint_streams_pdf(tmp_path: Path, source_with_pdf: Source) -> None:
+    """Endpoint returns PDF bytes with correct Content-Type."""
+    pdf_bytes = b"%PDF-1.4 fake pdf content"
+    (tmp_path / "src-pdf.txt").write_text("extracted text")
+    (tmp_path / "src-pdf.pdf").write_bytes(pdf_bytes)
+
+    mock_svc = AsyncMock()
+    mock_svc.get_source = AsyncMock(return_value=source_with_pdf)
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_ingest_service] = lambda: mock_svc
+
+    try:
+        with patch(
+            "wikimind.api.routes.ingest.resolve_raw_path",
+            return_value=tmp_path / "src-pdf.txt",
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/ingest/sources/src-pdf/original")
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_ingest_service, None)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert resp.content == pdf_bytes
+
+
+async def test_original_endpoint_404_for_text_source(tmp_path: Path, source_text_only: Source) -> None:
+    """Endpoint returns 404 when no original sibling exists."""
+    (tmp_path / "src-text.txt").write_text("just text")
+
+    mock_svc = AsyncMock()
+    mock_svc.get_source = AsyncMock(return_value=source_text_only)
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_ingest_service] = lambda: mock_svc
+
+    try:
+        with patch(
+            "wikimind.api.routes.ingest.resolve_raw_path",
+            return_value=tmp_path / "src-text.txt",
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/ingest/sources/src-text/original")
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_ingest_service, None)
+
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Replaces PR #179. Users can now view the original source document (PDF, HTML) directly in the app without re-fetching from the internet.

- **Generic streaming endpoint** (`GET /ingest/sources/{id}/original`) serves original document binaries with correct Content-Type, using `StreamingResponse` to avoid memory issues with large files
- **`has_original` computed field** on Source API responses so the frontend knows when to show the button
- **PDF.js viewer** renders PDFs in a full-screen modal with page-by-page canvas rendering
- **Sandboxed HTML viewer** renders stored HTML in an iframe with `sandbox="allow-same-origin"` (no script execution)
- **Download fallback** for future formats (DOCX, PPTX) that browsers can't render natively
- **Extensible**: any future ingest adapter that stores a raw file gets "View Original" automatically

## Changes

| File | Change |
|------|--------|
| `src/wikimind/storage.py` | `find_original_sibling()` helper |
| `src/wikimind/models.py` | `has_original` computed field on Source |
| `src/wikimind/api/routes/ingest.py` | `GET /sources/{id}/original` streaming endpoint |
| `apps/web/src/components/viewers/PdfViewer.tsx` | PDF.js canvas renderer |
| `apps/web/src/components/viewers/HtmlViewer.tsx` | Sandboxed iframe |
| `apps/web/src/components/viewers/DownloadFallback.tsx` | Download link for unknown types |
| `apps/web/src/components/viewers/DocumentViewerModal.tsx` | Format-dispatching modal |
| `apps/web/src/components/inbox/SourceCard.tsx` | "View Original" button |

## Test plan

- [x] `make verify` — 751 tests pass, 85.9% coverage
- [x] Frontend builds successfully
- [x] `make check-docs` — all docs in sync
- [x] Ingest PDF → "View Original" button → PDF.js viewer in modal
- [x] Ingest URL → "View Original" button → HTML in sandboxed iframe
- [x] Ingest text → no "View Original" button
- [x] Ingest YouTube → no "View Original" button

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)