### PR TITLE
feat: BYOK — user-configurable LLM API keys with encryption

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_Uo61Wu"
+      "filename": ".merge_file_0glkQo"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -131,254 +131,380 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 134
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 162
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 162
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 176
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 176
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 190
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 190
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 204
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 204
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 218
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 218
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 232
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 232
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 246
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 246
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "is_verified": false,
+        "line_number": 260
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "is_verified": false,
+        "line_number": 260
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "is_verified": false,
+        "line_number": 274
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "is_verified": false,
+        "line_number": 274
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "is_verified": false,
+        "line_number": 288
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "is_verified": false,
+        "line_number": 288
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "is_verified": false,
+        "line_number": 302
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "is_verified": false,
+        "line_number": 302
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 330
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 330
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 344
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 344
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 372
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 372
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
         "is_verified": false,
-        "line_number": 262
+        "line_number": 388
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
         "is_verified": false,
-        "line_number": 262
+        "line_number": 388
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
         "is_verified": false,
-        "line_number": 269
+        "line_number": 395
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
         "is_verified": false,
-        "line_number": 269
+        "line_number": 395
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 402
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 402
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 418
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 418
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
         "is_verified": false,
-        "line_number": 299
+        "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
         "is_verified": false,
-        "line_number": 299
+        "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
         "is_verified": false,
-        "line_number": 308
+        "line_number": 434
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
         "is_verified": false,
-        "line_number": 308
+        "line_number": 434
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 441
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 441
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
         "is_verified": false,
-        "line_number": 333
+        "line_number": 459
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
         "is_verified": false,
-        "line_number": 333
+        "line_number": 459
       }
     ],
     "design-system/ui_kits/app/index.html": [
@@ -461,6 +587,22 @@
         "line_number": 349
       }
     ],
+    "tests/unit/test_api_keys.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_api_keys.py",
+        "hashed_secret": "1b657ee651b175468427832bfe2286843484e2ce",
+        "is_verified": false,
+        "line_number": 176
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_api_keys.py",
+        "hashed_secret": "9cea46b39bd44a1ef9f3e71bfe9e45c24d3300f6",
+        "is_verified": false,
+        "line_number": 201
+      }
+    ],
     "tests/unit/test_db_compat.py": [
       {
         "type": "Basic Auth Credentials",
@@ -480,5 +622,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T20:42:40Z"
+  "generated_at": "2026-04-23T20:44:00Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_0glkQo"
+      "filename": ".merge_file_DKROMv"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -131,380 +131,534 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 134
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 162
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 162
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 176
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 176
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 190
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 190
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 204
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 204
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 218
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 218
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 232
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 232
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 246
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 246
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 260
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 260
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 274
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 274
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 288
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 288
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 302
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 302
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 316
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 316
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 330
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 330
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 344
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 344
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 358
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 358
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 372
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 372
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "is_verified": false,
+        "line_number": 386
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "is_verified": false,
+        "line_number": 386
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "is_verified": false,
+        "line_number": 400
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "is_verified": false,
+        "line_number": 400
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "is_verified": false,
+        "line_number": 414
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "is_verified": false,
+        "line_number": 414
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "is_verified": false,
+        "line_number": 428
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "is_verified": false,
+        "line_number": 428
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "is_verified": false,
+        "line_number": 442
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "is_verified": false,
+        "line_number": 442
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 456
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 456
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 470
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 470
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 484
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 484
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 498
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 498
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 514
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 514
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 521
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 521
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
         "is_verified": false,
-        "line_number": 402
+        "line_number": 528
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
         "is_verified": false,
-        "line_number": 402
+        "line_number": 528
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
         "is_verified": false,
-        "line_number": 411
+        "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
         "is_verified": false,
-        "line_number": 411
+        "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
         "is_verified": false,
-        "line_number": 418
+        "line_number": 544
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
         "is_verified": false,
-        "line_number": 418
+        "line_number": 544
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
         "is_verified": false,
-        "line_number": 425
+        "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
         "is_verified": false,
-        "line_number": 425
+        "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
         "is_verified": false,
-        "line_number": 434
+        "line_number": 560
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
         "is_verified": false,
-        "line_number": 434
+        "line_number": 560
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
         "is_verified": false,
-        "line_number": 441
+        "line_number": 567
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
         "is_verified": false,
-        "line_number": 441
+        "line_number": 567
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
         "is_verified": false,
-        "line_number": 459
+        "line_number": 585
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
         "is_verified": false,
-        "line_number": 459
+        "line_number": 585
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 594
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 594
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 601
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 601
       }
     ],
     "design-system/ui_kits/app/index.html": [
@@ -622,5 +776,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T20:44:00Z"
+  "generated_at": "2026-04-23T20:44:06Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_DKROMv"
+      "filename": ".merge_file_0Gl41p"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -131,534 +131,688 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 134
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 162
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 162
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
+        "hashed_secret": "7c40b15babc4ed6d48bb4cfd907cd1a3e83e6961",
         "is_verified": false,
         "line_number": 176
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
+        "hashed_secret": "7c40b15babc4ed6d48bb4cfd907cd1a3e83e6961",
         "is_verified": false,
         "line_number": 176
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 190
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 190
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 204
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 204
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 218
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 218
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 232
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 232
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 246
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 246
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 260
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 260
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 274
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 274
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 288
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 288
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 302
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 302
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 316
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 316
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 330
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 330
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 344
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 344
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 358
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 358
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 372
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 372
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 386
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 386
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 400
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 400
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 414
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 414
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 428
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 428
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 442
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 442
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 456
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 456
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 470
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 470
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 484
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 484
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 498
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 498
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "is_verified": false,
+        "line_number": 512
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "is_verified": false,
+        "line_number": 512
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "is_verified": false,
+        "line_number": 526
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "is_verified": false,
+        "line_number": 526
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "is_verified": false,
+        "line_number": 540
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "is_verified": false,
+        "line_number": 540
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "is_verified": false,
+        "line_number": 554
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
+        "is_verified": false,
+        "line_number": 554
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "is_verified": false,
+        "line_number": 568
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "is_verified": false,
+        "line_number": 568
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 582
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 582
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 596
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 596
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 610
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 610
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 624
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 624
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 638
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 638
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 652
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 652
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
         "is_verified": false,
-        "line_number": 514
+        "line_number": 668
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
         "is_verified": false,
-        "line_number": 514
+        "line_number": 668
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
         "is_verified": false,
-        "line_number": 521
+        "line_number": 675
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
         "is_verified": false,
-        "line_number": 521
+        "line_number": 675
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 682
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 682
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
         "is_verified": false,
-        "line_number": 537
+        "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
         "is_verified": false,
-        "line_number": 537
+        "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
         "is_verified": false,
-        "line_number": 544
+        "line_number": 698
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
         "is_verified": false,
-        "line_number": 544
+        "line_number": 698
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
         "is_verified": false,
-        "line_number": 551
+        "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
         "is_verified": false,
-        "line_number": 551
+        "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
         "is_verified": false,
-        "line_number": 560
+        "line_number": 714
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
         "is_verified": false,
-        "line_number": 560
+        "line_number": 714
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
         "is_verified": false,
-        "line_number": 567
+        "line_number": 721
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
         "is_verified": false,
-        "line_number": 567
+        "line_number": 721
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
         "is_verified": false,
-        "line_number": 585
+        "line_number": 739
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
         "is_verified": false,
-        "line_number": 585
+        "line_number": 739
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
         "is_verified": false,
-        "line_number": 594
+        "line_number": 748
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
         "is_verified": false,
-        "line_number": 594
+        "line_number": 748
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
         "is_verified": false,
-        "line_number": 601
+        "line_number": 755
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
         "is_verified": false,
-        "line_number": 601
+        "line_number": 755
       }
     ],
     "design-system/ui_kits/app/index.html": [
@@ -776,5 +930,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T20:44:06Z"
+  "generated_at": "2026-04-23T20:44:13Z"
 }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ considered, and the consequences.
 | [024](adr-024-gunicorn-autoscaling-horizontal-readiness.md) | Gunicorn Auto-Scaling and Horizontal Scaling Readiness | Unknown |
 | [025](adr-025-docling-serve-sidecar.md) | Docling-Serve Sidecar for PDF Extraction | Unknown |
 | [026](adr-026-article-export-layer.md) | Article Export Layer (PDF, LinkedIn, Slides) | Unknown |
