### PR TITLE
fix: use enum name for Postgres provider column queries

### DIFF
--- a/src/wikimind/services/api_keys.py
+++ b/src/wikimind/services/api_keys.py
@@ -118,7 +118,7 @@ async def set_user_api_key(
     result = await session.execute(
         select(UserApiKey).where(
             UserApiKey.user_id == user_id,
-            UserApiKey.provider == provider,
+            UserApiKey.provider == provider.name,
         )
     )
     existing = result.scalar_one_or_none()
@@ -160,7 +160,7 @@ async def get_user_api_key(
     result = await session.execute(
         select(UserApiKey).where(
             UserApiKey.user_id == user_id,
-            UserApiKey.provider == provider,
+            UserApiKey.provider == provider.name,
         )
     )
     record = result.scalar_one_or_none()
@@ -204,7 +204,7 @@ async def delete_user_api_key(
     result = await session.execute(
         select(UserApiKey).where(
             UserApiKey.user_id == user_id,
-            UserApiKey.provider == provider,
+            UserApiKey.provider == provider.name,
         )
     )
     record = result.scalar_one_or_none()


### PR DESCRIPTION
## Summary

BYOK provider queries fail silently on Postgres because the native enum type stores member names (`OPENAI`) but SQLAlchemy sends StrEnum values (`openai`). Uses `provider.name` in WHERE clauses so queries match.

This is why BYOK-configured providers still showed as "Disabled" on Fly.io despite the key being stored successfully.

## Test plan

- [x] 836 tests pass
- [ ] Manual: set OpenAI key on Fly.io → provider shows "Enabled" + "Make Default" button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)