### PR TITLE
refactor: type Article.page_type as PageType enum and batch backlink commits

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -502,7 +502,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             )
             session.add(bl)
             try:
-                await session.commit()
+                await session.flush()
             except IntegrityError:
                 await session.rollback()
                 log.debug(
@@ -510,6 +510,7 @@ Compile this into a wiki article following the JSON schema exactly."""
                     source=source_article_id,
                     target=rb.target_id,
                 )
+        await session.commit()
 
     def _generate_unique_slug(self, title: str) -> str:
         """Generate a URL-safe slug from a title."""

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -10,7 +10,7 @@ from datetime import date, datetime
 from enum import StrEnum
 
 from pydantic import BaseModel, computed_field
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import Column, String, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
@@ -186,7 +186,10 @@ class Article(SQLModel, table=True):
     # same source with the same provider replaces this article in place;
     # different providers stack as separate articles for comparison.
     provider: Provider | None = None
-    page_type: str = Field(default=PageType.SOURCE)
+    page_type: PageType = Field(
+        default=PageType.SOURCE,
+        sa_column=Column(String, default=PageType.SOURCE),
+    )
 
     # ORM relationships — used for eager-loading backlinks
     backlinks_out: list["Backlink"] = Relationship(

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -183,6 +183,7 @@ class TestEmbeddingServiceMocked:
                 "documents": [["Some chunk text"]],
             }
             svc._collection = mock_collection
+            svc._min_score = 0.65
 
             results = svc.search("query text", limit=5)
 


### PR DESCRIPTION
## Summary

- **Article.page_type typed as `str` instead of `PageType` enum** -- every caller already passes `PageType` values, but the field annotation was `str`, losing type safety. Now declared as `PageType` with an explicit `sa_column=Column(String)` so SQLAlchemy still stores the string value in SQLite while Python code gets enum validation. (Closes #197)
- **`_persist_resolved_backlinks` committed per-row** -- each iteration called `session.commit()`, producing N database round trips for N backlinks. Replaced with `session.flush()` per row (to catch `IntegrityError` on duplicates) and a single `session.commit()` after the loop. (Closes #198)
- Fixed pre-existing test issue in `test_embedding.py::test_search_returns_results` (missing `_min_score` attribute).

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] Full pytest suite passes (778 passed, 5 skipped; 1 pre-existing failure in `test_config.py` unrelated to this PR)

Closes #197, closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)