### PR TITLE
fix: Postgres-compatible INSERT in Alembic migration 0003

### DIFF
--- a/alembic/versions/0003_add_article_concept_and_article_source_join_tables.py
+++ b/alembic/versions/0003_add_article_concept_and_article_source_join_tables.py
@@ -60,13 +60,12 @@ def upgrade() -> None:  # noqa: C901, PLR0912
                 if isinstance(concept_names, list):
                     for name in concept_names:
                         if name:
-                            conn.execute(
-                                sa.text(
-                                    "INSERT OR IGNORE INTO articleconcept (article_id, concept_name) "
-                                    "VALUES (:article_id, :concept_name)"
-                                ),
-                                {"article_id": article_id, "concept_name": str(name)},
-                            )
+                            dialect = conn.dialect.name
+                            if dialect == "sqlite":
+                                sql = "INSERT OR IGNORE INTO articleconcept (article_id, concept_name) VALUES (:article_id, :concept_name)"
+                            else:
+                                sql = "INSERT INTO articleconcept (article_id, concept_name) VALUES (:article_id, :concept_name) ON CONFLICT DO NOTHING"
+                            conn.execute(sa.text(sql), {"article_id": article_id, "concept_name": str(name)})
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -76,13 +75,12 @@ def upgrade() -> None:  # noqa: C901, PLR0912
                 if isinstance(source_ids, list):
                     for sid in source_ids:
                         if sid:
-                            conn.execute(
-                                sa.text(
-                                    "INSERT OR IGNORE INTO articlesource (article_id, source_id) "
-                                    "VALUES (:article_id, :source_id)"
-                                ),
-                                {"article_id": article_id, "source_id": str(sid)},
-                            )
+                            dialect = conn.dialect.name
+                            if dialect == "sqlite":
+                                sql = "INSERT OR IGNORE INTO articlesource (article_id, source_id) VALUES (:article_id, :source_id)"
+                            else:
+                                sql = "INSERT INTO articlesource (article_id, source_id) VALUES (:article_id, :source_id) ON CONFLICT DO NOTHING"
+                            conn.execute(sa.text(sql), {"article_id": article_id, "source_id": str(sid)})
             except (json.JSONDecodeError, TypeError):
                 pass
 


### PR DESCRIPTION
## Summary

- **Problem:** Fly.io deploy crashes because the Alembic migration 0003 uses `INSERT OR IGNORE` (SQLite-only). The entrypoint runs `alembic upgrade head` BEFORE `init_db`, so the database.py fixes from #308 never get a chance to run.
- **Fix:** Same dialect check in the Alembic migration file.
- **Tested:** `alembic upgrade head` + full server startup against Postgres 16 locally.

## Test plan

- [x] `alembic upgrade head` against local Postgres 16
- [x] Full server startup + ingest against Postgres
- [x] SQLite still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)