+| [026](adr-026-byok-api-key-encryption.md) | BYOK API Key Encryption at Rest | Accepted |
 | [026](adr-026-multi-replica-gateway.md) | Multi-Replica Gateway — Horizontal Scaling | Unknown |
 | [026](adr-026-onboarding-wizard.md) | First-Run Onboarding Wizard | Accepted |
 

--- a/docs/adr/adr-026-byok-api-key-encryption.md
+++ b/docs/adr/adr-026-byok-api-key-encryption.md
@@ -1,0 +1,82 @@
+# ADR-026: BYOK API Key Encryption at Rest
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind uses system-wide API keys (from environment variables or OS keychain)
+to access LLM providers.  In a multi-user deployment, users should be able to
+supply their own API keys so they can use their own accounts and billing.
+User-supplied keys must be stored securely at rest in the database.
+
+Requirements:
+- Encrypt user API keys before storing in the database
+- Use a unique encryption key per row to limit blast radius of any single key leak
+- Derive encryption keys from an existing secret (JWT_SECRET_KEY) to avoid
+  requiring operators to manage yet another secret
+- When a user has their own key for a provider, use it instead of the system key
+
+## Decision
+
+### Encryption scheme
+
+- **Algorithm**: Fernet symmetric encryption (AES-128-CBC + HMAC-SHA256 via
+  the `cryptography` library)
+- **Key derivation**: PBKDF2-HMAC-SHA256 with 100,000 iterations (OWASP 2023
+  minimum for SHA-256)
+- **Key material**: `JWT_SECRET_KEY` (already required for authentication) +
+  a 16-byte random per-row salt
+- **Storage**: `UserApiKey` table with `encrypted_key` (Fernet ciphertext,
+  base64) and `salt` (hex-encoded)
+
+### Data model
+
+```
+UserApiKey(table=True)
+  id:            UUID primary key
+  user_id:       FK -> user.id (indexed)
+  provider:      Provider enum (anthropic | openai | google)
+  encrypted_key: str  -- Fernet ciphertext
+  salt:          str  -- hex-encoded 16-byte random salt
+  created_at:    datetime
+  updated_at:    datetime
+  UNIQUE(user_id, provider)
+```
+
+### API endpoints
+
+- `PUT  /api/settings/api-keys/{provider}` -- set/update a key
+- `GET  /api/settings/api-keys`            -- list providers (masked hints only)
+- `DELETE /api/settings/api-keys/{provider}` -- remove a key
+
+API responses never return raw keys -- only masked hints (first 4 + last 4
+characters).
+
+### LLM router integration
+
+When making LLM calls, the router checks for a user-specific BYOK key:
+1. Look up `UserApiKey` for `(user_id, provider)` in the database
+2. If found, decrypt and create a temporary (non-cached) provider instance
+3. If not found, fall back to the system-wide key
+
+BYOK provider instances are intentionally NOT cached in the router's
+`_provider_cache` to prevent one user's key from leaking to another.
+
+## Consequences
+
+### Positive
+- Users can use their own billing accounts without exposing keys to the operator
+- Per-row salt means compromising one ciphertext does not help decrypt others
+- No new secret to manage -- reuses existing JWT_SECRET_KEY
+- Backward compatible -- system keys continue to work as before
+
+### Negative
+- Rotating JWT_SECRET_KEY invalidates all stored user keys (they become
+  undecryptable).  Operators must warn users to re-enter keys after rotation.
+- PBKDF2 key derivation adds ~50ms per LLM call when a user key is used
+  (negligible vs. LLM latency).  Could be optimized with an in-memory TTL
+  cache per user/provider if needed.
+- BYOK provider instances are created fresh per-call, adding minor overhead
+  (SDK client initialization) compared to the cached system-key path.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1287,6 +1287,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingStatusResponse'
+  /api/settings/api-keys/{provider}:
+    put:
+      tags:
+      - Settings
+      summary: Set Api Key
+      description: Store or update an API key for a provider.
+      operationId: set_api_key_api_settings_api_keys__provider__put
+      parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Provider
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetApiKeyRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeySetResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Settings
+      summary: Delete Api Key
+      description: Delete a stored API key for a provider.
+      operationId: delete_api_key_api_settings_api_keys__provider__delete
+      parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Provider
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyDeleteResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/settings/api-keys:
+    get:
+      tags:
+      - Settings
+      summary: List Api Keys
+      description: List configured providers with masked key hints.
+      operationId: list_api_keys_api_settings_api_keys_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyListResponse'
   /auth/login/{provider}:
     get:
       tags:
