### PR TITLE
fix: explicitly disable SSL for asyncpg on Fly.io

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,14 +179,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 457
+        "line_number": 458
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 481
+        "line_number": 482
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -217,5 +217,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T19:19:43Z"
+  "generated_at": "2026-04-21T01:13:10Z"
 }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -299,8 +299,8 @@ class Settings(BaseSettings):
             sslmode = params.pop("sslmode", [None])[0]
             if sslmode is not None and "ssl" not in params:
                 if sslmode == "disable":
-                    # Explicitly disable SSL — newer asyncpg defaults to attempting TLS.
-                    params["ssl"] = ["disable"]
+                    # Strip entirely — asyncpg defaults to no SSL, so omitting is correct.
+                    pass
                 elif sslmode in ("require", "verify-ca", "verify-full"):
                     params["ssl"] = [sslmode]
                 else:

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -299,7 +299,8 @@ class Settings(BaseSettings):
             sslmode = params.pop("sslmode", [None])[0]
             if sslmode is not None and "ssl" not in params:
                 if sslmode == "disable":
-                    pass  # no ssl param needed — asyncpg default is no-SSL
+                    # Explicitly disable SSL — newer asyncpg defaults to attempting TLS.
+                    params["ssl"] = ["disable"]
                 elif sslmode in ("require", "verify-ca", "verify-full"):
                     params["ssl"] = [sslmode]
                 else:

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -49,12 +49,19 @@ def _create_engine_from_url(url: str):
             connect_args={"check_same_thread": False},
         )
     if is_postgres(url):
+        connect_args: dict = {}
+        # asyncpg defaults to attempting TLS; explicitly disable when URL says so.
+        if "ssl=disable" in url:
+            connect_args["ssl"] = False
+            # Strip from URL so asyncpg doesn't receive the string value.
+            url = url.replace("?ssl=disable&", "?").replace("?ssl=disable", "").replace("&ssl=disable", "")
         return create_async_engine(
             url,
             echo=False,
             pool_size=10,
             max_overflow=20,
             pool_pre_ping=True,
+            connect_args=connect_args,
         )
     dialect = url.split("://", maxsplit=1)[0]
     raise ValueError(f"Unsupported database dialect: {dialect}. Use sqlite+aiosqlite or postgresql+asyncpg.")


### PR DESCRIPTION
## Summary

- Fixes production crash-loop on wikimind.fly.dev (503 → ConnectionResetError during TLS handshake)
- Newer asyncpg versions default to attempting TLS; Fly.io internal Postgres doesn't support SSL
- The previous code correctly identified `sslmode=disable` but incorrectly dropped the param (assuming asyncpg wouldn't try SSL by default)
- Now explicitly passes `ssl=False` via `connect_args` to the SQLAlchemy engine

## Root cause

`DATABASE_URL=postgres://...?sslmode=disable` → config stripped `sslmode` and produced a clean URL → asyncpg (newer default) attempted TLS → Fly Postgres rejected → `ConnectionResetError` → gunicorn worker died → health check failed → crash loop (10 restarts)

## Test plan

- [x] `tests/unit/test_config.py` — 24 passed
- [x] `tests/unit/test_database.py` — 9 passed  
- [x] `make lint` — all checks passed
- [ ] Deploy and verify wikimind.fly.dev returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)