### PR TITLE
feat: add staging environment with smoke test gates before prod deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,29 +1,83 @@
+# ===============================================================
+# 🚀  Deploy to Fly.io — Staging-Gated Production Pipeline
+# ===============================================================
+#
+#   - chains after the Docker workflow (build → scan → GHCR publish)
+#   - deploys staging first, smoke-tests it, then promotes to prod
+#   - auto-provisions apps, volumes, Postgres, and secrets
+#   - fails loudly on real errors; suppresses only idempotent ones
+#
 # ---------------------------------------------------------------
-# Deploy to Fly.io  (staging -> smoke tests -> production)
+# Pipeline
 # ---------------------------------------------------------------
 #
-# Chains after the Docker workflow: when Docker builds, scans,
-# and publishes a multi-arch image to GHCR on push to main,
-# this workflow pulls that image and deploys it.
+#   Docker (build + Trivy + GHCR publish)
+#     │
+#     ▼
+#   1️⃣  deploy-staging
+#     │  • ensure app + volume exist
+#     │  • ensure Postgres cluster + attach
+#     │  • stage secrets (--stage, no restart)
+#     │  • deploy docling-serve sidecar
+#     │  • deploy app from GHCR :latest
+#     │
+#     ▼
+#   2️⃣  smoke-test-staging
+#     │  • GET /health  → 200
+#     │  • GET /docs    → 200
+#     │  • GET /auth/me → 200 or 401
+#     │  ✖ failure → summary alert, prod skipped
+#     │
+#     ▼
+#   3️⃣  deploy-production
+#     │  • same provisioning as staging
+#     │  • deploy docling-serve sidecar
+#     │  • deploy app from GHCR :latest
+#     │
+#     ▼
+#   4️⃣  verify-production
+#        • poll /health for 60s
 #
-# Pipeline:
-#   deploy-staging -> smoke-test-staging -> deploy-production -> verify-production
+# ---------------------------------------------------------------
+# Auto-provisioning (both environments)
+# ---------------------------------------------------------------
 #
-# If staging smoke tests fail, production is NOT deployed and
-# a GitHub Actions summary alert is created.
+#   Resource          │ Behavior
+#   ──────────────────┼─────────────────────────────────────────
+#   Fly app           │ Created if missing
+#   Volume            │ Created if missing (1 GB)
+#   Postgres cluster  │ Created if missing (⚠️ WARNING emitted)
+#   Postgres attach   │ Idempotent; real errors fail the job
+#   Secrets           │ Staged (--stage) from GitHub secrets
+#   Docling sidecar   │ App created if missing, deployed
 #
-# Fully automated provisioning (zero manual steps):
-#   - App + volume created if they don't exist
-#   - Postgres cluster created if it doesn't exist (with WARNING)
-#   - Postgres attach (idempotent, fails loudly on real errors)
-#   - Secrets staged (no restart) from GitHub repository secrets
+#   Why ⚠️ on Postgres create: a new cluster has empty data.
+#   If the old cluster was deleted, you've lost data. The warning
+#   ensures operators notice and investigate.
 #
-# Required GitHub repository secrets:
-#   - FLY_API_TOKEN (deploy token with access to all apps)
-#   - ANTHROPIC_API_KEY
-#   - WIKIMIND_AUTH__JWT_SECRET_KEY
-#   - WIKIMIND_AUTH__GOOGLE_CLIENT_ID
-#   - WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET
+# ---------------------------------------------------------------
+# Required GitHub repository secrets
+# ---------------------------------------------------------------
+#
+#   Secret                              │ Purpose
+#   ────────────────────────────────────┼────────────────────────
+#   FLY_API_TOKEN                       │ Fly.io deploy token
+#   ANTHROPIC_API_KEY                   │ LLM provider key
+#   WIKIMIND_AUTH__JWT_SECRET_KEY        │ JWT signing key
+#   WIKIMIND_AUTH__GOOGLE_CLIENT_ID      │ OAuth client ID
+#   WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET  │ OAuth client secret
+#
+# ---------------------------------------------------------------
+# Fly.io apps managed by this workflow
+# ---------------------------------------------------------------
+#
+#   App               │ Config             │ Purpose
+#   ──────────────────┼────────────────────┼──────────────────
+#   wikimind-staging  │ fly.staging.toml   │ Pre-prod gate
+#   wikimind          │ fly.toml           │ Production
+#   wikimind-docling  │ fly.docling.toml   │ PDF sidecar
+#   wikimind-db       │ (Postgres cluster) │ Shared database
+#
 # ---------------------------------------------------------------
 
 name: Deploy
