### PR TITLE
feat(web): align UI to WikiMind design system

### DIFF
--- a/apps/web/src/components/ask/AskView.tsx
+++ b/apps/web/src/components/ask/AskView.tsx
@@ -296,7 +296,7 @@ function AskViewInner() {
             isSavingSelection={fileBackSel.isPending}
           />
           {pendingError && (
-            <div className="mt-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+            <div className="mt-4 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
               {pendingError}
             </div>
           )}

--- a/apps/web/src/components/ask/ConversationHistory.tsx
+++ b/apps/web/src/components/ask/ConversationHistory.tsx
@@ -15,7 +15,7 @@ export function ConversationHistory({ conversations, activeId }: Props) {
         </h2>
         <Link
           to="/ask"
-          className="text-xs font-medium text-blue-600 hover:underline"
+          className="text-xs font-medium text-brand-600 hover:underline"
         >
           + New
         </Link>
@@ -28,8 +28,10 @@ export function ConversationHistory({ conversations, activeId }: Props) {
             <li key={c.id}>
               <Link
                 to={`/ask/${c.id}`}
-                className={`block rounded px-2 py-2 text-sm hover:bg-slate-100 ${
-                  c.id === activeId ? "bg-slate-100 font-medium" : ""
+                className={`block rounded-md px-2 py-2 text-sm transition ${
+                  c.id === activeId
+                    ? "bg-brand-50 font-medium"
+                    : "hover:bg-slate-100"
                 }`}
               >
                 <div className="flex items-center gap-1.5 truncate">

--- a/apps/web/src/components/ask/ConversationThread.tsx
+++ b/apps/web/src/components/ask/ConversationThread.tsx
@@ -109,16 +109,16 @@ export function ConversationThread({
             type="button"
             onClick={onExport}
             disabled={isExporting}
-            className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:opacity-50"
           >
             {isExporting ? "Exporting..." : "Export markdown"}
           </button>
           <button
             type="button"
             onClick={handleToggleSelectionMode}
-            className={`rounded-lg border px-4 py-2 text-sm font-medium ${
+            className={`rounded-md border px-4 py-2 text-sm font-medium transition ${
               selectionMode
-                ? "border-blue-400 bg-blue-50 text-blue-700"
+                ? "border-brand-400 bg-brand-50 text-brand-700"
                 : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
             }`}
           >
@@ -129,7 +129,7 @@ export function ConversationThread({
               type="button"
               onClick={onSaveSelection}
               disabled={isSavingSelection}
-              className="rounded-lg border border-blue-500 bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 disabled:opacity-50"
+              className="rounded-md border border-brand-500 bg-brand-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-700 disabled:opacity-50"
             >
               {isSavingSelection
                 ? "Saving..."
@@ -170,7 +170,7 @@ function PendingTurnCard({
       </header>
       <div className="flex items-center gap-2 text-sm text-slate-500">
         <div
-          className="h-2 w-2 animate-pulse rounded-full bg-blue-500"
+          className="h-2 w-2 animate-pulse rounded-full bg-brand-500"
           aria-hidden
         />
         <span>{isStreaming ? "Generating answer..." : "Thinking..."}</span>

--- a/apps/web/src/components/ask/QueryInput.tsx
+++ b/apps/web/src/components/ask/QueryInput.tsx
@@ -40,13 +40,13 @@ export function QueryInput({ onSubmit, disabled }: Props) {
         disabled={disabled}
         rows={2}
         placeholder="Ask a question about your wiki…"
-        className="flex-1 resize-none rounded-lg border border-slate-300 px-4 py-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-slate-100 disabled:text-slate-400"
+        className="flex-1 resize-none rounded-md border border-slate-300 px-4 py-3 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:bg-slate-100 disabled:text-slate-400"
       />
       <button
         type="button"
         onClick={handleSubmit}
         disabled={disabled || !value.trim()}
-        className="rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-slate-300"
+        className="rounded-md bg-brand-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-brand-700 disabled:bg-brand-300"
       >
         Ask
       </button>

--- a/apps/web/src/components/ask/SaveThreadButton.tsx
+++ b/apps/web/src/components/ask/SaveThreadButton.tsx
@@ -18,7 +18,7 @@ export function SaveThreadButton({ isFiledBack, isSaving, onClick }: Props) {
       type="button"
       onClick={onClick}
       disabled={isSaving}
-      className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+      className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:opacity-50"
     >
       {label}
     </button>

--- a/apps/web/src/components/ask/TurnCard.tsx
+++ b/apps/web/src/components/ask/TurnCard.tsx
@@ -64,9 +64,9 @@ export function TurnCard({ query, onEdit, forkCount, selectionMode, isSelected, 
 
   return (
     <article
-      className={`group rounded-lg border p-5 shadow-sm ${
+      className={`group rounded-lg border p-5 shadow-sm transition ${
         selectionMode && isSelected
-          ? "border-blue-400 bg-blue-50"
+          ? "border-brand-400 bg-brand-50"
           : "border-slate-200 bg-white"
       }`}
     >
@@ -76,7 +76,7 @@ export function TurnCard({ query, onEdit, forkCount, selectionMode, isSelected, 
             type="checkbox"
             checked={isSelected ?? false}
             onChange={onToggleSelect}
-            className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            className="mt-1 h-4 w-4 rounded border-slate-300 text-brand-600 focus:ring-brand-500"
             aria-label={`Select turn Q${query.turn_index + 1}`}
           />
         )}
@@ -124,14 +124,14 @@ export function TurnCard({ query, onEdit, forkCount, selectionMode, isSelected, 
                 onChange={(e) => setEditText(e.target.value)}
                 onKeyDown={handleEditKeyDown}
                 rows={2}
-                className="w-full resize-none rounded border border-blue-300 bg-blue-50 p-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full resize-none rounded-md border border-brand-300 bg-brand-50 p-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
               />
               <div className="mt-1 flex items-center gap-2">
                 <button
                   type="button"
                   onClick={handleEditSubmit}
                   disabled={!editText.trim() || editText.trim() === query.question}
-                  className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                  className="rounded-md bg-brand-600 px-3 py-1 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-50"
                 >
                   Fork
                 </button>
@@ -164,7 +164,7 @@ export function TurnCard({ query, onEdit, forkCount, selectionMode, isSelected, 
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
-          className="mt-2 text-sm font-medium text-blue-600 hover:underline"
+          className="mt-2 text-sm font-medium text-brand-600 hover:underline"
         >
           {expanded ? "Show less" : "Show more"}
         </button>
@@ -181,7 +181,7 @@ export function TurnCard({ query, onEdit, forkCount, selectionMode, isSelected, 
               <Link
                 key={`${title}-${i}`}
                 to={`/wiki/${encodeURIComponent(slug)}`}
-                className="rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 hover:underline"
+                className="rounded-full bg-sky-50 px-3 py-1 text-xs font-medium text-sky-700 hover:bg-sky-100 hover:underline"
               >
                 {title}
               </Link>

--- a/apps/web/src/components/health/FindingCard.tsx
+++ b/apps/web/src/components/health/FindingCard.tsx
@@ -71,7 +71,7 @@ function ResolveDropdown({ finding, resolution }: { finding: LintContradictionFi
 
   if (resolution) {
     return (
-      <span className="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+      <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 border border-emerald-200">
         {resolution.replace(/_/g, " ")}
       </span>
     );
@@ -107,7 +107,7 @@ function ResolveDropdown({ finding, resolution }: { finding: LintContradictionFi
             placeholder="Optional note..."
             value={note}
             onChange={(e) => setNote(e.target.value)}
-            className="w-full rounded border border-slate-200 px-2 py-1 text-xs text-slate-700 placeholder:text-slate-400 focus:border-sky-300 focus:outline-none"
+            className="w-full rounded-md border border-slate-200 px-2 py-1 text-xs text-slate-700 placeholder:text-slate-400 focus:border-brand-300 focus:outline-none"
           />
         </div>
       )}
@@ -210,13 +210,13 @@ function ContradictionActions({
     <div className="mt-3 flex flex-wrap items-center gap-2">
       <Link
         to={`/wiki/${finding.article_a_id}`}
-        className="rounded border border-sky-300 px-2 py-1 text-xs text-sky-700 hover:bg-sky-50"
+        className="rounded-md border border-brand-200 px-2 py-1 text-xs text-brand-700 hover:bg-brand-50"
       >
         View Article A
       </Link>
       <Link
         to={`/wiki/${finding.article_b_id}`}
-        className="rounded border border-sky-300 px-2 py-1 text-xs text-sky-700 hover:bg-sky-50"
+        className="rounded-md border border-brand-200 px-2 py-1 text-xs text-brand-700 hover:bg-brand-50"
       >
         View Article B
       </Link>
@@ -231,7 +231,7 @@ function OrphanActions({ finding }: { finding: LintOrphanFinding }) {
     <div className="mt-3 flex flex-wrap items-center gap-2">
       <Link
         to={`/wiki/${finding.article_id}`}
-        className="rounded border border-sky-300 px-2 py-1 text-xs text-sky-700 hover:bg-sky-50"
+        className="rounded-md border border-brand-200 px-2 py-1 text-xs text-brand-700 hover:bg-brand-50"
       >
         View Article
       </Link>
@@ -242,9 +242,9 @@ function OrphanActions({ finding }: { finding: LintOrphanFinding }) {
 
 function StructuralDetail({ finding }: { finding: LintStructuralFinding }) {
   const typeColors: Record<string, string> = {
-    source_no_concepts: "bg-red-100 text-red-700",
-    concept_insufficient_synthesizes: "bg-amber-100 text-amber-700",
-    missing_inverse_link: "bg-blue-100 text-blue-700",
+    source_no_concepts: "bg-rose-50 text-rose-700",
+    concept_insufficient_synthesizes: "bg-amber-50 text-amber-700",
+    missing_inverse_link: "bg-sky-50 text-sky-700",
   };
   const color =
     typeColors[finding.violation_type] ?? "bg-slate-100 text-slate-700";
@@ -258,7 +258,7 @@ function StructuralDetail({ finding }: { finding: LintStructuralFinding }) {
           {finding.violation_type.replace(/_/g, " ")}
         </span>
         {finding.auto_repaired && (
-          <span className="rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">
+          <span className="rounded-full bg-emerald-50 px-1.5 py-0.5 text-xs font-medium text-emerald-700 border border-emerald-200">
             Auto-fixed
           </span>
         )}
@@ -273,7 +273,7 @@ function StructuralActions({ finding }: { finding: LintStructuralFinding }) {
     <div className="mt-3 flex flex-wrap items-center gap-2">
       <Link
         to={`/wiki/${finding.article_id}`}
-        className="rounded border border-sky-300 px-2 py-1 text-xs text-sky-700 hover:bg-sky-50"
+        className="rounded-md border border-brand-200 px-2 py-1 text-xs text-brand-700 hover:bg-brand-50"
       >
         View Article
       </Link>

--- a/apps/web/src/components/settings/CostDashboard.tsx
+++ b/apps/web/src/components/settings/CostDashboard.tsx
@@ -33,7 +33,7 @@ export function CostDashboard({ warningThresholdPct = 80 }: CostDashboardProps) 
   const pct = Math.min(data.budget_pct, 100);
   const gaugeColor =
     data.budget_pct >= 100
-      ? "bg-red-500"
+      ? "bg-rose-500"
       : data.budget_pct >= warningThresholdPct
         ? "bg-amber-500"
         : "bg-emerald-500";

--- a/apps/web/src/components/settings/ProviderCard.tsx
+++ b/apps/web/src/components/settings/ProviderCard.tsx
@@ -58,9 +58,7 @@ export function ProviderCard({ name, info, isDefault, onSetKey }: ProviderCardPr
   }
 
   return (
-    <Card
-      className={`p-4 ${isDefault ? "border-l-4 border-l-brand-300" : ""}`}
-    >
+    <Card className="p-4">
       <div className="mb-2 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <span className="font-semibold text-slate-800 capitalize">{name}</span>

--- a/apps/web/src/components/shared/Layout.tsx
+++ b/apps/web/src/components/shared/Layout.tsx
@@ -25,7 +25,7 @@ export function Layout({ children }: LayoutProps) {
   const dismissToast = useWebSocketStore((s) => s.dismissToast);
 
   return (
-    <div className="flex h-screen w-screen bg-slate-50">
+    <div className="flex h-screen w-screen bg-slate-50 text-slate-900 antialiased">
       <aside className="flex w-56 shrink-0 flex-col border-r border-slate-200 bg-white">
         <Link to="/" className="flex items-center gap-2 px-5 py-5 border-b border-slate-200 cursor-pointer no-underline">
           <span className="text-xl">🧠</span>

--- a/apps/web/src/components/viewers/PdfViewer.tsx
+++ b/apps/web/src/components/viewers/PdfViewer.tsx
@@ -77,7 +77,7 @@ export function PdfViewer({ url }: PdfViewerProps) {
       )}
       <div ref={containerRef} className="p-4" />
       {!loading && pageCount > 0 && (
-        <div className="sticky bottom-0 bg-white/80 px-4 py-2 text-center text-xs text-slate-500 backdrop-blur">
+        <div className="sticky bottom-0 border-t border-slate-200 bg-white px-4 py-2 text-center text-xs text-slate-500">
           {pageCount} page{pageCount !== 1 ? "s" : ""}
         </div>
       )}

--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -97,7 +97,7 @@ export function ArticleReader({ article }: ArticleReaderProps) {
             </Badge>
           ))}
         </div>
-        <h1 className="text-3xl font-bold text-slate-900">{article.title}</h1>
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900">{article.title}</h1>
         {article.summary ? (
           <p className="mt-2 text-base text-slate-600">{article.summary}</p>
         ) : null}

--- a/apps/web/src/components/wiki/BacklinkPanel.tsx
+++ b/apps/web/src/components/wiki/BacklinkPanel.tsx
@@ -56,7 +56,7 @@ export function BacklinkPanel({ article, hasFigures, figureCount }: BacklinkPane
               e.preventDefault();
               document.getElementById("figures-tables")?.scrollIntoView({ behavior: "smooth" });
             }}
-            className="flex items-center gap-2 rounded px-2 py-1 text-sm text-blue-600 hover:bg-blue-50"
+            className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-brand-700 hover:bg-brand-50"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z" />

--- a/apps/web/src/components/wiki/FiguresPanel.tsx
+++ b/apps/web/src/components/wiki/FiguresPanel.tsx
@@ -102,8 +102,8 @@ export function FiguresPanel({ sources, onImageCount }: Props) {
                   onClick={() => setFilter("figure")}
                   className={`rounded-full px-3 py-1 text-xs font-medium transition ${
                     filter === "figure"
-                      ? "bg-blue-600 text-white"
-                      : "bg-blue-50 text-blue-700 hover:bg-blue-100"
+                      ? "bg-brand-600 text-white"
+                      : "bg-brand-50 text-brand-700 hover:bg-brand-100"
                   }`}
                 >
                   Figures ({figCount})
@@ -131,7 +131,7 @@ export function FiguresPanel({ sources, onImageCount }: Props) {
                 key={img.url}
                 type="button"
                 onClick={() => setSelectedImg(img.url)}
-                className="group overflow-hidden rounded-lg border border-slate-200 bg-white transition hover:border-blue-300 hover:shadow-lg"
+                className="group overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition hover:border-brand-300 hover:shadow"
               >
                 <div className="flex items-center justify-center bg-slate-50 p-3">
                   <img
@@ -144,7 +144,7 @@ export function FiguresPanel({ sources, onImageCount }: Props) {
                 <div className="flex items-center gap-2 border-t border-slate-100 px-3 py-2">
                   <span
                     className={`inline-block h-2 w-2 rounded-full ${
-                      img.kind === "table" ? "bg-amber-400" : "bg-blue-400"
+                      img.kind === "table" ? "bg-amber-400" : "bg-brand-400"
                     }`}
                   />
                   <span className="text-sm font-medium text-slate-700">
@@ -163,7 +163,7 @@ export function FiguresPanel({ sources, onImageCount }: Props) {
       {/* Lightbox */}
       {selectedImg && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-8 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-8"
           onClick={() => setSelectedImg(null)}
         >
           <div

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,8 +1,8 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap");
 
 html,
 body,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
 html,
 body,
 #root {
@@ -18,6 +20,8 @@ body {
     "Helvetica Neue",
     Arial,
     sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 .wikilink-unresolved {

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -17,6 +17,20 @@ export default {
           900: "#1f3251",
         },
       },
+      fontFamily: {
+        sans: ['"Inter"', "ui-sans-serif", "system-ui", "sans-serif"],
+        mono: [
+          '"JetBrains Mono"',
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Consolas",
+          "monospace",
+        ],
+      },
+      transitionDuration: {
+        DEFAULT: "180ms",
+      },
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION
## Summary

The frontend had accumulated color inconsistencies where some components (especially the Ask view) used generic Tailwind `blue-*` classes while the design system specifies `brand-*` (#4673ad scale) everywhere. Other violations included `backdrop-blur` usage (forbidden), `red-*` / `green-*` instead of `rose-*` / `emerald-*`, missing font configuration, and a colored left border on provider cards.

This PR brings every component into alignment with the WikiMind design system spec:

- **Tailwind config**: Add Inter + JetBrains Mono font families, set default transition to 180ms
- **Global styles**: Import JetBrains Mono, enable antialiased rendering
- **Ask view** (6 files): Replace all `blue-*` with `brand-*` for buttons, focus rings, selection states, edit UI, source/related chips
- **Health view**: Use `brand-*` for action links, `emerald-*` for success badges, `rose-*` for danger
- **Settings**: Remove colored left border on default provider card (design system: "no colored left borders")
- **Wiki view**: Add `tracking-tight` to article H1, use `brand-*` for figures/backlink links, remove `backdrop-blur` from lightbox
- **PDF viewer**: Replace `backdrop-blur` + alpha background with solid white + border

## Test plan

- [x] `make verify` passes (lint, format, typecheck, tests, desktop build)
- [ ] Visual review: open each view (Inbox, Ask, Wiki, Health, Settings) and confirm brand-blue is used consistently
- [ ] Confirm no `blue-*`, `red-*`, `green-*` classes remain in component files
- [ ] Confirm no `backdrop-blur` or gradient classes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)