### PR TITLE
fix: isolate sweep_wikilinks sessions to prevent greenlet crash

### DIFF
--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -38,7 +38,7 @@ _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
 async def _sweep_single_article(
-    article: Article,
+    article_id: str,
     session: AsyncSession,
 ) -> bool:
     """Resolve unresolved brackets in a single article's .md file.
@@ -47,9 +47,18 @@ async def _sweep_single_article(
     identity-map conflicts when multiple articles create Backlinks for
     overlapping article pairs (issue #163).
 
+    The article is re-loaded from the database inside this session to
+    prevent greenlet_spawn errors caused by accessing attributes on an
+    object bound to a different session (issue #168).
+
     Returns True if any replacement was made (file rewritten + backlinks
     persisted), False if the file was unchanged.
     """
+    article = await session.get(Article, article_id)
+    if article is None:
+        log.warning("sweep: article not found, skipping", article_id=article_id)
+        return False
+
     file_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
     if not file_path.exists():
         log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
@@ -93,10 +102,9 @@ async def _sweep_single_article(
     file_path.write_text(new_content, encoding="utf-8")
 
     # Persist Backlink rows — use get-or-create to handle duplicates
-    # gracefully. The selectin eager loading on Article pre-populates the
-    # identity map with existing Backlinks, so merge() would conflict
-    # (SAWarning + IntegrityError). Instead we check for each backlink
-    # by composite PK and only insert when it doesn't already exist (#163).
+    # gracefully. We check each backlink by composite PK and only insert
+    # when it doesn't already exist, avoiding identity-map conflicts
+    # (#163) and SAWarning/IntegrityError from merge().
     for rb in resolved:
         existing = await session.get(Backlink, (article.id, rb.target_id))
         if existing is not None:
@@ -220,13 +228,18 @@ async def sweep_wikilinks(_ctx, user_id: str | None = None) -> None:
             if orphan_count:
                 log.info("sweep: cleaned orphaned concept pages", count=orphan_count)
 
-            stmt = select(Article)
-            if user_id is not None:
-                stmt = stmt.where(Article.user_id == user_id)
-            result = await job_session.execute(stmt)
-            articles = list(result.scalars().all())
+            # Load article IDs in a separate short-lived session so the
+            # objects are not bound to job_session.  This avoids greenlet_spawn
+            # errors when per-article sessions access overlapping Backlink
+            # rows that would conflict with job_session's identity map (#168).
+            async with session_factory() as list_session:
+                stmt = select(Article.id)
+                if user_id is not None:
+                    stmt = stmt.where(Article.user_id == user_id)
+                result = await list_session.execute(stmt)
+                article_ids: list[str] = list(result.scalars().all())
 
-            if not articles:
+            if not article_ids:
                 job.status = JobStatus.COMPLETE
                 job.result_summary = "No articles to sweep"
                 job_session.add(job)
@@ -235,24 +248,24 @@ async def sweep_wikilinks(_ctx, user_id: str | None = None) -> None:
                 return
 
             updated_count = 0
-            for article in articles:
+            for aid in article_ids:
                 # Each article gets its own session to prevent identity-map
                 # conflicts when both the source compiler and the sweep
-                # create Backlinks for overlapping article pairs (#163).
+                # create Backlinks for overlapping article pairs (#163, #168).
                 async with session_factory() as article_session:
-                    changed = await _sweep_single_article(article, article_session)
+                    changed = await _sweep_single_article(aid, article_session)
                     if changed:
                         updated_count += 1
 
             job.status = JobStatus.COMPLETE
             job.completed_at = utcnow_naive()
-            job.result_summary = f"Swept {len(articles)} articles, updated {updated_count}"
+            job.result_summary = f"Swept {len(article_ids)} articles, updated {updated_count}"
             job_session.add(job)
             await job_session.commit()
 
             log.info(
                 "sweep_wikilinks complete",
-                total=len(articles),
+                total=len(article_ids),
                 updated=updated_count,
             )
 

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -48,7 +48,7 @@ async def test_resolves_bracket_and_creates_backlink(db_session: AsyncSession, t
     md_path.write_text("Some text about [[Machine Learning]] in the body.\n")
     source = await _make_article(db_session, "AI Overview", str(md_path), slug="ai-overview")
 
-    changed = await _sweep_single_article(source, db_session)
+    changed = await _sweep_single_article(source.id, db_session)
 
     assert changed is True
     content = md_path.read_text()
@@ -73,7 +73,7 @@ async def test_no_brackets_no_write(db_session: AsyncSession, tmp_path: Path) ->
     md_path.write_text(original)
     article = await _make_article(db_session, "Clean Article", str(md_path))
 
-    changed = await _sweep_single_article(article, db_session)
+    changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
     assert md_path.read_text() == original
@@ -86,7 +86,7 @@ async def test_unknown_bracket_stays(db_session: AsyncSession, tmp_path: Path) -
     md_path.write_text("See also [[Nonexistent Topic]] for more.\n")
     article = await _make_article(db_session, "Some Article", str(md_path))
 
-    changed = await _sweep_single_article(article, db_session)
+    changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
     content = md_path.read_text()
@@ -105,7 +105,7 @@ async def test_already_resolved_link_not_rewritten(db_session: AsyncSession, tmp
     md_path.write_text(original)
     article = await _make_article(db_session, "Resolved Article", str(md_path))
 
-    changed = await _sweep_single_article(article, db_session)
+    changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
     assert md_path.read_text() == original
@@ -120,11 +120,11 @@ async def test_idempotent_rerun_after_sweep(db_session: AsyncSession, tmp_path: 
     source = await _make_article(db_session, "AI Overview", str(md_path), slug="ai-overview")
 
     # First run: should make changes
-    changed1 = await _sweep_single_article(source, db_session)
+    changed1 = await _sweep_single_article(source.id, db_session)
     assert changed1 is True
 
     # Second run: no changes (bracket already resolved, Backlink already exists)
-    changed2 = await _sweep_single_article(source, db_session)
+    changed2 = await _sweep_single_article(source.id, db_session)
     assert changed2 is False
 
 
@@ -136,7 +136,7 @@ async def test_multiple_brackets_partial_resolution(db_session: AsyncSession, tm
     md_path.write_text("Uses [[React]] and [[Unknown Framework]] for UI.\n")
     source = await _make_article(db_session, "Frontend Guide", str(md_path))
 
-    changed = await _sweep_single_article(source, db_session)
+    changed = await _sweep_single_article(source.id, db_session)
 
     assert changed is True
     content = md_path.read_text()
@@ -151,7 +151,7 @@ async def test_self_link_excluded(db_session: AsyncSession, tmp_path: Path) -> N
     md_path.write_text("This article about [[Self Referencing]] itself.\n")
     article = await _make_article(db_session, "Self Referencing", str(md_path), slug="self-referencing")
 
-    changed = await _sweep_single_article(article, db_session)
+    changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
     content = md_path.read_text()
@@ -163,5 +163,5 @@ async def test_missing_file_handled_gracefully(db_session: AsyncSession, tmp_pat
     """Article whose file_path doesn't exist -> skip gracefully."""
     article = await _make_article(db_session, "Missing File", str(tmp_path / "does-not-exist.md"))
 
-    changed = await _sweep_single_article(article, db_session)
+    changed = await _sweep_single_article(article.id, db_session)
     assert changed is False

--- a/tests/unit/test_sweep_session.py
+++ b/tests/unit/test_sweep_session.py
@@ -56,7 +56,7 @@ async def test_sweep_creates_backlinks(db_session: AsyncSession, tmp_path: Path)
     md_path.write_text("Research on [[Quantum Computing]] is advancing.\n")
     source = await _make_article(db_session, "Physics Overview", str(md_path))
 
-    changed = await _sweep_single_article(source, db_session)
+    changed = await _sweep_single_article(source.id, db_session)
 
     assert changed is True
     content = md_path.read_text()
@@ -103,12 +103,9 @@ async def test_sweep_handles_duplicate_backlinks(async_engine: AsyncEngine, tmp_
         target_id = target.id
 
     # Sweep in a fresh session — no SAWarning or IntegrityError should occur.
+    # The function now re-loads the article internally, so we just pass the ID.
     async with factory() as sweep_session:
-        # Re-load the article in this session's identity map.
-        result = await sweep_session.execute(select(Article).where(Article.id == source_id))
-        source_reloaded = result.scalar_one()
-
-        changed = await _sweep_single_article(source_reloaded, sweep_session)
+        changed = await _sweep_single_article(source_id, sweep_session)
 
     assert changed is True
     content = md_path.read_text()
@@ -180,10 +177,10 @@ async def test_sweep_wikilinks_uses_isolated_sessions(
     with patch("wikimind.jobs.sweep.get_session_factory", return_value=counting_factory):
         await sweep_wikilinks(None)
 
-    # Should have at least 3 calls: 1 job session + 2 per article
-    # (one per article in the loop). The key assertion is > 1.
-    assert counting_factory.call_count >= 3, (
-        f"Expected at least 3 session factory calls (1 job + 2 articles), got {counting_factory.call_count}"
+    # Should have at least 5 calls: 1 job session + 1 cleanup session
+    # + 1 list session + 2 per-article sessions. The key assertion is > 1.
+    assert counting_factory.call_count >= 5, (
+        f"Expected at least 5 session factory calls, got {counting_factory.call_count}"
     )
 
     # Verify the backlink was actually created.


### PR DESCRIPTION
## Summary

- **Problem**: `sweep_wikilinks` crashed mid-sweep with `greenlet_spawn has not been called; can't call await_only() here`, preceded by SAWarning identity-map conflicts on `Backlink` rows. The root cause was passing SQLAlchemy-bound `Article` objects across session boundaries -- attribute access on these objects triggered lazy loads in the wrong async context.
- **Fix**: Changed `_sweep_single_article` to accept an `article_id` string instead of a full `Article` object, and re-load the article within each per-article isolated session. Also moved the article listing query into its own short-lived session so no ORM objects leak from `job_session` into per-article sessions.
- Same pattern as the #152 fix in the compiler -- each unit of work gets its own session with no cross-session object sharing.

## Changes

- `src/wikimind/jobs/sweep.py`: `_sweep_single_article` now takes `article_id: str`, re-fetches the article via `session.get()`. `sweep_wikilinks` queries `Article.id` in a dedicated `list_session` and iterates over plain string IDs.
- `tests/unit/test_sweep.py`: Updated all call sites to pass `article.id` instead of the article object.
- `tests/unit/test_sweep_session.py`: Updated call sites; adjusted session-count assertion to account for the new `list_session`.

## Test plan

- [x] `make verify` passes (lint, format, typecheck, 766 tests, 84% coverage)
- [x] Existing sweep tests updated and passing
- [x] Session isolation test verifies >= 5 session factory calls (job + cleanup + list + 2 per-article)

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)