### PR TITLE
fix: serve SPA for browser navigations to top-level routes

### DIFF
--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlmodel import select
 from starlette.responses import FileResponse, HTMLResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from wikimind.api.routes import admin, api_keys, auth, export, ingest, jobs, lint, query, wiki, ws
@@ -32,6 +33,60 @@ from wikimind.middleware.security_headers import SecurityHeadersMiddleware
 from wikimind.models import Article, IngestStatus, Source, UserPreference
 
 log = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# SPA fallback middleware — intercepts browser navigations that would
+# otherwise hit API routes sharing the same path (e.g. /settings, /health).
+# ---------------------------------------------------------------------------
+# Paths/prefixes that should always be handled by FastAPI, never the SPA.
+_API_ONLY_PREFIXES = (
+    "/api/",
+    "/assets/",
+    "/images/",
+    "/auth/",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/ws",
+)
+
+
+class SPAFallbackMiddleware:
+    """Serve index.html for browser navigations to SPA routes.
+
+    When the frontend static build is present, browser requests (Accept:
+    text/html) to paths that are *not* API-only are answered with
+    index.html before FastAPI routing runs.  This prevents API route
+    handlers mounted at top-level paths (e.g. /settings, /health) from
+    returning JSON when the user refreshes a browser page.
+
+    Programmatic API calls (Accept: application/json) are always passed
+    through to FastAPI unchanged.
+    """
+
+    def __init__(self, app: ASGIApp, *, static_dir: Path) -> None:
+        self._app = app
+        self._index_bytes = (static_dir / "index.html").read_bytes()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Intercept browser navigations and serve index.html for SPA routes."""
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        path: str = scope.get("path", "/")
+        headers = dict(scope.get("headers", []))
+        accept = (headers.get(b"accept", b"") or b"").decode("latin-1")
+
+        is_html_request = "text/html" in accept and "application/json" not in accept
+        is_api_path = any(path.startswith(p) for p in _API_ONLY_PREFIXES)
+
+        if is_html_request and not is_api_path:
+            response = HTMLResponse(self._index_bytes)
+            await response(scope, receive, send)
+            return
+
+        await self._app(scope, receive, send)
 
 
 async def _apply_db_preferences() -> None:
@@ -221,9 +276,21 @@ for _candidate in [Path("/app/static"), Path(__file__).resolve().parent.parent.p
 if _static_dir is not None:
     _index_html = (_static_dir / "index.html").read_text()
 
+    # Middleware intercepts browser navigations to SPA routes that would
+    # otherwise collide with top-level API routes (e.g. /settings, /health).
+    # Must be added here (after static dir discovery) so the index.html
+    # content is available.  Starlette evaluates middleware outermost-first,
+    # so this wraps all preceding middleware and runs first on every request.
+    app.add_middleware(SPAFallbackMiddleware, static_dir=_static_dir)
+
     @app.get("/{path:path}")
     async def spa_fallback(path: str):
-        """Serve index.html for all SPA routes (catch-all)."""
+        """Serve index.html for all SPA routes (catch-all).
+
+        Handles SPA routes that do NOT collide with an API route (e.g.
+        /inbox, /wiki, /ask).  Colliding paths (/settings, /health) are
+        handled earlier by ``SPAFallbackMiddleware`` for browser requests.
+        """
         # Check if the path matches a real static file
         assert _static_dir is not None  # guarded by outer `if`
         static_file = (_static_dir / path).resolve()

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,6 +1,13 @@
-"""Tests for security headers and error handling middleware."""
+"""Tests for security headers, error handling, and SPA fallback middleware."""
+
+from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from starlette.responses import JSONResponse
+
+from wikimind.main import SPAFallbackMiddleware
 
 
 @pytest.mark.asyncio
@@ -21,3 +28,104 @@ async def test_error_handling_returns_json_on_404(client):
     assert response.status_code == 404
     # FastAPI's default 404 is JSON — middleware should not interfere
     assert response.headers["content-type"].startswith("application/json")
+
+
+# ---------------------------------------------------------------------------
+# SPAFallbackMiddleware — unit tests with a minimal FastAPI app
+# ---------------------------------------------------------------------------
+
+_INDEX_CONTENT = "<html><body>SPA</body></html>"
+
+
+@pytest.fixture
+def spa_app(tmp_path: Path) -> FastAPI:
+    """Minimal FastAPI app with SPAFallbackMiddleware and a /health route."""
+    index = tmp_path / "index.html"
+    index.write_text(_INDEX_CONTENT)
+
+    inner_app = FastAPI()
+
+    @inner_app.get("/health")
+    async def health():
+        return JSONResponse({"status": "ok"})
+
+    @inner_app.get("/settings")
+    async def settings():
+        return JSONResponse({"llm": "mock"})
+
+    inner_app.add_middleware(SPAFallbackMiddleware, static_dir=tmp_path)
+    return inner_app
+
+
+@pytest.fixture
+async def spa_client(spa_app: FastAPI):
+    """Async test client for the minimal SPA app."""
+    transport = ASGITransport(app=spa_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_spa_html_request_serves_index(spa_client: AsyncClient):
+    """Browser navigation (Accept: text/html) to /health should return the SPA."""
+    resp = await spa_client.get("/health", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "SPA" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_spa_json_request_passes_through(spa_client: AsyncClient):
+    """API call (Accept: application/json) to /health should return JSON."""
+    resp = await spa_client.get("/health", headers={"Accept": "application/json"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_spa_settings_html_serves_index(spa_client: AsyncClient):
+    """Browser navigation to /settings should return the SPA."""
+    resp = await spa_client.get("/settings", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "SPA" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_spa_settings_json_passes_through(spa_client: AsyncClient):
+    """API call to /settings should return JSON."""
+    resp = await spa_client.get("/settings", headers={"Accept": "application/json"})
+    assert resp.status_code == 200
+    assert resp.json() == {"llm": "mock"}
+
+
+@pytest.mark.asyncio
+async def test_spa_no_accept_header_passes_through(spa_client: AsyncClient):
+    """Request with no Accept header should reach the API handler."""
+    resp = await spa_client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_spa_api_prefix_not_intercepted(spa_client: AsyncClient):
+    """Paths under /api/ should never be intercepted by the SPA middleware."""
+    resp = await spa_client.get("/api/anything", headers={"Accept": "text/html"})
+    # No route registered at /api/anything, so FastAPI returns 404
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_spa_auth_prefix_not_intercepted(spa_client: AsyncClient):
+    """Paths under /auth/ should pass through to FastAPI."""
+    resp = await spa_client.get("/auth/login", headers={"Accept": "text/html"})
+    assert resp.status_code == 404  # no route registered, but not intercepted
+
+
+@pytest.mark.asyncio
+async def test_spa_docs_not_intercepted(spa_client: AsyncClient):
+    """The /docs path should pass through to FastAPI's built-in docs."""
+    resp = await spa_client.get("/docs", headers={"Accept": "text/html"})
+    # FastAPI serves its own HTML at /docs
+    assert resp.status_code == 200
+    assert "swagger" in resp.text.lower() or "openapi" in resp.text.lower()


### PR DESCRIPTION
## Summary
- Adds `SPAFallbackMiddleware` that intercepts browser navigations (`Accept: text/html`) to non-API paths and serves `index.html`
- Fixes `/settings` and `/health` showing raw JSON on browser refresh
- API calls (`Accept: application/json`) and health checks (no Accept header) are unaffected
- Middleware only active when frontend build exists (production)

Closes #332

## Test plan
- [ ] Browser: navigate to `/settings` → SPA loads
- [ ] Browser: refresh on `/settings` → SPA loads (not raw JSON)
- [ ] Browser: refresh on `/health` → SPA loads
- [ ] API: `curl localhost:7842/api/settings` → returns JSON
- [ ] API: `curl localhost:7842/health` (no Accept header) → returns JSON health check
- [ ] `/docs` and `/auth/*` paths still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)