### PR TITLE
fix: add missing ADRs to MkDocs nav and enable docs build on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,15 @@ on:
     paths:
       - "docs/**"
       - "src/**"
+  pull_request:
+    paths:
+      - "docs/**"
 
 permissions:
   contents: write
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +30,22 @@ jobs:
 
       - name: Build documentation
         run: cd docs && mkdocs build --strict
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: pip install -r docs/requirements.txt
 
       - name: Deploy to GitHub Pages
         run: cd docs && mkdocs gh-deploy --force

--- a/docs/docs/architecture/adr/adr-026-article-export-layer.md
+++ b/docs/docs/architecture/adr/adr-026-article-export-layer.md
@@ -1,0 +1,1 @@
+../../../adr/adr-026-article-export-layer.md

--- a/docs/docs/architecture/adr/adr-026-byok-api-key-encryption.md
+++ b/docs/docs/architecture/adr/adr-026-byok-api-key-encryption.md
@@ -1,0 +1,1 @@
+../../../adr/adr-026-byok-api-key-encryption.md

--- a/docs/docs/architecture/adr/adr-026-multi-replica-gateway.md
+++ b/docs/docs/architecture/adr/adr-026-multi-replica-gateway.md
@@ -1,0 +1,1 @@
+../../../adr/adr-026-multi-replica-gateway.md

--- a/docs/docs/architecture/adr/adr-026-onboarding-wizard.md
+++ b/docs/docs/architecture/adr/adr-026-onboarding-wizard.md
@@ -1,0 +1,1 @@
+../../../adr/adr-026-onboarding-wizard.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,6 +129,10 @@ nav:
           - ADR-023 Container architecture: architecture/adr/adr-023-production-container-architecture.md
           - ADR-024 Gunicorn autoscaling: architecture/adr/adr-024-gunicorn-autoscaling-horizontal-readiness.md
           - ADR-025 docling-serve sidecar: architecture/adr/adr-025-docling-serve-sidecar.md
+          - ADR-026 Article export layer: architecture/adr/adr-026-article-export-layer.md
+          - ADR-026 BYOK API key encryption: architecture/adr/adr-026-byok-api-key-encryption.md
+          - ADR-026 Multi-replica gateway: architecture/adr/adr-026-multi-replica-gateway.md
+          - ADR-026 Onboarding wizard: architecture/adr/adr-026-onboarding-wizard.md
   - API Reference:
       - OpenAPI: api/openapi.md
   - Development:


### PR DESCRIPTION
## Summary
- Added four missing ADR-026 files (article export layer, BYOK API key encryption, multi-replica gateway, onboarding wizard) to the MkDocs nav config and created their symlinks in `docs/docs/architecture/adr/`, fixing `mkdocs build --strict` failures caused by broken cross-references from `adr-024-gunicorn-autoscaling-horizontal-readiness.md`.
- Split the Documentation CI workflow into separate `build` and `deploy` jobs, with `deploy` gated on push-to-main. Added a `pull_request` trigger on `docs/**` paths so broken doc links are caught before merge.

## Test plan
- [x] `mkdocs build --strict` passes locally with no warnings or errors
- [x] `make lint`, `make format`, `make typecheck` all pass
- [ ] CI Documentation workflow runs on this PR and passes the build step
- [ ] Deploy step is skipped (not a push to main)

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)