### PR TITLE
fix: disable SSL for asyncpg on Fly.io when no sslmode is set

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,14 +179,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 458
+        "line_number": 463
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 482
+        "line_number": 487
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -217,5 +217,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-21T01:13:10Z"
+  "generated_at": "2026-04-21T01:31:41Z"
 }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -309,6 +309,11 @@ class Settings(BaseSettings):
                         sslmode=sslmode,
                     )
                     params["ssl"] = [sslmode]
+            # Fly.io internal Postgres doesn't support SSL. When no ssl/sslmode
+            # param is present and we're running on Fly, explicitly disable SSL
+            # to prevent asyncpg's default SSL-first connection attempt.
+            if "ssl" not in params and os.environ.get("FLY_APP_NAME"):
+                params["ssl"] = ["disable"]
             raw = urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
             self.database_url = raw
         return self


### PR DESCRIPTION
## Problem

App crash-loops on Fly.io because asyncpg defaults to SSL when no `ssl` or `sslmode` param is in the DATABASE_URL. Fly.io internal Postgres doesn't support SSL, causing `ConnectionResetError` during TLS handshake.

PR #271 handled the case where `sslmode=disable` is explicitly set, but Fly's DATABASE_URL often has **no sslmode at all**.

## Fix

Detect Fly.io via `FLY_APP_NAME` env var (present on all Fly machines). When no `ssl` param exists in the URL and we're on Fly, explicitly add `ssl=disable`.

## Test plan

- [x] All 24 config tests pass
- [x] ruff clean