### PR TITLE
fix: avoid slug collisions in article compilation

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -328,7 +328,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         provider: Provider | None,
     ) -> Article:
         """Create a brand-new article (no existing same-provider article)."""
-        slug = self._generate_unique_slug(result.title)
+        slug = await self._generate_unique_slug(result.title, session)
 
         resolved, unresolved = await resolve_backlink_candidates(
             result.backlink_suggestions,
@@ -511,10 +511,21 @@ Compile this into a wiki article following the JSON schema exactly."""
                     target=rb.target_id,
                 )
 
-    def _generate_unique_slug(self, title: str) -> str:
-        """Generate a URL-safe slug from a title."""
+    async def _generate_unique_slug(self, title: str, session: AsyncSession) -> str:
+        """Generate a URL-safe slug from a title, avoiding collisions.
+
+        Tries the base slug first; if it already exists, appends ``-2``,
+        ``-3``, etc. until a unique value is found.
+        """
         base = slugify(title, max_length=80)
-        return base
+        candidate = base
+        suffix = 2
+        while True:
+            existing = (await session.execute(select(Article).where(Article.slug == candidate))).scalars().first()
+            if existing is None:
+                return candidate
+            candidate = f"{base}-{suffix}"
+            suffix += 1
 
     def _write_article_file(
         self,

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -183,6 +183,7 @@ class TestEmbeddingServiceMocked:
                 "documents": [["Some chunk text"]],
             }
             svc._collection = mock_collection
+            svc._min_score = 0.65
 
             results = svc.search("query text", limit=5)
 

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -195,9 +195,44 @@ def test_overall_confidence_inferred() -> None:
     assert c._overall_confidence(_result(claims=claims)) == ConfidenceLevel.INFERRED
 
 
-def test_generate_unique_slug() -> None:
+async def test_generate_unique_slug(db_session) -> None:
     c = _make_compiler()
-    assert c._generate_unique_slug("Hello World!") == "hello-world"
+    assert await c._generate_unique_slug("Hello World!", db_session) == "hello-world"
+
+
+async def test_generate_unique_slug_avoids_collision(db_session) -> None:
+    """When a slug already exists, append -2, -3, etc."""
+    c = _make_compiler()
+    # Create an article that occupies "hello-world"
+    existing = Article(
+        slug="hello-world",
+        title="Hello World",
+        file_path="general/hello-world.md",
+        confidence=ConfidenceLevel.SOURCED,
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    slug = await c._generate_unique_slug("Hello World!", db_session)
+    assert slug == "hello-world-2"
+
+
+async def test_generate_unique_slug_skips_multiple_collisions(db_session) -> None:
+    """When -2 also exists, continue to -3."""
+    c = _make_compiler()
+    for s in ("hello-world", "hello-world-2"):
+        db_session.add(
+            Article(
+                slug=s,
+                title="Hello World",
+                file_path=f"general/{s}.md",
+                confidence=ConfidenceLevel.SOURCED,
+            )
+        )
+    await db_session.commit()
+
+    slug = await c._generate_unique_slug("Hello World!", db_session)
+    assert slug == "hello-world-3"
 
 
 def test_write_article_file(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Closes #185, closes #167.

- **Problem:** `_generate_unique_slug` returned the base slug without checking for collisions. If another article had the same title (or the same source was recompiled under a different LLM provider producing an identical title), the `INSERT` failed with `IntegrityError` and the source was stuck in `PROCESSING` state permanently.
- **Solution:** Make `_generate_unique_slug` async and query the database for existing slugs. If the base slug is taken, append `-2`, `-3`, etc. until a unique value is found. This handles both same-title collisions (#185) and cross-provider recompile collisions (#167).
- Also fixes a pre-existing test gap: adds missing `_min_score` mock attribute in `test_search_returns_results`.

## Test plan

- [x] Existing `test_generate_unique_slug` updated to async with DB session
- [x] New `test_generate_unique_slug_avoids_collision` -- verifies `-2` suffix when base slug exists
- [x] New `test_generate_unique_slug_skips_multiple_collisions` -- verifies `-3` when both base and `-2` exist
- [x] All 776 unit tests pass
- [x] `ruff check` and `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)