### PR TITLE
chore: adopt stricter ruff rules for code quality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,12 @@ select = [
     "ARG",    # flake8-unused-arguments
     "C90",    # mccabe — cyclomatic complexity
     "TCH",    # flake8-type-checking
+    "EM",     # flake8-errmsg — no string literals in exceptions
+    "FURB",   # refurb — modern Python idioms
+    "G",      # flake8-logging-format — logging best practices
+    "FA",     # flake8-future-annotations — from __future__ import annotations
+    "PGH",    # pygrep-hooks — misc. code quality (blanket noqa, etc.)
+    "FLY",    # flynt — prefer f-strings over .format()
 ]
 ignore = [
     "E501",   # line too long — handled by formatter
@@ -163,9 +169,10 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "T20", "PERF", "S", "N", "DTZ", "ARG"]
-"scripts/**/*.py" = ["T20", "S"]
+"tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "T20", "PERF", "S", "N", "DTZ", "ARG", "EM"]
+"scripts/**/*.py" = ["T20", "S", "EM"]
 "alembic/**/*.py" = ["N"]
+"vulture_whitelist.py" = ["B018", "F405", "PGH004"]  # Intentional dead-code references for vulture
 
 [tool.ruff.lint.isort]
 known-first-party = ["wikimind"]

--- a/scripts/backfill_images.py
+++ b/scripts/backfill_images.py
@@ -132,7 +132,7 @@ async def backfill(dry_run: bool = False) -> int:
                 log.info("Backfilled images", source_id=source.id, title=source.title, image_count=count)
                 processed += 1
             except Exception:
-                log.error("Failed to process", source_id=source.id, title=source.title, exc_info=True)
+                log.exception("Failed to process", source_id=source.id, title=source.title)
                 errors += 1
 
     log.info("Backfill complete", processed=processed, skipped=skipped, errors=errors)

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -68,7 +68,8 @@ def _create_engine_from_url(url: str):
             connect_args=connect_args,
         )
     dialect = url.split("://", maxsplit=1)[0]
-    raise ValueError(f"Unsupported dialect: {dialect}. Use sqlite+aiosqlite or postgresql+asyncpg.")
+    msg = f"Unsupported dialect: {dialect}. Use sqlite+aiosqlite or postgresql+asyncpg."
+    raise ValueError(msg)
 
 
 def get_db_path() -> Path:
@@ -405,10 +406,8 @@ def _repair_json_array(raw: str) -> str | None:
         pass
 
     inner = raw.strip()
-    if inner.startswith("["):
-        inner = inner[1:]
-    if inner.endswith("]"):
-        inner = inner[:-1]
+    inner = inner.removeprefix("[")
+    inner = inner.removesuffix("]")
 
     items = [part for part in inner.split('"') if part.strip()]
     return json.dumps(items)

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -184,7 +184,7 @@ class ConceptCompiler:
         source_material = _build_source_material(source_articles, user_id=concept.user_id)
         source_ids = [a.id for a in source_articles]
         ct = await _collect_contradictions(source_ids, session)
-        contradiction_section = ct if ct else "No known contradictions."
+        contradiction_section = ct or "No known contradictions."
         prompt = template.format(
             concept_name=concept.description or concept.name,
             concept_description=concept.description or concept.name,

--- a/src/wikimind/engine/concept_kind_registry.py
+++ b/src/wikimind/engine/concept_kind_registry.py
@@ -82,6 +82,5 @@ async def validate_registry_against_prompts(session: AsyncSession) -> None:
         if kind.prompt_template_key not in PROMPT_TEMPLATES
     ]
     if missing:
