### PR TITLE
fix: clean up orphan concept-page rows missing markdown files

### DIFF
--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -180,14 +180,21 @@ async def init_db():
         ("0003_backfill_concepts", _backfill_concepts_from_articles),
         ("0004_relative_paths", None),  # handled separately (needs session)
         ("0005_backfill_join_tables", _backfill_join_tables_from_json),
+        ("0006_cleanup_orphan_concepts", None),  # handled separately (needs session)
     ]
+
+    # Migrations that need a full AsyncSession (SQLModel ORM) instead of raw SQL
+    _session_migrations = {
+        "0004_relative_paths": _migrate_to_relative_paths,
+        "0006_cleanup_orphan_concepts": _cleanup_orphan_concept_rows,
+    }
 
     for version, migration_fn in _versioned_migrations:
         if await _migration_applied(engine, version):
             continue
-        if version == "0004_relative_paths":
+        if version in _session_migrations:
             async with get_session_factory()() as session:
-                await _migrate_to_relative_paths(session)
+                await _session_migrations[version](session)
         else:
             await migration_fn(engine)  # type: ignore[operator]
         await _record_migration(engine, version)
@@ -612,6 +619,55 @@ async def _backfill_join_tables_from_json(engine) -> None:  # noqa: C901
                                 )
                 except (json.JSONDecodeError, TypeError):
                     pass
+
+
+async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
+    """Delete concept-page Article rows whose markdown files no longer exist on disk.
+
+    Stale rows appear when the naming scheme changes (e.g. the old non-prefixed
+    ``prompt-caching/`` was replaced by ``concept-prompt-caching/``) and the DB
+    rows were never cleaned up.  This removes the Article **and** any Backlink
+    rows that reference it.
+
+    Runs once at startup.  Idempotent -- re-running when no orphans exist is a
+    no-op.  See issue #169.
+    """
+    from sqlalchemy import delete as sa_delete  # noqa: PLC0415
+    from sqlalchemy import or_ as sa_or  # noqa: PLC0415
+
+    from wikimind.models import Article, Backlink, PageType  # noqa: PLC0415
+    from wikimind.storage import resolve_wiki_path  # noqa: PLC0415
+
+    result = await session.execute(select(Article).where(Article.page_type == PageType.CONCEPT))
+    concept_articles = list(result.scalars().all())
+
+    cleaned = 0
+    for article in concept_articles:
+        file_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
+        if file_path.exists():
+            continue
+
+        # Remove backlinks referencing the orphaned article first.
+        await session.execute(
+            sa_delete(Backlink).where(
+                sa_or(
+                    Backlink.source_article_id == article.id,
+                    Backlink.target_article_id == article.id,
+                )
+            )
+        )
+        await session.execute(sa_delete(Article).where(Article.id == article.id))
+        cleaned += 1
+        log.warning(
+            "startup: removed orphaned concept page (file missing)",
+            article_id=article.id,
+            slug=article.slug,
+            path=str(file_path),
+        )
+
+    if cleaned:
+        await session.commit()
+        log.info("startup: cleaned orphaned concept rows", count=cleaned)
 
 
 async def _migrate_to_relative_paths(session: AsyncSession) -> None:

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,15 +1,26 @@
 """Tests for database session lifecycle — commit on success, rollback on error."""
 
+from __future__ import annotations
+
 import contextlib
 import json
 import uuid
