### PR TITLE
fix: eliminate ThreadPoolExecutor-per-call in storage sync bridge (#182)

### DIFF
--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -183,6 +183,7 @@ class TestEmbeddingServiceMocked:
                 "documents": [["Some chunk text"]],
             }
             svc._collection = mock_collection
+            svc._min_score = 0.65
 
             results = svc.search("query text", limit=5)
 


### PR DESCRIPTION
## Summary

Closes #182.

The `_run_async()` sync-to-async bridge that previously created a fresh
`ThreadPoolExecutor(max_workers=1)` on every call was already removed in
the per-user file storage namespacing refactor (#209). The current
`storage.py` uses only async `FileStorage` methods backed by
`asyncio.to_thread`, so the thread-pool leak described in #182 no longer
exists.

This PR fixes a pre-existing test gap exposed by the `_min_score`
filtering added to `EmbeddingService.search()`:

- **`tests/unit/test_embedding.py`** -- `test_search_returns_results`
  bypassed `__init__` via `__new__` but never set `svc._min_score`,
  causing an `AttributeError` when the min-score filter path is
  exercised. Added `svc._min_score = 0.65` to match production defaults.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `pytest tests/unit/test_embedding.py` -- all 17 tests pass
- [x] Full test suite: 778 passed, 1 pre-existing failure (unrelated config test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)