### PR TITLE
chore: adopt security and correctness ruff rules (phase 2 of #217)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,10 @@ select = [
     "RET",    # flake8-return
     "T20",    # flake8-print
     "ISC",    # flake8-implicit-str-concat
+    "S",      # flake8-bandit (security)
+    "A",      # flake8-builtins (shadowing)
+    "DTZ",    # flake8-datetimez (naive datetime)
+    "N",      # pep8-naming
 ]
 ignore = [
     "E501",   # line too long — handled by formatter
@@ -142,11 +146,16 @@ ignore = [
     "PIE804",  # unnecessary-dict-kwargs — Pydantic uses **{"alias": ...} patterns intentionally
     "RET504",  # unnecessary-assign — readability-first over short-circuit returns
     "ISC001",  # single-line-implicit-string-concat — conflicts with formatter
+    "S101",   # assert — mirror [tool.bandit] skip
+    "S105",   # hardcoded password — false positives on key-name mappings (mirror bandit)
+    "A002",   # builtin-argument-shadowing — FastAPI route params named `id`/`type` are common
+    "A003",   # builtin-attribute-shadowing — SQLModel/Pydantic models define `id`/`type` fields
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "T20", "PERF"]
-"scripts/**/*.py" = ["T20"]
+"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "T20", "PERF", "S", "N", "DTZ"]
+"scripts/**/*.py" = ["T20", "S"]
+"alembic/**/*.py" = ["N"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["wikimind"]


### PR DESCRIPTION
## Summary

Phase 2 of #217 — security and correctness. Adds four rule categories that catch real bugs:

- **`S`** (flake8-bandit) — `eval()`, `exec()`, hardcoded passwords, insecure subprocess calls. Mirrors the existing `[tool.bandit]` skips: `S101` (assert) and `S105` (hardcoded-password false positives on key-name mappings).
- **`A`** (flake8-builtins) — shadowing builtins like `id`, `type`, `list`. Ignores `A002`/`A003` for FastAPI route params and SQLModel/Pydantic fields that legitimately use `id`/`type` names.
- **`DTZ`** (flake8-datetimez) — forbids naive `datetime.now()`/`utcnow()`. Critical for a knowledge-management app that timestamps articles. Source code already uses `utcnow_naive()` consistently; the 27 violations were all in test fixtures, which are scoped out.
- **`N`** (pep8-naming) — enforces the `snake_case`/`PascalCase`/`UPPER_CASE` rule already documented in CLAUDE.md.

Per-file ignores: `tests/**` skips `S`, `N`, `DTZ`; `scripts/**` skips `S`; `alembic/**` skips `N` (auto-generated migration filenames are timestamped).

No source-code violations after enabling these; the PR is a pure config change.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `make verify` passes in CI

Part of #217. Depends-on-merge: can land independently of phase 1.

https://claude.ai/code/session_01Y1Lpv753VcuBjUgU7ghTAq