### PR TITLE
refactor: return 'anonymous' user_id when auth is disabled

### DIFF
--- a/src/wikimind/api/deps.py
+++ b/src/wikimind/api/deps.py
@@ -1,23 +1,28 @@
 """Shared FastAPI dependencies for route handlers.
 
 Provides user identity extraction for multi-user data isolation.
-When auth is disabled (single-user mode), user_id is None and all
-queries return unfiltered data.
+When auth is disabled (single-user mode), user_id defaults to
+``ANONYMOUS_USER_ID`` so every record has a non-null owner.
 """
 
 from fastapi import Depends, HTTPException, Request
 
 from wikimind.config import get_settings
 
-
-async def get_current_user_id(request: Request) -> str | None:
-    """Extract current user ID from request state. Returns None in single-user mode."""
-    return getattr(request.state, "user_id", None)
+ANONYMOUS_USER_ID = "anonymous"
 
 
-async def require_user_id(user_id: str | None = Depends(get_current_user_id)) -> str:
-    """Require authentication. Raises 401 if auth is enabled but no user."""
+async def get_current_user_id(request: Request) -> str:
+    """Extract current user ID from request state.
+
+    Returns ``ANONYMOUS_USER_ID`` when auth is disabled (single-user mode).
+    """
+    return getattr(request.state, "user_id", None) or ANONYMOUS_USER_ID
+
+
+async def require_user_id(user_id: str = Depends(get_current_user_id)) -> str:
+    """Require authentication. Raises 401 if auth is enabled but no user is set."""
     settings = get_settings()
-    if settings.auth.enabled and user_id is None:
+    if settings.auth.enabled and user_id == ANONYMOUS_USER_ID:
         raise HTTPException(status_code=401, detail="Authentication required")
-    return user_id or ""
+    return user_id

