### PR TITLE
refactor: replace magic values with named constants (#266)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@
 # WIKIMIND_QA__MAX_PRIOR_TURNS_IN_CONTEXT=5
 # WIKIMIND_QA__PRIOR_ANSWER_TRUNCATE_CHARS=500
 # WIKIMIND_QA__CONVERSATION_TITLE_MAX_CHARS=120
+# WIKIMIND_QA__MAX_TOKENS=2048
 
 # ----------------------------------------------------------------------------
 # Force-Enable a Provider (only needed if you want a key-less provider active)
@@ -85,6 +86,7 @@
 # ----------------------------------------------------------------------------
 # WIKIMIND_SERVER__HOST=127.0.0.1
 # WIKIMIND_SERVER__PORT=7842
+# WIKIMIND_SERVER__WS_KEEPALIVE_SECONDS=30.0
 
 # ----------------------------------------------------------------------------
 # Job Queue / Redis (optional)
@@ -95,6 +97,22 @@
 # docker-compose friendly); the prefixed form wins when both are set.
 # WIKIMIND_REDIS_URL=redis://localhost:6379/0
 # REDIS_URL=redis://localhost:6379/0
+
+# ----------------------------------------------------------------------------
+# Ingestion (optional)
+# ----------------------------------------------------------------------------
+# HTTP timeout for fetching URLs and PDFs
+# WIKIMIND_INGEST__HTTP_TIMEOUT_SECONDS=30
+
+# ----------------------------------------------------------------------------
+# Compiler (optional)
+# ----------------------------------------------------------------------------
+# Max output tokens for LLM compilation calls
+# WIKIMIND_COMPILER__MAX_TOKENS=8192
+# Max chars of source text sent to the compiler LLM
+# WIKIMIND_COMPILER__SOURCE_TEXT_MAX_CHARS=60000
+# Max chars per concept source article
+# WIKIMIND_COMPILER__CONCEPT_SOURCE_MAX_CHARS=5000
 
 # ----------------------------------------------------------------------------
 # PDF Extraction (docling-serve sidecar)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_h67PjF"
+      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -127,134 +127,6 @@
     }
   ],
   "results": {
-    ".secrets.baseline": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
-        "is_verified": false,
-        "line_number": 134
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
-        "is_verified": false,
-        "line_number": 134
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
-        "is_verified": false,
-        "line_number": 148
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
-        "is_verified": false,
-        "line_number": 148
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
-        "is_verified": false,
-        "line_number": 157
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
-        "is_verified": false,
-        "line_number": 157
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
-        "is_verified": false,
-        "line_number": 164
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
-        "is_verified": false,
-        "line_number": 164
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
-        "is_verified": false,
-        "line_number": 171
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
-        "is_verified": false,
-        "line_number": 171
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 187
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 187
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
-        "is_verified": false,
-        "line_number": 205
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
-        "is_verified": false,
-        "line_number": 205
-      }
-    ],
     "design-system/ui_kits/app/index.html": [
       {
         "type": "Base64 High Entropy String",
@@ -354,5 +226,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-21T20:42:12Z"
+  "generated_at": "2026-04-23T13:52:58Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": ".merge_file_h67PjF"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -127,6 +127,134 @@
     }
   ],
   "results": {
+    ".secrets.baseline": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 205
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 205
+      }
+    ],
     "design-system/ui_kits/app/index.html": [
       {
         "type": "Base64 High Entropy String",
@@ -179,14 +307,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 382
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 406
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -226,5 +354,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-21T16:54:02Z"
+  "generated_at": "2026-04-21T20:42:12Z"
 }

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -209,10 +209,11 @@ async def set_default_provider(request: DefaultProviderRequest):
         )
 
     # Providers that need API keys
-    if request.provider not in ("ollama", "mock") and not get_api_key(request.provider):
+    no_key_providers = {Provider.OLLAMA.value, Provider.MOCK.value}
+    if request.provider not in no_key_providers and not get_api_key(request.provider):
         raise HTTPException(
             status_code=400,
-            detail=(f"Provider {request.provider} has no API key configured"),
+            detail=f"Provider {request.provider} has no API key configured",
         )
 
     await _set_preference("llm.default_provider", request.provider)

--- a/src/wikimind/api/routes/ws.py
+++ b/src/wikimind/api/routes/ws.py
@@ -14,6 +14,8 @@ import json
 import structlog
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from wikimind.config import get_settings
+
 log = structlog.get_logger()
 
 router = APIRouter()
@@ -105,7 +107,8 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         # Keep connection alive, handle pings
         while True:
             try:
-                data = await asyncio.wait_for(websocket.receive_text(), timeout=30.0)
+                keepalive = get_settings().server.ws_keepalive_seconds
+                data = await asyncio.wait_for(websocket.receive_text(), timeout=keepalive)
                 msg = json.loads(data)
                 if msg.get("type") == "ping":
                     await manager.send_to(websocket, {"event": "pong"})

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -127,6 +127,7 @@ class ServerConfig(BaseModel):
 
     host: str = "127.0.0.1"
     port: int = 7842