@@ -43,7 +97,7 @@ permissions:
 
 jobs:
   # -----------------------------------------------------------
-  # 1. Deploy to staging
+  # 1️⃣  Deploy to staging
   # -----------------------------------------------------------
   deploy-staging:
     name: deploy to staging
@@ -54,13 +108,14 @@ jobs:
       github.event.workflow_run.event == 'push'
 
     steps:
-      - name: Checkout code
+      - name: ⬇️  Checkout code
         uses: actions/checkout@v4
 
-      - name: Install flyctl
+      - name: 🪁  Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Validate required secrets
+      # 0️⃣  Pre-flight: ensure all secrets are configured
+      - name: 🔐  Validate required secrets
         run: |
           missing=0
           for var in ANTHROPIC_API_KEY JWT_SECRET_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET; do
@@ -76,20 +131,23 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
-      - name: Ensure staging app exists
+      # 1️⃣  Ensure staging infrastructure exists
+      - name: 🏗️  Ensure staging app exists
         run: |
           if ! flyctl status --app wikimind-staging 2>/dev/null; then
             echo "Creating staging app..."
             flyctl apps create wikimind-staging --org personal
             flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
           fi
-          # Ensure Postgres cluster exists.
+
+          # Postgres cluster — created if missing, with loud warning
           if ! flyctl status --app wikimind-db 2>/dev/null; then
             echo "::warning::Creating NEW Postgres cluster — database will be empty!"
             flyctl postgres create --name wikimind-db --org personal --region ord \
               --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
           fi
-          # Attach is idempotent — only suppress "already attached" errors.
+
+          # Attach — idempotent; only suppress "already attached" errors
           output=$(flyctl postgres attach wikimind-db --app wikimind-staging 2>&1) || {
             if echo "$output" | grep -qi "already attached\|already exists"; then
               echo "Postgres already attached to staging"
@@ -101,7 +159,8 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Stage secrets for staging
+      # 2️⃣  Stage secrets (--stage avoids double-restart before deploy)
+      - name: 🔑  Stage secrets for staging
         run: |
           flyctl secrets set --stage --app wikimind-staging \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
@@ -115,20 +174,21 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
-      - name: Deploy docling-serve sidecar
+      # 3️⃣  Deploy sidecar + app
+      - name: 🧠  Deploy docling-serve sidecar
         run: |
           flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
           flyctl deploy --config fly.docling.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Deploy to staging
+      - name: 🚀  Deploy to staging
         run: flyctl deploy --config fly.staging.toml --image ghcr.io/${{ github.repository }}:latest --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   # -----------------------------------------------------------
-  # 2. Smoke-test staging
+  # 2️⃣  Smoke-test staging
   # -----------------------------------------------------------
   smoke-test-staging:
     name: smoke-test staging
@@ -137,7 +197,7 @@ jobs:
     needs: deploy-staging
 
     steps:
-      - name: Wait for staging to become healthy
+      - name: ⏳  Wait for staging to become healthy
         run: |
           echo "Waiting for staging to become healthy..."
           for i in $(seq 1 30); do
@@ -155,19 +215,19 @@ jobs:
             sleep 2
           done
 
-      - name: "Smoke: GET /health returns 200"
+      - name: "🩺  Smoke: GET /health → 200"
         run: |
           code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/health)
           echo "/health -> $code"
           [ "$code" = "200" ] || { echo "::error::/health returned $code"; exit 1; }
 
