### PR TITLE
fix: handle 'already contains' error from fly postgres attach

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
 
           # Attach — idempotent; only suppress "already attached" errors
           output=$(flyctl postgres attach wikimind-db --app wikimind-staging 2>&1) || {
-            if echo "$output" | grep -qi "already attached\|already exists"; then
+            if echo "$output" | grep -qi "already attached\|already exists\|already contains"; then
               echo "Postgres already attached to staging"
             else
               echo "::error::Postgres attach failed: $output"
@@ -276,7 +276,7 @@ jobs:
           fi
 
           output=$(flyctl postgres attach wikimind-db --app wikimind 2>&1) || {
-            if echo "$output" | grep -qi "already attached\|already exists"; then
+            if echo "$output" | grep -qi "already attached\|already exists\|already contains"; then
               echo "Postgres already attached to production"
             else
               echo "::error::Postgres attach failed: $output"


### PR DESCRIPTION
## Summary

- Production deploy fails because `fly postgres attach` now returns "already contains a secret named DATABASE_URL" instead of "already exists"
- The idempotent grep in the deploy workflow didn't match the new wording
- Adds `already contains` to the grep pattern in both staging and production steps

## Test plan

- [x] Merge and re-run deploy — production step should pass the postgres attach check

🤖 Generated with [Claude Code](https://claude.com/claude-code)