### PR TITLE
chore: adopt tier-1 ruff rules (phase 1 of #217)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,15 @@ select = [
     "SIM",    # flake8-simplify
     "RUF",    # ruff-specific rules
     "PL",     # pylint rules (via ruff)
+    "PLC0415", # import-outside-top-level (not enabled by default under PL)
     "D",      # pydocstyle
+    "C4",     # flake8-comprehensions
+    "PIE",    # flake8-pie
+    "PERF",   # perflint
+    "RSE",    # flake8-raise
+    "RET",    # flake8-return
+    "T20",    # flake8-print
+    "ISC",    # flake8-implicit-str-concat
 ]
 ignore = [
     "E501",   # line too long — handled by formatter
@@ -131,10 +139,14 @@ ignore = [
     "PLR2004", # magic value comparison — too noisy for early stage
     "PLR0915", # too many statements — some functions are legitimately long
     "PLW0603", # global statement — acceptable for singleton patterns (engine, session factory)
+    "PIE804",  # unnecessary-dict-kwargs — Pydantic uses **{"alias": ...} patterns intentionally
+    "RET504",  # unnecessary-assign — readability-first over short-circuit returns
+    "ISC001",  # single-line-implicit-string-concat — conflicts with formatter
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104"]
+"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "T20", "PERF"]
+"scripts/**/*.py" = ["T20"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["wikimind"]

--- a/scripts/check_doc_sync.py
+++ b/scripts/check_doc_sync.py
@@ -86,19 +86,18 @@ def load_config(path: Path) -> tuple[list[Rule], dict[str, Any]]:
     raw_rules = data.get("rules", []) or []
     escape = data.get("escape_hatches", {}) or {}
 
-    rules: list[Rule] = []
-    for raw in raw_rules:
-        rules.append(
-            Rule(
-                name=raw["name"],
-                when_changed=list(raw.get("when_changed", [])),
-                when_diff_contains=list(raw.get("when_diff_contains", [])),
-                require_changed=list(raw.get("require_changed", [])),
-                require_one_of=list(raw.get("require_one_of", [])),
-                severity=raw.get("severity", "error"),
-                fix_hint=raw.get("fix_hint", ""),
-            )
+    rules: list[Rule] = [
+        Rule(
+            name=raw["name"],
+            when_changed=list(raw.get("when_changed", [])),
+            when_diff_contains=list(raw.get("when_diff_contains", [])),
+            require_changed=list(raw.get("require_changed", [])),
+            require_one_of=list(raw.get("require_one_of", [])),
+            severity=raw.get("severity", "error"),
+            fix_hint=raw.get("fix_hint", ""),
         )
+        for raw in raw_rules
+    ]
     return rules, escape
 
 

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -44,7 +44,7 @@ def _create_engine_from_url(url: str):
             echo=False,
             connect_args={"check_same_thread": False},
         )
-    elif is_postgres(url):
+    if is_postgres(url):
         return create_async_engine(
             url,
             echo=False,
@@ -52,9 +52,8 @@ def _create_engine_from_url(url: str):
             max_overflow=20,
             pool_pre_ping=True,
         )
-    else:
-        dialect = url.split("://", maxsplit=1)[0]
-        raise ValueError(f"Unsupported database dialect: {dialect}. Use sqlite+aiosqlite or postgresql+asyncpg.")
+    dialect = url.split("://", maxsplit=1)[0]
+    raise ValueError(f"Unsupported database dialect: {dialect}. Use sqlite+aiosqlite or postgresql+asyncpg.")
 
 
 def get_db_path() -> Path:

--- a/src/wikimind/db_compat.py
+++ b/src/wikimind/db_compat.py
@@ -44,10 +44,9 @@ def json_array_contains(dialect: str, column_name: str, value: str) -> ClauseEle
     """
     if dialect == "postgresql":
         return text(f"{column_name}::jsonb @> cast(:val as jsonb)").bindparams(val=json_mod.dumps([value]))
-    else:
-        # SQLite: LIKE-based search matching the existing .contains() pattern
-        needle = f'"{value}"'
-        return literal_column(column_name).contains(needle)
+    # SQLite: LIKE-based search matching the existing .contains() pattern
+    needle = f'"{value}"'
+    return literal_column(column_name).contains(needle)
 
 
 def json_array_elements_subquery(dialect: str, table_name: str, column_name: str, value_alias: str = "elem"):

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -540,11 +540,8 @@ Compile this into a wiki article following the JSON schema exactly."""
 
         file_path = concept_dir / f"{slug}.md"
 
-        related_lines: list[str] = []
-        for rb in resolved:
-            related_lines.append(f"- [{rb.candidate_text}](/wiki/{rb.target_id})")
-        for text in unresolved:
-            related_lines.append(f"- [[{text}]]")
+        related_lines: list[str] = [f"- [{rb.candidate_text}](/wiki/{rb.target_id})" for rb in resolved]
+        related_lines.extend(f"- [[{text}]]" for text in unresolved)
         backlinks = "\n".join(related_lines)
 
         claims = "\n".join(
@@ -613,7 +610,6 @@ provider: {provider_str}
 
         if ratio >= 0.8:
             return ConfidenceLevel.SOURCED
-        elif ratio >= 0.4:
+        if ratio >= 0.4:
             return ConfidenceLevel.MIXED
-        else:
-            return ConfidenceLevel.INFERRED
+        return ConfidenceLevel.INFERRED

--- a/src/wikimind/engine/concept_kind_registry.py
+++ b/src/wikimind/engine/concept_kind_registry.py
@@ -76,10 +76,11 @@ async def validate_registry_against_prompts(session: AsyncSession) -> None:
     """Check that every ConceptKindDef prompt_template_key exists in PROMPT_TEMPLATES."""
     result = await session.execute(select(ConceptKindDef))
     kinds = result.scalars().all()
-    missing: list[str] = []
-    for kind in kinds:
-        if kind.prompt_template_key not in PROMPT_TEMPLATES:
-            missing.append(f"{kind.name} -> {kind.prompt_template_key}")
+    missing: list[str] = [
+        f"{kind.name} -> {kind.prompt_template_key}"
+        for kind in kinds
+        if kind.prompt_template_key not in PROMPT_TEMPLATES
+    ]
     if missing:
         raise RegistryTemplateMismatchError(
             f"ConceptKindDef rows reference missing prompt templates: {', '.join(missing)}"

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -77,7 +77,7 @@ def _extract_claims(article: Article) -> list[str]:
         if in_claims_section:
             if stripped.startswith("## "):
                 break
-            if stripped.startswith("- ") or stripped.startswith("* "):
+            if stripped.startswith(("- ", "* ")):
                 claims.append(stripped[2:].strip())
 
     if not claims:

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -198,10 +198,7 @@ async def run_lint(
 
         # Emit WebSocket alert
         if contradictions:
-            article_titles: list[str] = []
-            for c in contradictions:
-                if not c.dismissed:
-                    article_titles.append(c.description)
+            article_titles: list[str] = [c.description for c in contradictions if not c.dismissed]
             if article_titles:
                 await emit_linter_alert("contradiction", article_titles, user_id=user_id)
 

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -142,16 +142,15 @@ class LLMRouter:
         """Create and return a provider instance."""
         if provider == Provider.ANTHROPIC:
             return AnthropicProvider()
-        elif provider == Provider.OPENAI:
+        if provider == Provider.OPENAI:
             return OpenAIProvider()
-        elif provider == Provider.GOOGLE:
+        if provider == Provider.GOOGLE:
             return GoogleProvider()
-        elif provider == Provider.OLLAMA:
+        if provider == Provider.OLLAMA:
             return OllamaProvider(self.settings.llm.ollama_base_url)
-        elif provider == Provider.MOCK:
+        if provider == Provider.MOCK:
             return MockProvider()
-        else:
-            raise ValueError(f"Provider {provider} not implemented yet")
+        raise ValueError(f"Provider {provider} not implemented yet")
 
     def _get_model(self, provider: Provider) -> str:
         """Return the configured model name for a provider."""

--- a/src/wikimind/engine/providers/openai.py
+++ b/src/wikimind/engine/providers/openai.py
@@ -29,12 +29,12 @@ class OpenAIProvider:
         messages = [{"role": "system", "content": request.system}]
         messages.extend(request.messages)
 
-        kwargs: dict[str, object] = dict(
-            model=model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            messages=messages,
-        )
+        kwargs: dict[str, object] = {
+            "model": model,
+            "max_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            "messages": messages,
+        }
         if request.response_format == "json":
             kwargs["response_format"] = {"type": "json_object"}
 
@@ -128,14 +128,14 @@ class OpenAIProvider:
         messages.extend(request.messages)
         start = time.monotonic()
 
-        kwargs: dict[str, object] = dict(
-            model=model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            messages=messages,
-            stream=True,
-            stream_options={"include_usage": True},
-        )
+        kwargs: dict[str, object] = {
+            "model": model,
+            "max_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
         if request.response_format == "json":
             kwargs["response_format"] = {"type": "json_object"}
 

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -576,8 +576,7 @@ class QueryService:
                     detail=(f"Turn indices {sorted(missing)} not found in conversation {selection.conversation_id}"),
                 )
 
-            for query in queries:
-                selected_turns.append(SelectedTurn(conversation=conversation, query=query))
+            selected_turns.extend(SelectedTurn(conversation=conversation, query=query) for query in queries)
 
         if not selected_turns:
             raise HTTPException(status_code=400, detail="No turns selected")

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -496,7 +496,7 @@ class WikiService:
 
         max_score = max(raw_scores.values())
         if max_score == 0:
-            return {aid: 0.0 for aid in raw_scores}
+            return dict.fromkeys(raw_scores, 0.0)
 
         return {aid: s / max_score for aid, s in raw_scores.items()}
 

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -67,7 +67,7 @@ def _article_entry(article: Article) -> str:
     return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
 
 
-async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: PLR0912
+async def regenerate_index_md(session: AsyncSession) -> str:
     """Regenerate the wiki/index.md content catalog from the database.
 
     Reads all Articles + their concepts, groups by concept, writes a
@@ -141,22 +141,21 @@ async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: PLR0912
     concept_page_articles = [a for a in articles if a.page_type == PageType.CONCEPT]
     if concept_page_articles:
         lines.append("## Concept Pages\n\n")
-        for article in sorted(concept_page_articles, key=lambda a: a.slug):
-            lines.append(_article_entry(article))
+        lines.extend(_article_entry(article) for article in sorted(concept_page_articles, key=lambda a: a.slug))
         lines.append("\n")
 
     # Concepts sorted alphabetically
     for concept_name in sorted(concept_articles):
         lines.append(f"## {concept_name}\n\n")
-        for article in sorted(concept_articles[concept_name], key=lambda a: a.slug):
-            lines.append(_article_entry(article))
+        lines.extend(
+            _article_entry(article) for article in sorted(concept_articles[concept_name], key=lambda a: a.slug)
+        )
         lines.append("\n")
 
     # Uncategorized section at the bottom
     if uncategorized:
         lines.append("## Uncategorized\n\n")
-        for article in sorted(uncategorized, key=lambda a: a.slug):
-            lines.append(_article_entry(article))
+        lines.extend(_article_entry(article) for article in sorted(uncategorized, key=lambda a: a.slug))
         lines.append("\n")
 
     index_path.write_text("".join(lines), encoding="utf-8")

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -183,6 +183,7 @@ class TestEmbeddingServiceMocked:
                 "documents": [["Some chunk text"]],
             }
             svc._collection = mock_collection
+            svc._min_score = 0.65
 
             results = svc.search("query text", limit=5)
 

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -16,12 +16,12 @@ from wikimind.models import CompletionRequest, CompletionResponse, Provider, Tas
 
 
 def _req(**kw) -> CompletionRequest:
-    base = dict(
-        system="sys",
-        messages=[{"role": "user", "content": "hi"}],
-        max_tokens=64,
-        task_type=TaskType.QA,
-    )
+    base = {
+        "system": "sys",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 64,
+        "task_type": TaskType.QA,
+    }
     base.update(kw)
     return CompletionRequest(**base)
 

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -36,12 +36,12 @@ from wikimind.models import (
 
 
 def _req(**kw) -> CompletionRequest:
-    base = dict(
-        system="sys",
-        messages=[{"role": "user", "content": "hi"}],
-        max_tokens=64,
-        task_type=TaskType.QA,
-    )
+    base = {
+        "system": "sys",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 64,
+        "task_type": TaskType.QA,
+    }
     base.update(kw)
     return CompletionRequest(**base)
 

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -140,7 +140,7 @@ async def test_error_handling_wikimind_error() -> None:
 
     @app.get("/boom")
     async def boom():
-        raise _MyErr()
+        raise _MyErr
 
     @app.get("/crash")
     async def crash():

--- a/tests/unit/test_phase2_compiler.py
+++ b/tests/unit/test_phase2_compiler.py
@@ -34,15 +34,15 @@ from wikimind.models import (
 
 
 def _result(**overrides):
-    defaults = dict(
-        title="Test Article",
-        summary="A two sentence summary. It explains things.",
-        key_claims=[CompiledClaim(claim="X", confidence=ConfidenceLevel.SOURCED)],
-        concepts=["test-concept"],
-        backlink_suggestions=["Related"],
-        open_questions=["Q?"],
-        article_body="Body of article. " * 50,
-    )
+    defaults = {
+        "title": "Test Article",
+        "summary": "A two sentence summary. It explains things.",
+        "key_claims": [CompiledClaim(claim="X", confidence=ConfidenceLevel.SOURCED)],
+        "concepts": ["test-concept"],
+        "backlink_suggestions": ["Related"],
+        "open_questions": ["Q?"],
+        "article_body": "Body of article. " * 50,
+    }
     defaults.update(overrides)
     return CompilationResult(**defaults)
 


### PR DESCRIPTION
## Summary

Phase 1 of #217 — the "quick wins" tier. Adds high-value, low-noise ruff rule categories used by Pydantic, Polars, FastAPI, and Ruff itself, and closes the `PLC0415` gap that motivated the issue.

Rules added to `select`:
- `C4` — flake8-comprehensions
- `PIE` — flake8-pie (with `PIE804` ignored — Pydantic uses `**{"alias": ...}` intentionally)
- `PERF` — perflint
- `RSE` — flake8-raise
- `RET` — flake8-return (with `RET504` ignored for readability)
- `T20` — flake8-print (ignored in `tests/` and `scripts/`)
- `ISC` — flake8-implicit-str-concat (with `ISC001` ignored to avoid formatter conflict)
- `PLC0415` — import-outside-top-level (the specific gap that motivated #217 — now mechanically enforced)

Per-file ignores tightened: tests also skip `T20`, `PERF`; scripts skip `T20`.

All new violations were resolved — most auto-fixed by `ruff --fix`, remaining ones rewritten to idiomatic forms (list comprehensions, dict literals, tuple `startswith`).

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `make verify` passes in CI

https://claude.ai/code/session_01Y1Lpv753VcuBjUgU7ghTAq