-      - name: "Smoke: GET /docs returns 200"
+      - name: "📖  Smoke: GET /docs → 200"
         run: |
           code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/docs)
           echo "/docs -> $code"
           [ "$code" = "200" ] || { echo "::error::/docs returned $code"; exit 1; }
 
-      - name: "Smoke: GET /auth/me returns 200 or 401"
+      - name: "🔐  Smoke: GET /auth/me → 200 or 401"
         run: |
           code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/auth/me)
           echo "/auth/me -> $code"
@@ -176,7 +236,7 @@ jobs:
             exit 1
           fi
 
-      - name: Create alert on failure
+      - name: 🚨  Create alert on failure
         if: failure()
         run: |
           echo "## Staging smoke tests failed" >> "$GITHUB_STEP_SUMMARY"
@@ -186,7 +246,7 @@ jobs:
           echo "Check the failed steps above for details." >> "$GITHUB_STEP_SUMMARY"
 
   # -----------------------------------------------------------
-  # 3. Deploy to production (only if staging passed)
+  # 3️⃣  Deploy to production (only if staging passed)
   # -----------------------------------------------------------
   deploy-production:
     name: deploy to production
@@ -195,24 +255,26 @@ jobs:
     needs: smoke-test-staging
 
     steps:
-      - name: Checkout code
+      - name: ⬇️  Checkout code
         uses: actions/checkout@v4
 
-      - name: Install flyctl
+      - name: 🪁  Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Ensure production app exists
+      - name: 🏗️  Ensure production app exists
         run: |
           if ! flyctl status --app wikimind 2>/dev/null; then
             echo "Creating production app..."
             flyctl apps create wikimind --org personal
             flyctl volumes create wikimind_data --region ord --size 1 --app wikimind --yes
           fi
+
           if ! flyctl status --app wikimind-db 2>/dev/null; then
             echo "::warning::Creating NEW Postgres cluster — database will be empty!"
             flyctl postgres create --name wikimind-db --org personal --region ord \
               --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
           fi
