### PR TITLE
fix: write-before-delete ordering prevents data loss on recompilation failure

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -408,7 +408,6 @@ Compile this into a wiki article following the JSON schema exactly."""
         old_concept_ids = existing.concept_ids
 
         old_path = resolve_wiki_path(existing.file_path, user_id=source.user_id)
-        old_path.unlink(missing_ok=True)
 
         resolved, unresolved = await resolve_backlink_candidates(
             result.backlink_suggestions,
@@ -418,6 +417,11 @@ Compile this into a wiki article following the JSON schema exactly."""
         )
 
         relative_path = self._write_article_file(result, source, existing.slug, resolved, unresolved)
+
+        # Delete old file only after new file is written successfully to
+        # avoid data loss if the write fails (issue #183).
+        if old_path != resolve_wiki_path(relative_path, user_id=source.user_id):
+            old_path.unlink(missing_ok=True)
 
         existing.title = result.title
         existing.summary = result.summary

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -235,7 +235,11 @@ class ConceptCompiler:
         existing = await self._find_existing_concept_article(concept.name, session)
         relative_path = self._write_concept_file(compilation, concept, source_articles)
         if existing is not None:
-            resolve_wiki_path(existing.file_path, user_id=concept.user_id).unlink(missing_ok=True)
+            # Delete old file only after new file is written successfully to
+            # avoid data loss if the write fails (issue #183).
+            old_path = resolve_wiki_path(existing.file_path, user_id=concept.user_id)
+            if old_path != resolve_wiki_path(relative_path, user_id=concept.user_id):
+                old_path.unlink(missing_ok=True)
             existing.title = compilation.title
             existing.summary = compilation.overview
             existing.file_path = relative_path

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -183,6 +183,7 @@ class TestEmbeddingServiceMocked:
                 "documents": [["Some chunk text"]],
             }
             svc._collection = mock_collection
+            svc._min_score = 0.65
 
             results = svc.search("query text", limit=5)
 


### PR DESCRIPTION
## Summary

Closes #183.

`_replace_article_in_place` (compiler.py) and `_save_concept_page` (concept_compiler.py) deleted the old `.md` file before writing the new one. If the write failed (storage error, disk full), the old file was permanently lost while the Article DB row still referenced it.

- **compiler.py**: Moved the `old_path.unlink()` call to after `_write_article_file()` succeeds, and only deletes if the old and new paths differ (same-path means the write already overwrote it)
- **concept_compiler.py**: Same pattern -- delete old file only after the new file is written and only when paths differ
- **test_embedding.py**: Added missing `svc._min_score = 0.65` initialization to fix a pre-existing test gap

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `pytest tests/` -- all tests pass (1 pre-existing env-dependent failure in test_config unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)