### PR TITLE
refactor: async file writers + concurrent contradiction checks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,14 +156,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 453
+        "line_number": 454
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 477
+        "line_number": 478
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -194,5 +194,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T13:18:48Z"
+  "generated_at": "2026-04-20T14:03:31Z"
 }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -156,6 +156,7 @@ class LinterConfig(BaseModel):
     enable_pair_cache: bool = True
     contradiction_batch_enabled: bool = True
     contradiction_batch_size: int = 10
+    max_concept_concurrency: int = 5
 
 
 class EmbeddingConfig(BaseModel):

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -50,7 +50,7 @@ from wikimind.services.taxonomy import (
     upsert_concepts,
 )
 from wikimind.services.wiki_index import regenerate_index_md
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import LocalFileStorage, resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -336,7 +336,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             relation_types=self._last_typed_suggestions,
         )
 
-        relative_path = self._write_article_file(result, source, slug, resolved, unresolved)
+        relative_path = await self._write_article_file(result, source, slug, resolved, unresolved)
 
         article = Article(
             slug=slug,
@@ -416,7 +416,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             relation_types=self._last_typed_suggestions,
         )
 
-        relative_path = self._write_article_file(result, source, existing.slug, resolved, unresolved)
+        relative_path = await self._write_article_file(result, source, existing.slug, resolved, unresolved)
 
         # Delete old file only after new file is written successfully to
         # avoid data loss if the write fails (issue #183).
@@ -532,7 +532,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             candidate = f"{base}-{suffix}"
             suffix += 1
 