+    ws_keepalive_seconds: float = 30.0
 
 
 class QAConfig(BaseModel):
@@ -135,6 +136,7 @@ class QAConfig(BaseModel):
     max_prior_turns_in_context: int = 5
     prior_answer_truncate_chars: int = 500
     conversation_title_max_chars: int = 120
+    max_tokens: int = 2048
 
 
 class TaxonomyConfig(BaseModel):
@@ -143,6 +145,20 @@ class TaxonomyConfig(BaseModel):
     rebuild_threshold: int = 5
     max_hierarchy_depth: int = 3
     concept_page_min_sources: int = 2
+
+
+class IngestConfig(BaseModel):
+    """Ingestion configuration."""
+
+    http_timeout_seconds: int = 30
+
+
+class CompilerConfig(BaseModel):
+    """Compiler configuration."""
+
+    max_tokens: int = 8192
+    source_text_max_chars: int = 60000
+    concept_source_max_chars: int = 5000
 
 
 class LinterConfig(BaseModel):
@@ -229,6 +245,8 @@ class Settings(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
     qa: QAConfig = Field(default_factory=QAConfig)
     taxonomy: TaxonomyConfig = Field(default_factory=TaxonomyConfig)
+    ingest: IngestConfig = Field(default_factory=IngestConfig)
+    compiler: CompilerConfig = Field(default_factory=CompilerConfig)
     linter: LinterConfig = Field(default_factory=LinterConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -176,10 +176,11 @@ class Compiler:
                 sorted(existing_concepts)
             )
 
+        settings = get_settings()
         request = CompletionRequest(
             system=COMPILER_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}],
-            max_tokens=8192,
+            max_tokens=settings.compiler.max_tokens,
             temperature=0.2,
             response_format="json",
             task_type=TaskType.COMPILE,
@@ -215,6 +216,7 @@ class Compiler:
 
     def _build_user_prompt(self, doc: NormalizedDocument) -> str:
         """Build the user prompt for the LLM compiler."""
+        max_chars = get_settings().compiler.source_text_max_chars
         meta = f"Title: {doc.title}"
         if doc.author:
             meta += f"\nAuthor: {doc.author}"
@@ -225,7 +227,7 @@ class Compiler:
 
 ---
 
-{doc.clean_text[:60000]}
+{doc.clean_text[:max_chars]}
 
 ---
 

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -124,6 +124,7 @@ async def _collect_source_articles(concept_name: str, session: AsyncSession) -> 
 
 
 def _build_source_material(articles: list[Article], user_id: str | None = None) -> str:
+    max_chars = get_settings().compiler.concept_source_max_chars
     parts: list[str] = []
     for i, article in enumerate(articles, 1):
         section = f"### Source {i}: {article.title}\n"
@@ -131,8 +132,8 @@ def _build_source_material(articles: list[Article], user_id: str | None = None) 
             section += f"Summary: {article.summary}\n"
         try:
             fc = resolve_wiki_path(article.file_path, user_id=user_id).read_text(encoding="utf-8")
-            if len(fc) > 5000:
-                fc = fc[:5000] + "\n[...truncated...]"
+            if len(fc) > max_chars:
+                fc = fc[:max_chars] + "\n[...truncated...]"
             section += f"\nContent:\n{fc}\n"
         except (OSError, ValueError):
             pass
@@ -204,7 +205,7 @@ class ConceptCompiler:
         request = CompletionRequest(
             system=prompt,
             messages=[{"role": "user", "content": "Synthesize a concept page from these sources."}],
-            max_tokens=8192,
+            max_tokens=self.settings.compiler.max_tokens,
             temperature=0.3,
             response_format="json",
             task_type=TaskType.COMPILE,

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -302,7 +302,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         return CompletionRequest(
             system=QA_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_message}],
-            max_tokens=2048,
+            max_tokens=self.settings.qa.max_tokens,
             temperature=0.3,
             response_format="json",
             task_type=TaskType.QA,

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -37,7 +37,8 @@ class URLAdapter:
         log.info("Ingesting URL", url=url)
 
         # Fetch page
-        async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
+        timeout = get_settings().ingest.http_timeout_seconds
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
             response = await client.get(url, headers={"User-Agent": "WikiMind/0.1 (knowledge compiler)"})
             response.raise_for_status()
             html = response.text

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 import httpx
 import structlog
 
+from wikimind.config import get_settings
 from wikimind.ingest.adapters.pdf import PDFAdapter
 from wikimind.ingest.adapters.text import TextAdapter
 from wikimind.ingest.adapters.url import URLAdapter
@@ -75,7 +76,8 @@ class IngestService:
 
     async def _ingest_pdf_url(self, url: str, session: AsyncSession) -> tuple[Source, NormalizedDocument]:
         """Download a PDF from *url* and delegate to :class:`PDFAdapter`."""
