### PR TITLE
fix: reset budget flags at month boundary, log budget check errors

### DIFF
--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -105,8 +105,8 @@ class LLMRouter:
 
     def __init__(self):
         self.settings = get_settings()
-        self._budget_warning_sent = False
-        self._budget_exceeded_sent = False
+        self._budget_warning_sent: tuple[int, int] | None = None
+        self._budget_exceeded_sent: tuple[int, int] | None = None
         self._cached_spend: float | None = None
         self._cache_expires_at: float = 0.0
 
@@ -160,6 +160,15 @@ class LLMRouter:
 
     async def _check_budget(self) -> None:
         """Check monthly budget and emit warnings if thresholds are exceeded."""
+        current_month = utcnow_naive()
+        month_key = (current_month.year, current_month.month)
+
+        # Reset flags when the calendar month rolls over
+        if self._budget_warning_sent and self._budget_warning_sent != month_key:
+            self._budget_warning_sent = None
+        if self._budget_exceeded_sent and self._budget_exceeded_sent != month_key:
+            self._budget_exceeded_sent = None
+
         if self._budget_warning_sent and self._budget_exceeded_sent:
             return
 
@@ -167,7 +176,7 @@ class LLMRouter:
         if self._cached_spend is not None and now < self._cache_expires_at:
             spend = self._cached_spend
         else:
-            start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)
+            start_of_month = current_month.replace(day=1, hour=0, minute=0, second=0)
             async with get_session_factory()() as session:
                 result = await session.execute(
                     select(func.sum(CostLog.cost_usd)).where(CostLog.created_at >= start_of_month)
@@ -182,14 +191,19 @@ class LLMRouter:
         pct = spend / budget * 100
 
         if pct >= self.settings.llm.budget_warning_pct * 100 and not self._budget_warning_sent:
-            log.warning("Budget warning threshold reached", spend_usd=spend, budget_usd=budget, pct=round(pct, 1))
+            log.warning(
+                "Budget warning threshold reached",
+                spend_usd=spend,
+                budget_usd=budget,
+                pct=round(pct, 1),
+            )
             await emit_budget_warning(spend, budget, pct)
-            self._budget_warning_sent = True
+            self._budget_warning_sent = month_key
 
         if pct >= 100.0 and not self._budget_exceeded_sent:
             log.error("Budget exceeded", spend_usd=spend, budget_usd=budget)
             await emit_budget_exceeded(spend, budget)
-            self._budget_exceeded_sent = True
+            self._budget_exceeded_sent = month_key
 
     async def complete(
         self,
@@ -230,8 +244,15 @@ class LLMRouter:
                     cost_usd=response.cost_usd,
                     latency_ms=response.latency_ms,
                 )
+
+                def _log_budget_error(t: asyncio.Task) -> None:
+                    if not t.cancelled():
+                        exc = t.exception()
+                        if exc:
+                            log.warning("budget check failed", error=str(exc))
+
                 task = asyncio.create_task(self._check_budget())
-                task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+                task.add_done_callback(_log_budget_error)
                 return response
 
             except Exception as e:

--- a/tests/unit/test_budget_check.py
+++ b/tests/unit/test_budget_check.py
@@ -59,8 +59,8 @@ async def test_budget_warning_fires_at_threshold() -> None:
 
     mock_warn.assert_awaited_once()
     mock_exceeded.assert_not_awaited()
-    assert router._budget_warning_sent is True
-    assert router._budget_exceeded_sent is False
+    assert router._budget_warning_sent is not None
+    assert router._budget_exceeded_sent is None
 
 
 async def test_budget_exceeded_fires_at_100pct() -> None:
@@ -76,8 +76,8 @@ async def test_budget_exceeded_fires_at_100pct() -> None:
 
     mock_warn.assert_awaited_once()
     mock_exceeded.assert_awaited_once()
-    assert router._budget_warning_sent is True
-    assert router._budget_exceeded_sent is True
+    assert router._budget_warning_sent is not None
+    assert router._budget_exceeded_sent is not None
 
 
 async def test_warning_fires_only_once() -> None:
@@ -128,7 +128,7 @@ async def test_cache_prevents_requery_within_ttl() -> None:
         first_call_count = session.execute.await_count
         # Reset warning flag so second call doesn't short-circuit at the top,
         # but cache is still valid so no DB query should happen.
-        router._budget_warning_sent = False
+        router._budget_warning_sent = None
         await router._check_budget()
 
     # session.execute should not have been called again
@@ -148,14 +148,14 @@ async def test_below_threshold_no_events() -> None:
 
     mock_warn.assert_not_awaited()
     mock_exceeded.assert_not_awaited()
-    assert router._budget_warning_sent is False
-    assert router._budget_exceeded_sent is False
+    assert router._budget_warning_sent is None
+    assert router._budget_exceeded_sent is None
 
 
 async def test_both_flags_set_returns_early_without_query() -> None:
     router = _make_router()
-    router._budget_warning_sent = True
-    router._budget_exceeded_sent = True
+    router._budget_warning_sent = (2026, 4)
+    router._budget_exceeded_sent = (2026, 4)
     factory = _mock_session_factory(spend=999.0)
 
     with patch.object(llm_router_mod, "get_session_factory", return_value=factory):

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -183,6 +183,7 @@ class TestEmbeddingServiceMocked:
                 "documents": [["Some chunk text"]],
             }
             svc._collection = mock_collection
+            svc._min_score = 0.65
 
             results = svc.search("query text", limit=5)
 


### PR DESCRIPTION
## Summary

Budget warning and exceeded flags in `LLMRouter` were stored as plain booleans that were never cleared when the calendar month rolled over. Once a warning fired in January, no budget notifications would fire for February or any subsequent month -- spend resets to zero but flags stay `True`.

Separately, the `_check_budget` done-callback retrieved the task exception but discarded it silently, making budget-check failures invisible in logs.

- **#184**: Store `(year, month)` tuple instead of `bool` for `_budget_warning_sent` / `_budget_exceeded_sent`. Reset flags when the current month no longer matches the stored month.
- **#186**: Replace the silent `lambda t: t.exception()` callback with a named function that logs a warning when the budget check task raises.
- Fix missing `_min_score` attribute in `test_search_returns_results` test fixture.

Closes #184, closes #186

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] `pytest tests/unit/test_embedding.py` -- all 17 tests pass
- [ ] Manual: set budget to a low value, trigger warnings, advance system clock past month boundary, confirm warnings fire again in the new month
- [ ] Manual: inject a DB failure in `_check_budget` and confirm the warning log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)