### PR TITLE
feat: auto-deploy docling-serve sidecar in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,13 @@ jobs:
       - name: 🪁  Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: 🧠  Deploy docling-serve sidecar
+        run: |
+          flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
+          flyctl deploy --config fly.docling.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
       - name: 🚀  Deploy to Fly.io
         run: flyctl deploy --image ghcr.io/${{ github.repository }}:latest --remote-only
         env:

--- a/fly.docling.toml
+++ b/fly.docling.toml
@@ -1,0 +1,42 @@
+# fly.docling.toml — Fly.io config for the docling-serve PDF extraction sidecar.
+#
+# This runs on the Fly internal network (no public HTTP). The main wikimind
+# app reaches it at http://wikimind-docling.internal:5001.
+#
+# First-time setup:
+#   fly apps create wikimind-docling
+#
+# Deploy (done automatically by CI):
+#   fly deploy --app wikimind-docling --config fly.docling.toml
+
+app = "wikimind-docling"
+primary_region = "ord"
+
+[build]
+  image = "quay.io/docling-project/docling-serve-cpu:latest"
+
+[http_service]
+  internal_port = 5001
+  # No public routing — only reachable on .internal network
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 10
+    soft_limit = 5
+
+[checks]
+  [checks.health]
+    type = "http"
+    port = 5001
+    path = "/health"
+    interval = "30s"
+    timeout = "10s"
+    grace_period = "30s"
+
+[[vm]]
+  memory = "4gb"
+  cpu_kind = "shared"
+  cpus = 2

--- a/fly.toml
+++ b/fly.toml
@@ -18,8 +18,7 @@ primary_region = "ord"
   WIKIMIND_SERVER__HOST = "0.0.0.0"
   WIKIMIND_SERVER__PORT = "7842"
   WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
-  # Gunicorn workers (see gunicorn.conf.py).
-  # Each worker is lightweight (~50MB RSS) since ML models run in docling-serve sidecar.
+  # Gunicorn workers — lightweight now that ML runs in docling-serve sidecar.
   WEB_CONCURRENCY = "4"
 
 [http_service]
@@ -29,7 +28,6 @@ primary_region = "ord"
   auto_start_machines = true
   min_machines_running = 0
 
-  # Fly spins up additional machines when connections exceed soft_limit.
   [http_service.concurrency]
     type = "connections"
     hard_limit = 50


### PR DESCRIPTION
## Summary

- Adds `fly.docling.toml` config for the docling-serve sidecar Fly app
- Updates deploy workflow to deploy the sidecar before the main app
- Auto-creates the `wikimind-docling` app if it doesn't exist

Without this, the main app deploys but can't reach docling-serve for PDF extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)