### PR TITLE
fix(web): add required `canvas` param to pdfjs render call

### DIFF
--- a/apps/web/src/components/viewers/PdfViewer.tsx
+++ b/apps/web/src/components/viewers/PdfViewer.tsx
@@ -39,7 +39,7 @@ export function PdfViewer({ url }: PdfViewerProps) {
           canvas.style.margin = "0 auto 16px auto";
           container.appendChild(canvas);
           const ctx = canvas.getContext("2d")!;
-          await page.render({ canvasContext: ctx, viewport }).promise;
+          await page.render({ canvasContext: ctx, viewport, canvas }).promise;
         }
         setLoading(false);
       } catch (err) {


### PR DESCRIPTION
## Summary

The current `pdfjs-dist` type definitions require `canvas` alongside `canvasContext` and `viewport` in `page.render()`. Without it, `tsc -b` fails with:

```
PdfViewer.tsx(42,29): error TS2345: Property 'canvas' is missing in type
'{ canvasContext: CanvasRenderingContext2D; viewport: PageViewport; }'
but required in type 'RenderParameters'.
```

This breaks the Docker `prod` stage (frontend build) on every PR — including PRs that don't touch the web app. The `canvas` DOM element is already in scope on the line above, so this is a trivial one-line fix.

Surfaced while investigating CI failures on #218/#219/#220/#221 (issue #217 phases) — every one of them fails `build prod image` for this same reason.

## Test plan

- [x] `npm run build` passes locally
- [ ] CI `build prod image` passes
- [ ] In-browser smoke test of the PDF viewer (verify it still renders — the API addition is a type-level requirement; runtime shouldn't change)

https://claude.ai/code/session_01Y1Lpv753VcuBjUgU7ghTAq