### PR TITLE
chore: add complementary tooling — C90, interrogate, dead-code targets (phase 4 of #217)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,13 @@ bandit: ## Run bandit security scanner
 vulture: ## Detect dead code (80% confidence)
 	$(BIN)/vulture src/wikimind vulture_whitelist.py --min-confidence 80
 
+.PHONY: dead-code
+dead-code: vulture ## Alias for vulture — find unused functions, imports, variables
+
+.PHONY: doc-coverage
+doc-coverage: ## Measure docstring coverage (fails if below fail-under threshold)
+	$(BIN)/interrogate -c pyproject.toml src/wikimind
+
 .PHONY: security
 security: bandit vulture ## Run security and dead-code checks
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make docstyle` | Run pydocstyle docstring checks |
 | `make bandit` | Run bandit security scanner |
 | `make vulture` | Detect dead code (80% confidence) |
+| `make dead-code` | Alias for vulture — find unused functions, imports, variables |
+| `make doc-coverage` | Measure docstring coverage (fails if below fail-under threshold) |
 | `make security` | Run security and dead-code checks |
 | `make verify` | Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop) |
 | `make coverage-check` | Run tests and fail if coverage is under 80% |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ lint = [
     "types-toml>=0.10.0",
     "bandit[toml]>=1.7",
     "vulture>=2.11",
+    "interrogate>=1.7.0",
     # Doc-sync scripts (export_openapi, check_doc_sync, etc.)
     "pyyaml>=6.0",
     "pathspec>=0.12",
@@ -130,6 +131,7 @@ select = [
     "N",      # pep8-naming
     "PT",     # flake8-pytest-style
     "ARG",    # flake8-unused-arguments
+    "C90",    # mccabe — cyclomatic complexity
 ]
 ignore = [
     "E501",   # line too long — handled by formatter
@@ -171,6 +173,9 @@ quote-style = "double"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
 
 # ---------- Pylint ----------
 [tool.pylint.main]
@@ -246,3 +251,19 @@ exclude_lines = [
 [tool.bandit]
 exclude_dirs = ["tests", "build", "dist"]
 skips = ["B101", "B105"]  # B101: assert ok; B105: false positives on key-name mappings
+
+# ---------- Interrogate (docstring coverage) ----------
+[tool.interrogate]
+# Start at 80% — ratchet up over time (issue #217 phase 4). Matches
+# pydocstyle's scope (src/wikimind only, excluding tests + migrations).
+fail-under = 80
+exclude = ["tests", "alembic", "scripts", "build", "dist"]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-private = false
+ignore-semiprivate = true
+ignore-property-decorators = false
+ignore-module = true
+quiet = false
+verbose = 1

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -227,7 +227,7 @@ async def lint_wiki(_ctx, user_id: str | None = None):
             await session.commit()
 
 
-async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user_id: str | None = None):
+async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user_id: str | None = None):  # noqa: C901
     """Recompile an existing article from its source or concept.
 
     Args:

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -67,7 +67,7 @@ def _article_entry(article: Article) -> str:
     return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
 
 
-async def regenerate_index_md(session: AsyncSession) -> str:
+async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: C901
     """Regenerate the wiki/index.md content catalog from the database.
 
     Reads all Articles + their concepts, groups by concept, writes a


### PR DESCRIPTION
## Summary

Phase 4 of #217 — complementary tooling to supplement ruff.

### Ruff
- Added `C90` (mccabe) with `max-complexity = 12`.
- Two existing functions exceed the threshold and are flagged with `# noqa: C901` rather than refactored in this PR:
  - `recompile_article` (complexity 13) in `src/wikimind/jobs/worker.py`
  - `regenerate_index_md` (complexity 16) in `src/wikimind/services/wiki_index.py`
  
  Both are orchestration code worth refactoring, but scope is out-of-bounds for a tooling PR. Tracking them via `noqa` keeps the threshold enforced for all new code.

### Interrogate (docstring coverage)
- Added `interrogate>=1.7.0` to the `lint` extra.
- Configured `[tool.interrogate]` with `fail-under = 80`. IBM's ref uses 100%; WikiMind starts at 80 and can ratchet up over time.
- Excludes `tests/`, `alembic/`, `scripts/` to match pydocstyle's scope.

### Makefile
- `make dead-code` — alias for `make vulture`.
- `make doc-coverage` — runs interrogate against `src/wikimind`.

### Deferred
- Dropping standalone pylint/bandit in favor of ruff equivalents is a separate evaluation once the new ruff categories bed in. Retained for now.

## Test plan
- [x] `ruff check src/ tests/` passes
- [ ] `make doc-coverage` — will report current baseline (may fail until devs add missing docstrings or fail-under is dropped)
- [ ] `make dead-code` still works as before

Part of #217.

https://claude.ai/code/session_01Y1Lpv753VcuBjUgU7ghTAq