@@ -1528,6 +1601,74 @@ components:
       - sync
       title: AllSettingsResponse
       description: Full application settings response.
+    ApiKeyDeleteResponse:
+      properties:
+        provider:
+          type: string
+          title: Provider
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - provider
+      - status
+      title: ApiKeyDeleteResponse
+      description: Response after deleting an API key.
+    ApiKeyInfo:
+      properties:
+        provider:
+          type: string
+          title: Provider
+        key_hint:
+          type: string
+          title: Key Hint
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - provider
+      - key_hint
+      - created_at
+      - updated_at
+      title: ApiKeyInfo
+      description: Summary of a configured API key (no raw key exposed).
+    ApiKeyListResponse:
+      properties:
+        keys:
+          items:
+            $ref: '#/components/schemas/ApiKeyInfo'
+          type: array
+          title: Keys
+      type: object
+      required:
+      - keys
+      title: ApiKeyListResponse
+      description: List of configured API key providers.
+    ApiKeySetResponse:
+      properties:
+        provider:
+          type: string
+          title: Provider
+        key_hint:
+          type: string
+          title: Key Hint
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - provider
+      - key_hint
+      - status
+      title: ApiKeySetResponse
+      description: Response after setting an API key.
     ArticleResponse:
       properties:
         id:
@@ -2905,6 +3046,16 @@ components:
       - resolution
       title: ResolveContradictionResponse
       description: Response after resolving a contradiction.
+    SetApiKeyRequest:
+      properties:
+        api_key:
+          type: string
+          title: Api Key
+      type: object
+      required:
+      - api_key
+      title: SetApiKeyRequest
+      description: Request to store an API key for a provider.
     SettingsUpdateRequest:
       properties:
         monthly_budget_usd:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     # Security / keychain
     "keyring>=25.4.1",
     "PyJWT>=2.8.0",
+    "cryptography>=42.0.0",
 
     # Sync
     "boto3>=1.35.49",