-        async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
+        timeout = get_settings().ingest.http_timeout_seconds
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
             response = await client.get(
                 url,
                 headers={"User-Agent": "WikiMind/0.1 (knowledge compiler)"},
@@ -98,7 +100,8 @@ class IngestService:
         download gateway). We detect ``application/pdf`` in the
         ``Content-Type`` header and re-route accordingly.
         """
-        async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
+        timeout = get_settings().ingest.http_timeout_seconds
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
             response = await client.get(
                 url,
                 headers={"User-Agent": "WikiMind/0.1 (knowledge compiler)"},
@@ -150,7 +153,6 @@ import trafilatura  # noqa: E402, F401
 from youtube_transcript_api import YouTubeTranscriptApi  # noqa: E402, F401
 
 from wikimind.api.routes.ws import emit_source_progress  # noqa: E402, F401
-from wikimind.config import get_settings  # noqa: E402, F401
 from wikimind.engine.llm_router import get_llm_router  # noqa: E402, F401
 from wikimind.ingest.adapters.pdf import (  # noqa: E402
     _convert_via_docling_serve,

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -41,6 +41,7 @@ _FAKE_QA_SETTINGS = SimpleNamespace(
         max_prior_turns_in_context=5,
         prior_answer_truncate_chars=500,
         conversation_title_max_chars=120,
+        max_tokens=2048,
     ),
 )
 
@@ -85,6 +86,7 @@ async def test_ask_with_file_back_creates_article_end_to_end(
                     max_prior_turns_in_context=5,
                     prior_answer_truncate_chars=500,
                     conversation_title_max_chars=120,
+                    max_tokens=2048,
                 ),
             ),
         ),
@@ -245,6 +247,7 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
                     max_prior_turns_in_context=5,
                     prior_answer_truncate_chars=500,
                     conversation_title_max_chars=120,
+                    max_tokens=2048,
                 ),
             ),
         ),

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -144,7 +144,11 @@ class TestSynthesizesLinks:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -186,7 +190,11 @@ class TestConceptPageOutput:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -219,7 +227,11 @@ class TestTriggerThreshold:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -250,7 +262,11 @@ class TestTriggerThreshold:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -270,7 +286,11 @@ class TestTriggerThreshold:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=5)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=5),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -303,7 +323,11 @@ class TestWithMockedLLM:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -335,7 +359,11 @@ class TestWithMockedLLM:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2)
+                    data_dir=str(tmp_path),
+                    taxonomy=SimpleNamespace(concept_page_min_sources=2),
+                    compiler=SimpleNamespace(
+                        max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
+                    ),
                 ),
             ),
         ):
@@ -360,7 +388,11 @@ class TestWithMockedLLM:
         mr = AsyncMock()
         mr.complete = AsyncMock(return_value=fr)
         mr.parse_json_response = lambda r: json.loads(r.content)
-        s = SimpleNamespace(data_dir=str(tmp_path), taxonomy=SimpleNamespace(concept_page_min_sources=2))
+        s = SimpleNamespace(
+            data_dir=str(tmp_path),
+            taxonomy=SimpleNamespace(concept_page_min_sources=2),
+            compiler=SimpleNamespace(max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000),
+        )
         with (
             patch("wikimind.engine.concept_compiler.get_llm_router", return_value=mr),
             patch("wikimind.engine.concept_compiler.get_settings", return_value=s),

--- a/tests/unit/test_concept_recompilation.py
+++ b/tests/unit/test_concept_recompilation.py
@@ -102,6 +102,7 @@ def _settings(tmp_path: Path, min_sources: int = 2) -> SimpleNamespace:
     return SimpleNamespace(
         data_dir=str(tmp_path),
         taxonomy=SimpleNamespace(concept_page_min_sources=min_sources),
+        compiler=SimpleNamespace(max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000),
     )
 
 

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -38,6 +38,7 @@ def _agent(tmp_path) -> QAAgent:
                     max_prior_turns_in_context=5,
                     prior_answer_truncate_chars=500,
                     conversation_title_max_chars=120,
+                    max_tokens=2048,
                 ),
             ),
         ),


### PR DESCRIPTION
## Summary

Hard-coded timeouts, token limits, and text truncation thresholds scattered across the codebase made it difficult to understand what each value controls and impossible to tune without code changes. This PR extracts them into Settings config classes so they are documented, discoverable, and overridable via environment variables.

## Changes

- **IngestConfig** (`ingest.http_timeout_seconds`): replaces `timeout=30` in HTTP clients across `ingest/service.py` and `ingest/adapters/url.py`
- **CompilerConfig** (`compiler.max_tokens`, `source_text_max_chars`, `concept_source_max_chars`): replaces `8192`, `60000`, and `5000` in `compiler.py` and `concept_compiler.py`
- **QAConfig** (`qa.max_tokens`): replaces `2048` in `qa_agent.py`
- **ServerConfig** (`server.ws_keepalive_seconds`): replaces `30.0` in `ws.py`
- Provider string comparison in `settings.py` now uses `Provider.OLLAMA.value` / `Provider.MOCK.value` instead of raw string literals
- `.env.example` updated with all new fields

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `pytest tests/ -x` — 788 tests pass, 5 skipped
- [ ] Verify new env vars override defaults correctly in a running instance

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)