### PR TITLE
chore: add docker-compose for local Postgres development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,10 +189,19 @@
 # ----------------------------------------------------------------------------
 # Database (optional)
 # ----------------------------------------------------------------------------
-# Defaults to SQLite at ~/.wikimind/db/wikimind.db. Override for Postgres:
-# WIKIMIND_DATABASE_URL=postgresql+asyncpg://localhost:5432/wikimind
+# Defaults to SQLite at ~/.wikimind/db/wikimind.db — zero-setup for dev.
 #
-# For Postgres, run `alembic upgrade head` before first startup.
+# To match the Fly.io production environment (Postgres), start a local
+# Postgres container and point the app at it:
+#
+#   make pg-up           # start Postgres on port 5433
+#   make dev-postgres    # run the app against it
+#   make test-postgres   # run tests against it
+#   make pg-down         # stop Postgres
+#
+# The make targets auto-set WIKIMIND_DATABASE_URL. To override (e.g.
+# to point at an external Postgres instance), set it explicitly:
+# WIKIMIND_DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/wikimind
 #
 # Verbose SQL query logging — dev only, very noisy
 # WIKIMIND_DATABASE__ECHO=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": ".merge_file_xQNtNT"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -127,6 +127,180 @@
     }
   ],
   "results": {
+    ".env.example": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 204
+      }
+    ],
+    ".secrets.baseline": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 205
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 205
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 221
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 221
+      }
+    ],
+    "Makefile": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "Makefile",
+        "hashed_secret": "a2af834e65ad267df89a30dd525c7aac8451b394",
+        "is_verified": false,
+        "line_number": 110
+      }
+    ],
     "design-system/ui_kits/app/index.html": [
       {
         "type": "Base64 High Entropy String",
@@ -148,6 +322,15 @@
         "hashed_secret": "eadc3f93238dda49ec69d9ffa9416a74f348d9ca",
         "is_verified": false,
         "line_number": 36
+      }
+    ],
+    "docker-compose.dev.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.dev.yml",
+        "hashed_secret": "a2af834e65ad267df89a30dd525c7aac8451b394",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "docs/superpowers/plans/2026-04-17-postgres-compatibility.md": [
@@ -242,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-26T03:53:56Z"
+  "generated_at": "2026-04-26T16:01:15Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_xQNtNT"
+      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -134,162 +134,6 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
         "line_number": 204
-      }
-    ],
-    ".secrets.baseline": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
-        "is_verified": false,
-        "line_number": 134
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
-        "is_verified": false,
-        "line_number": 134
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
-        "is_verified": false,
-        "line_number": 148
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
-        "is_verified": false,
-        "line_number": 148
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
-        "is_verified": false,
-        "line_number": 157
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
-        "is_verified": false,
-        "line_number": 157
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
-        "is_verified": false,
-        "line_number": 164
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
-        "is_verified": false,
-        "line_number": 164
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
-        "is_verified": false,
-        "line_number": 171
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
-        "is_verified": false,
-        "line_number": 171
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 187
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 187
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
-        "is_verified": false,
-        "line_number": 205
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
-        "is_verified": false,
-        "line_number": 205
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
-        "is_verified": false,
-        "line_number": 214
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
-        "is_verified": false,
-        "line_number": 214
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
-        "is_verified": false,
-        "line_number": 221
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
-        "is_verified": false,
-        "line_number": 221
       }
     ],
     "Makefile": [
@@ -425,5 +269,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-26T16:01:15Z"
+  "generated_at": "2026-04-26T16:02:18Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,29 @@ dev: check-venv ## Run fast-reload dev server on :7842 (uvicorn)
 serve: ## Run production server on :7842 (gunicorn)
 	$(BIN)/gunicorn wikimind.main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 127.0.0.1:7842
 
+DEV_PG_URL := postgresql+asyncpg://wikimind:wikimind@localhost:5433/wikimind
+
+.PHONY: pg-up
+pg-up: ## Start local Postgres (docker-compose.dev.yml, port 5433)
+	$(COMPOSE_CMD) -f docker-compose.dev.yml up -d
+	@echo "Postgres running on localhost:5433"
+	@echo "  WIKIMIND_DATABASE_URL=$(DEV_PG_URL)"
+
+.PHONY: pg-down
+pg-down: ## Stop local Postgres
+	$(COMPOSE_CMD) -f docker-compose.dev.yml down
+
 .PHONY: dev-postgres
-dev-postgres: check-venv ## Run dev server against Postgres (set WIKIMIND_DATABASE_URL in .env)
-	@test -n "$${WIKIMIND_DATABASE_URL:-}" || { echo "ERROR: Set WIKIMIND_DATABASE_URL in .env or environment"; exit 1; }
+dev-postgres: check-venv ## Run dev server against local Postgres (make pg-up first)
+	WIKIMIND_DATABASE_URL=$${WIKIMIND_DATABASE_URL:-$(DEV_PG_URL)} \
 	$(BIN)/python -m alembic upgrade head
+	WIKIMIND_DATABASE_URL=$${WIKIMIND_DATABASE_URL:-$(DEV_PG_URL)} \
 	$(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
+
+.PHONY: test-postgres
+test-postgres: ## Run tests against local Postgres (make pg-up first)
+	WIKIMIND_DATABASE_URL=$${WIKIMIND_DATABASE_URL:-$(DEV_PG_URL)} \
+	$(BIN)/pytest $(ARGS)
 
 .PHONY: worker
 worker: ## Start ARQ background job worker

--- a/README.md
+++ b/README.md
@@ -240,7 +240,10 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 |--------|-------------|
 | `make dev` | Run fast-reload dev server on :7842 (uvicorn) |
 | `make serve` | Run production server on :7842 (gunicorn) |
-| `make dev-postgres` | Run dev server against Postgres (set WIKIMIND_DATABASE_URL in .env) |
+| `make pg-up` | Start local Postgres (docker-compose.dev.yml, port 5433) |
+| `make pg-down` | Stop local Postgres |
+| `make dev-postgres` | Run dev server against local Postgres (make pg-up first) |
+| `make test-postgres` | Run tests against local Postgres (make pg-up first) |
 | `make worker` | Start ARQ background job worker |
 
 ### 🔍 QUALITY

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,31 @@
+# Local Postgres for development — matches the Fly.io environment.
+#
+# This runs ONLY Postgres, not the full app stack. The app still runs
+# on the host via `make dev-postgres` (uvicorn with --reload).
+#
+# Usage:
+#   make pg-up          # start Postgres
+#   make dev-postgres   # run the app against it
+#   make test-postgres  # run tests against it
+#   make pg-down        # stop Postgres
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: wikimind-dev-postgres
+    environment:
+      POSTGRES_USER: wikimind
+      POSTGRES_PASSWORD: wikimind
+      POSTGRES_DB: wikimind
+    ports:
+      - "5433:5432"
+    volumes:
+      - wikimind-dev-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U wikimind"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  wikimind-dev-pgdata:


### PR DESCRIPTION
## Summary

Local dev used SQLite while Fly.io uses Postgres, which hid multiple deploy-blocking bugs (#305, #308, #309, #310). This adds a minimal `docker-compose.dev.yml` that runs just Postgres for local dev, with ergonomic Makefile targets so developers can easily test against the same database engine as production.

**Problem:** SQLite and Postgres have different SQL dialects (INSERT syntax, type handling, SSL). Bugs in Postgres-specific code paths only surfaced at deploy time, causing a chain of emergency fixes.

**Solution:** Make it trivial to run against Postgres locally:

```bash
make pg-up          # start Postgres on port 5433
make dev-postgres   # run the app against it (auto-runs alembic migrations)
make test-postgres  # run tests against it
make pg-down        # stop Postgres
```

**What changed:**
- `docker-compose.dev.yml` -- minimal Postgres 16 Alpine on port 5433 (avoids conflict with system Postgres on 5432)
- `Makefile` -- `pg-up`, `pg-down`, updated `dev-postgres` (no longer requires manual env var), new `test-postgres`
- `.env.example` -- clearer instructions on switching between SQLite and Postgres
- `README.md` -- auto-regenerated make-targets section

**What did NOT change:** `make dev` still uses SQLite for zero-setup development.

Closes #306

## Test plan

- [ ] `make pg-up` starts Postgres container on port 5433
- [ ] `make dev-postgres` runs alembic migrations and starts the app
- [ ] `make test-postgres` runs the test suite against Postgres
- [ ] `make pg-down` stops the container
- [ ] `make dev` still uses SQLite (default unchanged)
- [ ] `make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)