--- a/src/wikimind/api/routes/api_keys.py
+++ b/src/wikimind/api/routes/api_keys.py
@@ -1,0 +1,156 @@
+"""BYOK API key management endpoints.
+
+Lets authenticated users store, list, and delete their own LLM provider
+API keys.  Keys are encrypted at rest (Fernet + PBKDF2).  Responses
+never expose raw keys -- only provider names and masked hints.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.api.deps import require_user_id
+from wikimind.database import get_session
+from wikimind.models import Provider
+from wikimind.services.api_keys import (
+    decrypt_api_key,
+    delete_user_api_key,
+    list_user_api_keys,
+    mask_api_key,
+    set_user_api_key,
+)
+
+router = APIRouter()
+
+# Providers that accept user-supplied API keys (Ollama and Mock don't use keys)
+_BYOK_PROVIDERS = {Provider.ANTHROPIC, Provider.OPENAI, Provider.GOOGLE}
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class SetApiKeyRequest(BaseModel):
+    """Request to store an API key for a provider."""
+
+    api_key: str
+
+
+class ApiKeyInfo(BaseModel):
+    """Summary of a configured API key (no raw key exposed)."""
+
+    provider: str
+    key_hint: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ApiKeyListResponse(BaseModel):
+    """List of configured API key providers."""
+
+    keys: list[ApiKeyInfo]
+
+
+class ApiKeySetResponse(BaseModel):
+    """Response after setting an API key."""
+
+    provider: str
+    key_hint: str
+    status: str
+
+
+class ApiKeyDeleteResponse(BaseModel):
+    """Response after deleting an API key."""
+
+    provider: str
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------
+
+
+def _validate_provider(provider: str) -> Provider:
+    """Validate and return the provider enum, raising 400 for invalid values."""
+    try:
+        p = Provider(provider)
+    except ValueError as err:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown provider: {provider}",
+        ) from err
+    if p not in _BYOK_PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Provider {provider} does not support user API keys",
+        )
+    return p
+
+
+@router.put(
+    "/{provider}",
+    response_model=ApiKeySetResponse,
+)
+async def set_api_key(
+    provider: str,
+    request: SetApiKeyRequest,
+    user_id: str = Depends(require_user_id),
+    session: AsyncSession = Depends(get_session),
+) -> ApiKeySetResponse:
+    """Store or update an API key for a provider."""
+    p = _validate_provider(provider)
+
+    if not request.api_key.strip():
+        raise HTTPException(status_code=400, detail="API key must not be empty")
+
+    await set_user_api_key(session, user_id, p, request.api_key.strip())
+    hint = mask_api_key(request.api_key.strip())
+    return ApiKeySetResponse(provider=p.value, key_hint=hint, status="ok")
+
+
+@router.get(
+    "",
+    response_model=ApiKeyListResponse,
+)
+async def list_api_keys(
+    user_id: str = Depends(require_user_id),
+    session: AsyncSession = Depends(get_session),
+) -> ApiKeyListResponse:
+    """List configured providers with masked key hints."""
+    records = await list_user_api_keys(session, user_id)
+    keys = []
+    for record in records:
+        plaintext = decrypt_api_key(record.encrypted_key, record.salt)
+        keys.append(
+            ApiKeyInfo(
+                provider=record.provider.value,
+                key_hint=mask_api_key(plaintext),
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+            )
+        )
+    return ApiKeyListResponse(keys=keys)
+
+
+@router.delete(
+    "/{provider}",
+    response_model=ApiKeyDeleteResponse,
+)
+async def delete_api_key(
+    provider: str,
+    user_id: str = Depends(require_user_id),
+    session: AsyncSession = Depends(get_session),
+) -> ApiKeyDeleteResponse:
+    """Delete a stored API key for a provider."""
+    p = _validate_provider(provider)
+    deleted = await delete_user_api_key(session, user_id, p)
+    if not deleted:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No API key configured for provider {provider}",
+        )
+    return ApiKeyDeleteResponse(provider=p.value, status="deleted")

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -23,6 +23,7 @@ from wikimind.api.routes.ws import emit_budget_exceeded, emit_budget_warning
 from wikimind.config import get_api_key, get_settings
 from wikimind.database import get_session_factory
 from wikimind.models import CompletionRequest, CompletionResponse, CostLog, Provider, TaskType
+from wikimind.services.api_keys import get_user_api_key
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -174,18 +175,28 @@ class LLMRouter:
             return True  # No API key needed
         return bool(get_api_key(provider.value))
 
-    async def _get_provider_instance(self, provider: Provider) -> ProviderProtocol:
-        """Return a cached provider instance, creating it on first use."""
-        if provider in self._provider_cache:
+    async def _get_provider_instance(
+        self,
+        provider: Provider,
+        api_key_override: str | None = None,
+    ) -> ProviderProtocol:
+        """Return a provider instance.
+
+        When *api_key_override* is supplied (BYOK), a fresh instance is
+        created with that key and is NOT cached -- the user's key must
+        not leak into the shared singleton cache.  Without an override,
+        the system-wide cached instance is returned.
+        """
+        if api_key_override is None and provider in self._provider_cache:
             return self._provider_cache[provider]
 
         instance: ProviderProtocol
         if provider == Provider.ANTHROPIC:
-            instance = AnthropicProvider()
+            instance = AnthropicProvider(api_key_override=api_key_override)
         elif provider == Provider.OPENAI:
-            instance = OpenAIProvider()
+            instance = OpenAIProvider(api_key_override=api_key_override)
         elif provider == Provider.GOOGLE:
-            instance = GoogleProvider()
+            instance = GoogleProvider(api_key_override=api_key_override)
         elif provider == Provider.OLLAMA:
             instance = OllamaProvider(self.settings.llm.ollama_base_url)
         elif provider == Provider.MOCK:
@@ -194,8 +205,23 @@ class LLMRouter:
             msg = f"Provider {provider} not implemented yet"
             raise ValueError(msg)
 
-        self._provider_cache[provider] = instance
+        # Only cache system-key instances
+        if api_key_override is None:
+            self._provider_cache[provider] = instance
         return instance
+
+    async def _resolve_user_key(self, provider: Provider, user_id: str | None) -> str | None:
+        """Look up a user's BYOK key for the given provider, if any."""
+        if not user_id:
+            return None
+        if provider in (Provider.OLLAMA, Provider.MOCK):
+            return None
+        try:
+            async with get_session_factory()() as session:
+                return await get_user_api_key(session, user_id, provider)
+        except Exception:
+            log.debug("BYOK key lookup failed", provider=provider, exc_info=True)
+            return None
 
     def _get_model(self, provider: Provider) -> str:
         """Return the configured model name for a provider."""
@@ -319,19 +345,32 @@ class LLMRouter:
         self,
         request: CompletionRequest,
         session=None,  # kept for backward compat
+        user_id: str | None = None,
     ) -> CompletionResponse:
-        """Execute LLM completion with provider selection and fallback."""
+        """Execute LLM completion with provider selection and fallback.
+
+        When *user_id* is provided, the router checks for a BYOK key
+        for each candidate provider and uses it instead of the system key.
+        """
         provider_order = self._get_provider_order(request.preferred_provider)
 
         last_error = None
         for provider in provider_order:
-            if not self._is_provider_available(provider):
+            # Check for user BYOK key first
+            user_key = await self._resolve_user_key(provider, user_id)
+            if not user_key and not self._is_provider_available(provider):
                 continue
 
             model = self._get_model(provider)
             try:
-                log.info("LLM call", provider=provider, model=model, task=request.task_type)
-                instance = await self._get_provider_instance(provider)
+                log.info(
+                    "LLM call",
+                    provider=provider,
+                    model=model,
+                    task=request.task_type,
+                    byok=bool(user_key),
+                )
+                instance = await self._get_provider_instance(provider, api_key_override=user_key)
                 response = await instance.complete(request, model)
 
                 # Log cost in independent session
@@ -372,6 +411,7 @@ class LLMRouter:
         temperature: float = 0.3,
         preferred_provider: Provider | None = None,
         session=None,  # kept for backward compat
