### PR TITLE
feat: Docker smoke tests for production image verification

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,119 @@
+# ===============================================================
+# Docker Smoke Tests — Production Image Verification
+# ===============================================================
+#
+#   - builds the prod Docker image
+#   - runs it with mock LLM config (no API keys, no Redis)
+#   - hits key endpoints to catch runtime failures:
+#     * import errors / missing libraries
+#     * sslmode crashes
+#     * frontend URL issues
+#     * auth blocking static files
+#   - runs on PRs that touch Docker/src files and on push to main
+# ---------------------------------------------------------------
+
+name: Docker smoke tests
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "docker-compose.prod.yml"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "src/**"
+      - "apps/web/**"
+      - "docker/**"
+      - "gunicorn.conf.py"
+      - ".github/workflows/smoke.yml"
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "docker-compose.prod.yml"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "src/**"
+      - "apps/web/**"
+      - "docker/**"
+      - "gunicorn.conf.py"
+      - ".github/workflows/smoke.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Docker smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      # -----------------------------------------------------------
+      # 0. Checkout
+      # -----------------------------------------------------------
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # -----------------------------------------------------------
+      # 1. Set up Python + uv (for running pytest)
+      # -----------------------------------------------------------
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      # -----------------------------------------------------------
+      # 2. Install test dependencies
+      # -----------------------------------------------------------
+      - name: Install test dependencies
+        run: uv sync --frozen --extra test
+
+      # -----------------------------------------------------------
+      # 3. Set up Docker Buildx (layer caching for faster builds)
+      # -----------------------------------------------------------
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # -----------------------------------------------------------
+      # 4. Run smoke tests
+      # -----------------------------------------------------------
+      # The test suite builds the Docker image as a fixture, starts
+      # a container, and hits endpoints. We pass --timeout=600 to
+      # allow for the Docker build step within the test.
+      - name: Run Docker smoke tests
+        run: |
+          uv run pytest tests/smoke/ \
+            -m e2e \
+            -v \
+            --timeout=600 \
+            -x
+
+      # -----------------------------------------------------------
+      # 5. Capture container logs on failure
+      # -----------------------------------------------------------
+      - name: Capture container logs on failure
+        if: failure()
+        run: |
+          docker logs wikimind-smoke-test 2>&1 || echo "No container logs available"
+          docker logs wikimind-smoke-test-auth 2>&1 || echo "No auth container logs available"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
       - name: 🧪  Run pytest
         run: |
           uv run pytest \
+            -m "not e2e" \
             --cov=wikimind \
             --cov-branch \
             --cov-report=term-missing \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,6 +198,15 @@
         "line_number": 4
       }
     ],
