### PR TITLE
fix: propagate user_id from source to article during compilation

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -352,6 +352,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             concept_ids=json.dumps(result.concepts),
             provider=provider,
             page_type=PageType.SOURCE,
+            user_id=source.user_id,
         )
         session.add(article)
 
@@ -434,6 +435,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         existing.concept_ids = json.dumps(result.concepts)
         existing.page_type = PageType.SOURCE
         existing.updated_at = utcnow_naive()
+        existing.user_id = source.user_id
         session.add(existing)
 
         source.status = IngestStatus.COMPILED

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -258,6 +258,7 @@ class ConceptCompiler:
             existing.provider = self._last_provider_used
             existing.updated_at = now
             existing.page_type = PageType.CONCEPT
+            existing.user_id = concept.user_id
             session.add(existing)
             old_links = await session.execute(
                 select(Backlink).where(
@@ -280,6 +281,7 @@ class ConceptCompiler:
                 source_ids=json.dumps(source_ids),
                 provider=self._last_provider_used,
                 page_type=PageType.CONCEPT,
+                user_id=concept.user_id,
             )
             session.add(article)
             await session.commit()

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -5,6 +5,7 @@ registers all routers, and configures CORS for Electron and web dev servers.
 """
 
 import asyncio
+import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -29,7 +30,7 @@ from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
 from wikimind.middleware.request_logging import RequestLoggingMiddleware
 from wikimind.middleware.security_headers import SecurityHeadersMiddleware
-from wikimind.models import IngestStatus, Source, UserPreference
+from wikimind.models import Article, IngestStatus, Source, UserPreference
 
 log = structlog.get_logger()
 
@@ -74,6 +75,28 @@ async def lifespan(_app: FastAPI):
         if stuck:
             await session.commit()
             log.info("Reset stuck processing sources", count=len(stuck))
+
+    # Backfill article.user_id from linked source for articles created
+    # before user_id propagation was fixed. One-time migration that
+    # becomes a no-op once all articles have a user_id set.
+    async with get_session_factory()() as session:
+        result = await session.execute(
+            select(Article).where(Article.user_id.is_(None))  # type: ignore[union-attr]
+        )
+        orphan_articles = list(result.scalars().all())
+        backfilled = 0
+        for article in orphan_articles:
+            source_ids = json.loads(article.source_ids) if article.source_ids else []
+            if not source_ids:
+                continue
+            source = await session.get(Source, source_ids[0])
+            if source and source.user_id:
+                article.user_id = source.user_id
+                session.add(article)
+                backfilled += 1
+        if backfilled:
+            await session.commit()
+            log.info("Backfilled article user_id from source", count=backfilled)
 
     # Warm up the Docling converter in a background thread so ML model
     # weights (~500 MB) are downloaded and loaded before the first PDF


### PR DESCRIPTION
## Summary

When a source is ingested with a user_id, the compilation pipeline creates articles with `user_id=None` because neither `Compiler.save_article()` nor `ConceptCompiler._save_concept_page()` copies the user_id to the Article record. This makes compiled articles invisible to their owners when auth filtering is enabled.

- Set `user_id=source.user_id` when creating new articles in `Compiler._create_article()`
- Set `user_id=source.user_id` when replacing articles in `Compiler._replace_article_in_place()`
- Set `user_id=concept.user_id` when creating/updating concept pages in `ConceptCompiler._save_concept_page()`
- Add a one-time startup backfill in `lifespan()` that sets `article.user_id` from the linked source for existing articles where user_id is NULL

## Test plan

- [x] All 764 existing tests pass
- [x] ruff lint and format checks pass
- [x] Manual: ingest a source with a logged-in user, verify the compiled article has the correct user_id
- [ ] Manual: restart the server with existing NULL-user_id articles linked to sources that have user_id, verify backfill log message and articles become visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)