### PR TITLE
refactor: replace broad except-Exception with specific catches

### DIFF
--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -63,7 +63,7 @@ async def ask_stream(
             except asyncio.CancelledError:
                 log.info("SSE client disconnected, aborting stream")
                 await session.rollback()
-            except Exception as e:
+            except Exception as e:  # Intentional broad catch — SSE must send error event, not crash
                 log.error("SSE stream error", error=str(e))
                 error_payload = json.dumps({"code": "stream_failed", "message": str(e)})
                 yield f"event: error\ndata: {error_payload}\n\n"

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -295,7 +295,7 @@ async def test_llm_connection(provider: str):
             status="ok",
             latency_ms=response.latency_ms,
         )
-    except Exception as e:
+    except Exception as e:  # TODO: narrow once provider error hierarchy is unified
         return LLMTestResponse(
             provider=provider,
             status="error",

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -3,6 +3,7 @@
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -177,7 +178,7 @@ async def get_health(
             orphans_count=detail.report.orphans_count,
             status=detail.report.status,
         )
-    except Exception:
+    except (HTTPException, SQLAlchemyError):
         count_result = await session.execute(select(func.count()).select_from(Article))
         return HealthSummaryResponse(
             total_articles=count_result.scalar() or 0,

--- a/src/wikimind/api/routes/ws.py
+++ b/src/wikimind/api/routes/ws.py
@@ -70,7 +70,7 @@ class ConnectionManager:
         for ws in targets:
             try:
                 await ws.send_text(message)
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, ConnectionError, OSError):
                 dead.add(ws)
         for ws in dead:
             self.disconnect(ws)
@@ -79,7 +79,7 @@ class ConnectionManager:
         """Send an event to a specific client."""
         try:
             await ws.send_text(json.dumps(event))
-        except Exception:
+        except (WebSocketDisconnect, RuntimeError, ConnectionError, OSError):
             self.disconnect(ws)
 
 

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -120,7 +120,7 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         except SQLAlchemyError:
             await session.rollback()
             raise
-        except Exception:
+        except Exception:  # Intentional broad catch — ensure rollback for any error
             await session.rollback()
             raise
 

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 from slugify import slugify
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
@@ -206,7 +206,7 @@ class Compiler:
             result.provider = self._last_provider_used
             result.page_type = PageType.SOURCE
             return result
-        except Exception as e:
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
             log.error(
                 "Failed to parse compilation response",
                 error=str(e),
@@ -377,7 +377,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             # pairs (issue #152 — greenlet_spawn error).
             async with get_session_factory()() as concept_session:
                 await maybe_trigger_concept_pages(concept_session)
-        except Exception:
+        except (SQLAlchemyError, RuntimeError, ValueError):
             log.warning("taxonomy upsert failed", article_id=article.id)
 
         try:
@@ -386,12 +386,12 @@ Compile this into a wiki article following the JSON schema exactly."""
                 article.title,
                 extra={"source_id": source.id, "article_slug": article.slug},
             )
-        except Exception:
+        except OSError:
             log.warning("activity log write failed", op="compile", article_id=article.id)
 
         try:
             await regenerate_index_md(session)
-        except Exception:
+        except (OSError, SQLAlchemyError):
             log.warning("index.md regeneration failed", article_id=article.id)
 
         log.info(
@@ -463,7 +463,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             # also updates concept pages (issue #162).
             async with get_session_factory()() as concept_session:
                 await maybe_trigger_concept_pages(concept_session)
-        except Exception:
+        except (SQLAlchemyError, RuntimeError, ValueError):
             log.warning(
                 "taxonomy upsert failed",
                 article_id=existing.id,
@@ -476,12 +476,12 @@ Compile this into a wiki article following the JSON schema exactly."""
                 existing.title,
                 extra={"source_id": source.id, "article_slug": existing.slug},
             )
-        except Exception:
+        except OSError:
             log.warning("activity log write failed", op="compile", article_id=existing.id)
 
         try:
             await regenerate_index_md(session)
-        except Exception:
+        except (OSError, SQLAlchemyError):
             log.warning("index.md regeneration failed", article_id=existing.id)
 
         log.info(

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -213,7 +213,7 @@ class ConceptCompiler:
         try:
             response = await self.router.complete(request, session=session)
             self._last_provider_used = response.provider_used
-        except Exception:
+        except (RuntimeError, ValueError):
             log.warning(
                 "Concept page LLM call failed",
                 concept=concept.name,
@@ -223,7 +223,7 @@ class ConceptCompiler:
         try:
             data = self.router.parse_json_response(response)
             compilation = ConceptCompilationResult(**data)
-        except Exception:
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
             log.warning(
                 "Concept page response parsing failed",
                 concept=concept.name,

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -296,7 +296,7 @@ async def _run_batch(
                     await _create_contradiction_backlink(session, art_a.id, art_b.id, ctx)
             return findings
 
-        except Exception:
+        except (RuntimeError, json.JSONDecodeError, ValueError, KeyError):
             if attempt == 0:
                 log.warning("Batch LLM call failed, retrying once", exc_info=True)
             else:
@@ -614,7 +614,7 @@ async def _compare_article_pair(
     try:
         response = await router.complete(request, session=None)
         data = router.parse_json_response(response)
-    except Exception:
+    except (RuntimeError, json.JSONDecodeError, ValueError, KeyError):
         log.warning(
             "LLM call failed for contradiction check",
             article_a=article_a.title,

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -205,7 +205,7 @@ async def run_lint(
             if article_titles:
                 await emit_linter_alert("contradiction", article_titles, user_id=user_id)
 
-    except Exception as e:
+    except Exception as e:  # Intentional broad catch — job runner must not crash
         log.error("Lint run failed", error=str(e), exc_info=True)
         report.status = LintReportStatus.FAILED
         report.error_message = str(e)

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
@@ -238,7 +239,7 @@ class LLMRouter:
             async with get_session_factory()() as cost_session:
                 cost_session.add(cost_entry)
                 await cost_session.commit()
-        except Exception:
+        except SQLAlchemyError:
             log.debug("cost log write failed (table may not exist)", exc_info=True)
 
     async def complete(
@@ -280,7 +281,7 @@ class LLMRouter:
                 task.add_done_callback(_log_budget_error)
                 return response
 
-            except Exception as e:
+            except Exception as e:  # TODO: narrow once provider error hierarchy is unified
                 log.warning("LLM provider failed", provider=provider, error=str(e))
                 last_error = e
                 if not self.settings.llm.fallback_enabled:
@@ -354,7 +355,7 @@ class LLMRouter:
                 )
                 return response
 
-            except Exception as e:
+            except Exception as e:  # TODO: narrow once provider error hierarchy is unified
                 log.warning("LLM multimodal provider failed", provider=provider, error=str(e))
                 last_error = e
                 if not self.settings.llm.fallback_enabled:
@@ -398,7 +399,7 @@ class LLMRouter:
                 )
                 instance = await self._get_provider_instance(provider)
                 return await instance.stream(request, model)
-            except Exception as e:
+            except Exception as e:  # TODO: narrow once provider error hierarchy is unified
                 log.warning(
                     "LLM stream provider failed",
                     provider=provider,

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -364,7 +364,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                     filed_article.title,
                     extra={"conversation_id": ctx.conversation.id},
                 )
-        except Exception:
+        except OSError:
             log.warning("activity log write failed", op="query")
 
         await session.refresh(query_record)
@@ -470,7 +470,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                 content = "\n".join(lines[1:-1])
             data = json.loads(content)
             result = QueryResult(**data)
-        except Exception as e:
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
             log.error("Failed to parse streamed QA response", error=str(e))
             result = QueryResult(
                 answer="Error processing answer. Please try again.",
@@ -517,7 +517,7 @@ conversation context contradicts the wiki, prefer the wiki."""
     def _read_article_content(self, file_path: str, user_id: str | None = None) -> str | None:
         try:
             return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
-        except Exception:
+        except OSError:
             return None
 
     async def _query_llm(
@@ -535,7 +535,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         try:
             data = self.router.parse_json_response(response)
             return QueryResult(**data)
-        except Exception as e:
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
             log.error("Failed to parse QA response", error=str(e))
             return QueryResult(
                 answer="Error processing answer. Please try again.",

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -214,7 +214,7 @@ class PDFAdapter:
         # back into the extracted text.
         try:
             clean_text = await self._enhance_with_vision(file_bytes, clean_text, source.id)
-        except Exception:
+        except Exception:  # TODO: narrow once provider error hierarchy is unified
             log.warning("Vision enhancement failed — using extracted text as-is", source_id=source.id)
 
         text_path = raw_dir / f"{source.id}.txt"

--- a/src/wikimind/jobs/background.py
+++ b/src/wikimind/jobs/background.py
@@ -176,7 +176,7 @@ class BackgroundCompiler:
         """Run compile_source directly in the current event loop."""
         try:
             await compile_source({}, source_id, user_id=user_id, doc=doc)
-        except Exception:
+        except Exception:  # Intentional broad catch — background task must not crash
             log.exception("in-process compilation failed", source_id=source_id)
 
     @staticmethod
@@ -184,7 +184,7 @@ class BackgroundCompiler:
         """Run lint_wiki directly in the current event loop."""
         try:
             await lint_wiki({}, user_id=user_id)
-        except Exception:
+        except Exception:  # Intentional broad catch — background task must not crash
             log.exception("in-process lint failed")
 
     @staticmethod
@@ -192,7 +192,7 @@ class BackgroundCompiler:
         """Run recompile_article directly in the current event loop."""
         try:
             await recompile_article({}, article_id, mode, job_id, user_id=user_id)
-        except Exception:
+        except Exception:  # Intentional broad catch — background task must not crash
             log.exception("in-process recompile failed", article_id=article_id)
 
     @staticmethod
@@ -200,7 +200,7 @@ class BackgroundCompiler:
         """Run sweep_wikilinks directly in the current event loop."""
         try:
             await sweep_wikilinks({}, user_id=user_id)
-        except Exception:
+        except Exception:  # Intentional broad catch — background task must not crash
             log.exception("in-process sweep failed")
 
 

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -256,7 +256,7 @@ async def sweep_wikilinks(_ctx, user_id: str | None = None) -> None:
                 updated=updated_count,
             )
 
-        except Exception as e:
+        except Exception as e:  # Intentional broad catch — job runner must not crash
             log.error("sweep_wikilinks failed", error=str(e))
             job.status = JobStatus.FAILED
             job.error = str(e)

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -167,7 +167,7 @@ async def compile_source(
                         )
                         embedding_service.embed_article(article.id, article.title, content)
                         log.info("Article embedded", article_id=article.id)
-                except Exception as embed_err:
+                except (RuntimeError, ValueError, OSError) as embed_err:
                     log.warning(
                         "Embedding failed (non-fatal)",
                         article_id=article.id,
@@ -179,7 +179,7 @@ async def compile_source(
             # idempotent, and safe to fire on every compile.
             await sweep_wikilinks(ctx, user_id=user_id)
 
-        except Exception as e:
+        except Exception as e:  # Intentional broad catch — job runner must not crash
             log.error("compile_source failed", source_id=source_id, error=str(e))
 
             source.status = IngestStatus.FAILED
@@ -228,7 +228,7 @@ async def lint_wiki(_ctx, user_id: str | None = None):
 
             log.info("lint_wiki complete", summary=job.result_summary)
 
-        except Exception as e:
+        except Exception as e:  # Intentional broad catch — job runner must not crash
             log.error("lint_wiki failed", error=str(e))
             job.status = JobStatus.FAILED
             job.error = str(e)
@@ -338,7 +338,7 @@ async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user
 
             log.info("recompile_article complete", article_id=article_id, mode=mode)
 
-        except Exception as e:
+        except Exception as e:  # Intentional broad catch — job runner must not crash
             log.error("recompile_article failed", article_id=article_id, error=str(e))
 
             job.status = JobStatus.FAILED

--- a/src/wikimind/middleware/error_handling.py
+++ b/src/wikimind/middleware/error_handling.py
@@ -33,7 +33,7 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
                 path=request.url.path,
             )
             return _error_response(exc.status_code, exc.code, exc.message, request_id)
-        except Exception as exc:
+        except Exception as exc:  # Intentional broad catch — middleware must not leak errors
             request_id = _get_request_id(request)
             log.exception(
                 "unhandled_error",

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -275,7 +275,7 @@ class EmbeddingService:
         """
         try:
             self._collection.delete(where={"article_id": article_id})
-        except Exception:
+        except (ValueError, RuntimeError):
             # Collection may be empty or article may not exist -- both are fine
             log.debug("delete_article no-op", article_id=article_id)
 
@@ -302,6 +302,6 @@ def get_embedding_service() -> EmbeddingService | None:
         return None
     try:
         return EmbeddingService()
-    except Exception:
+    except (OSError, RuntimeError, ValueError):
         log.warning("Failed to initialize EmbeddingService")
         return None

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -11,6 +11,7 @@ import functools
 from contextlib import suppress
 from pathlib import Path
 
+import httpx
 import structlog
 from fastapi import HTTPException
 from sqlmodel import select
@@ -57,7 +58,7 @@ class IngestService:
         """
         try:
             source, doc = await self._adapter.ingest_url(url, session)
-        except Exception as e:
+        except (httpx.HTTPError, ValueError, OSError) as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
         source.user_id = user_id
@@ -144,7 +145,7 @@ class IngestService:
                 source.title or "untitled",
                 extra={"source_type": source.source_type, "source_url": source.source_url},
             )
-        except Exception:
+        except OSError:
             log.warning("activity log write failed", op="ingest", source_id=source.id)
 
     @staticmethod

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -299,7 +299,7 @@ class QueryService:
                         conversation=_to_conversation_response(conversation),
                     )
                     yield (f"event: done\ndata: {done_payload.model_dump_json()}\n\n")
-        except Exception as e:
+        except Exception as e:  # Intentional broad catch — SSE must send error event, not crash
             log.error("Stream failed", error=str(e))
             error_payload = json.dumps({"code": "stream_failed", "message": str(e)})
             yield f"event: error\ndata: {error_payload}\n\n"

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 from slugify import slugify
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 
 from wikimind.config import get_settings
@@ -200,7 +201,7 @@ async def maybe_trigger_concept_pages(session: AsyncSession) -> list[str]:
             article = await compiler.compile_concept_page(concept, session)
             if article is not None:
                 compiled.append(concept.name)
-        except Exception:
+        except (RuntimeError, ValueError, SQLAlchemyError):
             log.warning("Concept page compilation failed", concept=concept.name, exc_info=True)
     return compiled
 

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -73,7 +73,7 @@ def _read_article_content(file_path: str, user_id: str | None = None) -> str:
     """
     try:
         return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
-    except Exception:
+    except OSError:
         return ""
 
 
@@ -441,7 +441,7 @@ class WikiService:
                 try:
                     semantic_results = embedding_service.search(q, limit=limit)
                     merged = _merge_hybrid_scores(keyword_scores_map, semantic_results)
-                except Exception:
+                except (RuntimeError, ValueError, OSError):
                     log.warning("Semantic search failed, falling back to keyword-only")
                     merged = keyword_scores_map
             else:


### PR DESCRIPTION
## Summary

Closes #263.

Broad `except Exception` catches across the codebase have been replaced with specific exception types where the error domain is well-defined:

- **JSON parsing** → `json.JSONDecodeError`, `KeyError`, `ValueError`, `TypeError`
- **File I/O / activity log** → `OSError`
- **DB operations** → `SQLAlchemyError`
- **LLM response parsing** → `json.JSONDecodeError`, `KeyError`, `ValueError`, `TypeError`
- **LLM call failures** → `RuntimeError`, `ValueError`
- **WebSocket send** → `WebSocketDisconnect`, `RuntimeError`, `ConnectionError`, `OSError`
- **Embedding/search** → `RuntimeError`, `ValueError`, `OSError`
- **URL ingestion** → `httpx.HTTPError`, `ValueError`, `OSError`

Intentional broad catches are preserved with explicit `# Intentional broad catch` comments in:
- Top-level job runners (`compile_source`, `lint_wiki`, `sweep_wikilinks`, `recompile_article`)
- Background task callbacks (`asyncio.create_task` wrappers)
- Error-handling middleware and SSE stream generators
- Session rollback safety nets

LLM provider fallback loops retain `except Exception` with `# TODO: narrow once provider error hierarchy is unified` — these need a unified provider error base class before narrowing is safe.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `pytest tests/ -x` — all 788 tests pass
- [ ] Manual smoke test: ingest a URL, compile, query, verify no unexpected crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)