### PR TITLE
fix: increase Playwright CI backend startup timeout to 60s

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,13 +107,13 @@ jobs:
         run: |
           uv run python -m uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 &
           echo "Waiting for backend to become ready..."
-          for i in {1..30}; do
+          for i in {1..60}; do
             if curl -sf http://127.0.0.1:7842/docs > /dev/null 2>&1; then
               echo "Backend ready after ${i}s"
               break
             fi
-            if [ $i -eq 30 ]; then
-              echo "❌ Backend failed to start within 30s"
+            if [ $i -eq 60 ]; then
+              echo "❌ Backend failed to start within 60s"
               exit 1
             fi
             sleep 1


### PR DESCRIPTION
## Summary

- The "Start backend" step in the Playwright e2e workflow has a health-check wait loop that polls `127.0.0.1:7842/docs` with a 30s timeout. On cold CI runs, `uv run` resolves/installs dependencies before launching uvicorn, consuming most of the 30s budget and causing flaky timeouts.
- Doubles the wait loop from 30 iterations to 60, giving the server enough headroom to start after `uv` finishes.

## Test plan

- [ ] Verify the e2e workflow passes on this PR's CI run without a timeout in the "Start backend" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)