+        user_id: str | None = None,
     ) -> CompletionResponse:
         """Execute a multimodal LLM completion with images and text.
 
@@ -387,6 +427,7 @@ class LLMRouter:
             temperature: Sampling temperature.
             preferred_provider: Optional provider preference.
             session: Deprecated -- cost logging now uses an independent session.
+            user_id: Optional user ID for BYOK key lookup.
 
         Returns:
             CompletionResponse with the LLM's text output.
@@ -398,7 +439,8 @@ class LLMRouter:
 
         last_error = None
         for provider in provider_order:
-            if not self._is_provider_available(provider):
+            user_key = await self._resolve_user_key(provider, user_id)
+            if not user_key and not self._is_provider_available(provider):
                 continue
 
             model = self._get_model(provider)
@@ -408,8 +450,9 @@ class LLMRouter:
                     provider=provider,
                     model=model,
                     task=task_type,
+                    byok=bool(user_key),
                 )
-                instance = await self._get_provider_instance(provider)
+                instance = await self._get_provider_instance(provider, api_key_override=user_key)
                 response = await instance.complete_multimodal(
                     system=system,
                     content_parts=content_parts,
@@ -441,6 +484,7 @@ class LLMRouter:
     async def stream_complete(
         self,
         request: CompletionRequest,
+        user_id: str | None = None,
     ) -> StreamSession:
         """Create a streaming LLM completion with provider fallback.
 
@@ -450,6 +494,7 @@ class LLMRouter:
 
         Args:
             request: The completion request.
+            user_id: Optional user ID for BYOK key lookup.
 
         Returns:
             A :class:`StreamSession` that yields text chunks.
@@ -461,7 +506,8 @@ class LLMRouter:
 
         last_error = None
         for provider in provider_order:
-            if not self._is_provider_available(provider):
+            user_key = await self._resolve_user_key(provider, user_id)
+            if not user_key and not self._is_provider_available(provider):
                 continue
 
             model = self._get_model(provider)
@@ -471,8 +517,9 @@ class LLMRouter:
                     provider=provider,
                     model=model,
                     task=request.task_type,
+                    byok=bool(user_key),
                 )