+
           output=$(flyctl postgres attach wikimind-db --app wikimind 2>&1) || {
             if echo "$output" | grep -qi "already attached\|already exists"; then
               echo "Postgres already attached to production"
@@ -224,7 +286,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Stage secrets for production
+      - name: 🔑  Stage secrets for production
         run: |
           flyctl secrets set --stage --app wikimind \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
@@ -238,20 +300,20 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
-      - name: Deploy docling-serve sidecar
+      - name: 🧠  Deploy docling-serve sidecar
         run: |
           flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
           flyctl deploy --config fly.docling.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Deploy to production
+      - name: 🚀  Deploy to production
         run: flyctl deploy --image ghcr.io/${{ github.repository }}:latest --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   # -----------------------------------------------------------
-  # 4. Verify production
+  # 4️⃣  Verify production
   # -----------------------------------------------------------
   verify-production:
     name: verify production
@@ -260,7 +322,7 @@ jobs:
     needs: deploy-production
 
     steps:
-      - name: Verify deployment health
+      - name: ✅  Verify deployment health
         run: |
           echo "Waiting for production to become healthy..."
           for i in $(seq 1 30); do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,18 @@
 # If staging smoke tests fail, production is NOT deployed and
 # a GitHub Actions summary alert is created.
 #
-# Both staging and production are auto-provisioned:
+# Auto-provisioning:
 #   - App + volume created if they don't exist
-#   - Secrets synced from GitHub repository secrets
-#   - Only manual prerequisite: Postgres must be attached once per app
-#     (fly postgres attach wikimind-db --app <APP_NAME>)
+#   - Postgres attach (idempotent, fails loudly on real errors)
+#   - Secrets staged (no restart) from GitHub repository secrets
+#   - Postgres cluster must exist — NOT auto-created (data-loss risk)
+#
+# One-time manual setup (per environment):
+#   fly postgres create --name wikimind-db --org personal --region ord \
+#     --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
 #
 # Required GitHub repository secrets:
-#   - FLY_API_TOKEN (deploy token with access to both apps)
+#   - FLY_API_TOKEN (deploy token with access to all apps)
 #   - ANTHROPIC_API_KEY
 #   - WIKIMIND_AUTH__JWT_SECRET_KEY
 #   - WIKIMIND_AUTH__GOOGLE_CLIENT_ID
@@ -60,6 +64,22 @@ jobs:
       - name: Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Validate required secrets
+        run: |
+          missing=0
+          for var in ANTHROPIC_API_KEY JWT_SECRET_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Required secret ${var} is empty or not configured"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
+          GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
+
       - name: Ensure staging app exists
         run: |
           if ! flyctl status --app wikimind-staging 2>/dev/null; then
@@ -67,31 +87,26 @@ jobs:
             flyctl apps create wikimind-staging --org personal
             flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
           fi
-          # Ensure Postgres cluster exists and is attached.
-          # fly postgres create is NOT idempotent — it errors if the cluster
-          # already exists, so we check first.
-          if ! flyctl status --app wikimind-db 2>/dev/null; then
-            echo "Creating Postgres cluster..."
-            flyctl postgres create --name wikimind-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
-          fi
-          # Attach is idempotent — errors harmlessly if already attached.
-          flyctl postgres attach wikimind-db --app wikimind-staging 2>/dev/null || true
+          # Postgres cluster must already exist (manual one-time setup).
+          # Attach is idempotent — only suppress "already attached" errors.
+          output=$(flyctl postgres attach wikimind-db --app wikimind-staging 2>&1) || {
+            if echo "$output" | grep -qi "already attached\|already exists"; then
+              echo "Postgres already attached to staging"
+            else
+              echo "::error::Postgres attach failed: $output"
+              exit 1
+            fi
+          }
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Sync secrets from production to staging
+      - name: Stage secrets for staging
         run: |
-          echo "Copying secrets from wikimind to wikimind-staging..."
-          # Export prod secrets (key=value), import to staging.
-          # flyctl secrets list outputs NAME | DIGEST | DEPLOYED — we need
-          # to re-set them from the prod app. Since we can't read secret
-          # values via CLI, we use the same GitHub secrets the prod app uses.
-          flyctl secrets set --app wikimind-staging \
+          flyctl secrets set --stage --app wikimind-staging \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
-            2>/dev/null || true
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -192,28 +207,37 @@ jobs:
             flyctl apps create wikimind --org personal
             flyctl volumes create wikimind_data --region ord --size 1 --app wikimind --yes
           fi
-          if ! flyctl status --app wikimind-db 2>/dev/null; then
-            echo "Creating Postgres cluster..."
-            flyctl postgres create --name wikimind-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
-          fi
-          flyctl postgres attach wikimind-db --app wikimind 2>/dev/null || true
+          output=$(flyctl postgres attach wikimind-db --app wikimind 2>&1) || {
+            if echo "$output" | grep -qi "already attached\|already exists"; then
+              echo "Postgres already attached to production"
+            else
+              echo "::error::Postgres attach failed: $output"
+              exit 1
+            fi
+          }
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Sync secrets to production
+      - name: Stage secrets for production
         run: |
-          flyctl secrets set --app wikimind \
+          flyctl secrets set --stage --app wikimind \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
-            2>/dev/null || true
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
+
+      - name: Deploy docling-serve sidecar
+        run: |
+          flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
+          flyctl deploy --config fly.docling.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Deploy to production
         run: flyctl deploy --image ghcr.io/${{ github.repository }}:latest --remote-only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,18 @@
 # ---------------------------------------------------------------
-# 🚀  Deploy to Fly.io
+# Deploy to Fly.io  (staging -> smoke tests -> production)
 # ---------------------------------------------------------------
 #
 # Chains after the Docker workflow: when Docker builds, scans,
 # and publishes a multi-arch image to GHCR on push to main,
-# this workflow pulls that image and deploys it to Fly.io.
+# this workflow pulls that image and deploys it.
 #
-# Prerequisites:
+# Pipeline:
+#   deploy-staging -> smoke-test-staging -> deploy-production -> verify-production
+#
+# If staging smoke tests fail, production is NOT deployed and
+# a GitHub Actions summary alert is created.
+#
+# Prerequisites (production — already set up):
 #   1. Fly app created:  fly apps create wikimind
 #   2. Volume created:   fly volumes create wikimind_data --region ord --size 1
 #   3. Postgres attached: fly postgres create --name wikimind-db && fly postgres attach wikimind-db
@@ -15,8 +21,15 @@
 #        fly secrets set WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32)
 #        fly secrets set WIKIMIND_AUTH__GOOGLE_CLIENT_ID=...
 #        fly secrets set WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
-#   5. FLY_API_TOKEN added as a GitHub repository secret:
-#        fly tokens create deploy -x 999999h
+#   5. FLY_API_TOKEN added as a GitHub repository secret
+#
+# Prerequisites (staging):
+#   1. fly apps create wikimind-staging
+#   2. fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging
+#   3. fly postgres attach wikimind-db --app wikimind-staging
+#   4. Secrets set (same as production, or use test values):
+#        fly secrets set --app wikimind-staging ANTHROPIC_API_KEY=...
+#        fly secrets set --app wikimind-staging WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32)
 # ---------------------------------------------------------------
 
 name: Deploy
@@ -35,46 +48,137 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: deploy to Fly.io
+  # -----------------------------------------------------------
+  # 1. Deploy to staging
+  # -----------------------------------------------------------
+  deploy-staging:
+    name: deploy to staging
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Only deploy when Docker workflow succeeded on a push (not schedule or PR)
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
 
     steps:
-      - name: ⬇️  Checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: 🪁  Install flyctl
+      - name: Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: 🧠  Deploy docling-serve sidecar
+      - name: Deploy docling-serve sidecar
         run: |
           flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
           flyctl deploy --config fly.docling.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: 🚀  Deploy to Fly.io
+      - name: Deploy to staging
+        run: flyctl deploy --config fly.staging.toml --image ghcr.io/${{ github.repository }}:latest --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  # -----------------------------------------------------------
+  # 2. Smoke-test staging
+  # -----------------------------------------------------------
+  smoke-test-staging:
+    name: smoke-test staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: deploy-staging
+
+    steps:
+      - name: Wait for staging to become healthy
+        run: |
+          echo "Waiting for staging to become healthy..."
+          for i in $(seq 1 30); do
+            status=$(curl -sf https://wikimind-staging.fly.dev/health \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" \
+              2>/dev/null || echo "")
+            if [ "$status" = "ok" ]; then
+              echo "Staging healthy after $((i*2))s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Staging health check failed after 60s"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: "Smoke: GET /health returns 200"
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/health)
+          echo "/health -> $code"
+          [ "$code" = "200" ] || { echo "::error::/health returned $code"; exit 1; }
+
+      - name: "Smoke: GET /docs returns 200"
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/docs)
+          echo "/docs -> $code"
+          [ "$code" = "200" ] || { echo "::error::/docs returned $code"; exit 1; }
+
+      - name: "Smoke: GET /auth/me returns 200 or 401"
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/auth/me)
+          echo "/auth/me -> $code"
+          if [ "$code" != "200" ] && [ "$code" != "401" ]; then
+            echo "::error::/auth/me returned $code (expected 200 or 401)"
+            exit 1
+          fi
+
+      - name: Create alert on failure
+        if: failure()
+        run: |
+          echo "## Staging smoke tests failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Production deploy was **skipped** because staging smoke tests did not pass." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Check the failed steps above for details." >> "$GITHUB_STEP_SUMMARY"
+
+  # -----------------------------------------------------------
+  # 3. Deploy to production (only if staging passed)
+  # -----------------------------------------------------------
+  deploy-production:
+    name: deploy to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: smoke-test-staging
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to production
         run: flyctl deploy --image ghcr.io/${{ github.repository }}:latest --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: ✅  Verify deployment health
