### PR TITLE
fix: revert WEB_CONCURRENCY to 4 for Fly.io deploy health checks

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,9 +18,10 @@ primary_region = "ord"
   WIKIMIND_SERVER__HOST = "0.0.0.0"
   WIKIMIND_SERVER__PORT = "7842"
   WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
-  # Gunicorn workers — keep low on 1-CPU/1GB Fly.io machines to avoid
-  # memory pressure and startup timeout cascades.
-  WEB_CONCURRENCY = "2"
+  # Gunicorn workers — 4 ensures at least one worker can respond to health
+  # checks while others are still initializing (DB init, migrations).
+  # Fewer workers caused deploy timeouts (health check fails within 5 min).
+  WEB_CONCURRENCY = "4"
 
 [http_service]
   internal_port = 7842


### PR DESCRIPTION
## Summary

- **Problem:** Deploy fails — with 2 workers, all are busy with DB init and none can respond to Fly's health check within the 5-minute deploy timeout.
- **Fix:** Revert WEB_CONCURRENCY from 2 back to 4. With 4 workers, at least one finishes init early enough to handle health checks.

One-line change in `fly.toml`.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)