-                instance = await self._get_provider_instance(provider)
+                instance = await self._get_provider_instance(provider, api_key_override=user_key)
                 return await instance.stream(request, model)
             except Exception as e:  # TODO: narrow once provider error hierarchy is unified
                 log.warning(

--- a/src/wikimind/engine/providers/anthropic.py
+++ b/src/wikimind/engine/providers/anthropic.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 class AnthropicProvider:
     """Anthropic LLM provider."""
 
-    def __init__(self):
-        api_key = get_api_key("anthropic")
+    def __init__(self, api_key_override: str | None = None):
+        api_key = api_key_override or get_api_key("anthropic")
         if not api_key:
             msg = "Anthropic API key not configured"
             raise ValueError(msg)

--- a/src/wikimind/engine/providers/google.py
+++ b/src/wikimind/engine/providers/google.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
 class GoogleProvider:
     """Google Gemini LLM provider."""
 
-    def __init__(self) -> None:
-        api_key = get_api_key("google")
+    def __init__(self, api_key_override: str | None = None) -> None:
+        api_key = api_key_override or get_api_key("google")
         if not api_key:
             msg = "Google API key not configured"
             raise ValueError(msg)

--- a/src/wikimind/engine/providers/openai.py
+++ b/src/wikimind/engine/providers/openai.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 class OpenAIProvider:
     """OpenAI LLM provider."""
 
-    def __init__(self):
-        api_key = get_api_key("openai")
+    def __init__(self, api_key_override: str | None = None):
+        api_key = api_key_override or get_api_key("openai")
         if not api_key:
             msg = "OpenAI API key not configured"
             raise ValueError(msg)

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -17,7 +17,7 @@ from sqlmodel import select
 from starlette.responses import FileResponse, HTMLResponse
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-from wikimind.api.routes import admin, auth, export, ingest, jobs, lint, query, wiki, ws
+from wikimind.api.routes import admin, api_keys, auth, export, ingest, jobs, lint, query, wiki, ws
 from wikimind.api.routes import settings as settings_router
 from wikimind.api.routes.ws import _start_redis_subscriber, stop_redis_subscriber
 from wikimind.config import get_settings
@@ -169,6 +169,7 @@ app.include_router(query.router, prefix="/query", tags=["Query"])
 app.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
 app.include_router(lint.router, prefix="/lint", tags=["Lint"])
 app.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
+app.include_router(api_keys.router, prefix="/api/settings/api-keys", tags=["Settings"])
 app.include_router(ws.router, tags=["WebSocket"])
 app.include_router(auth.router, prefix="/auth", tags=["Auth"])
 app.include_router(admin.router, prefix="/admin", tags=["Admin"])

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -367,6 +367,25 @@ class SyncLog(SQLModel, table=True):
     error: str | None = None
 
 
+class UserApiKey(SQLModel, table=True):
+    """Encrypted user-provided API key for an LLM provider (BYOK).
+
+    Each row stores a Fernet-encrypted API key with a per-row salt.
+    The encryption key is derived from ``JWT_SECRET_KEY + salt`` via
+    PBKDF2-HMAC-SHA256.  See ADR-026.
+    """
+
+    __table_args__ = (UniqueConstraint("user_id", "provider", name="uq_userapikey_user_provider"),)
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
+    provider: Provider
+    encrypted_key: str  # Fernet-encrypted API key (base64)
+    salt: str  # Per-row salt (hex-encoded)
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    updated_at: datetime = Field(default_factory=utcnow_naive)
+
+
 class UserPreference(SQLModel, table=True):
     """Lightweight key-value store for runtime settings overrides.
 

--- a/src/wikimind/services/api_keys.py
+++ b/src/wikimind/services/api_keys.py
@@ -1,0 +1,214 @@
+"""BYOK API key management — encrypt, decrypt, CRUD operations.
+
+Encrypts user-provided LLM API keys at rest using Fernet symmetric
+encryption.  The Fernet key is derived from ``JWT_SECRET_KEY`` +
+a per-row random salt via PBKDF2-HMAC-SHA256.  See ADR-026.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import TYPE_CHECKING
+
+import structlog
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from sqlmodel import select
+
+from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
+from wikimind.models import Provider, UserApiKey
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+log = structlog.get_logger()
+
+# PBKDF2 iteration count — balances security vs. latency for per-request
+# key derivation.  100_000 is the OWASP 2023 minimum for SHA-256.
+PBKDF2_ITERATIONS = 100_000
+
+
+def _derive_fernet_key(salt: bytes) -> bytes:
+    """Derive a 32-byte Fernet key from JWT_SECRET_KEY and a per-row salt."""
+    settings = get_settings()
+    secret = settings.auth.jwt_secret_key
+    if not secret:
+        raise ValueError(
+            "JWT_SECRET_KEY must be configured for BYOK encryption. "
+            "Set WIKIMIND_AUTH__JWT_SECRET_KEY in your environment."
+        )
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=PBKDF2_ITERATIONS,
+    )
+    return base64.urlsafe_b64encode(kdf.derive(secret.encode()))
+
+
+def encrypt_api_key(plaintext: str) -> tuple[str, str]:
+    """Encrypt an API key, returning (encrypted_key, salt_hex).
+
+    Args:
+        plaintext: The raw API key to encrypt.
+
+    Returns:
+        Tuple of (Fernet-encrypted key as base64 string, salt as hex string).
+    """
+    salt = os.urandom(16)
+    fernet_key = _derive_fernet_key(salt)
+    f = Fernet(fernet_key)
+    encrypted = f.encrypt(plaintext.encode())
+    return encrypted.decode(), salt.hex()
+
+
+def decrypt_api_key(encrypted_key: str, salt_hex: str) -> str:
+    """Decrypt an API key.
+
+    Args:
+        encrypted_key: Fernet-encrypted key (base64 string).
+        salt_hex: Hex-encoded salt used during encryption.
+
+    Returns:
+        The decrypted plaintext API key.
+    """
+    salt = bytes.fromhex(salt_hex)
+    fernet_key = _derive_fernet_key(salt)
+    f = Fernet(fernet_key)
+    return f.decrypt(encrypted_key.encode()).decode()
+
+
+def mask_api_key(key: str) -> str:
+    """Return a masked hint of the API key (first 4 + last 4 chars).
+
+    Args:
+        key: The plaintext API key.
+
+    Returns:
+        A masked string like "sk-p...xyz1".
+    """
+    if len(key) <= 8:
+        return "****"
+    return f"{key[:4]}...{key[-4:]}"
+
+
+async def set_user_api_key(
+    session: AsyncSession,
+    user_id: str,
+    provider: Provider,
+    api_key: str,
+) -> UserApiKey:
+    """Store or update a user's API key for a provider.
+
+    Args:
+        session: Database session.
+        user_id: The user's ID.
+        provider: LLM provider enum value.
+        api_key: Plaintext API key to encrypt and store.
+
+    Returns:
+        The created or updated UserApiKey record.
+    """
+    encrypted_key, salt_hex = encrypt_api_key(api_key)
+
+    result = await session.execute(
+        select(UserApiKey).where(
+            UserApiKey.user_id == user_id,
+            UserApiKey.provider == provider,
+        )
+    )
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        existing.encrypted_key = encrypted_key
+        existing.salt = salt_hex
+        existing.updated_at = utcnow_naive()
+        session.add(existing)
+        log.info("user API key updated", user_id=user_id, provider=provider)
+        return existing
+
+    record = UserApiKey(
+        user_id=user_id,
+        provider=provider,
+        encrypted_key=encrypted_key,
+        salt=salt_hex,
+    )
+    session.add(record)
+    log.info("user API key stored", user_id=user_id, provider=provider)
+    return record
+
+
+async def get_user_api_key(
+    session: AsyncSession,
+    user_id: str,
+    provider: Provider,
+) -> str | None:
+    """Retrieve and decrypt a user's API key for a provider.
+
+    Args:
+        session: Database session.
+        user_id: The user's ID.
+        provider: LLM provider enum value.
+
+    Returns:
+        The decrypted API key, or None if not configured.
+    """
+    result = await session.execute(
+        select(UserApiKey).where(
+            UserApiKey.user_id == user_id,
+            UserApiKey.provider == provider,
+        )
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        return None
+    return decrypt_api_key(record.encrypted_key, record.salt)
+
+
+async def list_user_api_keys(
+    session: AsyncSession,
+    user_id: str,
+) -> list[UserApiKey]:
+    """List all configured API key providers for a user (no decryption).
+
+    Args:
+        session: Database session.
+        user_id: The user's ID.
+
+    Returns:
+        List of UserApiKey records (encrypted_key is NOT decrypted).
+    """
+    result = await session.execute(select(UserApiKey).where(UserApiKey.user_id == user_id))
+    return list(result.scalars().all())
+
+
+async def delete_user_api_key(
+    session: AsyncSession,
+    user_id: str,
+    provider: Provider,
+) -> bool:
+    """Delete a user's API key for a provider.
+
+    Args:
+        session: Database session.
+        user_id: The user's ID.
+        provider: LLM provider enum value.
+
+    Returns:
+        True if a key was deleted, False if none existed.
+    """
+    result = await session.execute(
+        select(UserApiKey).where(
+            UserApiKey.user_id == user_id,
+            UserApiKey.provider == provider,
+        )
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        return False
+    await session.delete(record)
+    log.info("user API key deleted", user_id=user_id, provider=provider)
+    return True

--- a/src/wikimind/services/api_keys.py
+++ b/src/wikimind/services/api_keys.py
@@ -36,10 +36,11 @@ def _derive_fernet_key(salt: bytes) -> bytes:
     settings = get_settings()
     secret = settings.auth.jwt_secret_key
     if not secret:
-        raise ValueError(
+        msg = (
             "JWT_SECRET_KEY must be configured for BYOK encryption. "
             "Set WIKIMIND_AUTH__JWT_SECRET_KEY in your environment."
         )
+        raise ValueError(msg)
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),
         length=32,

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -1,0 +1,227 @@
+"""Tests for BYOK API key management (issue #247)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from wikimind.config import get_settings
+from wikimind.models import Provider
+from wikimind.services.api_keys import (
+    decrypt_api_key,
+    delete_user_api_key,
+    encrypt_api_key,
+    get_user_api_key,
+    list_user_api_keys,
+    mask_api_key,
+    set_user_api_key,
+)
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — encryption helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEncryption:
+    """Test encrypt/decrypt round-trip and masking."""
+
+    def test_encrypt_decrypt_roundtrip(self, monkeypatch):
+        """Encrypting then decrypting returns the original key."""
+        monkeypatch.setenv("WIKIMIND_AUTH__JWT_SECRET_KEY", "test-secret-key-for-byok")
+        get_settings.cache_clear()
+        try:
+            original = "sk-ant-api03-xxxxxxxxxxxxxxxxxxxx"
+            encrypted, salt_hex = encrypt_api_key(original)
+            decrypted = decrypt_api_key(encrypted, salt_hex)
+            assert decrypted == original
+        finally:
+            get_settings.cache_clear()
+
+    def test_different_salts_produce_different_ciphertexts(self, monkeypatch):
+        """Each encryption should use a unique salt."""
+        monkeypatch.setenv("WIKIMIND_AUTH__JWT_SECRET_KEY", "test-secret-key-for-byok")
+        get_settings.cache_clear()
+        try:
+            key = "sk-test-key-12345"
+            encrypted1, salt1 = encrypt_api_key(key)
+            encrypted2, salt2 = encrypt_api_key(key)
+            assert salt1 != salt2
+            assert encrypted1 != encrypted2
+            # But both decrypt to the same value
+            assert decrypt_api_key(encrypted1, salt1) == key
+            assert decrypt_api_key(encrypted2, salt2) == key
+        finally:
+            get_settings.cache_clear()
+
+    def test_mask_api_key_long(self):
+        """Long keys show first 4 and last 4 chars."""
+        assert mask_api_key("sk-ant-api03-xxxxxxxxxxxxxxxxxxxx") == "sk-a...xxxx"
+
+    def test_mask_api_key_short(self):
+        """Short keys are fully masked."""
+        assert mask_api_key("abc") == "****"
+        assert mask_api_key("12345678") == "****"
+
+    def test_mask_api_key_nine_chars(self):
+        """9-char keys show first 4 and last 4."""
+        assert mask_api_key("123456789") == "1234...6789"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — service layer CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestServiceCRUD:
+    """Test set/get/list/delete operations on UserApiKey."""
+
+    @pytest.fixture(autouse=True)
+    def _set_jwt_secret(self, monkeypatch):
+        monkeypatch.setenv("WIKIMIND_AUTH__JWT_SECRET_KEY", "test-secret-key-for-byok")
+        get_settings.cache_clear()
+        yield
+        get_settings.cache_clear()
+
+    async def test_set_and_get(self, db_session: AsyncSession):
+        """Setting a key then getting it returns the original."""
+        await set_user_api_key(db_session, "user-1", Provider.ANTHROPIC, "sk-test-123")
+        await db_session.commit()
+
+        result = await get_user_api_key(db_session, "user-1", Provider.ANTHROPIC)
+        assert result == "sk-test-123"
+
+    async def test_get_nonexistent(self, db_session: AsyncSession):
+        """Getting a key that doesn't exist returns None."""
+        result = await get_user_api_key(db_session, "user-1", Provider.OPENAI)
+        assert result is None
+
+    async def test_update_existing(self, db_session: AsyncSession):
+        """Setting a key twice updates the existing record."""
+        await set_user_api_key(db_session, "user-1", Provider.ANTHROPIC, "old-key")
+        await db_session.commit()
+        await set_user_api_key(db_session, "user-1", Provider.ANTHROPIC, "new-key")
+        await db_session.commit()
+
+        result = await get_user_api_key(db_session, "user-1", Provider.ANTHROPIC)
+        assert result == "new-key"
+
+    async def test_list_keys(self, db_session: AsyncSession):
+        """Listing returns all configured providers for a user."""
+        await set_user_api_key(db_session, "user-1", Provider.ANTHROPIC, "key-a")
+        await set_user_api_key(db_session, "user-1", Provider.OPENAI, "key-b")
+        await db_session.commit()
+
+        records = await list_user_api_keys(db_session, "user-1")
+        providers = {r.provider for r in records}
+        assert providers == {Provider.ANTHROPIC, Provider.OPENAI}
+
+    async def test_list_isolation(self, db_session: AsyncSession):
+        """Listing only returns keys for the specified user."""
+        await set_user_api_key(db_session, "user-1", Provider.ANTHROPIC, "key-a")
+        await set_user_api_key(db_session, "user-2", Provider.OPENAI, "key-b")
+        await db_session.commit()
+
+        records = await list_user_api_keys(db_session, "user-1")
+        assert len(records) == 1
+        assert records[0].provider == Provider.ANTHROPIC
+
+    async def test_delete(self, db_session: AsyncSession):
+        """Deleting a key removes it."""
+        await set_user_api_key(db_session, "user-1", Provider.ANTHROPIC, "key-a")
+        await db_session.commit()
+
+        deleted = await delete_user_api_key(db_session, "user-1", Provider.ANTHROPIC)
+        assert deleted is True
+        await db_session.commit()
+
+        result = await get_user_api_key(db_session, "user-1", Provider.ANTHROPIC)
+        assert result is None
+
+    async def test_delete_nonexistent(self, db_session: AsyncSession):
+        """Deleting a nonexistent key returns False."""
+        deleted = await delete_user_api_key(db_session, "user-1", Provider.GOOGLE)
+        assert deleted is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — API routes (single-request per test)
+# ---------------------------------------------------------------------------
+
+
+class TestAPIRoutes:
+    """Test BYOK API endpoints via the test client.
+
+    Each test exercises a single endpoint. Cross-request state is NOT
+    guaranteed by the test client override of ``get_session`` (the override
+    does not commit), so each test is self-contained.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _set_jwt_secret(self, monkeypatch):
+        monkeypatch.setenv("WIKIMIND_AUTH__JWT_SECRET_KEY", "test-secret-key-for-byok")
+        get_settings.cache_clear()
+        yield
+        get_settings.cache_clear()
+
+    async def test_set_key(self, client: AsyncClient):
+        """PUT /api/settings/api-keys/{provider} stores a key."""
+        resp = await client.put(
+            "/api/settings/api-keys/anthropic",
+            json={"api_key": "sk-ant-test-1234567890abcdef"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["provider"] == "anthropic"
+        assert data["status"] == "ok"
+        assert "sk-a" in data["key_hint"]
+        assert "cdef" in data["key_hint"]
+
+    async def test_list_keys_empty(self, client: AsyncClient):
+        """GET /api/settings/api-keys returns empty list when none configured."""
+        resp = await client.get("/api/settings/api-keys")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["keys"] == []
+
+    async def test_delete_nonexistent(self, client: AsyncClient):
+        """DELETE for a non-configured provider returns 404."""
+        resp = await client.delete("/api/settings/api-keys/google")
+        assert resp.status_code == 404
+
+    async def test_invalid_provider(self, client: AsyncClient):
+        """PUT with an invalid provider returns 400."""
+        resp = await client.put(
+            "/api/settings/api-keys/invalid",
+            json={"api_key": "some-key"},
+        )
+        assert resp.status_code == 400
+
+    async def test_ollama_rejected(self, client: AsyncClient):
+        """PUT for ollama (no API key needed) returns 400."""
+        resp = await client.put(
+            "/api/settings/api-keys/ollama",
+            json={"api_key": "some-key"},
+        )
+        assert resp.status_code == 400
+
+    async def test_empty_key_rejected(self, client: AsyncClient):
+        """PUT with an empty key returns 400."""
+        resp = await client.put(
+            "/api/settings/api-keys/anthropic",
+            json={"api_key": "   "},
+        )
+        assert resp.status_code == 400
+
+    async def test_mock_rejected(self, client: AsyncClient):
+        """PUT for mock (no API key needed) returns 400."""
+        resp = await client.put(
+            "/api/settings/api-keys/mock",
+            json={"api_key": "some-key"},
+        )
+        assert resp.status_code == 400

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -232,7 +232,7 @@ async def test_router_complete_falls_through_to_next_provider() -> None:
 
     instances = [bad, good]
 
-    async def get_instance(_p):
+    async def get_instance(_p, **_kw):
         return instances.pop(0)
 
     with (
@@ -475,7 +475,7 @@ async def test_router_stream_complete_falls_through_on_error() -> None:
 
     instances = [bad, good]
 
-    async def get_instance(_p):
+    async def get_instance(_p, **_kw):
         return instances.pop(0)
 
     with (


### PR DESCRIPTION
## Summary

Users need to supply their own LLM API keys for personal billing in multi-user deployments. System-wide keys shouldn't be shared across users.

This PR adds Bring Your Own Key (BYOK) support:

- **New `UserApiKey` model** stores encrypted API keys per user per provider
- **Fernet encryption** with PBKDF2-HMAC-SHA256 key derivation from `JWT_SECRET_KEY` + per-row random salt (100k iterations, OWASP 2023 minimum)
- **API endpoints** at `PUT/GET/DELETE /api/settings/api-keys/{provider}` for Anthropic, OpenAI, and Google (Ollama/Mock don't use keys)
- **LLM router integration** — when a user has a BYOK key, it creates a fresh (non-cached) provider instance with that key; falls back to system key otherwise
- Raw keys are never returned in API responses — only masked hints (first 4 + last 4 chars)

## Changes

- `src/wikimind/models.py` — `UserApiKey` table with unique constraint on (user_id, provider)
- `src/wikimind/services/api_keys.py` — encrypt/decrypt/CRUD service layer
- `src/wikimind/api/routes/api_keys.py` — thin route handlers delegating to service
- `src/wikimind/engine/llm_router.py` — `_resolve_user_key()` + `api_key_override` plumbing through `complete()`, `complete_multimodal()`, `stream_complete()`
- `src/wikimind/engine/providers/{anthropic,openai,google}.py` — accept optional `api_key_override` constructor parameter
- `pyproject.toml` — added `cryptography>=42.0.0` dependency
- `docs/adr/adr-026-byok-api-key-encryption.md` — documents encryption scheme and trade-offs

## Test plan

- [x] 19 new tests in `tests/unit/test_api_keys.py` covering:
  - Encrypt/decrypt round-trip with different salts
  - Key masking (long, short, boundary cases)
  - Service CRUD: set, get, update, list, delete, isolation between users
  - Route validation: invalid provider, Ollama/Mock rejection, empty key
- [x] Updated 2 existing LLM router tests to handle new `api_key_override` kwarg
- [x] `make verify` passes (lint + format + typecheck + 790 tests + 84% coverage)

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)