### PR TITLE
fix: set TypeScript target to ES2020 in tsconfig.node.json for Docker build

### DIFF
--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",


### PR DESCRIPTION
## Summary

Docker frontend build (`tsc -b && vite build`) fails with:
```
vite.config.ts(40,17): error TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'.
Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
```

`tsconfig.node.json` (used for `vite.config.ts`) had no `target` or `lib` set, so TypeScript defaulted to ES3 which lacks `Object.fromEntries` (ES2019+). Added `"target": "ES2020"` and `"lib": ["ES2020"]` to align with `tsconfig.json`.

## Changes
- `apps/web/tsconfig.node.json`: added `target` and `lib` compiler options set to ES2020

## Test plan
- [x] `npx tsc -b` passes locally with no errors
- [ ] Docker build completes the frontend stage without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)