-    def _write_article_file(
+    async def _write_article_file(
         self,
         result: CompilationResult,
         source: Source,
@@ -545,16 +545,9 @@ Compile this into a wiki article following the JSON schema exactly."""
         Returns the wiki-relative path (e.g. ``concept-slug/article.md``)
         for storage in Article.file_path.
         """
-        wiki_dir = Path(self.settings.data_dir) / "wiki"
-        if source.user_id:
-            wiki_dir = wiki_dir / source.user_id
-
         concept = result.concepts[0] if result.concepts else "general"
         concept_slug = slugify(concept)
-        concept_dir = wiki_dir / concept_slug
-        concept_dir.mkdir(parents=True, exist_ok=True)
-
-        file_path = concept_dir / f"{slug}.md"
+        relative_path = f"{concept_slug}/{slug}.md"
 
         related_lines: list[str] = [f"- [{rb.candidate_text}](/wiki/{rb.target_id})" for rb in resolved]
         related_lines.extend(f"- [[{text}]]" for text in unresolved)
@@ -608,13 +601,16 @@ provider: {provider_str}
 - {source.title or source.source_url or "Uploaded document"} (ingested {source.ingested_at.strftime("%Y-%m-%d")})
 """
 
-        file_path.write_text(content, encoding="utf-8")
+        wiki_root = Path(self.settings.data_dir) / "wiki"
+        if source.user_id:
+            wiki_root = wiki_root / source.user_id
+        storage = LocalFileStorage(root=wiki_root)
+        await storage.write(relative_path, content)
 
         # Post-write frontmatter validation (best-effort, log warnings)
         validate_frontmatter(content)
 
-        # Return relative path for DB storage instead of absolute Path
-        return str(file_path.relative_to(wiki_dir))
+        return relative_path
 
     def _overall_confidence(self, result: CompilationResult) -> ConfidenceLevel:
         """Determine overall confidence from claims."""

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -26,7 +26,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import LocalFileStorage, resolve_wiki_path
 
 log = structlog.get_logger()
 
@@ -283,7 +283,7 @@ class ConceptCompiler:
             await session.refresh(article)
         # Write the file AFTER DB commit — prevents orphaned DB rows
         # pointing at files that were never written (#169).
-        self._write_concept_file(compilation, concept, source_articles)
+        await self._write_concept_file(compilation, concept, source_articles)
         await self._create_synthesizes_links(article.id, source_ids, session)
         await self._create_related_to_links(article, compilation.related_concepts, session)
         return article
@@ -295,17 +295,12 @@ class ConceptCompiler:
         )
         return result.scalar_one_or_none()
 
-    def _write_concept_file(
+    async def _write_concept_file(
         self, compilation: ConceptCompilationResult, concept: Concept, source_articles: list[Article]
     ) -> str:
         """Write concept page markdown. Returns wiki-relative path."""
-        wiki_dir = Path(self.settings.data_dir) / "wiki"
-        if concept.user_id:
-            wiki_dir = wiki_dir / concept.user_id
         slug = slugify(concept.name)
-        concept_dir = wiki_dir / slug
-        concept_dir.mkdir(parents=True, exist_ok=True)
-        file_path = concept_dir / f"{slug}.md"
+        relative_path = f"{slug}/{slug}.md"
         now = utcnow_naive()
         source_ids = [a.id for a in source_articles]
         sources_lines = [f"- [{a.title}](/wiki/{a.id})" for a in source_articles]
@@ -360,8 +355,12 @@ provider: {self._last_provider_used or "unknown"}
 
 {compilation.sources_summary}
 """
-        file_path.write_text(content, encoding="utf-8")
-        return str(file_path.relative_to(wiki_dir))
+        wiki_root = Path(self.settings.data_dir) / "wiki"
+        if concept.user_id:
+            wiki_root = wiki_root / concept.user_id
+        storage = LocalFileStorage(root=wiki_root)
+        await storage.write(relative_path, content)
+        return relative_path
 
     async def _create_synthesizes_links(
         self, concept_article_id: str, source_article_ids: list[str], session: AsyncSession

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -10,6 +10,7 @@ contradictions are modelled as first-class edges in the knowledge graph.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import itertools
 import json
@@ -435,26 +436,21 @@ async def _process_uncached_pairs(
 # ---------------------------------------------------------------------------
 
 
-async def detect_contradictions(
+async def _check_concept(
+    concept_id: str | None,
+    concept_name: str,
+    pairs: list[tuple[Article, Article]],
     session: AsyncSession,
     router: LLMRouter,
     settings: Settings,
     report: LintReport,
+    semaphore: asyncio.Semaphore,
 ) -> list[ContradictionFinding]:
-    """For each concept, LLM-compare article pairs within that concept bucket."""
-    cfg = settings.linter
-    findings: list[ContradictionFinding] = []
+    """Check contradiction pairs for a single concept, bounded by *semaphore*."""
+    async with semaphore:
+        cfg = settings.linter
+        findings: list[ContradictionFinding] = []
 
-    all_work = await _collect_work(session, cfg)
-
-    total_pairs = sum(len(pairs) for _, _, pairs in all_work)
-    report.total_pairs = total_pairs
-    report.checked_pairs = 0
-    session.add(report)
-    await session.flush()
-
-    checked = 0
-    for concept_id, concept_name, pairs in all_work:  # type: ignore[assignment]
         log.info(
             "Checking contradictions in concept",
             concept=concept_name,
@@ -463,6 +459,7 @@ async def detect_contradictions(
 
         # Separate cached pairs from uncached pairs that need LLM calls
         uncached_pairs: list[tuple[Article, Article, list[str], list[str]]] = []
+        checked = 0
         for article_a, article_b in pairs:
             if cfg.enable_pair_cache:
                 cached = await _check_pair_cache(session, article_a, article_b)
@@ -472,15 +469,23 @@ async def detect_contradictions(
                         a=article_a.title[:30],
                         b=article_b.title[:30],
                     )
-                    cached_findings = _findings_from_cached(cached, report.id, article_a, article_b, concept_id)
+                    cached_findings = _findings_from_cached(
+                        cached,
+                        report.id,
+                        article_a,
+                        article_b,
+                        concept_id,
+                    )
                     findings.extend(cached_findings)
                     for f in cached_findings:
                         ctx = f"{f.article_a_claim} vs {f.article_b_claim}"
-                        await _create_contradiction_backlink(session, article_a.id, article_b.id, ctx)
+                        await _create_contradiction_backlink(
+                            session,
+                            article_a.id,
+                            article_b.id,
+                            ctx,
+                        )
                     checked += 1
-                    report.checked_pairs = checked
-                    session.add(report)
-                    await session.flush()
                     continue
 
             # Collect claims for uncached pair
@@ -490,15 +495,64 @@ async def detect_contradictions(
                 uncached_pairs.append((article_a, article_b, claims_a, claims_b))
             else:
                 checked += 1
-                report.checked_pairs = checked
-                session.add(report)
-                await session.flush()
 
         # Process uncached pairs: batch or per-pair
         new_findings, checked = await _process_uncached_pairs(
-            uncached_pairs, concept_id, router, settings, report, session, checked
+            uncached_pairs,
+            concept_id,
+            router,
+            settings,
+            report,
+            session,
+            checked,
         )
         findings.extend(new_findings)
+
+        return findings
+
+
+async def detect_contradictions(
+    session: AsyncSession,
+    router: LLMRouter,
+    settings: Settings,
+    report: LintReport,
+) -> list[ContradictionFinding]:
+    """For each concept, LLM-compare article pairs within that concept bucket.
+
+    Concepts are checked concurrently up to ``cfg.max_concept_concurrency``
+    (default 5) via ``asyncio.gather`` with a semaphore.
+    """
+    cfg = settings.linter
+
+    all_work = await _collect_work(session, cfg)
+
+    total_pairs = sum(len(pairs) for _, _, pairs in all_work)
+    report.total_pairs = total_pairs
+    report.checked_pairs = 0
+    session.add(report)
+    await session.flush()
+
+    semaphore = asyncio.Semaphore(cfg.max_concept_concurrency)
+
+    tasks = [
+        _check_concept(
+            concept_id,  # type: ignore[arg-type]
+            concept_name,  # type: ignore[arg-type]
+            pairs,
+            session,
+            router,
+            settings,
+            report,
+            semaphore,
+        )
+        for concept_id, concept_name, pairs in all_work
+    ]
+
+    results = await asyncio.gather(*tasks)
+
+    findings: list[ContradictionFinding] = []
+    for concept_findings in results:
+        findings.extend(concept_findings)
 
     return findings
 

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -235,14 +235,14 @@ async def test_generate_unique_slug_skips_multiple_collisions(db_session) -> Non
     assert slug == "hello-world-3"
 
 
-def test_write_article_file(tmp_path) -> None:
+async def test_write_article_file(tmp_path) -> None:
     with (
         patch.object(compiler_mod, "get_llm_router"),
         patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
     ):
         c = Compiler()
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
-    rel_path = c._write_article_file(_result(), src, "test-slug", [], [])
+    rel_path = await c._write_article_file(_result(), src, "test-slug", [], [])
     assert isinstance(rel_path, str)
     full_path = Path(tmp_path) / "wiki" / rel_path
     assert full_path.exists()
@@ -251,7 +251,7 @@ def test_write_article_file(tmp_path) -> None:
     assert "test-slug" in text
 
 
-def test_write_article_file_no_concepts(tmp_path) -> None:
+async def test_write_article_file_no_concepts(tmp_path) -> None:
     with (
         patch.object(compiler_mod, "get_llm_router"),
         patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
@@ -267,7 +267,7 @@ def test_write_article_file_no_concepts(tmp_path) -> None:
         article_body="x",
     )
     src = Source(source_type=SourceType.TEXT, title=None)
-    rel_path = c._write_article_file(r, src, "no-concept", [], [])
+    rel_path = await c._write_article_file(r, src, "no-concept", [], [])
     assert isinstance(rel_path, str)
     full_path = Path(tmp_path) / "wiki" / rel_path
     assert full_path.exists()

--- a/tests/unit/test_phase2_compiler.py
+++ b/tests/unit/test_phase2_compiler.py
@@ -277,14 +277,14 @@ def test_parse_frontmatter_extracts_yaml():
     assert data["page_type"] == "source"
 
 
-def test_write_article_file_includes_page_type(tmp_path):
+async def test_write_article_file_includes_page_type(tmp_path):
     with (
         patch.object(compiler_mod, "get_llm_router"),
         patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
     ):
         c = Compiler()
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X")
-    rel_path = c._write_article_file(_result(), src, "test-slug", [], [])
+    rel_path = await c._write_article_file(_result(), src, "test-slug", [], [])
     full_path = Path(tmp_path) / "wiki" / rel_path
     assert full_path.exists()
     text = full_path.read_text()


### PR DESCRIPTION
## Summary

- **Async file writers (#187):** Convert `_write_article_file` and `_write_concept_file` from sync methods (using `Path.write_text()`) to `async` methods (using `LocalFileStorage.write()`), eliminating sync I/O in the async call chain and removing the implicit ThreadPoolExecutor-per-call overhead.
- **Concurrent contradiction checks (#159):** Replace the sequential concept loop in `detect_contradictions` with `asyncio.gather()` bounded by a configurable semaphore (`max_concept_concurrency`, default 5), so multiple concepts are checked in parallel instead of one at a time.
- Pre-existing test fix: add missing `_min_score` attribute in embedding search test.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] All 774 unit tests pass

Closes #187
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)