+    "tests/smoke/test_docker_smoke.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/smoke/test_docker_smoke.py",
+        "hashed_secret": "66fa1e465d736956a523b45d783eb038e9a3fb14",
+        "is_verified": false,
+        "line_number": 349
+      }
+    ],
     "tests/unit/test_db_compat.py": [
       {
         "type": "Basic Auth Credentials",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ test = [
     "pytest>=8.3.3",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
+    "pytest-timeout>=2.3.1",
     "httpx>=0.27.2",
     "greenlet>=3.0.0",
 ]

--- a/tests/smoke/test_docker_smoke.py
+++ b/tests/smoke/test_docker_smoke.py
@@ -379,7 +379,13 @@ class TestAuthEnabled:
 
     def test_spa_routes_exempt_from_auth(self, auth_container_url: str):
         """SPA HTML pages should load without auth for client-side login flow."""
-        resp = httpx.get(f"{auth_container_url}/", timeout=10)
+        # Browsers send Accept: text/html on page loads; the auth middleware
+        # uses this to distinguish SPA page loads from API calls and exempts them.
+        resp = httpx.get(
+            f"{auth_container_url}/",
+            headers={"Accept": "text/html"},
+            timeout=10,
+        )
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
 

--- a/tests/smoke/test_docker_smoke.py
+++ b/tests/smoke/test_docker_smoke.py
@@ -86,7 +86,7 @@ def _wait_for_health(base_url: str, timeout: int = STARTUP_TIMEOUT_SECONDS) -> E
             resp = httpx.get(f"{base_url}/health", timeout=5)
             if resp.status_code == 200:
                 return None
-        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+        except httpx.TransportError as exc:
             last_error = exc
         time.sleep(HEALTH_POLL_INTERVAL)
     return last_error or TimeoutError("Health check timed out")

--- a/tests/smoke/test_docker_smoke.py
+++ b/tests/smoke/test_docker_smoke.py
@@ -1,0 +1,461 @@
+"""Docker production image smoke tests.
+
+These tests build the production Docker image, run the container with
+mock/test configuration, and verify that key endpoints return expected
+responses. They catch runtime failures (missing libraries, import errors,
+sslmode crashes, auth blocking static files) that unit tests and linting
+cannot detect.
+
+Requires Docker to be available on the host. Marked with ``@pytest.mark.e2e``
+so they are excluded from the default ``make test`` run.
+
+Usage::
+
+    pytest tests/smoke/ -m e2e -v
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+from contextlib import closing
+
+import httpx
+import pytest
+
+# ---------------------------------------------------------------------------
+# Markers — all tests in this module require Docker and are slow
+# ---------------------------------------------------------------------------
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+IMAGE_NAME = "wikimind-smoke:test"
+CONTAINER_NAME = "wikimind-smoke-test"
+STARTUP_TIMEOUT_SECONDS = 120
+HEALTH_POLL_INTERVAL = 2
+
+
+def _find_free_port() -> int:
+    """Find an available TCP port on the host."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+def _docker_available() -> bool:
+    """Check if Docker daemon is running."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _repo_root() -> str:
+    """Return the repository root (where Dockerfile lives)."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _wait_for_health(base_url: str, timeout: int = STARTUP_TIMEOUT_SECONDS) -> Exception | None:
+    """Poll the health endpoint until it responds 200 or timeout expires.
+
+    Returns None on success, or the last exception on timeout.
+    """
+    deadline = time.time() + timeout
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=5)
+            if resp.status_code == 200:
+                return None
+        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+            last_error = exc
+        time.sleep(HEALTH_POLL_INTERVAL)
+    return last_error or TimeoutError("Health check timed out")
+
+
+def _stop_container(name: str) -> None:
+    """Force-remove a Docker container by name."""
+    subprocess.run(
+        ["docker", "rm", "-f", name],
+        capture_output=True,
+        check=False,
+    )
+
+
+def _get_container_logs(name: str) -> str:
+    """Fetch container stdout+stderr logs."""
+    result = subprocess.run(
+        ["docker", "logs", name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return f"{result.stdout}\n{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def docker_image() -> str:
+    """Build the production Docker image once per test module.
+
+    Returns the image tag. Skips the entire module if Docker is unavailable.
+    """
+    if not _docker_available():
+        pytest.skip("Docker is not available")
+
+    repo_root = _repo_root()
+
+    result = subprocess.run(
+        [
+            "docker",
+            "build",
+            "--target",
+            "prod",
+            "--tag",
+            IMAGE_NAME,
+            "--file",
+            os.path.join(repo_root, "Dockerfile"),
+            repo_root,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Docker build failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
+
+    return IMAGE_NAME
+
+
+@pytest.fixture(scope="module")
+def container_url(docker_image: str):
+    """Start a container from the prod image and yield its base URL.
+
+    The container runs with:
+    - Mock LLM enabled (no API keys needed)
+    - SQLite backend (no Postgres required)
+    - Auth disabled
+    - Single gunicorn worker for fast startup
+
+    Tears down the container after all tests in the module complete.
+    """
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    # Stop any leftover container from a previous run
+    _stop_container(CONTAINER_NAME)
+
+    # Start the container
+    run_result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            CONTAINER_NAME,
+            "-p",
+            f"{port}:7842",
+            "-e",
+            "WIKIMIND_LLM__MOCK__ENABLED=true",
+            "-e",
+            "WIKIMIND_LLM__DEFAULT_PROVIDER=mock",
+            "-e",
+            "WIKIMIND_AUTH__ENABLED=false",
+            "-e",
+            "WEB_CONCURRENCY=1",
+            docker_image,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if run_result.returncode != 0:
+        pytest.fail(f"Container start failed:\n{run_result.stderr}")
+
+    # Wait for the container to become healthy
+    error = _wait_for_health(base_url)
+    if error is not None:
+        logs = _get_container_logs(CONTAINER_NAME)
+        _stop_container(CONTAINER_NAME)
+        pytest.fail(
+            f"Container failed to become healthy within {STARTUP_TIMEOUT_SECONDS}s.\n"
+            f"Last error: {error}\n"
+            f"Container logs:\n{logs}"
+        )
+
+    yield base_url
+
+    # Teardown
+    _stop_container(CONTAINER_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests — basic endpoint checks
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    """Verify the health check endpoint works in the production image."""
+
+    def test_health_returns_200(self, container_url: str):
+        resp = httpx.get(f"{container_url}/health", timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert "version" in data
+
+    def test_health_json_content_type(self, container_url: str):
+        resp = httpx.get(f"{container_url}/health", timeout=10)
+        assert "application/json" in resp.headers["content-type"]
+
+
+class TestDocsEndpoint:
+    """Verify OpenAPI docs are accessible."""
+
+    def test_docs_returns_200(self, container_url: str):
+        resp = httpx.get(f"{container_url}/docs", timeout=10)
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_openapi_json_returns_200(self, container_url: str):
+        resp = httpx.get(f"{container_url}/openapi.json", timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["info"]["title"] == "WikiMind Gateway"
+
+
+class TestSPAServing:
+    """Verify the SPA (React frontend) is served correctly."""
+
+    def test_root_serves_html(self, container_url: str):
+        resp = httpx.get(f"{container_url}/", timeout=10)
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        # The built React app should contain a root div for mounting
+        assert "root" in resp.text or "id=" in resp.text
+
+    def test_spa_route_fallback(self, container_url: str):
+        """Non-API routes should serve index.html for SPA client-side routing."""
+        resp = httpx.get(f"{container_url}/inbox", timeout=10)
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+
+class TestIngestEndpoint:
+    """Verify the ingest API accepts requests in the production image."""
+
+    def test_ingest_text_accepts_request(self, container_url: str):
+        resp = httpx.post(
+            f"{container_url}/ingest/text",
+            json={
+                "content": "Smoke test content for WikiMind.",
+                "title": "Smoke Test",
+                "auto_compile": False,
+            },
+            timeout=30,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "id" in data
+        assert data["title"] == "Smoke Test"
+
+    def test_ingest_url_validates_input(self, container_url: str):
+        """POST with missing required fields should return 422."""
+        resp = httpx.post(
+            f"{container_url}/ingest/url",
+            json={},
+            timeout=10,
+        )
+        assert resp.status_code == 422
+
+
+class TestAuthFlow:
+    """Verify auth middleware behavior in the production image."""
+
+    def test_auth_disabled_health_accessible(self, container_url: str):
+        """With auth disabled, health endpoint requires no token."""
+        resp = httpx.get(f"{container_url}/health", timeout=10)
+        assert resp.status_code == 200
+
+    def test_auth_disabled_api_accessible(self, container_url: str):
+        """With auth disabled, API endpoints require no token."""
+        resp = httpx.get(f"{container_url}/ingest/sources", timeout=10)
+        assert resp.status_code == 200
+
+    def test_auth_me_returns_anonymous(self, container_url: str):
+        """With auth disabled, /auth/me returns an anonymous stub user."""
+        resp = httpx.get(
+            f"{container_url}/auth/me",
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "anonymous"
+
+
+class TestAuthEnabled:
+    """Verify auth enforcement when enabled via a separate container."""
+
+    @pytest.fixture(scope="class")
+    def auth_container_url(self, docker_image: str):
+        """Start a container with auth enabled."""
+        port = _find_free_port()
+        base_url = f"http://127.0.0.1:{port}"
+        name = f"{CONTAINER_NAME}-auth"
+
+        _stop_container(name)
+
+        run_result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                name,
+                "-p",
+                f"{port}:7842",
+                "-e",
+                "WIKIMIND_LLM__MOCK__ENABLED=true",
+                "-e",
+                "WIKIMIND_LLM__DEFAULT_PROVIDER=mock",
+                "-e",
+                "WIKIMIND_AUTH__ENABLED=true",
+                "-e",
+                "WIKIMIND_AUTH__JWT_SECRET_KEY=smoke-test-secret-key-for-ci",
+                "-e",
+                "WEB_CONCURRENCY=1",
+                docker_image,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if run_result.returncode != 0:
+            pytest.fail(f"Auth container start failed:\n{run_result.stderr}")
+
+        error = _wait_for_health(base_url)
+        if error is not None:
+            logs = _get_container_logs(name)
+            _stop_container(name)
+            pytest.fail(f"Auth container failed to start.\nLast error: {error}\nLogs:\n{logs}")
+
+        yield base_url
+        _stop_container(name)
+
+    def test_health_exempt_from_auth(self, auth_container_url: str):
+        """Health endpoint should be accessible even with auth enabled."""
+        resp = httpx.get(f"{auth_container_url}/health", timeout=10)
+        assert resp.status_code == 200
+
+    def test_docs_exempt_from_auth(self, auth_container_url: str):
+        """Docs endpoint should be accessible even with auth enabled."""
+        resp = httpx.get(f"{auth_container_url}/docs", timeout=10)
+        assert resp.status_code == 200
+
+    def test_spa_routes_exempt_from_auth(self, auth_container_url: str):
+        """SPA HTML pages should load without auth for client-side login flow."""
+        resp = httpx.get(f"{auth_container_url}/", timeout=10)
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_api_requires_auth(self, auth_container_url: str):
+        """API endpoints should require a token when auth is enabled."""
+        resp = httpx.get(
+            f"{auth_container_url}/ingest/sources",
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        assert resp.status_code == 401
+
+    def test_api_rejects_invalid_token(self, auth_container_url: str):
+        """API endpoints should reject invalid JWT tokens."""
+        resp = httpx.get(
+            f"{auth_container_url}/ingest/sources",
+            headers={
+                "Authorization": "Bearer invalid-token",
+                "Accept": "application/json",
+            },
+            timeout=10,
+        )
+        assert resp.status_code == 401
+
+    def test_static_assets_exempt_from_auth(self, auth_container_url: str):
+        """Static asset paths should not require auth."""
+        # The /assets/ path is exempt per auth middleware EXEMPT_PREFIXES.
+        # Request a nonexistent asset -- we just check it's not 401.
+        resp = httpx.get(f"{auth_container_url}/assets/nonexistent.js", timeout=10)
+        assert resp.status_code != 401
+
+
+class TestContainerBasics:
+    """Verify container runtime basics."""
+
+    def test_gunicorn_is_running(self, container_url: str, docker_image: str):
+        """Gunicorn should be the process manager in the prod image."""
+        result = subprocess.run(
+            ["docker", "exec", CONTAINER_NAME, "ps", "aux"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # ps may not be available in slim images; fall back to checking
+        # the health endpoint works (which implies gunicorn is running).
+        if result.returncode == 0:
+            assert "gunicorn" in result.stdout
+        else:
+            # If ps is not available, the health check passing is proof enough
+            resp = httpx.get(f"{container_url}/health", timeout=10)
+            assert resp.status_code == 200
+
+    def test_non_root_user(self, container_url: str):
+        """The container should run as non-root (wikimind user)."""
+        result = subprocess.run(
+            ["docker", "exec", CONTAINER_NAME, "whoami"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            assert result.stdout.strip() == "wikimind"
+
+    def test_data_dir_writable(self, container_url: str):
+        """The data directory should be writable by the container user."""
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                CONTAINER_NAME,
+                "sh",
+                "-c",
+                "touch /home/wikimind/.wikimind/smoke-test && rm /home/wikimind/.wikimind/smoke-test",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3225,6 +3225,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -4698,6 +4710,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "types-toml" },
@@ -4727,6 +4740,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 transcribe = [
     { name = "openai-whisper" },
@@ -4768,6 +4782,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.3.1" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "python-slugify", specifier = ">=8.0.4" },


### PR DESCRIPTION
## Problem

Multiple issues surfaced only at runtime during Fly.io deployment that CI never caught: sslmode crashes, missing libraries, frontend URL issues, auth blocking static files. Unit tests and lint checks cannot detect these because they never build or run the actual Docker production image.

## Solution

Add end-to-end smoke tests that build the production Docker image, start a container with mock/test configuration, and verify key endpoints respond correctly. A dedicated CI workflow (`smoke.yml`) runs these on PRs that touch Docker/backend/frontend files.

## Changes

- **`tests/smoke/test_docker_smoke.py`** -- 20 smoke tests in 7 test classes:
  - `TestHealthEndpoint` -- health check returns 200 with correct JSON
  - `TestDocsEndpoint` -- OpenAPI docs and JSON schema accessible
  - `TestSPAServing` -- root serves React SPA HTML, SPA routes fall back to index.html
  - `TestIngestEndpoint` -- text ingest accepts requests, URL ingest validates input
  - `TestAuthFlow` -- auth disabled allows unauthenticated access, /auth/me returns anonymous
  - `TestAuthEnabled` -- separate container with auth enabled verifies exempt paths (health, docs, SPA, static assets) and protected API endpoints (401 without token, 401 with invalid token)
  - `TestContainerBasics` -- gunicorn running, non-root user, writable data directory

- **`.github/workflows/smoke.yml`** -- CI workflow triggered on PRs/pushes that touch Dockerfile, src/, apps/web/, docker/, gunicorn.conf.py

- **`tests/unit/test_embedding.py`** -- fix missing `_min_score` attribute on mocked `EmbeddingService` in `test_search_returns_results`

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] Existing unit tests pass (17/17 embedding tests, health test)
- [x] Smoke tests collected (20 tests) and properly marked with `@pytest.mark.e2e`
- [ ] Smoke tests pass when Docker is available (`pytest tests/smoke/ -m e2e -v`)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)