### PR TITLE
refactor: break down long functions exceeding complexity thresholds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ ignore = [
     "D406",   # section-name-should-end-with-newline — not Google style
     "PLR0913", # too many arguments — common in FastAPI routes
     "PLR2004", # magic value comparison — too noisy for early stage
-    "PLR0915", # too many statements — some functions are legitimately long
+    # PLR0915 — removed: functions refactored to stay within thresholds
     "PLW0603", # global statement — acceptable for singleton patterns (engine, session factory)
     "PIE804",  # unnecessary-dict-kwargs — Pydantic uses **{"alias": ...} patterns intentionally
     "RET504",  # unnecessary-assign — readability-first over short-circuit returns

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -555,7 +555,55 @@ async def _backfill_concepts_from_articles(engine) -> None:
             )
 
 
-async def _backfill_join_tables_from_json(engine) -> None:  # noqa: C901
+async def _backfill_concept_links(conn, article_id: str, concept_ids_raw: str) -> None:
+    """Insert ArticleConcept rows from a JSON-encoded concept list.
+
+    Args:
+        conn: Active async connection (inside a transaction).
+        article_id: The article UUID.
+        concept_ids_raw: JSON string of concept names.
+    """
+    try:
+        concept_names = json.loads(concept_ids_raw)
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(concept_names, list):
+        return
+    for name in concept_names:
+        if name:
+            await conn.execute(
+                sa_text(
+                    "INSERT OR IGNORE INTO articleconcept"
+                    " (article_id, concept_name)"
+                    " VALUES (:article_id, :concept_name)"
+                ),
+                {"article_id": article_id, "concept_name": str(name)},
+            )
+
+
+async def _backfill_source_links(conn, article_id: str, source_ids_raw: str) -> None:
+    """Insert ArticleSource rows from a JSON-encoded source ID list.
+
+    Args:
+        conn: Active async connection (inside a transaction).
+        article_id: The article UUID.
+        source_ids_raw: JSON string of source UUIDs.
+    """
+    try:
+        source_ids = json.loads(source_ids_raw)
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(source_ids, list):
+        return
+    for sid in source_ids:
+        if sid:
+            await conn.execute(
+                sa_text("INSERT OR IGNORE INTO articlesource (article_id, source_id) VALUES (:article_id, :source_id)"),
+                {"article_id": article_id, "source_id": str(sid)},
+            )
+
+
+async def _backfill_join_tables_from_json(engine) -> None:
     """Populate ArticleConcept and ArticleSource from legacy JSON columns.
 
     Idempotent: existing rows are skipped via INSERT OR IGNORE (SQLite)
@@ -585,40 +633,10 @@ async def _backfill_join_tables_from_json(engine) -> None:  # noqa: C901
 
         for row in rows:
             article_id, concept_ids_raw, source_ids_raw = row
-
             if concept_ids_raw:
-                try:
-                    concept_names = json.loads(concept_ids_raw)
-                    if isinstance(concept_names, list):
-                        for name in concept_names:
-                            if name:
-                                await conn.execute(
-                                    sa_text(
-                                        "INSERT OR IGNORE INTO articleconcept"
-                                        " (article_id, concept_name)"
-                                        " VALUES (:article_id, :concept_name)"
-                                    ),
-                                    {"article_id": article_id, "concept_name": str(name)},
-                                )
-                except (json.JSONDecodeError, TypeError):
-                    pass
-
+                await _backfill_concept_links(conn, article_id, concept_ids_raw)
             if source_ids_raw:
-                try:
-                    source_ids = json.loads(source_ids_raw)
-                    if isinstance(source_ids, list):
-                        for sid in source_ids:
-                            if sid:
-                                await conn.execute(
-                                    sa_text(
-                                        "INSERT OR IGNORE INTO articlesource"
-                                        " (article_id, source_id)"
-                                        " VALUES (:article_id, :source_id)"
-                                    ),
-                                    {"article_id": article_id, "source_id": str(sid)},
-                                )
-                except (json.JSONDecodeError, TypeError):
-                    pass
+                await _backfill_source_links(conn, article_id, source_ids_raw)
 
 
 async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -61,6 +61,64 @@ log = structlog.get_logger()
 # ---------------------------------------------------------------------------
 
 
+def _build_normalized_doc(source: Source) -> NormalizedDocument:
+    """Read a source's cleaned text file and build a NormalizedDocument.
+
+    Used as fallback when no pre-built document is passed (ARQ path or
+    recompilation). Every ingest adapter writes a cleaned ``.txt`` and
+    stores its path on the Source record (see issue #59).
+
+    Args:
+        source: The source record with a non-null ``file_path``.
+
+    Returns:
+        A NormalizedDocument ready for compilation.
+
+    Raises:
+        ValueError: If the source has no ``file_path``.
+    """
+    if not source.file_path:
+        raise ValueError("No cleaned text file path for source")
+
+    text_path = resolve_raw_path(source.file_path, user_id=source.user_id)
+    content = text_path.read_text(encoding="utf-8")
+
+    return NormalizedDocument(
+        raw_source_id=source.id,
+        clean_text=content,
+        title=source.title or "Untitled",
+        author=source.author,
+        published_date=source.published_date,
+        estimated_tokens=_ingest_service.estimate_tokens(content),
+        chunks=_ingest_service.chunk_text(content, source.id),
+    )
+
+
+def _try_embed_article(article: Article) -> None:
+    """Embed article chunks for semantic search (non-blocking, best-effort).
+
+    Silently logs and returns on failure so compilation is never blocked
+    by embedding errors.
+
+    Args:
+        article: The article to embed.
+    """
+    if not _SEARCH_AVAILABLE:
+        return
+    try:
+        embedding_service = get_embedding_service()
+        if embedding_service is not None:
+            content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text(encoding="utf-8")
+            embedding_service.embed_article(article.id, article.title, content)
+            log.info("Article embedded", article_id=article.id)
+    except (RuntimeError, ValueError, OSError) as embed_err:
+        log.warning(
+            "Embedding failed (non-fatal)",
+            article_id=article.id,
+            error=str(embed_err),
+        )
+
+
 async def compile_source(
     ctx,
     source_id: str,
@@ -111,27 +169,8 @@ async def compile_source(
 
         try:
             if doc is None:
-                # Fallback: re-read from disk (ARQ path or recompile).
-                # Every adapter writes a cleaned .txt and stores its path on
-                # the Source record (see issue #59). The worker is
-                # format-agnostic and just reads UTF-8 text.
-                if not source.file_path:
-                    raise ValueError("No cleaned text file path for source")
-
-                text_path = resolve_raw_path(source.file_path, user_id=source.user_id)
-                content = text_path.read_text(encoding="utf-8")
-
                 await emit_source_progress(source_id, "Normalizing content...", user_id=user_id)
-
-                doc = NormalizedDocument(
-                    raw_source_id=source.id,
-                    clean_text=content,
-                    title=source.title or "Untitled",
-                    author=source.author,
-                    published_date=source.published_date,
-                    estimated_tokens=_ingest_service.estimate_tokens(content),
-                    chunks=_ingest_service.chunk_text(content, source.id),
-                )
+                doc = _build_normalized_doc(source)
 
             await emit_source_progress(source_id, "Compiling with LLM...", user_id=user_id)
 
@@ -156,25 +195,9 @@ async def compile_source(
             await session.commit()
 
             await emit_compilation_complete(article.slug, article.title, user_id=user_id)
-
             log.info("compile_source complete", source_id=source_id, slug=article.slug)
 
-            # Embed article chunks for semantic search (non-blocking)
-            if _SEARCH_AVAILABLE:
-                try:
-                    embedding_service = get_embedding_service()
-                    if embedding_service is not None:
-                        content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text(
-                            encoding="utf-8"
-                        )
-                        embedding_service.embed_article(article.id, article.title, content)
-                        log.info("Article embedded", article_id=article.id)
-                except (RuntimeError, ValueError, OSError) as embed_err:
-                    log.warning(
-                        "Embedding failed (non-fatal)",
-                        article_id=article.id,
-                        error=str(embed_err),
-                    )
+            _try_embed_article(article)
 
             # Sweep existing articles — a newly compiled article may resolve
             # brackets that were previously unresolvable. Fast (no LLM),
@@ -257,11 +280,67 @@ async def _get_article_concept_names(article: Article, session) -> list[str]:
     return names
 
 
-async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user_id: str | None = None):  # noqa: C901
+async def _recompile_from_source(article: Article, session) -> None:
+    """Recompile an article by re-reading and re-compiling its primary source.
+
+    Args:
+        article: The article to recompile.
+        session: Async database session.
+
+    Raises:
+        ValueError: If the article has no linked sources or the source file
+            is missing.
+    """
+    source_ids = await _get_article_source_ids(article, session)
+    if not source_ids:
+        raise ValueError("Article has no linked sources")
+
+    source = await session.get(Source, source_ids[0])
+    if not source or not source.file_path:
+        raise ValueError("Source or source file_path not found")
+
+    doc = _build_normalized_doc(source)
+
+    compiler = Compiler()
+    result = await compiler.compile(doc, session)
+    if not result:
+        raise ValueError("Compiler returned no result")
+
+    await compiler.save_article(result, source, session)
+
+
+async def _recompile_from_concept(article: Article, session) -> None:
+    """Recompile an article by regenerating its concept page.
+
+    Args:
+        article: The article to recompile.
+        session: Async database session.
+
+    Raises:
+        ValueError: If the article has no linked concepts or the concept
+            is not found.
+    """
+    concept_names = await _get_article_concept_names(article, session)
+    if not concept_names:
+        raise ValueError("Article has no linked concepts")
+
+    concept_name = concept_names[0]
+    result = await session.execute(select(Concept).where(Concept.name == concept_name))
+    concept = result.scalars().first()
+    if not concept:
+        raise ValueError("Concept not found")
+
+    concept_compiler = ConceptCompiler()
+    result_article = await concept_compiler.compile_concept_page(concept, session)
+    if not result_article:
+        raise ValueError("ConceptCompiler returned no result")
+
+
+async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user_id: str | None = None):
     """Recompile an existing article from its source or concept.
 
     Args:
-        ctx: ARQ context (unused in dev mode).
+        _ctx: ARQ context (unused in dev mode).
         article_id: The article UUID to recompile.
         mode: "source" or "concept".
         _job_id: Pre-created Job record ID to update.
@@ -303,50 +382,9 @@ async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user
 
         try:
             if mode == "source":
-                source_ids = await _get_article_source_ids(article, session)
-                if not source_ids:
-                    raise ValueError("Article has no linked sources")
-
-                source = await session.get(Source, source_ids[0])
-                if not source or not source.file_path:
-                    raise ValueError("Source or source file_path not found")
-
-                content = resolve_raw_path(source.file_path, user_id=source.user_id).read_text(encoding="utf-8")
-
-                doc = NormalizedDocument(
-                    raw_source_id=source.id,
-                    clean_text=content,
-                    title=source.title or "Untitled",
-                    author=source.author,
-                    published_date=source.published_date,
-                    estimated_tokens=_ingest_service.estimate_tokens(content),
-                    chunks=_ingest_service.chunk_text(content, source.id),
-                )
-
-                compiler = Compiler()
-                result = await compiler.compile(doc, session)
-
-                if not result:
-                    raise ValueError("Compiler returned no result")
-
-                await compiler.save_article(result, source, session)
-
+                await _recompile_from_source(article, session)
             elif mode == "concept":
-                concept_names = await _get_article_concept_names(article, session)
-                if not concept_names:
-                    raise ValueError("Article has no linked concepts")
-
-                concept_name = concept_names[0]
-                result = await session.execute(select(Concept).where(Concept.name == concept_name))
-                concept = result.scalars().first()
-                if not concept:
-                    raise ValueError("Concept not found")
-
-                concept_compiler = ConceptCompiler()
-                result_article = await concept_compiler.compile_concept_page(concept, session)
-
-                if not result_article:
-                    raise ValueError("ConceptCompiler returned no result")
+                await _recompile_from_concept(article, session)
 
             job.status = JobStatus.COMPLETE
             job.completed_at = utcnow_naive()
@@ -355,7 +393,6 @@ async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user
             await session.commit()
 
             await emit_article_recompiled(article_id, article.page_type, "complete", user_id=user_id)
-
             log.info("recompile_article complete", article_id=article_id, mode=mode)
 
         except Exception as e:  # Intentional broad catch — job runner must not crash

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -70,47 +70,32 @@ def _article_entry(article: Article) -> str:
     return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
 
 
-async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: C901, PLR0912
-    """Regenerate the wiki/index.md content catalog from the database.
+async def _group_articles_by_concept(
+    articles: list[Article],
+    session: AsyncSession,
+) -> tuple[dict[str, list[Article]], list[Article]]:
+    """Group articles by concept name and identify uncategorized articles.
 
-    Reads all Articles + their concepts, groups by concept, writes a
-    markdown catalog with page_type frontmatter. Concept pages are shown
-    prominently as entry points. Rewritten in place on every call
-    (NOT append-only).
+    Reads from the ArticleConcept join table with a fallback to the legacy
+    ``Article.concept_ids`` JSON column for pre-migration data.
 
     Args:
+        articles: All articles to categorize.
         session: Async database session.
 
     Returns:
-        The wiki-relative path string of the written file.
+        A tuple of (concept_name -> article list, uncategorized articles).
     """
-    settings = get_settings()
-    wiki_dir = Path(settings.data_dir) / "wiki"
-    wiki_dir.mkdir(parents=True, exist_ok=True)
-    index_path = wiki_dir / "index.md"
-
-    # Fetch all articles and concepts
-    articles_result = await session.execute(select(Article))
-    articles: list[Article] = list(articles_result.scalars().all())
-
     concepts_result = await session.execute(select(Concept))
-    concepts: list[Concept] = list(concepts_result.scalars().all())
-    concept_map: dict[str, str] = {c.id: c.name for c in concepts}
+    concept_map: dict[str, str] = {c.id: c.name for c in concepts_result.scalars().all()}
 
-    # Count articles by page_type
-    type_counts: Counter[str] = Counter()
-    for article in articles:
-        type_counts[article.page_type] += 1
-
-    # Group articles by concept name
-    concept_articles: dict[str, list[Article]] = defaultdict(list)
-    uncategorized: list[Article] = []
-
-    # Build article -> concept names mapping from join table
     ac_result = await session.execute(select(ArticleConcept))
     article_concept_map: dict[str, list[str]] = defaultdict(list)
     for ac in ac_result.scalars().all():
         article_concept_map[ac.article_id].append(ac.concept_name)
+
+    concept_articles: dict[str, list[Article]] = defaultdict(list)
+    uncategorized: list[Article] = []
 
     for article in articles:
         raw_ids = article_concept_map.get(article.id, [])
@@ -129,7 +114,24 @@ async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: C901, PLR0
             name = concept_map.get(raw_id, raw_id)
             concept_articles[name].append(article)
 
-    # Build the markdown content with page_type frontmatter
+    return concept_articles, uncategorized
+
+
+def _build_index_lines(
+    articles: list[Article],
+    concept_articles: dict[str, list[Article]],
+    uncategorized: list[Article],
+) -> list[str]:
+    """Build the markdown lines for the wiki index page.
+
+    Args:
+        articles: All articles (for summary counts).
+        concept_articles: Articles grouped by concept name.
+        uncategorized: Articles not tagged with any concept.
+
+    Returns:
+        List of markdown strings to be joined into the index file.
+    """
     now = utcnow_naive()
     frontmatter = (
         f"---\npage_type: index\ntitle: Wiki Index\nslug: index\nscope: global\ngenerated: {now.isoformat()}\n---\n\n"
@@ -139,6 +141,7 @@ async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: C901, PLR0
 
     # Article counts by type
     if articles:
+        type_counts: Counter[str] = Counter(a.page_type for a in articles)
         lines.append(f"**{len(articles)} articles** \u2014 ")
         type_parts: list[str] = []
         for pt in [PageType.SOURCE, PageType.CONCEPT, PageType.ANSWER, PageType.INDEX, PageType.META]:
@@ -151,22 +154,48 @@ async def regenerate_index_md(session: AsyncSession) -> str:  # noqa: C901, PLR0
     concept_page_articles = [a for a in articles if a.page_type == PageType.CONCEPT]
     if concept_page_articles:
         lines.append("## Concept Pages\n\n")
-        lines.extend(_article_entry(article) for article in sorted(concept_page_articles, key=lambda a: a.slug))
+        lines.extend(_article_entry(a) for a in sorted(concept_page_articles, key=lambda a: a.slug))
         lines.append("\n")
 
     # Concepts sorted alphabetically
     for concept_name in sorted(concept_articles):
         lines.append(f"## {concept_name}\n\n")
-        lines.extend(
-            _article_entry(article) for article in sorted(concept_articles[concept_name], key=lambda a: a.slug)
-        )
+        lines.extend(_article_entry(a) for a in sorted(concept_articles[concept_name], key=lambda a: a.slug))
         lines.append("\n")
 
     # Uncategorized section at the bottom
     if uncategorized:
         lines.append("## Uncategorized\n\n")
-        lines.extend(_article_entry(article) for article in sorted(uncategorized, key=lambda a: a.slug))
+        lines.extend(_article_entry(a) for a in sorted(uncategorized, key=lambda a: a.slug))
         lines.append("\n")
+
+    return lines
+
+
+async def regenerate_index_md(session: AsyncSession) -> str:
+    """Regenerate the wiki/index.md content catalog from the database.
+
+    Reads all Articles + their concepts, groups by concept, writes a
+    markdown catalog with page_type frontmatter. Concept pages are shown
+    prominently as entry points. Rewritten in place on every call
+    (NOT append-only).
+
+    Args:
+        session: Async database session.
+
+    Returns:
+        The wiki-relative path string of the written file.
+    """
+    settings = get_settings()
+    wiki_dir = Path(settings.data_dir) / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    index_path = wiki_dir / "index.md"
+
+    articles_result = await session.execute(select(Article))
+    articles: list[Article] = list(articles_result.scalars().all())
+
+    concept_articles, uncategorized = await _group_articles_by_concept(articles, session)
+    lines = _build_index_lines(articles, concept_articles, uncategorized)
 
     index_path.write_text("".join(lines), encoding="utf-8")
     log.info("index.md regenerated", article_count=len(articles))


### PR DESCRIPTION
## Summary

- Extract helper functions from `compile_source`, `recompile_article`, `regenerate_index_md`, and `_backfill_join_tables_from_json` to bring them within PLR0915 (too many statements) and C901 (cyclomatic complexity) thresholds
- Remove the global `PLR0915` suppression from `pyproject.toml` and per-function `# noqa: C901` comments that are no longer needed
- No behavioral changes -- purely structural refactoring

## Motivation

Several functions exceeded ruff's complexity thresholds, requiring global and per-file suppressions in `pyproject.toml`. This PR extracts focused helpers where clear responsibility boundaries exist, making each function easier to read while staying within lint limits.

## Changes

| File | What changed |
|------|-------------|
| `src/wikimind/jobs/worker.py` | Extract `_build_normalized_doc()` (source file reading), `_try_embed_article()` (best-effort embedding), `_recompile_from_source()`, and `_recompile_from_concept()` |
| `src/wikimind/services/wiki_index.py` | Extract `_group_articles_by_concept()` (DB queries + grouping logic) and `_build_index_lines()` (markdown generation) |
| `src/wikimind/database.py` | Extract `_backfill_concept_links()` and `_backfill_source_links()` from `_backfill_join_tables_from_json` |
| `pyproject.toml` | Remove `PLR0915` from the global ignore list |

## Test plan

- [x] `make verify` passes (lint, format, typecheck, 771 tests, 84% coverage)
- [x] No new `PLR0915` or `C901` violations with the suppression removed

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)