+  # -----------------------------------------------------------
+  # 4. Verify production
+  # -----------------------------------------------------------
+  verify-production:
+    name: verify production
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: deploy-production
+
+    steps:
+      - name: Verify deployment health
         run: |
-          echo "Waiting for deployment to become healthy..."
+          echo "Waiting for production to become healthy..."
           for i in $(seq 1 30); do
             status=$(curl -sf https://wikimind.fly.dev/health \
               | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" \
               2>/dev/null || echo "")
             if [ "$status" = "ok" ]; then
-              echo "Deployment healthy after $((i*2))s"
+              echo "Production healthy after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::Health check failed after 60s"
+          echo "::error::Production health check failed after 60s"
           exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,23 +12,18 @@
 # If staging smoke tests fail, production is NOT deployed and
 # a GitHub Actions summary alert is created.
 #
-# Prerequisites (production — already set up):
-#   1. Fly app created:  fly apps create wikimind
-#   2. Volume created:   fly volumes create wikimind_data --region ord --size 1
-#   3. Postgres attached: fly postgres create --name wikimind-db && fly postgres attach wikimind-db
-#   4. Secrets set:
-#        fly secrets set ANTHROPIC_API_KEY=...
-#        fly secrets set WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32)
-#        fly secrets set WIKIMIND_AUTH__GOOGLE_CLIENT_ID=...
-#        fly secrets set WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
-#   5. FLY_API_TOKEN added as a GitHub repository secret
+# Both staging and production are auto-provisioned:
+#   - App + volume created if they don't exist
+#   - Secrets synced from GitHub repository secrets
+#   - Only manual prerequisite: Postgres must be attached once per app
+#     (fly postgres attach wikimind-db --app <APP_NAME>)
 #
-# Staging is auto-provisioned by the workflow:
-#   - App created if it doesn't exist
-#   - Volume created if it doesn't exist
-#   - Secrets copied from production
-#   - Only manual prerequisite: Postgres must be attached once
-#     (fly postgres attach wikimind-db --app wikimind-staging)
+# Required GitHub repository secrets:
+#   - FLY_API_TOKEN (deploy token with access to both apps)
+#   - ANTHROPIC_API_KEY
+#   - WIKIMIND_AUTH__JWT_SECRET_KEY
+#   - WIKIMIND_AUTH__GOOGLE_CLIENT_ID
+#   - WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET
 # ---------------------------------------------------------------
 
 name: Deploy
@@ -181,6 +176,32 @@ jobs:
 
       - name: Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Ensure production app exists
+        run: |
+          if ! flyctl status --app wikimind 2>/dev/null; then
+            echo "Creating production app..."
+            flyctl apps create wikimind --org personal
+            flyctl volumes create wikimind_data --region ord --size 1 --app wikimind --yes
+            echo "::warning::Production app created. You must manually run: fly postgres attach wikimind-db --app wikimind"
+          fi
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Sync secrets to production
+        run: |
+          flyctl secrets set --app wikimind \
+            ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+            WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
+            WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
+            2>/dev/null || true
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
+          GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
       - name: Deploy to production
         run: flyctl deploy --image ghcr.io/${{ github.repository }}:latest --remote-only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,11 @@
 # If staging smoke tests fail, production is NOT deployed and
 # a GitHub Actions summary alert is created.
 #
-# Auto-provisioning:
+# Fully automated provisioning (zero manual steps):
 #   - App + volume created if they don't exist
+#   - Postgres cluster created if it doesn't exist (with WARNING)
 #   - Postgres attach (idempotent, fails loudly on real errors)
 #   - Secrets staged (no restart) from GitHub repository secrets
-#   - Postgres cluster must exist — NOT auto-created (data-loss risk)
-#
-# One-time manual setup (per environment):
-#   fly postgres create --name wikimind-db --org personal --region ord \
-#     --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
 #
 # Required GitHub repository secrets:
 #   - FLY_API_TOKEN (deploy token with access to all apps)
@@ -87,7 +83,12 @@ jobs:
             flyctl apps create wikimind-staging --org personal
             flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
           fi
-          # Postgres cluster must already exist (manual one-time setup).
+          # Ensure Postgres cluster exists.
+          if ! flyctl status --app wikimind-db 2>/dev/null; then
+            echo "::warning::Creating NEW Postgres cluster — database will be empty!"
+            flyctl postgres create --name wikimind-db --org personal --region ord \
+              --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
+          fi
           # Attach is idempotent — only suppress "already attached" errors.
           output=$(flyctl postgres attach wikimind-db --app wikimind-staging 2>&1) || {
             if echo "$output" | grep -qi "already attached\|already exists"; then
@@ -206,6 +207,11 @@ jobs:
             echo "Creating production app..."
             flyctl apps create wikimind --org personal
             flyctl volumes create wikimind_data --region ord --size 1 --app wikimind --yes
+          fi
+          if ! flyctl status --app wikimind-db 2>/dev/null; then
+            echo "::warning::Creating NEW Postgres cluster — database will be empty!"
+            flyctl postgres create --name wikimind-db --org personal --region ord \
+              --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
           fi
           output=$(flyctl postgres attach wikimind-db --app wikimind 2>&1) || {
             if echo "$output" | grep -qi "already attached\|already exists"; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,16 @@ jobs:
             echo "Creating staging app..."
             flyctl apps create wikimind-staging --org personal
             flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
-            echo "::warning::Staging app created. You must manually run: fly postgres attach wikimind-db --app wikimind-staging"
           fi
+          # Ensure Postgres cluster exists and is attached.
+          # fly postgres create is NOT idempotent — it errors if the cluster
+          # already exists, so we check first.
+          if ! flyctl status --app wikimind-db 2>/dev/null; then
+            echo "Creating Postgres cluster..."
+            flyctl postgres create --name wikimind-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
+          fi
+          # Attach is idempotent — errors harmlessly if already attached.
+          flyctl postgres attach wikimind-db --app wikimind-staging 2>/dev/null || true
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -183,8 +191,12 @@ jobs:
             echo "Creating production app..."
             flyctl apps create wikimind --org personal
             flyctl volumes create wikimind_data --region ord --size 1 --app wikimind --yes
-            echo "::warning::Production app created. You must manually run: fly postgres attach wikimind-db --app wikimind"
           fi
+          if ! flyctl status --app wikimind-db 2>/dev/null; then
+            echo "Creating Postgres cluster..."
+            flyctl postgres create --name wikimind-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
+          fi
+          flyctl postgres attach wikimind-db --app wikimind 2>/dev/null || true
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,13 +23,12 @@
 #        fly secrets set WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
 #   5. FLY_API_TOKEN added as a GitHub repository secret
 #
-# Prerequisites (staging):
-#   1. fly apps create wikimind-staging
-#   2. fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging
-#   3. fly postgres attach wikimind-db --app wikimind-staging
-#   4. Secrets set (same as production, or use test values):
-#        fly secrets set --app wikimind-staging ANTHROPIC_API_KEY=...
-#        fly secrets set --app wikimind-staging WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32)
+# Staging is auto-provisioned by the workflow:
+#   - App created if it doesn't exist
+#   - Volume created if it doesn't exist
+#   - Secrets copied from production
+#   - Only manual prerequisite: Postgres must be attached once
+#     (fly postgres attach wikimind-db --app wikimind-staging)
 # ---------------------------------------------------------------
 
 name: Deploy
@@ -65,6 +64,37 @@ jobs:
 
       - name: Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Ensure staging app exists
+        run: |
+          if ! flyctl status --app wikimind-staging 2>/dev/null; then
+            echo "Creating staging app..."
+            flyctl apps create wikimind-staging --org personal
+            flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
+            echo "::warning::Staging app created. You must manually run: fly postgres attach wikimind-db --app wikimind-staging"
+          fi
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Sync secrets from production to staging
+        run: |
+          echo "Copying secrets from wikimind to wikimind-staging..."
+          # Export prod secrets (key=value), import to staging.
+          # flyctl secrets list outputs NAME | DIGEST | DEPLOYED — we need
+          # to re-set them from the prod app. Since we can't read secret
+          # values via CLI, we use the same GitHub secrets the prod app uses.
+          flyctl secrets set --app wikimind-staging \
+            ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+            WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
+            WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
+            2>/dev/null || true
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
+          GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
       - name: Deploy docling-serve sidecar
         run: |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ fly secrets set ANTHROPIC_API_KEY=sk-...
 
 Fly.io auto-scales machines based on connection count (see `fly.toml`).
 
+#### Staging environment
+
+CI deploys to a staging app (`wikimind-staging`) before production. Smoke tests
+run against staging; production is only promoted when they pass. See
+`.github/workflows/deploy.yml` for the full pipeline.
+
+First-time staging setup:
+
+```bash
+fly apps create wikimind-staging
+fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging
+fly postgres attach wikimind-db --app wikimind-staging
+fly secrets set --app wikimind-staging ANTHROPIC_API_KEY=... WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32)
+```
+
+Manual deploy: `fly deploy --config fly.staging.toml --remote-only`
+
 ### PostgreSQL without Docker
 
 For shared access across multiple devices without the full Docker stack:

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,0 +1,63 @@
+# fly.staging.toml — Fly.io deployment for WikiMind staging environment.
+#
+# Pre-prod environment used by CI to run smoke tests before promoting
+# to production.  Same machine specs as production (fly.toml).
+#
+# First-time setup:
+#   fly apps create wikimind-staging
+#   fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging
+#   fly postgres attach wikimind-db --app wikimind-staging   # or a separate staging DB
+#   fly secrets set --app wikimind-staging \
+#     ANTHROPIC_API_KEY=... \
+#     WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32) \
+#     WIKIMIND_AUTH__GOOGLE_CLIENT_ID=... \
+#     WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
+#
+# Manual deploy:
+#   fly deploy --config fly.staging.toml --remote-only
+
+app = "wikimind-staging"
+primary_region = "ord"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  WIKIMIND_SERVER__HOST = "0.0.0.0"
+  WIKIMIND_SERVER__PORT = "7842"
+  WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
+  WEB_CONCURRENCY = "4"
+
+[http_service]
+  internal_port = 7842
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 50
+    soft_limit = 25
+
+
+[deploy]
+  strategy = "rolling"
+
+[mounts]
+  source = "wikimind_staging_data"
+  destination = "/home/wikimind/.wikimind"
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[checks]
+  [checks.health]
+    type = "http"
+    port = 7842
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "60s"


### PR DESCRIPTION
## Summary

- Adds `fly.staging.toml` for a `wikimind-staging` Fly.io app (same specs as production, separate volume)
- Restructures `.github/workflows/deploy.yml` into a 4-job pipeline: `deploy-staging` -> `smoke-test-staging` -> `deploy-production` -> `verify-production`
- Smoke tests hit `/health`, `/docs`, and `/auth/me` on the staging URL; if any fail, production deploy is blocked and a GitHub Actions summary alert is created
- Documents staging setup in README

## Motivation

Deploying directly to production is risky. A staging gate catches broken builds before they reach users. This was requested in #307.

## How it works

1. **deploy-staging** -- deploys the GHCR image to `wikimind-staging` using `fly.staging.toml`
2. **smoke-test-staging** -- curl-based checks against the staging URL (health, docs, auth)
3. **deploy-production** -- only runs if smoke tests pass; deploys same image to production
4. **verify-production** -- confirms production is healthy after deploy

The staging app and Postgres do not need to exist yet. Create them with:
```bash
fly apps create wikimind-staging
fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging
fly postgres attach wikimind-db --app wikimind-staging
fly secrets set --app wikimind-staging ANTHROPIC_API_KEY=... WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32)
```

## Test plan

- [ ] Verify `fly.staging.toml` is valid: `fly config validate --config fly.staging.toml`
- [ ] Review workflow YAML for correct job dependencies and conditional logic
- [ ] Create staging app on Fly.io and trigger a deploy to verify the full pipeline
- [ ] Confirm production is blocked when staging smoke tests fail

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)