+from typing import TYPE_CHECKING
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
-from wikimind.database import _repair_json_array, _repair_malformed_json_arrays, get_session
-from wikimind.models import Article, ConfidenceLevel, Source, SourceType
+from wikimind.database import (
+    _cleanup_orphan_concept_rows,
+    _repair_json_array,
+    _repair_malformed_json_arrays,
+    get_session,
+)
+from wikimind.models import Article, Backlink, ConfidenceLevel, PageType, Source, SourceType
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -170,3 +181,120 @@ class TestRepairMalformedJsonArraysMigration:
         fixed = result.scalar_one()
         parsed = json.loads(fixed.source_ids)
         assert parsed == ["id1", "id2", "id3"]
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_orphan_concept_rows migration tests (issue #169)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupOrphanConceptRows:
+    async def test_deletes_concept_article_with_missing_file(self, db_session, tmp_path: Path):
+        """Concept article whose .md file doesn't exist on disk is deleted."""
+        article = Article(
+            id=str(uuid.uuid4()),
+            slug="concept-stale-topic",
+            title="Stale Topic",
+            file_path=str(tmp_path / "concept-stale-topic" / "concept-stale-topic.md"),
+            page_type=PageType.CONCEPT,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        await _cleanup_orphan_concept_rows(db_session)
+
+        result = await db_session.execute(select(Article).where(Article.id == article.id))
+        assert result.scalar_one_or_none() is None
+
+    async def test_keeps_concept_article_with_existing_file(self, db_session, tmp_path: Path):
+        """Concept article whose .md file exists on disk is preserved."""
+        md_dir = tmp_path / "concept-active-topic"
+        md_dir.mkdir(parents=True)
+        md_file = md_dir / "concept-active-topic.md"
+        md_file.write_text("# Active Topic\n")
+
+        article = Article(
+            id=str(uuid.uuid4()),
+            slug="concept-active-topic",
+            title="Active Topic",
+            file_path=str(md_file),
+            page_type=PageType.CONCEPT,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        await _cleanup_orphan_concept_rows(db_session)
+
+        result = await db_session.execute(select(Article).where(Article.id == article.id))
+        assert result.scalar_one_or_none() is not None
+
+    async def test_leaves_source_articles_untouched(self, db_session, tmp_path: Path):
+        """Source articles with missing files are NOT cleaned up (only concepts)."""
+        article = Article(
+            id=str(uuid.uuid4()),
+            slug="some-source",
+            title="Some Source",
+            file_path=str(tmp_path / "missing-source.md"),
+            page_type=PageType.SOURCE,
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        await _cleanup_orphan_concept_rows(db_session)
+
+        result = await db_session.execute(select(Article).where(Article.id == article.id))
+        assert result.scalar_one_or_none() is not None
+
+    async def test_deletes_associated_backlinks(self, db_session, tmp_path: Path):
+        """Backlinks referencing an orphaned concept article are also deleted."""
+        orphan = Article(
+            id=str(uuid.uuid4()),
+            slug="concept-orphan",
+            title="Orphan Concept",
+            file_path=str(tmp_path / "concept-orphan" / "concept-orphan.md"),
+            page_type=PageType.CONCEPT,
+        )
+        # A surviving article that links to the orphan
+        md_file = tmp_path / "surviving.md"
+        md_file.write_text("# Surviving\n")
+        survivor = Article(
+            id=str(uuid.uuid4()),
+            slug="surviving-article",
+            title="Surviving Article",
+            file_path=str(md_file),
+            page_type=PageType.SOURCE,
+        )
+        db_session.add_all([orphan, survivor])
+        await db_session.flush()
+
+        backlink = Backlink(
+            source_article_id=survivor.id,
+            target_article_id=orphan.id,
+            context="link to orphan",
+        )
+        db_session.add(backlink)
+        await db_session.commit()
+
+        await _cleanup_orphan_concept_rows(db_session)
+
+        # Orphan article gone
+        result = await db_session.execute(select(Article).where(Article.id == orphan.id))
+        assert result.scalar_one_or_none() is None
+
+        # Backlink also gone
+        result = await db_session.execute(
+            select(Backlink).where(
+                Backlink.source_article_id == survivor.id,
+                Backlink.target_article_id == orphan.id,
+            )
+        )
+        assert result.scalar_one_or_none() is None
+
+        # Survivor remains
+        result = await db_session.execute(select(Article).where(Article.id == survivor.id))
+        assert result.scalar_one_or_none() is not None
+
+    async def test_idempotent_no_orphans(self, db_session, tmp_path: Path):
+        """Running with zero concept articles is a no-op."""
+        await _cleanup_orphan_concept_rows(db_session)
+        # No error, no crash — just a no-op


### PR DESCRIPTION
## Summary

- **Problem**: `sweep_wikilinks` logs ~15 warnings per run for concept pages whose `Article.file_path` doesn't exist on disk. These are stale DB rows from the old non-prefixed naming scheme (e.g. `prompt-caching/`) that were never cleaned up when the `concept-` prefix was adopted.
- **Solution**: Add a one-shot startup migration (`0006_cleanup_orphan_concepts`) that deletes `Article` rows where `page_type='concept'` and the `.md` file is missing. Also cleans up associated `Backlink` rows. The sweep's existing `_cleanup_orphaned_concept_pages` already handles runtime discovery.
- Refactors `init_db()` session-migration dispatch from a single `if` branch into a lookup dict for cleaner extension.

## Test plan

- [x] `test_deletes_concept_article_with_missing_file` — orphan row deleted
- [x] `test_keeps_concept_article_with_existing_file` — valid row preserved
- [x] `test_leaves_source_articles_untouched` — only concept pages affected
- [x] `test_deletes_associated_backlinks` — backlinks referencing orphan cleaned up
- [x] `test_idempotent_no_orphans` — no-op when no orphans exist
- [x] `make verify` passes (lint, format, typecheck, 771 tests, 84% coverage)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)