### PR TITLE
fix: use ORM for migration recording — datetime/str type mismatch on Fly.io

### DIFF
--- a/alembic/versions/0003_add_article_concept_and_article_source_join_tables.py
+++ b/alembic/versions/0003_add_article_concept_and_article_source_join_tables.py
@@ -60,13 +60,12 @@ def upgrade() -> None:  # noqa: C901, PLR0912
                 if isinstance(concept_names, list):
                     for name in concept_names:
                         if name:
-                            conn.execute(
-                                sa.text(
-                                    "INSERT OR IGNORE INTO articleconcept (article_id, concept_name) "
-                                    "VALUES (:article_id, :concept_name)"
-                                ),
-                                {"article_id": article_id, "concept_name": str(name)},
-                            )
+                            dialect = conn.dialect.name
+                            if dialect == "sqlite":
+                                sql = "INSERT OR IGNORE INTO articleconcept (article_id, concept_name) VALUES (:article_id, :concept_name)"
+                            else:
+                                sql = "INSERT INTO articleconcept (article_id, concept_name) VALUES (:article_id, :concept_name) ON CONFLICT DO NOTHING"
+                            conn.execute(sa.text(sql), {"article_id": article_id, "concept_name": str(name)})
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -76,13 +75,12 @@ def upgrade() -> None:  # noqa: C901, PLR0912
                 if isinstance(source_ids, list):
                     for sid in source_ids:
                         if sid:
-                            conn.execute(
-                                sa.text(
-                                    "INSERT OR IGNORE INTO articlesource (article_id, source_id) "
-                                    "VALUES (:article_id, :source_id)"
-                                ),
-                                {"article_id": article_id, "source_id": str(sid)},
-                            )
+                            dialect = conn.dialect.name
+                            if dialect == "sqlite":
+                                sql = "INSERT OR IGNORE INTO articlesource (article_id, source_id) VALUES (:article_id, :source_id)"
+                            else:
+                                sql = "INSERT INTO articlesource (article_id, source_id) VALUES (:article_id, :source_id) ON CONFLICT DO NOTHING"
+                            conn.execute(sa.text(sql), {"article_id": article_id, "source_id": str(sid)})
             except (json.JSONDecodeError, TypeError):
                 pass
 

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -159,11 +159,11 @@ async def _migration_applied(engine, version: str) -> bool:
 
 async def _record_migration(engine, version: str) -> None:
     """Record a migration version as applied."""
-    async with engine.begin() as conn:
-        await conn.execute(
-            sa_text("INSERT INTO migrationhistory (version, applied_at) VALUES (:v, :ts)"),
-            {"v": version, "ts": utcnow_naive()},
-        )
+    from wikimind.models import MigrationHistory  # noqa: PLC0415
+
+    async with AsyncSession(engine) as session:
+        session.add(MigrationHistory(version=version, applied_at=utcnow_naive()))
+        await session.commit()
     log.info("migration applied", version=version)
 
 


### PR DESCRIPTION
## Summary

- **Problem:** Fly.io deploy crashes with `expected str, got datetime` — the `migrationhistory.applied_at` column is VARCHAR on the existing Fly.io database (from an older schema), but #308 changed `_record_migration` to pass a raw `datetime` object.
- **Fix:** Use the ORM (`MigrationHistory` model + `session.add()`) instead of raw SQL, so SQLAlchemy handles type coercion.
- **Tested:** Both Postgres and SQLite locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)