-        raise RegistryTemplateMismatchError(
-            f"ConceptKindDef rows reference missing prompt templates: {', '.join(missing)}"
-        )
+        msg = f"ConceptKindDef rows reference missing prompt templates: {', '.join(missing)}"
+        raise RegistryTemplateMismatchError(msg)

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -261,7 +261,8 @@ async def _run_batch(
             elif isinstance(data, dict) and "results" in data:
                 batch_results = data["results"]
             else:
-                raise ValueError(f"Unexpected batch response shape: {type(data)}")
+                msg = f"Unexpected batch response shape: {type(data)}"
+                raise ValueError(msg)
 
             parsed = _parse_batch_response(batch_results, len(pairs_with_claims))
 

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -206,7 +206,7 @@ async def run_lint(
                 await emit_linter_alert("contradiction", article_titles, user_id=user_id)
 
     except Exception as e:  # Intentional broad catch — job runner must not crash
-        log.error("Lint run failed", error=str(e), exc_info=True)
+        log.exception("Lint run failed", error=str(e))
         report.status = LintReportStatus.FAILED
         report.error_message = str(e)
         report.completed_at = utcnow_naive()

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -161,7 +161,8 @@ class LLMRouter:
         elif provider == Provider.MOCK:
             instance = MockProvider()
         else:
-            raise ValueError(f"Provider {provider} not implemented yet")
+            msg = f"Provider {provider} not implemented yet"
+            raise ValueError(msg)
 
         self._provider_cache[provider] = instance
         return instance
@@ -287,7 +288,8 @@ class LLMRouter:
                 if not self.settings.llm.fallback_enabled:
                     raise
 
-        raise RuntimeError(f"All LLM providers failed. Last error: {last_error}")
+        msg = f"All LLM providers failed. Last error: {last_error}"
+        raise RuntimeError(msg)
 
     async def complete_multimodal(
         self,
@@ -361,7 +363,8 @@ class LLMRouter:
                 if not self.settings.llm.fallback_enabled:
                     raise
 
-        raise RuntimeError(f"All LLM providers failed. Last error: {last_error}")
+        msg = f"All LLM providers failed. Last error: {last_error}"
+        raise RuntimeError(msg)
 
     async def stream_complete(
         self,
@@ -409,7 +412,8 @@ class LLMRouter:
                 if not self.settings.llm.fallback_enabled:
                     raise
 
-        raise RuntimeError(f"All LLM providers failed. Last error: {last_error}")
+        msg = f"All LLM providers failed. Last error: {last_error}"
+        raise RuntimeError(msg)
 
     def parse_json_response(self, response: CompletionResponse) -> dict:
         """Parse JSON from LLM response, stripping markdown fences if present."""

--- a/src/wikimind/engine/providers/anthropic.py
+++ b/src/wikimind/engine/providers/anthropic.py
@@ -21,7 +21,8 @@ class AnthropicProvider:
     def __init__(self):
         api_key = get_api_key("anthropic")
         if not api_key:
-            raise ValueError("Anthropic API key not configured")
+            msg = "Anthropic API key not configured"
+            raise ValueError(msg)
         self.client = anthropic.AsyncAnthropic(api_key=api_key)
 
     async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:

--- a/src/wikimind/engine/providers/google.py
+++ b/src/wikimind/engine/providers/google.py
@@ -23,7 +23,8 @@ class GoogleProvider:
     def __init__(self) -> None:
         api_key = get_api_key("google")
         if not api_key:
-            raise ValueError("Google API key not configured")
+            msg = "Google API key not configured"
+            raise ValueError(msg)
         self.client = genai.Client(api_key=api_key)
 
     async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:

--- a/src/wikimind/engine/providers/openai.py
+++ b/src/wikimind/engine/providers/openai.py
@@ -21,7 +21,8 @@ class OpenAIProvider:
     def __init__(self):
         api_key = get_api_key("openai")
         if not api_key:
-            raise ValueError("OpenAI API key not configured")
+            msg = "OpenAI API key not configured"
+            raise ValueError(msg)
         self.client = openai.AsyncOpenAI(api_key=api_key)
 
     async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -103,8 +103,7 @@ def _parse_pdf_date(raw: str | None) -> date | None:
         return None
     # Strip the ``D:`` prefix that PDF date strings use.
     cleaned = raw.strip()
-    if cleaned.startswith("D:"):
-        cleaned = cleaned[2:]
+    cleaned = cleaned.removeprefix("D:")
     # We only need YYYYMMDD — ignore time/timezone suffixes.
     if len(cleaned) < 8:
         return None

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -67,7 +67,8 @@ class URLAdapter:
         )
 
         if not downloaded:
-            raise ValueError(f"Could not extract content from {url}")
+            msg = f"Could not extract content from {url}"
+            raise ValueError(msg)
 
         # Parse metadata
         meta = trafilatura.extract_metadata(html)

--- a/src/wikimind/ingest/adapters/youtube.py
+++ b/src/wikimind/ingest/adapters/youtube.py
@@ -43,7 +43,8 @@ class YouTubeAdapter:
         # Extract video ID
         video_id = self._extract_video_id(url)
         if not video_id:
-            raise ValueError(f"Could not extract YouTube video ID from {url}")
+            msg = f"Could not extract YouTube video ID from {url}"
+            raise ValueError(msg)
 
         # Fetch transcript — offload the synchronous HTTP call to a thread
         # so it doesn't block the uvicorn event loop (issue #181).

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -330,7 +330,8 @@ def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
         ValueError: If the source has no `file_path` set.
     """
     if not source.file_path:
-        raise ValueError(f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument")
+        msg = f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument"
+        raise ValueError(msg)
     clean_text = resolve_raw_path(source.file_path, user_id=source.user_id).read_text(encoding="utf-8")
     return NormalizedDocument(
         raw_source_id=source.id,

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -78,7 +78,8 @@ def _build_normalized_doc(source: Source) -> NormalizedDocument:
         ValueError: If the source has no ``file_path``.
     """
     if not source.file_path:
-        raise ValueError("No cleaned text file path for source")
+        msg = "No cleaned text file path for source"
+        raise ValueError(msg)
 
     text_path = resolve_raw_path(source.file_path, user_id=source.user_id)
     content = text_path.read_text(encoding="utf-8")
@@ -181,7 +182,8 @@ async def compile_source(
             result = await compiler.compile(doc, session, progress_callback=_on_chunk_progress)
 
             if not result:
-                raise ValueError("Compiler returned no result")
+                msg = "Compiler returned no result"
+                raise ValueError(msg)
 
             await emit_source_progress(source_id, "Saving article...", user_id=user_id)
 
@@ -293,18 +295,21 @@ async def _recompile_from_source(article: Article, session) -> None:
     """
     source_ids = await _get_article_source_ids(article, session)
     if not source_ids:
-        raise ValueError("Article has no linked sources")
+        msg = "Article has no linked sources"
+        raise ValueError(msg)
 
     source = await session.get(Source, source_ids[0])
     if not source or not source.file_path:
-        raise ValueError("Source or source file_path not found")
+        msg = "Source or source file_path not found"
+        raise ValueError(msg)
 
     doc = _build_normalized_doc(source)
 
     compiler = Compiler()
     result = await compiler.compile(doc, session)
     if not result:
-        raise ValueError("Compiler returned no result")
+        msg = "Compiler returned no result"
+        raise ValueError(msg)
 
     await compiler.save_article(result, source, session)
 
@@ -322,18 +327,21 @@ async def _recompile_from_concept(article: Article, session) -> None:
     """
     concept_names = await _get_article_concept_names(article, session)
     if not concept_names:
-        raise ValueError("Article has no linked concepts")
+        msg = "Article has no linked concepts"
+        raise ValueError(msg)
 
     concept_name = concept_names[0]
     result = await session.execute(select(Concept).where(Concept.name == concept_name))
     concept = result.scalars().first()
     if not concept:
-        raise ValueError("Concept not found")
+        msg = "Concept not found"
+        raise ValueError(msg)
 
     concept_compiler = ConceptCompiler()
     result_article = await concept_compiler.compile_concept_page(concept, session)
     if not result_article:
-        raise ValueError("ConceptCompiler returned no result")
+        msg = "ConceptCompiler returned no result"
+        raise ValueError(msg)
 
 
 async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user_id: str | None = None):

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -125,7 +125,8 @@ class EmbeddingService:
 
     def __init__(self) -> None:
         if not _SEARCH_AVAILABLE:
-            raise RuntimeError("Search extras not installed. Install with: pip install 'wikimind[search]'")
+            msg = "Search extras not installed. Install with: pip install 'wikimind[search]'"
+            raise RuntimeError(msg)
 
         import chromadb  # noqa: PLC0415
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -11,10 +11,10 @@ from wikimind.api.routes import ingest, jobs, query, settings, wiki, ws  # noqa:
 from wikimind.models import *  # noqa: F403
 
 # Pydantic model_config
-_.model_config  # noqa
+_.model_config
 
 # ARQ worker settings
-_.cron_jobs  # noqa
-_.functions  # noqa
-_.on_startup  # noqa
-_.redis_settings  # noqa
+_.cron_jobs
+_.functions
+_.on_startup
+_.redis_settings


### PR DESCRIPTION
## Summary

WikiMind's ruff config was missing several useful rule sets commonly enabled in best-practice Python projects (Pydantic, Polars, FastAPI). This PR adds six new rule sets and fixes all resulting violations, improving code quality without changing behavior.

## Problem

Issue #217 identified that the ruff config didn't enable many valuable sub-rules. String literals in exceptions obscure tracebacks, older Python idioms (conditional slice vs `removeprefix`) reduce readability, and blanket `# noqa` comments hide the reason for suppression.

## Changes

**New rule sets enabled in `pyproject.toml`:**
- `EM` (flake8-errmsg) -- no string/f-string literals directly in exception constructors
- `FURB` (refurb) -- modern Python idioms (`removeprefix`/`removesuffix`, `or` vs ternary)
- `G` (flake8-logging-format) -- use `log.exception()` instead of `log.error(..., exc_info=True)`
- `FA` (flake8-future-annotations) -- future annotations best practices
- `PGH` (pygrep-hooks) -- blanket `# noqa` detection and misc. code quality
- `FLY` (flynt) -- prefer f-strings over `.format()`

**Code fixes across 17 files:**
- Extracted 22 exception message strings into `msg` variables (EM101/EM102)
- Replaced `str.startswith()` + slice with `str.removeprefix()`/`str.removesuffix()` (FURB188)
- Replaced `x if x else default` with `x or default` (FURB110)
- Replaced `log.error(..., exc_info=True)` with `log.exception(...)` (G201)
- Cleaned up `vulture_whitelist.py` noqa comments and added per-file-ignores

**Per-file-ignores added:**
- `tests/**` and `scripts/**` exempt from EM (exception message style less important in test/script code)
- `vulture_whitelist.py` exempt from B018/F405/PGH004 (intentional dead-code references)

## Test plan

- [x] `ruff check` passes with zero violations
- [x] `ruff format --check` passes
- [x] `mypy` passes (same 4 pre-existing errors, unrelated)
- [x] All 789 unit tests pass

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)