### PR TITLE
chore: add workflow_dispatch trigger to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Docker"]
     types: [completed]


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to deploy.yml so deploys can be triggered manually
- Prevents the chicken-and-egg problem where deploy-only changes can't be deployed without touching source code

## Test plan

- [x] After merge, run `gh workflow run deploy.yml` to trigger the deploy with the postgres attach fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)