--- a/src/wikimind/api/routes/admin.py
+++ b/src/wikimind/api/routes/admin.py
@@ -20,7 +20,7 @@ router = APIRouter()
 async def get_stats(
     session: AsyncSession = Depends(get_session),
     service: AdminService = Depends(get_admin_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Aggregate system statistics."""
     return await service.get_stats(session, user_id=user_id)
@@ -30,7 +30,7 @@ async def get_stats(
 async def get_orphans(
     session: AsyncSession = Depends(get_session),
     service: AdminService = Depends(get_admin_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Articles with missing wiki files."""
     return await service.get_orphan_articles(session, user_id=user_id)
@@ -40,7 +40,7 @@ async def get_orphans(
 async def get_eligible_concepts(
     session: AsyncSession = Depends(get_session),
     service: AdminService = Depends(get_admin_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Concepts eligible for page generation."""
     return await service.get_eligible_concepts(session, user_id=user_id)
@@ -49,7 +49,7 @@ async def get_eligible_concepts(
 @router.post("/sweep")
 async def trigger_sweep(
     service: AdminService = Depends(get_admin_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Trigger wikilink sweep manually."""
     return await service.trigger_sweep(user_id=user_id)

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.config import Settings, get_settings
 from wikimind.database import get_session
 from wikimind.models import User
@@ -273,7 +274,7 @@ async def me(request: Request, session: AsyncSession = Depends(get_session)) -> 
         if not settings.auth.enabled:
             # Auth disabled — return a stub user so the frontend knows
             # it can skip the login flow.
-            return {"id": "anonymous", "email": "", "name": "Anonymous", "avatar_url": None}
+            return {"id": ANONYMOUS_USER_ID, "email": "", "name": "Anonymous", "avatar_url": None}
         raise HTTPException(status_code=401)
     user = await session.get(User, request.state.user_id)
     if not user:

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -20,7 +20,7 @@ async def ingest_url(
     request: IngestURLRequest,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Ingest a web URL or YouTube video."""
     return await service.ingest_url(request.url, session, auto_compile=request.auto_compile, user_id=user_id)
@@ -32,7 +32,7 @@ async def ingest_pdf(
     auto_compile: bool = True,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Upload and ingest a PDF.
 
@@ -50,7 +50,7 @@ async def ingest_text(
     request: IngestTextRequest,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Ingest raw text or a note."""
     return await service.ingest_text(
@@ -69,7 +69,7 @@ async def list_sources(
     offset: int = 0,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """List all ingested sources."""
     return await service.list_sources(session, status=status, limit=limit, offset=offset, user_id=user_id)

--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -24,7 +24,7 @@ async def list_jobs(
     limit: int = 20,
     session: AsyncSession = Depends(get_session),
     service: CompilerService = Depends(get_compiler_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """List jobs with optional status filter."""
     return await service.list_jobs(session, status=status, limit=limit, user_id=user_id)

--- a/src/wikimind/api/routes/lint.py
+++ b/src/wikimind/api/routes/lint.py
@@ -26,7 +26,7 @@ router = APIRouter()
 @router.post("/run", response_model=LintRunResponse)
 async def run_lint(
     service: LinterService = Depends(get_linter_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Trigger a new lint run. Returns immediately with status."""
     return await service.trigger_run(user_id=user_id)
@@ -37,7 +37,7 @@ async def list_reports(
     limit: int = Query(default=20, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
     service: LinterService = Depends(get_linter_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """List lint reports ordered by most recent first."""
     return await service.list_reports(session, limit=limit, user_id=user_id)
@@ -47,7 +47,7 @@ async def list_reports(
 async def get_latest_report(
     session: AsyncSession = Depends(get_session),
     service: LinterService = Depends(get_linter_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Get the most recent lint report with all non-dismissed findings."""
     return await service.get_latest(session, user_id=user_id)

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -31,7 +31,7 @@ async def ask(
     request: QueryRequest,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Ask a question against the wiki and receive an answer with citations.
 
@@ -46,7 +46,7 @@ async def ask(
 async def ask_stream(
     request: QueryRequest,
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ) -> StreamingResponse:
     """Stream an answer token-by-token via Server-Sent Events.
 
@@ -84,7 +84,7 @@ async def query_history(
     limit: int = 50,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """List past queries (legacy endpoint — UI uses /conversations instead)."""
     return await service.query_history(session, limit=limit, user_id=user_id)
@@ -95,7 +95,7 @@ async def list_conversations(
     limit: int = 50,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """List conversations ordered by most recently updated first."""
     return await service.list_conversations(session, limit=limit, user_id=user_id)
@@ -106,7 +106,7 @@ async def get_conversation(
     conversation_id: str,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Return a single conversation with all its turns."""
     return await service.get_conversation(conversation_id, session, user_id=user_id)
@@ -131,7 +131,7 @@ async def file_back_selection(
     request: FileBackSelectionRequest,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """File selected turns from one or more conversations back to the wiki as a single article."""
     return await service.file_back_selection(request, session, user_id=user_id)
@@ -142,7 +142,7 @@ async def file_back_conversation(
     conversation_id: str,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """File the entire conversation back to the wiki as a single article."""
     return await service.file_back_conversation(conversation_id, session, user_id=user_id)
@@ -154,7 +154,7 @@ async def fork_conversation(
     fork_request: ForkRequest,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Fork a conversation at a specific turn with a new question.
 

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -310,7 +310,7 @@ async def test_llm_connection(provider: str):
     response_model=CostBreakdownResponse,
 )
 async def get_llm_cost_breakdown(
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Cost breakdown by provider and task type for current month."""
     start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)
@@ -382,7 +382,7 @@ async def get_llm_cost_breakdown(
 
 @router.get("/llm/cost", response_model=CostSummaryResponse)
 async def get_llm_cost(
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Cost summary for current month."""
     start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -60,7 +60,7 @@ async def list_articles(
     offset: int = 0,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """List wiki articles with optional filtering and source provenance."""
     return await service.list_articles(
@@ -83,7 +83,7 @@ async def get_article(
     id_or_slug: str,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Get full article by ID or slug, with content, backlinks, and source provenance."""
     return await service.get_article(id_or_slug, session, user_id=user_id)
@@ -93,7 +93,7 @@ async def get_article(
 async def get_graph(
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Full knowledge graph -- nodes and edges."""
     return await service.get_graph(session, user_id=user_id)
@@ -105,7 +105,7 @@ async def search(
     limit: int = 20,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Full-text search across wiki articles with source provenance."""
     return await service.search(q, session, limit=limit, user_id=user_id)
@@ -116,7 +116,7 @@ async def get_concepts(
     include_empty: bool = True,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Concept taxonomy tree."""
     return await service.get_concepts(session, include_empty=include_empty, user_id=user_id)
@@ -139,7 +139,7 @@ async def get_concept(
     name: str,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Concept detail with linked articles."""
     return await service.get_concept(name, session, user_id=user_id)
@@ -152,7 +152,7 @@ async def get_concept_articles(
     offset: int = 0,
     session: AsyncSession = Depends(get_session),
     service: WikiService = Depends(get_wiki_service),
-    user_id: str | None = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Articles tagged with this concept."""
     return await service.get_concept_articles(name, session, limit=limit, offset=offset, user_id=user_id)

--- a/src/wikimind/middleware/auth.py
+++ b/src/wikimind/middleware/auth.py
@@ -1,8 +1,8 @@
 """JWT authentication middleware for OAuth2-protected endpoints.
 
 When ``settings.auth.enabled`` is False (default), the middleware is a
-pass-through — every request proceeds with ``request.state.user_id = None``,
-preserving backward-compatible single-user mode.
+pass-through — every request proceeds with ``request.state.user_id = None``.
+The ``get_current_user_id`` dependency coalesces this to ``"anonymous"``.
 
 When enabled, the middleware extracts a JWT from the ``wikimind_session``
 HttpOnly cookie (set during the OAuth callback). If no cookie is present,

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -20,6 +20,7 @@ import pytest
 from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
+from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.engine.compiler import Compiler
 from wikimind.models import (
     Article,
@@ -53,6 +54,7 @@ async def test_wikilink_resolution_end_to_end(
         title="Existing Target",
         file_path=str(tmp_path / "existing-target.md"),
         confidence=ConfidenceLevel.SOURCED,
+        user_id=ANONYMOUS_USER_ID,
     )
     db_session.add(target)
 
@@ -63,6 +65,7 @@ async def test_wikilink_resolution_end_to_end(
         title="Test Source",
         status=IngestStatus.PROCESSING,
         ingested_at=utcnow_naive(),
+        user_id=ANONYMOUS_USER_ID,
     )
     db_session.add(source)
     await db_session.commit()
@@ -89,7 +92,7 @@ async def test_wikilink_resolution_end_to_end(
     assert backlinks[0].target_article_id == target.id
 
     # 4. Markdown has the resolved link by ID and the unresolved bracket
-    content = resolve_wiki_path(article.file_path).read_text()
+    content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text()
     assert f"[Existing Target](/wiki/{target.id})" in content
     assert "[[Nonexistent Topic]]" in content
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -74,8 +74,8 @@ async def test_middleware_passthrough_when_disabled(client):
 
 
 @pytest.mark.asyncio
-async def test_middleware_sets_user_id_none_when_disabled(client):
-    """When auth.enabled=False, request.state.user_id should be None."""
+async def test_middleware_sets_anonymous_user_id_when_disabled(client):
+    """When auth.enabled=False, get_current_user_id returns 'anonymous'."""
     # The /health endpoint succeeds without auth — that proves the middleware passed through
     response = await client.get("/health")
     assert response.status_code == 200

--- a/tests/unit/test_backlink_enforcer.py
+++ b/tests/unit/test_backlink_enforcer.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
+from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.config import get_settings
 from wikimind.engine.backlink_enforcer import enforce_backlinks, ensure_bidirectional
 from wikimind.engine.linter.contradictions import detect_contradictions
@@ -280,8 +281,8 @@ async def test_resolve_contradiction_422_invalid(client, async_engine):
 async def test_graph_api_includes_relation_type(client, async_engine):
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     async with factory() as session:
-        session.add(Article(id="a1", slug="art-a", title="Art A", file_path="/tmp/a.md"))
-        session.add(Article(id="a2", slug="art-b", title="Art B", file_path="/tmp/b.md"))
+        session.add(Article(id="a1", slug="art-a", title="Art A", file_path="/tmp/a.md", user_id=ANONYMOUS_USER_ID))
+        session.add(Article(id="a2", slug="art-b", title="Art B", file_path="/tmp/b.md", user_id=ANONYMOUS_USER_ID))
         session.add(
             Backlink(
                 source_article_id="a1",


### PR DESCRIPTION
## Summary

When auth is disabled, `get_current_user_id()` returned `None`, causing every record to have `user_id=NULL`. This made `WHERE user_id == None` queries fragile and would make future migration to auth painful.

- Add `ANONYMOUS_USER_ID = "anonymous"` constant in `deps.py` and return it from `get_current_user_id()` when auth is disabled (instead of `None`)
- Update route handler `user_id` parameter type annotations from `str | None` to `str` across all route files
- Update `require_user_id` to check against the constant instead of `None`
- Use the constant in `/auth/me` endpoint for consistency
- Fix tests that created DB records without `user_id` and expected API queries to match

Closes #262

## Test plan

- [x] `make verify` passes (lint, format, typecheck, 771 tests, 84% coverage)
- [x] Previously-failing integration tests fixed by setting `user_id=ANONYMOUS_USER_ID` on test data
- [x] No service/engine layer signatures changed -- only the auth dependency return value and immediate route handler annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)