### PR TITLE
fix: P0 multi-user data isolation — Epic #337

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1373,7 +1373,7 @@ paths:
       - Auth
       summary: Auth Callback
       description: Handle OAuth2 callback — exchange code for token, upsert user,
-        return JWT.
+        set cookie.
       operationId: auth_callback_auth_callback_get
       parameters:
       - name: code
@@ -1405,7 +1405,7 @@ paths:
       tags:
       - Auth
       summary: Me
-      description: Return current user profile.
+      description: Return current user profile, auto-provisioning if needed.
       operationId: me_auth_me_get
       responses:
         '200':
@@ -1429,6 +1429,22 @@ paths:
           content:
             application/json:
               schema: {}
+  /auth/account:
+    delete:
+      tags:
+      - Auth
+      summary: Delete Account
+      description: Delete the current user's account and all owned data.
+      operationId: delete_account_auth_account_delete
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Delete Account Auth Account Delete
   /admin/stats:
     get:
       tags:

--- a/scripts/test-user-isolation.sh
+++ b/scripts/test-user-isolation.sh
@@ -4,11 +4,10 @@
 # ===========================================================================
 #
 # End-to-end tests verifying that User A cannot see, modify, or delete
-# User B's data.  Exercises the full pipeline: ingest → compile → articles
-# → Q&A → conversations → file download.
+# User B's data.  Exercises the full pipeline: user creation → ingest →
+# compile → articles → Q&A → file download → account deletion.
 #
-# Requires the production stack (make deploy-up) with auth enabled and
-# at least one LLM provider configured.
+# ALL access is via the API — no direct database calls.
 #
 # Usage:
 #   ./scripts/test-user-isolation.sh                   # default localhost:7842
@@ -167,7 +166,7 @@ fi
 # ---------------------------------------------------------------------------
 
 mint_jwt() {
-    python3 -c "import jwt; print(jwt.encode({'sub':'$1'}, '$JWT_SECRET', algorithm='HS256'))"
+    python3 -c "import jwt; print(jwt.encode({'sub':'$1', 'email':'$1@test.local'}, '$JWT_SECRET', algorithm='HS256'))"
 }
 
 USER_A_ID="test-user-a-$(date +%s)"
@@ -211,28 +210,26 @@ else
 fi
 
 # ===========================================================================
-# Setup: Create test users via database
+# Setup: Create test users via GET /auth/me (auto-provision)
 # ===========================================================================
 
 echo ""
-bold "Setup: Creating test users"
+bold "Setup: Creating test users via API"
 echo ""
 
-COMPOSE_FILE="docker-compose.prod.yml"
-if ! docker compose -f "$COMPOSE_FILE" ps postgres --status running -q > /dev/null 2>&1; then
-    COMPOSE_FILE="docker-compose.yml"
-fi
+USER_A_RESP=$(api GET "/auth/me" "$TOKEN_A")
+USER_A_DB_ID=$(echo "$USER_A_RESP" | jq -r '.id')
+assert_eq "GET /auth/me auto-provisions User A" "$USER_A_ID" "$USER_A_DB_ID"
+info "User A: id=$USER_A_DB_ID  email=$(echo "$USER_A_RESP" | jq -r '.email')  name=$(echo "$USER_A_RESP" | jq -r '.name')"
 
-docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q -c "
-    INSERT INTO \"user\" (id, email, name, auth_provider, auth_provider_id, created_at, updated_at)
-    VALUES
-        ('${USER_A_ID}', '${USER_A_ID}@test.local', 'Test User A', 'test', '${USER_A_ID}', NOW(), NOW()),
-        ('${USER_B_ID}', '${USER_B_ID}@test.local', 'Test User B', 'test', '${USER_B_ID}', NOW(), NOW())
-    ON CONFLICT (id) DO NOTHING;
-" 2>/dev/null
+USER_B_RESP=$(api GET "/auth/me" "$TOKEN_B")
+USER_B_DB_ID=$(echo "$USER_B_RESP" | jq -r '.id')
+assert_eq "GET /auth/me auto-provisions User B" "$USER_B_ID" "$USER_B_DB_ID"
+info "User B: id=$USER_B_DB_ID  email=$(echo "$USER_B_RESP" | jq -r '.email')  name=$(echo "$USER_B_RESP" | jq -r '.name')"
 
-info "Created User A: $USER_A_ID"
-info "Created User B: $USER_B_ID"
+# Calling /auth/me again should return the same user (not create a duplicate)
+USER_A_AGAIN=$(api GET "/auth/me" "$TOKEN_A" | jq -r '.id')
+assert_eq "GET /auth/me is idempotent for User A" "$USER_A_ID" "$USER_A_AGAIN"
 
 # ===========================================================================
 # Test Group 1: Unauthenticated access is blocked
@@ -271,8 +268,6 @@ echo ""
 bold "2. Ingest sources (with compilation)"
 echo ""
 
-# -- User A ingests a text source and compiles it --
-
 SRC_A1=$(api POST "/ingest/text" "$TOKEN_A" \
     '{"content":"The Eiffel Tower is a wrought-iron lattice tower in Paris, France. It was constructed from 1887 to 1889 as the centerpiece of the 1889 World Fair. Named after engineer Gustave Eiffel, it stands 330 meters tall and is the most-visited paid monument in the world.","title":"Eiffel Tower Facts","auto_compile":true}')
 SRC_A1_ID=$(echo "$SRC_A1" | jq -r '.id')
@@ -280,15 +275,11 @@ SRC_A1_UID=$(echo "$SRC_A1" | jq -r '.user_id')
 assert_eq "Ingest as User A → user_id matches" "$USER_A_ID" "$SRC_A1_UID"
 info "Source A1: id=$SRC_A1_ID  user_id=$SRC_A1_UID  title=$(echo "$SRC_A1" | jq -r '.title')"
 
-# -- User A ingests a second source (no compile, for list tests) --
-
 SRC_A2=$(api POST "/ingest/text" "$TOKEN_A" \
     '{"content":"The Great Wall of China stretches over 13,000 miles across northern China.","title":"Great Wall Facts","auto_compile":false}')
 SRC_A2_ID=$(echo "$SRC_A2" | jq -r '.id')
 assert_neq "Ingest source 2 as User A → has ID" "null" "$SRC_A2_ID"
 info "Source A2: id=$SRC_A2_ID  title=$(echo "$SRC_A2" | jq -r '.title')  (no compile)"
-
-# -- User B ingests a source and compiles it --
 
 SRC_B1=$(api POST "/ingest/text" "$TOKEN_B" \
     '{"content":"Mount Fuji is the tallest mountain in Japan at 3,776 meters. It is an active stratovolcano that last erupted in 1707. It is one of Japans Three Holy Mountains.","title":"Mount Fuji Facts","auto_compile":true}')
@@ -362,18 +353,15 @@ echo ""
 bold "6. Original file download isolation"
 echo ""
 
-# Text sources don't have an "original" (only PDF/URL do), so we expect 404.
-# But the important thing is that User B's request doesn't leak User A's file.
-
 STATUS_A_OWN=$(api_status GET "/ingest/sources/$SRC_A1_ID/original" "$TOKEN_A")
 info "User A GET own source original → HTTP $STATUS_A_OWN"
 
 STATUS_B_CROSS=$(api_status GET "/ingest/sources/$SRC_A1_ID/original" "$TOKEN_B")
-assert_eq "User B GET User A's original → 404 (not 200)" "404" "$STATUS_B_CROSS"
+assert_eq "User B GET User A's original → 404" "404" "$STATUS_B_CROSS"
 info "User B cross-access → HTTP $STATUS_B_CROSS"
 
 STATUS_A_CROSS=$(api_status GET "/ingest/sources/$SRC_B1_ID/original" "$TOKEN_A")
-assert_eq "User A GET User B's original → 404 (not 200)" "404" "$STATUS_A_CROSS"
+assert_eq "User A GET User B's original → 404" "404" "$STATUS_A_CROSS"
 info "User A cross-access → HTTP $STATUS_A_CROSS"
 
 # ===========================================================================
@@ -399,7 +387,6 @@ if [[ "$B_ART_COUNT" -gt 0 ]]; then
 fi
 
 # Cross-check: User B should NOT see User A's articles
-# Get User A's first article slug and try to access it as User B
 if [[ "$A_ART_COUNT" -gt 0 ]]; then
     A_SLUG=$(echo "$A_ARTICLES" | jq -r '.[0].slug')
     A_ART_ID=$(echo "$A_ARTICLES" | jq -r '.[0].id')
@@ -413,7 +400,6 @@ if [[ "$A_ART_COUNT" -gt 0 ]]; then
     assert_eq "User B GET User A's article ($A_SLUG) → 404" "Article not found" "$DETAIL"
     info "User B cross-access: $(echo "$RESP_B_CROSS" | jq -c .)"
 
-    # Also try by ID
     RESP_B_ID=$(api GET "/wiki/articles/$A_ART_ID" "$TOKEN_B")
     DETAIL_ID=$(echo "$RESP_B_ID" | jq -r '.detail // empty')
     assert_eq "User B GET User A's article by ID ($A_ART_ID) → 404" "Article not found" "$DETAIL_ID"
@@ -422,10 +408,8 @@ else
     info "SKIPPED: No articles compiled for User A (LLM may not be configured)"
 fi
 
-# Reverse: User A should NOT see User B's articles
 if [[ "$B_ART_COUNT" -gt 0 ]]; then
     B_SLUG=$(echo "$B_ARTICLES" | jq -r '.[0].slug')
-
     RESP_A_CROSS=$(api GET "/wiki/articles/$B_SLUG" "$TOKEN_A")
     DETAIL=$(echo "$RESP_A_CROSS" | jq -r '.detail // empty')
     assert_eq "User A GET User B's article ($B_SLUG) → 404" "Article not found" "$DETAIL"
@@ -470,7 +454,6 @@ echo ""
 bold "9. Q&A conversation isolation"
 echo ""
 
-# User A asks a question (only works if articles exist)
 if [[ "$A_ART_COUNT" -gt 0 ]]; then
     QA_A=$(api POST "/query" "$TOKEN_A" '{"question":"What is the Eiffel Tower?"}')
     CONV_A_ID=$(echo "$QA_A" | jq -r '.conversation.id // empty')
@@ -479,23 +462,19 @@ if [[ "$A_ART_COUNT" -gt 0 ]]; then
         info "User A conversation: id=$CONV_A_ID"
         info "Answer preview: $(echo "$QA_A" | jq -r '.query.answer // empty' | head -c 100)..."
 
-        # User A can see their conversation
         RESP=$(api GET "/query/conversations/$CONV_A_ID" "$TOKEN_A")
         assert_contains "User A can view own conversation" "queries" "$RESP"
-        info "User A conversation detail: $(echo "$RESP" | jq -c '{id: .conversation.id, title: .conversation.title}')"
+        info "User A conversation: $(echo "$RESP" | jq -c '{id: .conversation.id, title: .conversation.title}')"
 
-        # User B cannot see User A's conversation
         RESP=$(api GET "/query/conversations/$CONV_A_ID" "$TOKEN_B")
         DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
         assert_eq "User B GET User A's conversation ($CONV_A_ID) → 404" "Conversation not found" "$DETAIL"
         info "User B cross-access: $(echo "$RESP" | jq -c .)"
 
-        # User B cannot export User A's conversation
         STATUS=$(api_status GET "/query/conversations/$CONV_A_ID/export" "$TOKEN_B")
         assert_eq "User B export User A's conversation → 404" "404" "$STATUS"
         info "User B export attempt → HTTP $STATUS"
 
-        # User A's conversation list vs User B's
         A_CONV_COUNT=$(api GET "/query/conversations" "$TOKEN_A" | jq 'length')
         B_CONV_COUNT=$(api GET "/query/conversations" "$TOKEN_B" | jq 'length')
         assert_gt "User A has conversations" "0" "$A_CONV_COUNT"
@@ -503,7 +482,6 @@ if [[ "$A_ART_COUNT" -gt 0 ]]; then
         info "User A conversations: $A_CONV_COUNT  |  User B conversations: $B_CONV_COUNT"
     else
         info "SKIPPED: Q&A returned no conversation (LLM may have failed)"
-        info "Response: $(echo "$QA_A" | jq -c . 2>/dev/null || echo "$QA_A")"
     fi
 else
     info "SKIPPED: No articles for User A — Q&A requires compiled articles"
@@ -546,9 +524,7 @@ B_GRAPH=$(api GET "/wiki/graph" "$TOKEN_B")
 B_NODE_COUNT=$(echo "$B_GRAPH" | jq '.nodes | length')
 info "User B graph nodes: $B_NODE_COUNT"
 
-# User B's graph should not include User A's articles
-if [[ "$A_NODE_COUNT" -gt 0 ]]; then
-    # Check that none of User A's article titles appear in User B's graph
+if [[ "$A_NODE_COUNT" -gt 0 ]] && [[ "$A_ART_COUNT" -gt 0 ]]; then
     A_FIRST_TITLE=$(echo "$A_ARTICLES" | jq -r '.[0].title' 2>/dev/null || echo "")
     if [[ -n "$A_FIRST_TITLE" ]]; then
         B_HAS_A_TITLE=$(echo "$B_GRAPH" | jq --arg t "$A_FIRST_TITLE" '[.nodes[] | select(.label == $t)] | length')
@@ -598,45 +574,36 @@ else
 fi
 
 # ===========================================================================
-# Cleanup
+# Cleanup: DELETE /auth/account removes all user data via API
 # ===========================================================================
 
 echo ""
-bold "Cleanup"
+bold "Cleanup: Delete accounts via API"
 echo ""
 
-# Delete sources via API (as the owning user)
-RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
-info "Deleted source A1 ($SRC_A1_ID): $(echo "$RESP" | jq -c .)"
+RESP_A=$(api DELETE "/auth/account" "$TOKEN_A")
+DELETED_A=$(echo "$RESP_A" | jq -r '.deleted // empty')
+assert_eq "DELETE /auth/account removes User A" "$USER_A_ID" "$DELETED_A"
+info "User A deleted: $(echo "$RESP_A" | jq -c .)"
 
-RESP=$(api DELETE "/ingest/sources/$SRC_A2_ID" "$TOKEN_A")
-info "Deleted source A2 ($SRC_A2_ID): $(echo "$RESP" | jq -c .)"
+RESP_B=$(api DELETE "/auth/account" "$TOKEN_B")
+DELETED_B=$(echo "$RESP_B" | jq -r '.deleted // empty')
+assert_eq "DELETE /auth/account removes User B" "$USER_B_ID" "$DELETED_B"
+info "User B deleted: $(echo "$RESP_B" | jq -c .)"
 
-RESP=$(api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
-info "Deleted source B1 ($SRC_B1_ID): $(echo "$RESP" | jq -c .)"
+# Verify the accounts are gone
+STATUS_A=$(api_status GET "/auth/me" "$TOKEN_A")
+# /auth/me now auto-provisions, so a GET would re-create the user.
+# Instead, verify their sources are gone.
+A_AFTER=$(api GET "/ingest/sources" "$TOKEN_A" | jq 'length')
+B_AFTER=$(api GET "/ingest/sources" "$TOKEN_B" | jq 'length')
+assert_eq "User A has 0 sources after account deletion" "0" "$A_AFTER"
+assert_eq "User B has 0 sources after account deletion" "0" "$B_AFTER"
+info "Post-deletion: User A sources=$A_AFTER  User B sources=$B_AFTER"
 
-# Verify sources are gone
-A_FINAL=$(api GET "/ingest/sources" "$TOKEN_A" | jq 'length')
-B_FINAL=$(api GET "/ingest/sources" "$TOKEN_B" | jq 'length')
-info "User A remaining sources: $A_FINAL"
-info "User B remaining sources: $B_FINAL"
-
-# Remove test users and their data from database.
-# Table names are lowercase (SQLModel convention). Use CASCADE-safe order.
-docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q <<EOSQL 2>/dev/null || true
-    DELETE FROM query WHERE conversation_id IN (SELECT id FROM conversation WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
-    DELETE FROM conversation WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
-    DELETE FROM articlesource WHERE article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
-    DELETE FROM articleconcept WHERE article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
-    DELETE FROM backlink WHERE source_article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
-    DELETE FROM backlink WHERE target_article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
-    DELETE FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
-    DELETE FROM source WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
-    DELETE FROM job WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
-    DELETE FROM "user" WHERE id IN ('${USER_A_ID}', '${USER_B_ID}');
-EOSQL
-info "Deleted User A ($USER_A_ID) and all data from database"
-info "Deleted User B ($USER_B_ID) and all data from database"
+# Clean up the auto-provisioned users from the verification step above
+api DELETE "/auth/account" "$TOKEN_A" > /dev/null 2>&1 || true
+api DELETE "/auth/account" "$TOKEN_B" > /dev/null 2>&1 || true
 
 # ===========================================================================
 # Summary

--- a/scripts/test-user-isolation.sh
+++ b/scripts/test-user-isolation.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# Multi-User Data Isolation Test Script
+# ===========================================================================
+#
+# Tests that User A cannot see, modify, or delete User B's data and vice
+# versa.  Requires the production stack (make deploy-up) with auth enabled.
+#
+# Usage:
+#   ./scripts/test-user-isolation.sh                   # default localhost:7842
+#   ./scripts/test-user-isolation.sh https://wikimind.fly.dev
+#
+# Prerequisites:
+#   - jq installed
+#   - Python 3 with PyJWT (pip install pyjwt)
+#   - Server running with WIKIMIND_AUTH__ENABLED=true
+#   - WIKIMIND_AUTH__JWT_SECRET_KEY set (reads from .env)
+# ===========================================================================
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:7842}"
+COOKIE_NAME="wikimind_session"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+red()   { printf "\033[31m%s\033[0m" "$*"; }
+green() { printf "\033[32m%s\033[0m" "$*"; }
+bold()  { printf "\033[1m%s\033[0m" "$*"; }
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    TOTAL=$((TOTAL + 1))
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        printf "  $(green PASS)  %s\n" "$label"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  $(red FAIL)  %s  (expected: %s, got: %s)\n" "$label" "$expected" "$actual"
+    fi
+}
+
+assert_contains() {
+    local label="$1" expected="$2" actual="$3"
+    TOTAL=$((TOTAL + 1))
+    if [[ "$actual" == *"$expected"* ]]; then
+        PASS=$((PASS + 1))
+        printf "  $(green PASS)  %s\n" "$label"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  $(red FAIL)  %s  (expected to contain: %s, got: %s)\n" "$label" "$expected" "$actual"
+    fi
+}
+
+api() {
+    # api <method> <path> [token] [data]
+    local method="$1" path="$2" token="${3:-}" data="${4:-}"
+    local -a args=(-s -X "$method")
+
+    if [[ -n "$token" ]]; then
+        args+=(-b "${COOKIE_NAME}=${token}")
+    fi
+    if [[ -n "$data" ]]; then
+        args+=(-H "Content-Type: application/json" -d "$data")
+    fi
+
+    args+=("${BASE_URL}${path}")
+    curl "${args[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Read JWT secret from .env
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+JWT_SECRET=""
+if [[ -f "$REPO_ROOT/.env" ]]; then
+    JWT_SECRET=$(grep -E '^WIKIMIND_AUTH__JWT_SECRET_KEY=' "$REPO_ROOT/.env" | cut -d= -f2- | tr -d '"' || true)
+fi
+if [[ -z "$JWT_SECRET" ]]; then
+    echo "ERROR: WIKIMIND_AUTH__JWT_SECRET_KEY not found in .env"
+    echo "       Set it or pass via: JWT_SECRET=... $0"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Generate JWTs for two test users
+# ---------------------------------------------------------------------------
+
+mint_jwt() {
+    python3 -c "import jwt; print(jwt.encode({'sub':'$1'}, '$JWT_SECRET', algorithm='HS256'))"
+}
+
+USER_A_ID="test-user-a-$(date +%s)"
+USER_B_ID="test-user-b-$(date +%s)"
+TOKEN_A=$(mint_jwt "$USER_A_ID")
+TOKEN_B=$(mint_jwt "$USER_B_ID")
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+echo ""
+bold "Multi-User Data Isolation Tests"
+echo ""
+echo "  Server:  $BASE_URL"
+echo "  User A:  $USER_A_ID"
+echo "  User B:  $USER_B_ID"
+echo ""
+
+# Check server is reachable
+HEALTH=$(curl -sf "${BASE_URL}/health" 2>/dev/null || true)
+if [[ -z "$HEALTH" ]]; then
+    echo "ERROR: Server not reachable at $BASE_URL"
+    exit 1
+fi
+
+# Check auth is enabled
+UNAUTH=$(api GET "/ingest/sources" "" "" 2>/dev/null)
+if echo "$UNAUTH" | jq -e '.error.code == "UNAUTHORIZED"' > /dev/null 2>&1; then
+    echo "  Auth:    enabled"
+else
+    echo "  WARNING: Auth may not be enabled — tests may not be meaningful"
+fi
+
+# ---------------------------------------------------------------------------
+# Create test users in the database
+# ---------------------------------------------------------------------------
+
+echo ""
+bold "Setup: Creating test users"
+echo ""
+
+# Use the Postgres container to insert users directly.  The docker-compose
+# service name is "postgres" in both dev and prod compose files.
+COMPOSE_FILE="docker-compose.prod.yml"
+if ! docker compose -f "$COMPOSE_FILE" ps postgres --status running -q > /dev/null 2>&1; then
+    COMPOSE_FILE="docker-compose.yml"
+fi
+
+docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q -c "
+    INSERT INTO \"user\" (id, email, name, auth_provider, auth_provider_id, created_at, updated_at)
+    VALUES
+        ('${USER_A_ID}', '${USER_A_ID}@test.local', 'Test User A', 'test', '${USER_A_ID}', NOW(), NOW()),
+        ('${USER_B_ID}', '${USER_B_ID}@test.local', 'Test User B', 'test', '${USER_B_ID}', NOW(), NOW())
+    ON CONFLICT (id) DO NOTHING;
+" 2>/dev/null
+
+echo "  Created User A and User B in database"
+
+# ===========================================================================
+# Test Group 1: Unauthenticated access is blocked
+# ===========================================================================
+
+echo ""
+bold "1. Unauthenticated access"
+echo ""
+
+RESP=$(api GET "/ingest/sources")
+CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
+assert_eq "GET /ingest/sources without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
+
+RESP=$(api GET "/wiki/articles")
+CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
+assert_eq "GET /wiki/articles without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
+
+RESP=$(api GET "/query/conversations")
+CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
+assert_eq "GET /query/conversations without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
+
+# ===========================================================================
+# Test Group 2: Source isolation (ingest)
+# ===========================================================================
+
+echo ""
+bold "2. Source isolation"
+echo ""
+
+# User A ingests two sources
+SRC_A1=$(api POST "/ingest/text" "$TOKEN_A" '{"content":"User A secret document one","title":"A-Doc-1","auto_compile":false}')
+SRC_A1_ID=$(echo "$SRC_A1" | jq -r '.id')
+SRC_A1_UID=$(echo "$SRC_A1" | jq -r '.user_id')
+assert_eq "Ingest source 1 as User A → user_id matches" "$USER_A_ID" "$SRC_A1_UID"
+
+SRC_A2=$(api POST "/ingest/text" "$TOKEN_A" '{"content":"User A secret document two","title":"A-Doc-2","auto_compile":false}')
+SRC_A2_ID=$(echo "$SRC_A2" | jq -r '.id')
+assert_eq "Ingest source 2 as User A → has ID" "true" "$([ -n "$SRC_A2_ID" ] && [ "$SRC_A2_ID" != "null" ] && echo true || echo false)"
+
+# User B ingests one source
+SRC_B1=$(api POST "/ingest/text" "$TOKEN_B" '{"content":"User B private note","title":"B-Doc-1","auto_compile":false}')
+SRC_B1_ID=$(echo "$SRC_B1" | jq -r '.id')
+SRC_B1_UID=$(echo "$SRC_B1" | jq -r '.user_id')
+assert_eq "Ingest source as User B → user_id matches" "$USER_B_ID" "$SRC_B1_UID"
+
+# User A sees only their sources
+A_COUNT=$(api GET "/ingest/sources" "$TOKEN_A" | jq 'length')
+assert_eq "User A source list count → 2" "2" "$A_COUNT"
+
+# User B sees only their source
+B_COUNT=$(api GET "/ingest/sources" "$TOKEN_B" | jq 'length')
+assert_eq "User B source list count → 1" "1" "$B_COUNT"
+
+# User A cannot access User B's source
+RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User A GET User B's source → Source not found" "Source not found" "$DETAIL"
+
+# User B cannot access User A's source
+RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User B GET User A's source → Source not found" "Source not found" "$DETAIL"
+
+# User B cannot delete User A's source
+RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User B DELETE User A's source → Source not found" "Source not found" "$DETAIL"
+
+# User A's source still exists after B's delete attempt
+RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User A's source survives User B's delete attempt" "A-Doc-1" "$TITLE"
+
+# ===========================================================================
+# Test Group 3: Article isolation (wiki)
+# ===========================================================================
+
+echo ""
+bold "3. Article isolation"
+echo ""
+
+# User A's articles
+A_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_A" | jq 'length')
+# User B's articles
+B_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_B" | jq 'length')
+assert_eq "User B cannot see User A's articles" "0" "$B_ARTICLES"
+
+# ===========================================================================
+# Test Group 4: Conversation isolation (Q&A)
+# ===========================================================================
+
+echo ""
+bold "4. Conversation isolation"
+echo ""
+
+A_CONVOS=$(api GET "/query/conversations" "$TOKEN_A" | jq 'length')
+B_CONVOS=$(api GET "/query/conversations" "$TOKEN_B" | jq 'length')
+assert_eq "User B has no conversations" "0" "$B_CONVOS"
+
+# ===========================================================================
+# Test Group 5: Settings / jobs endpoints require auth
+# ===========================================================================
+
+echo ""
+bold "5. Protected endpoints"
+echo ""
+
+RESP=$(api GET "/settings" "$TOKEN_A")
+assert_contains "GET /settings with auth → returns data" "llm" "$RESP"
+
+RESP=$(api GET "/settings")
+CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
+assert_eq "GET /settings without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
+
+RESP=$(api GET "/jobs" "$TOKEN_A")
+assert_eq "GET /jobs with auth → returns array" "true" "$(echo "$RESP" | jq 'type == "array"')"
+
+RESP=$(api GET "/jobs")
+CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
+assert_eq "GET /jobs without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
+
+RESP=$(api GET "/lint/reports" "$TOKEN_A")
+assert_eq "GET /lint/reports with auth → returns array" "true" "$(echo "$RESP" | jq 'type == "array"')"
+
+# ===========================================================================
+# Test Group 6: WebSocket auth (cannot impersonate via query param)
+# ===========================================================================
+
+echo ""
+bold "6. WebSocket auth"
+echo ""
+
+# We can't do a full WebSocket test from bash, but we can verify the
+# endpoint exists and the old query param pattern is gone from the source.
+if grep -qF 'query_params.get("user_id")' src/wikimind/api/routes/ws.py 2>/dev/null; then
+    assert_eq "WebSocket no longer reads user_id from query params" "gone" "still present"
+else
+    assert_eq "WebSocket no longer reads user_id from query params" "gone" "gone"
+fi
+
+if grep -q 'get_ws_user_id' src/wikimind/api/deps.py 2>/dev/null; then
+    assert_eq "get_ws_user_id helper exists in deps.py" "true" "true"
+else
+    assert_eq "get_ws_user_id helper exists in deps.py" "true" "false"
+fi
+
+# ===========================================================================
+# Cleanup: delete test sources (as the owning user)
+# ===========================================================================
+
+echo ""
+bold "Cleanup"
+echo ""
+
+api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_A" > /dev/null 2>&1
+api DELETE "/ingest/sources/$SRC_A2_ID" "$TOKEN_A" > /dev/null 2>&1
+api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_B" > /dev/null 2>&1
+
+# Remove test users
+docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q -c "
+    DELETE FROM \"user\" WHERE id IN ('${USER_A_ID}', '${USER_B_ID}');
+" 2>/dev/null
+
+echo "  Cleaned up test data"
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+
+echo ""
+echo "==========================================="
+if [[ $FAIL -eq 0 ]]; then
+    green "  ALL $TOTAL TESTS PASSED"
+else
+    red "  $FAIL/$TOTAL TESTS FAILED"
+fi
+echo ""
+echo "==========================================="
+echo ""
+
+exit "$FAIL"

--- a/scripts/test-user-isolation.sh
+++ b/scripts/test-user-isolation.sh
@@ -3,8 +3,12 @@
 # Multi-User Data Isolation Test Script
 # ===========================================================================
 #
-# Tests that User A cannot see, modify, or delete User B's data and vice
-# versa.  Requires the production stack (make deploy-up) with auth enabled.
+# End-to-end tests verifying that User A cannot see, modify, or delete
+# User B's data.  Exercises the full pipeline: ingest → compile → articles
+# → Q&A → conversations → file download.
+#
+# Requires the production stack (make deploy-up) with auth enabled and
+# at least one LLM provider configured.
 #
 # Usage:
 #   ./scripts/test-user-isolation.sh                   # default localhost:7842
@@ -15,6 +19,7 @@
 #   - Python 3 with PyJWT (pip install pyjwt)
 #   - Server running with WIKIMIND_AUTH__ENABLED=true
 #   - WIKIMIND_AUTH__JWT_SECRET_KEY set (reads from .env)
+#   - At least one LLM provider configured (for compilation + Q&A)
 # ===========================================================================
 
 set -euo pipefail
@@ -24,6 +29,7 @@ COOKIE_NAME="wikimind_session"
 PASS=0
 FAIL=0
 TOTAL=0
+MAX_WAIT=120   # seconds to wait for compilation
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,6 +52,18 @@ assert_eq() {
     fi
 }
 
+assert_neq() {
+    local label="$1" not_expected="$2" actual="$3"
+    TOTAL=$((TOTAL + 1))
+    if [[ "$actual" != "$not_expected" ]]; then
+        PASS=$((PASS + 1))
+        printf "  $(green PASS)  %s\n" "$label"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  $(red FAIL)  %s  (should NOT be: %s)\n" "$label" "$not_expected"
+    fi
+}
+
 assert_contains() {
     local label="$1" expected="$2" actual="$3"
     TOTAL=$((TOTAL + 1))
@@ -55,6 +73,18 @@ assert_contains() {
     else
         FAIL=$((FAIL + 1))
         printf "  $(red FAIL)  %s  (expected to contain: %s, got: %s)\n" "$label" "$expected" "$actual"
+    fi
+}
+
+assert_gt() {
+    local label="$1" threshold="$2" actual="$3"
+    TOTAL=$((TOTAL + 1))
+    if [[ "$actual" -gt "$threshold" ]]; then
+        PASS=$((PASS + 1))
+        printf "  $(green PASS)  %s\n" "$label"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  $(red FAIL)  %s  (expected > %s, got: %s)\n" "$label" "$threshold" "$actual"
     fi
 }
 
@@ -76,6 +106,43 @@ api() {
 
     args+=("${BASE_URL}${path}")
     curl "${args[@]}"
+}
+
+api_status() {
+    # Like api() but returns HTTP status code
+    local method="$1" path="$2" token="${3:-}"
+    local -a args=(-s -o /dev/null -w "%{http_code}" -X "$method")
+
+    if [[ -n "$token" ]]; then
+        args+=(-b "${COOKIE_NAME}=${token}")
+    fi
+
+    args+=("${BASE_URL}${path}")
+    curl "${args[@]}"
+}
+
+wait_for_compilation() {
+    # wait_for_compilation <source_id> <token> <label>
+    local source_id="$1" token="$2" label="$3"
+    local elapsed=0
+
+    info "Waiting for $label to compile (max ${MAX_WAIT}s)..."
+    while [[ $elapsed -lt $MAX_WAIT ]]; do
+        local status
+        status=$(api GET "/ingest/sources/$source_id" "$token" | jq -r '.status')
+        if [[ "$status" == "compiled" ]]; then
+            info "Compiled in ${elapsed}s"
+            return 0
+        elif [[ "$status" == "failed" ]]; then
+            info "Compilation FAILED after ${elapsed}s"
+            return 1
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+        printf "        $(dim "→ %ss ... status=%s")\n" "$elapsed" "$status"
+    done
+    info "Timed out after ${MAX_WAIT}s (status=$status)"
+    return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -139,7 +206,8 @@ UNAUTH=$(api GET "/ingest/sources" "" "" 2>/dev/null)
 if echo "$UNAUTH" | jq -e '.error.code == "UNAUTHORIZED"' > /dev/null 2>&1; then
     echo "  Auth:     enabled"
 else
-    echo "  WARNING:  Auth may not be enabled — tests may not be meaningful"
+    echo "  ERROR: Auth is not enabled — cannot test isolation"
+    exit 1
 fi
 
 # ===========================================================================
@@ -196,160 +264,304 @@ CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
 assert_eq "GET /jobs without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
 
 # ===========================================================================
-# Test Group 2: Source ingestion and ownership
+# Test Group 2: Ingest sources with auto_compile=true
 # ===========================================================================
 
 echo ""
-bold "2. Source ingestion and ownership"
+bold "2. Ingest sources (with compilation)"
 echo ""
 
-# -- User A ingests two sources --
+# -- User A ingests a text source and compiles it --
 
 SRC_A1=$(api POST "/ingest/text" "$TOKEN_A" \
-    '{"content":"User A secret document number one with sensitive data","title":"A-Doc-1","auto_compile":false}')
+    '{"content":"The Eiffel Tower is a wrought-iron lattice tower in Paris, France. It was constructed from 1887 to 1889 as the centerpiece of the 1889 World Fair. Named after engineer Gustave Eiffel, it stands 330 meters tall and is the most-visited paid monument in the world.","title":"Eiffel Tower Facts","auto_compile":true}')
 SRC_A1_ID=$(echo "$SRC_A1" | jq -r '.id')
 SRC_A1_UID=$(echo "$SRC_A1" | jq -r '.user_id')
-assert_eq "Ingest source 1 as User A → user_id matches" "$USER_A_ID" "$SRC_A1_UID"
+assert_eq "Ingest as User A → user_id matches" "$USER_A_ID" "$SRC_A1_UID"
 info "Source A1: id=$SRC_A1_ID  user_id=$SRC_A1_UID  title=$(echo "$SRC_A1" | jq -r '.title')"
 
-SRC_A2=$(api POST "/ingest/text" "$TOKEN_A" \
-    '{"content":"User A second document with more private info","title":"A-Doc-2","auto_compile":false}')
-SRC_A2_ID=$(echo "$SRC_A2" | jq -r '.id')
-SRC_A2_UID=$(echo "$SRC_A2" | jq -r '.user_id')
-assert_eq "Ingest source 2 as User A → user_id matches" "$USER_A_ID" "$SRC_A2_UID"
-info "Source A2: id=$SRC_A2_ID  user_id=$SRC_A2_UID  title=$(echo "$SRC_A2" | jq -r '.title')"
+# -- User A ingests a second source (no compile, for list tests) --
 
-# -- User B ingests one source --
+SRC_A2=$(api POST "/ingest/text" "$TOKEN_A" \
+    '{"content":"The Great Wall of China stretches over 13,000 miles across northern China.","title":"Great Wall Facts","auto_compile":false}')
+SRC_A2_ID=$(echo "$SRC_A2" | jq -r '.id')
+assert_neq "Ingest source 2 as User A → has ID" "null" "$SRC_A2_ID"
+info "Source A2: id=$SRC_A2_ID  title=$(echo "$SRC_A2" | jq -r '.title')  (no compile)"
+
+# -- User B ingests a source and compiles it --
 
 SRC_B1=$(api POST "/ingest/text" "$TOKEN_B" \
-    '{"content":"User B private note that A should never see","title":"B-Doc-1","auto_compile":false}')
+    '{"content":"Mount Fuji is the tallest mountain in Japan at 3,776 meters. It is an active stratovolcano that last erupted in 1707. It is one of Japans Three Holy Mountains.","title":"Mount Fuji Facts","auto_compile":true}')
 SRC_B1_ID=$(echo "$SRC_B1" | jq -r '.id')
 SRC_B1_UID=$(echo "$SRC_B1" | jq -r '.user_id')
-assert_eq "Ingest source 1 as User B → user_id matches" "$USER_B_ID" "$SRC_B1_UID"
+assert_eq "Ingest as User B → user_id matches" "$USER_B_ID" "$SRC_B1_UID"
 info "Source B1: id=$SRC_B1_ID  user_id=$SRC_B1_UID  title=$(echo "$SRC_B1" | jq -r '.title')"
 
 # ===========================================================================
-# Test Group 3: Source list isolation
+# Test Group 3: Wait for compilation to finish
 # ===========================================================================
 
 echo ""
-bold "3. Source list isolation"
+bold "3. Wait for compilation"
+echo ""
+
+wait_for_compilation "$SRC_A1_ID" "$TOKEN_A" "User A source" || true
+wait_for_compilation "$SRC_B1_ID" "$TOKEN_B" "User B source" || true
+
+# ===========================================================================
+# Test Group 4: Source list isolation
+# ===========================================================================
+
+echo ""
+bold "4. Source list isolation"
 echo ""
 
 A_SOURCES=$(api GET "/ingest/sources" "$TOKEN_A")
 A_COUNT=$(echo "$A_SOURCES" | jq 'length')
 assert_eq "User A sees exactly 2 sources" "2" "$A_COUNT"
-info "User A sources: $(echo "$A_SOURCES" | jq -c '[.[] | {id: .id, title: .title}]')"
+info "User A sources: $(echo "$A_SOURCES" | jq -c '[.[] | {id: .id, title: .title, status: .status}]')"
 
 B_SOURCES=$(api GET "/ingest/sources" "$TOKEN_B")
 B_COUNT=$(echo "$B_SOURCES" | jq 'length')
 assert_eq "User B sees exactly 1 source" "1" "$B_COUNT"
-info "User B sources: $(echo "$B_SOURCES" | jq -c '[.[] | {id: .id, title: .title}]')"
+info "User B sources: $(echo "$B_SOURCES" | jq -c '[.[] | {id: .id, title: .title, status: .status}]')"
 
 # ===========================================================================
-# Test Group 4: Cross-user source access is blocked
+# Test Group 5: Cross-user source access is blocked
 # ===========================================================================
 
 echo ""
-bold "4. Cross-user source access is blocked"
+bold "5. Cross-user source access is blocked"
 echo ""
 
-# User A tries to read User B's source
 RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
 DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
 assert_eq "User A GET User B's source ($SRC_B1_ID) → 404" "Source not found" "$DETAIL"
 info "Response: $(echo "$RESP" | jq -c .)"
 
-# User B tries to read User A's source
 RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
 DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
 assert_eq "User B GET User A's source ($SRC_A1_ID) → 404" "Source not found" "$DETAIL"
 info "Response: $(echo "$RESP" | jq -c .)"
 
-# User A can read their OWN source
 RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
 TITLE=$(echo "$RESP" | jq -r '.title')
-assert_eq "User A GET own source ($SRC_A1_ID) → A-Doc-1" "A-Doc-1" "$TITLE"
-info "Response: id=$(echo "$RESP" | jq -r '.id')  title=$TITLE  user_id=$(echo "$RESP" | jq -r '.user_id')"
+assert_eq "User A GET own source → success" "Eiffel Tower Facts" "$TITLE"
+info "id=$SRC_A1_ID  title=$TITLE  user_id=$(echo "$RESP" | jq -r '.user_id')"
 
-# User B can read their OWN source
 RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
 TITLE=$(echo "$RESP" | jq -r '.title')
-assert_eq "User B GET own source ($SRC_B1_ID) → B-Doc-1" "B-Doc-1" "$TITLE"
-info "Response: id=$(echo "$RESP" | jq -r '.id')  title=$TITLE  user_id=$(echo "$RESP" | jq -r '.user_id')"
+assert_eq "User B GET own source → success" "Mount Fuji Facts" "$TITLE"
+info "id=$SRC_B1_ID  title=$TITLE  user_id=$(echo "$RESP" | jq -r '.user_id')"
 
 # ===========================================================================
-# Test Group 5: Cross-user deletion is blocked
-# ===========================================================================
-
-echo ""
-bold "5. Cross-user deletion is blocked"
-echo ""
-
-# User B tries to delete User A's source
-RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
-DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
-assert_eq "User B DELETE User A's source ($SRC_A1_ID) → 404" "Source not found" "$DETAIL"
-info "Response: $(echo "$RESP" | jq -c .)"
-
-# Verify User A's source still exists
-RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
-TITLE=$(echo "$RESP" | jq -r '.title')
-assert_eq "User A's source survives User B's delete attempt" "A-Doc-1" "$TITLE"
-info "Source still exists: id=$SRC_A1_ID  title=$TITLE"
-
-# User A tries to delete User B's source
-RESP=$(api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
-DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
-assert_eq "User A DELETE User B's source ($SRC_B1_ID) → 404" "Source not found" "$DETAIL"
-info "Response: $(echo "$RESP" | jq -c .)"
-
-# Verify User B's source still exists
-RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
-TITLE=$(echo "$RESP" | jq -r '.title')
-assert_eq "User B's source survives User A's delete attempt" "B-Doc-1" "$TITLE"
-info "Source still exists: id=$SRC_B1_ID  title=$TITLE"
-
-# ===========================================================================
-# Test Group 6: Article isolation
+# Test Group 6: Original file download isolation
 # ===========================================================================
 
 echo ""
-bold "6. Article isolation"
+bold "6. Original file download isolation"
+echo ""
+
+# Text sources don't have an "original" (only PDF/URL do), so we expect 404.
+# But the important thing is that User B's request doesn't leak User A's file.
+
+STATUS_A_OWN=$(api_status GET "/ingest/sources/$SRC_A1_ID/original" "$TOKEN_A")
+info "User A GET own source original → HTTP $STATUS_A_OWN"
+
+STATUS_B_CROSS=$(api_status GET "/ingest/sources/$SRC_A1_ID/original" "$TOKEN_B")
+assert_eq "User B GET User A's original → 404 (not 200)" "404" "$STATUS_B_CROSS"
+info "User B cross-access → HTTP $STATUS_B_CROSS"
+
+STATUS_A_CROSS=$(api_status GET "/ingest/sources/$SRC_B1_ID/original" "$TOKEN_A")
+assert_eq "User A GET User B's original → 404 (not 200)" "404" "$STATUS_A_CROSS"
+info "User A cross-access → HTTP $STATUS_A_CROSS"
+
+# ===========================================================================
+# Test Group 7: Article isolation (post-compilation)
+# ===========================================================================
+
+echo ""
+bold "7. Article isolation (post-compilation)"
 echo ""
 
 A_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_A")
 A_ART_COUNT=$(echo "$A_ARTICLES" | jq 'length')
 info "User A article count: $A_ART_COUNT"
+if [[ "$A_ART_COUNT" -gt 0 ]]; then
+    info "User A articles: $(echo "$A_ARTICLES" | jq -c '[.[] | {slug, title}]')"
+fi
 
 B_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_B")
 B_ART_COUNT=$(echo "$B_ARTICLES" | jq 'length')
-assert_eq "User B sees 0 of User A's articles" "0" "$B_ART_COUNT"
 info "User B article count: $B_ART_COUNT"
+if [[ "$B_ART_COUNT" -gt 0 ]]; then
+    info "User B articles: $(echo "$B_ARTICLES" | jq -c '[.[] | {slug, title}]')"
+fi
+
+# Cross-check: User B should NOT see User A's articles
+# Get User A's first article slug and try to access it as User B
+if [[ "$A_ART_COUNT" -gt 0 ]]; then
+    A_SLUG=$(echo "$A_ARTICLES" | jq -r '.[0].slug')
+    A_ART_ID=$(echo "$A_ARTICLES" | jq -r '.[0].id')
+
+    RESP_A_OWN=$(api GET "/wiki/articles/$A_SLUG" "$TOKEN_A")
+    assert_contains "User A can read own article ($A_SLUG)" "title" "$RESP_A_OWN"
+    info "User A article: slug=$A_SLUG  title=$(echo "$RESP_A_OWN" | jq -r '.title')"
+
+    RESP_B_CROSS=$(api GET "/wiki/articles/$A_SLUG" "$TOKEN_B")
+    DETAIL=$(echo "$RESP_B_CROSS" | jq -r '.detail // empty')
+    assert_eq "User B GET User A's article ($A_SLUG) → 404" "Article not found" "$DETAIL"
+    info "User B cross-access: $(echo "$RESP_B_CROSS" | jq -c .)"
+
+    # Also try by ID
+    RESP_B_ID=$(api GET "/wiki/articles/$A_ART_ID" "$TOKEN_B")
+    DETAIL_ID=$(echo "$RESP_B_ID" | jq -r '.detail // empty')
+    assert_eq "User B GET User A's article by ID ($A_ART_ID) → 404" "Article not found" "$DETAIL_ID"
+    info "User B cross-access by ID: $(echo "$RESP_B_ID" | jq -c .)"
+else
+    info "SKIPPED: No articles compiled for User A (LLM may not be configured)"
+fi
+
+# Reverse: User A should NOT see User B's articles
+if [[ "$B_ART_COUNT" -gt 0 ]]; then
+    B_SLUG=$(echo "$B_ARTICLES" | jq -r '.[0].slug')
+
+    RESP_A_CROSS=$(api GET "/wiki/articles/$B_SLUG" "$TOKEN_A")
+    DETAIL=$(echo "$RESP_A_CROSS" | jq -r '.detail // empty')
+    assert_eq "User A GET User B's article ($B_SLUG) → 404" "Article not found" "$DETAIL"
+    info "User A cross-access: $(echo "$RESP_A_CROSS" | jq -c .)"
+else
+    info "SKIPPED: No articles compiled for User B (LLM may not be configured)"
+fi
 
 # ===========================================================================
-# Test Group 7: Conversation isolation
+# Test Group 8: Cross-user deletion is blocked
 # ===========================================================================
 
 echo ""
-bold "7. Conversation isolation"
+bold "8. Cross-user deletion is blocked"
 echo ""
 
-A_CONVOS=$(api GET "/query/conversations" "$TOKEN_A")
-A_CONV_COUNT=$(echo "$A_CONVOS" | jq 'length')
-info "User A conversation count: $A_CONV_COUNT"
+RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User B DELETE User A's source ($SRC_A1_ID) → 404" "Source not found" "$DETAIL"
+info "Response: $(echo "$RESP" | jq -c .)"
 
-B_CONVOS=$(api GET "/query/conversations" "$TOKEN_B")
-B_CONV_COUNT=$(echo "$B_CONVOS" | jq 'length')
-assert_eq "User B sees 0 of User A's conversations" "0" "$B_CONV_COUNT"
-info "User B conversation count: $B_CONV_COUNT"
+RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User A's source survives User B's delete attempt" "Eiffel Tower Facts" "$TITLE"
+info "Source still exists: id=$SRC_A1_ID  title=$TITLE"
+
+RESP=$(api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User A DELETE User B's source ($SRC_B1_ID) → 404" "Source not found" "$DETAIL"
+info "Response: $(echo "$RESP" | jq -c .)"
+
+RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User B's source survives User A's delete attempt" "Mount Fuji Facts" "$TITLE"
+info "Source still exists: id=$SRC_B1_ID  title=$TITLE"
 
 # ===========================================================================
-# Test Group 8: Protected endpoints require auth
+# Test Group 9: Q&A conversation isolation
 # ===========================================================================
 
 echo ""
-bold "8. Protected endpoints require auth"
+bold "9. Q&A conversation isolation"
+echo ""
+
+# User A asks a question (only works if articles exist)
+if [[ "$A_ART_COUNT" -gt 0 ]]; then
+    QA_A=$(api POST "/query" "$TOKEN_A" '{"question":"What is the Eiffel Tower?"}')
+    CONV_A_ID=$(echo "$QA_A" | jq -r '.conversation.id // empty')
+    if [[ -n "$CONV_A_ID" && "$CONV_A_ID" != "null" ]]; then
+        assert_neq "User A asked question → got conversation" "null" "$CONV_A_ID"
+        info "User A conversation: id=$CONV_A_ID"
+        info "Answer preview: $(echo "$QA_A" | jq -r '.query.answer // empty' | head -c 100)..."
+
+        # User A can see their conversation
+        RESP=$(api GET "/query/conversations/$CONV_A_ID" "$TOKEN_A")
+        assert_contains "User A can view own conversation" "queries" "$RESP"
+        info "User A conversation detail: $(echo "$RESP" | jq -c '{id: .conversation.id, title: .conversation.title}')"
+
+        # User B cannot see User A's conversation
+        RESP=$(api GET "/query/conversations/$CONV_A_ID" "$TOKEN_B")
+        DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+        assert_eq "User B GET User A's conversation ($CONV_A_ID) → 404" "Conversation not found" "$DETAIL"
+        info "User B cross-access: $(echo "$RESP" | jq -c .)"
+
+        # User B cannot export User A's conversation
+        STATUS=$(api_status GET "/query/conversations/$CONV_A_ID/export" "$TOKEN_B")
+        assert_eq "User B export User A's conversation → 404" "404" "$STATUS"
+        info "User B export attempt → HTTP $STATUS"
+
+        # User A's conversation list vs User B's
+        A_CONV_COUNT=$(api GET "/query/conversations" "$TOKEN_A" | jq 'length')
+        B_CONV_COUNT=$(api GET "/query/conversations" "$TOKEN_B" | jq 'length')
+        assert_gt "User A has conversations" "0" "$A_CONV_COUNT"
+        assert_eq "User B has 0 conversations" "0" "$B_CONV_COUNT"
+        info "User A conversations: $A_CONV_COUNT  |  User B conversations: $B_CONV_COUNT"
+    else
+        info "SKIPPED: Q&A returned no conversation (LLM may have failed)"
+        info "Response: $(echo "$QA_A" | jq -c . 2>/dev/null || echo "$QA_A")"
+    fi
+else
+    info "SKIPPED: No articles for User A — Q&A requires compiled articles"
+fi
+
+# ===========================================================================
+# Test Group 10: Search isolation
+# ===========================================================================
+
+echo ""
+bold "10. Search isolation"
+echo ""
+
+if [[ "$A_ART_COUNT" -gt 0 ]]; then
+    A_SEARCH=$(api GET "/wiki/search?q=eiffel" "$TOKEN_A")
+    A_SEARCH_COUNT=$(echo "$A_SEARCH" | jq 'length')
+    info "User A search 'eiffel': $A_SEARCH_COUNT results"
+
+    B_SEARCH=$(api GET "/wiki/search?q=eiffel" "$TOKEN_B")
+    B_SEARCH_COUNT=$(echo "$B_SEARCH" | jq 'length')
+    assert_eq "User B search for User A's content → 0 results" "0" "$B_SEARCH_COUNT"
+    info "User B search 'eiffel': $B_SEARCH_COUNT results"
+else
+    info "SKIPPED: No articles to search"
+fi
+
+# ===========================================================================
+# Test Group 11: Knowledge graph isolation
+# ===========================================================================
+
+echo ""
+bold "11. Knowledge graph isolation"
+echo ""
+
+A_GRAPH=$(api GET "/wiki/graph" "$TOKEN_A")
+A_NODE_COUNT=$(echo "$A_GRAPH" | jq '.nodes | length')
+info "User A graph nodes: $A_NODE_COUNT"
+
+B_GRAPH=$(api GET "/wiki/graph" "$TOKEN_B")
+B_NODE_COUNT=$(echo "$B_GRAPH" | jq '.nodes | length')
+info "User B graph nodes: $B_NODE_COUNT"
+
+# User B's graph should not include User A's articles
+if [[ "$A_NODE_COUNT" -gt 0 ]]; then
+    # Check that none of User A's article titles appear in User B's graph
+    A_FIRST_TITLE=$(echo "$A_ARTICLES" | jq -r '.[0].title' 2>/dev/null || echo "")
+    if [[ -n "$A_FIRST_TITLE" ]]; then
+        B_HAS_A_TITLE=$(echo "$B_GRAPH" | jq --arg t "$A_FIRST_TITLE" '[.nodes[] | select(.label == $t)] | length')
+        assert_eq "User B's graph does not contain User A's articles" "0" "$B_HAS_A_TITLE"
+    fi
+fi
+
+# ===========================================================================
+# Test Group 12: Protected endpoints require auth
+# ===========================================================================
+
+echo ""
+bold "12. Protected endpoints require auth"
 echo ""
 
 RESP=$(api GET "/settings" "$TOKEN_A")
@@ -365,11 +577,11 @@ assert_eq "GET /lint/reports with auth → returns array" "true" "$(echo "$RESP"
 info "Report count: $(echo "$RESP" | jq 'length')"
 
 # ===========================================================================
-# Test Group 9: WebSocket auth (source code verification)
+# Test Group 13: WebSocket auth (source code verification)
 # ===========================================================================
 
 echo ""
-bold "9. WebSocket auth (source code verification)"
+bold "13. WebSocket auth (source code verification)"
 echo ""
 
 if grep -qF 'query_params.get("user_id")' src/wikimind/api/routes/ws.py 2>/dev/null; then
@@ -386,7 +598,7 @@ else
 fi
 
 # ===========================================================================
-# Cleanup: delete test data via API, then remove users from DB
+# Cleanup
 # ===========================================================================
 
 echo ""
@@ -409,12 +621,22 @@ B_FINAL=$(api GET "/ingest/sources" "$TOKEN_B" | jq 'length')
 info "User A remaining sources: $A_FINAL"
 info "User B remaining sources: $B_FINAL"
 
-# Remove test users from database
-docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q -c "
-    DELETE FROM \"user\" WHERE id IN ('${USER_A_ID}', '${USER_B_ID}');
-" 2>/dev/null
-info "Deleted User A ($USER_A_ID) from database"
-info "Deleted User B ($USER_B_ID) from database"
+# Remove test users and their data from database.
+# Table names are lowercase (SQLModel convention). Use CASCADE-safe order.
+docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q <<EOSQL 2>/dev/null || true
+    DELETE FROM query WHERE conversation_id IN (SELECT id FROM conversation WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
+    DELETE FROM conversation WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
+    DELETE FROM articlesource WHERE article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
+    DELETE FROM articleconcept WHERE article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
+    DELETE FROM backlink WHERE source_article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
+    DELETE FROM backlink WHERE target_article_id IN (SELECT id FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}'));
+    DELETE FROM article WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
+    DELETE FROM source WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
+    DELETE FROM job WHERE user_id IN ('${USER_A_ID}', '${USER_B_ID}');
+    DELETE FROM "user" WHERE id IN ('${USER_A_ID}', '${USER_B_ID}');
+EOSQL
+info "Deleted User A ($USER_A_ID) and all data from database"
+info "Deleted User B ($USER_B_ID) and all data from database"
 
 # ===========================================================================
 # Summary

--- a/scripts/test-user-isolation.sh
+++ b/scripts/test-user-isolation.sh
@@ -32,6 +32,7 @@ TOTAL=0
 red()   { printf "\033[31m%s\033[0m" "$*"; }
 green() { printf "\033[32m%s\033[0m" "$*"; }
 bold()  { printf "\033[1m%s\033[0m" "$*"; }
+dim()   { printf "\033[2m%s\033[0m" "$*"; }
 
 assert_eq() {
     local label="$1" expected="$2" actual="$3"
@@ -55,6 +56,10 @@ assert_contains() {
         FAIL=$((FAIL + 1))
         printf "  $(red FAIL)  %s  (expected to contain: %s, got: %s)\n" "$label" "$expected" "$actual"
     fi
+}
+
+info() {
+    printf "        $(dim "→ %s")\n" "$*"
 }
 
 api() {
@@ -108,11 +113,17 @@ TOKEN_B=$(mint_jwt "$USER_B_ID")
 # ---------------------------------------------------------------------------
 
 echo ""
-bold "Multi-User Data Isolation Tests"
+bold "================================================================"
 echo ""
-echo "  Server:  $BASE_URL"
-echo "  User A:  $USER_A_ID"
-echo "  User B:  $USER_B_ID"
+bold "  Multi-User Data Isolation Tests"
+echo ""
+bold "================================================================"
+echo ""
+echo "  Server:   $BASE_URL"
+echo "  User A:   $USER_A_ID"
+echo "  User B:   $USER_B_ID"
+echo "  Token A:  ${TOKEN_A:0:20}..."
+echo "  Token B:  ${TOKEN_B:0:20}..."
 echo ""
 
 # Check server is reachable
@@ -121,25 +132,24 @@ if [[ -z "$HEALTH" ]]; then
     echo "ERROR: Server not reachable at $BASE_URL"
     exit 1
 fi
+echo "  Health:   $(echo "$HEALTH" | jq -r '.status')"
 
 # Check auth is enabled
 UNAUTH=$(api GET "/ingest/sources" "" "" 2>/dev/null)
 if echo "$UNAUTH" | jq -e '.error.code == "UNAUTHORIZED"' > /dev/null 2>&1; then
-    echo "  Auth:    enabled"
+    echo "  Auth:     enabled"
 else
-    echo "  WARNING: Auth may not be enabled — tests may not be meaningful"
+    echo "  WARNING:  Auth may not be enabled — tests may not be meaningful"
 fi
 
-# ---------------------------------------------------------------------------
-# Create test users in the database
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Setup: Create test users via database
+# ===========================================================================
 
 echo ""
 bold "Setup: Creating test users"
 echo ""
 
-# Use the Postgres container to insert users directly.  The docker-compose
-# service name is "postgres" in both dev and prod compose files.
 COMPOSE_FILE="docker-compose.prod.yml"
 if ! docker compose -f "$COMPOSE_FILE" ps postgres --status running -q > /dev/null 2>&1; then
     COMPOSE_FILE="docker-compose.yml"
@@ -153,19 +163,21 @@ docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind 
     ON CONFLICT (id) DO NOTHING;
 " 2>/dev/null
 
-echo "  Created User A and User B in database"
+info "Created User A: $USER_A_ID"
+info "Created User B: $USER_B_ID"
 
 # ===========================================================================
 # Test Group 1: Unauthenticated access is blocked
 # ===========================================================================
 
 echo ""
-bold "1. Unauthenticated access"
+bold "1. Unauthenticated access is blocked"
 echo ""
 
 RESP=$(api GET "/ingest/sources")
 CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
 assert_eq "GET /ingest/sources without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
+info "Response: $(echo "$RESP" | jq -c .)"
 
 RESP=$(api GET "/wiki/articles")
 CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
@@ -175,149 +187,234 @@ RESP=$(api GET "/query/conversations")
 CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
 assert_eq "GET /query/conversations without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
 
-# ===========================================================================
-# Test Group 2: Source isolation (ingest)
-# ===========================================================================
-
-echo ""
-bold "2. Source isolation"
-echo ""
-
-# User A ingests two sources
-SRC_A1=$(api POST "/ingest/text" "$TOKEN_A" '{"content":"User A secret document one","title":"A-Doc-1","auto_compile":false}')
-SRC_A1_ID=$(echo "$SRC_A1" | jq -r '.id')
-SRC_A1_UID=$(echo "$SRC_A1" | jq -r '.user_id')
-assert_eq "Ingest source 1 as User A → user_id matches" "$USER_A_ID" "$SRC_A1_UID"
-
-SRC_A2=$(api POST "/ingest/text" "$TOKEN_A" '{"content":"User A secret document two","title":"A-Doc-2","auto_compile":false}')
-SRC_A2_ID=$(echo "$SRC_A2" | jq -r '.id')
-assert_eq "Ingest source 2 as User A → has ID" "true" "$([ -n "$SRC_A2_ID" ] && [ "$SRC_A2_ID" != "null" ] && echo true || echo false)"
-
-# User B ingests one source
-SRC_B1=$(api POST "/ingest/text" "$TOKEN_B" '{"content":"User B private note","title":"B-Doc-1","auto_compile":false}')
-SRC_B1_ID=$(echo "$SRC_B1" | jq -r '.id')
-SRC_B1_UID=$(echo "$SRC_B1" | jq -r '.user_id')
-assert_eq "Ingest source as User B → user_id matches" "$USER_B_ID" "$SRC_B1_UID"
-
-# User A sees only their sources
-A_COUNT=$(api GET "/ingest/sources" "$TOKEN_A" | jq 'length')
-assert_eq "User A source list count → 2" "2" "$A_COUNT"
-
-# User B sees only their source
-B_COUNT=$(api GET "/ingest/sources" "$TOKEN_B" | jq 'length')
-assert_eq "User B source list count → 1" "1" "$B_COUNT"
-
-# User A cannot access User B's source
-RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
-DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
-assert_eq "User A GET User B's source → Source not found" "Source not found" "$DETAIL"
-
-# User B cannot access User A's source
-RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
-DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
-assert_eq "User B GET User A's source → Source not found" "Source not found" "$DETAIL"
-
-# User B cannot delete User A's source
-RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
-DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
-assert_eq "User B DELETE User A's source → Source not found" "Source not found" "$DETAIL"
-
-# User A's source still exists after B's delete attempt
-RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
-TITLE=$(echo "$RESP" | jq -r '.title')
-assert_eq "User A's source survives User B's delete attempt" "A-Doc-1" "$TITLE"
-
-# ===========================================================================
-# Test Group 3: Article isolation (wiki)
-# ===========================================================================
-
-echo ""
-bold "3. Article isolation"
-echo ""
-
-# User A's articles
-A_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_A" | jq 'length')
-# User B's articles
-B_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_B" | jq 'length')
-assert_eq "User B cannot see User A's articles" "0" "$B_ARTICLES"
-
-# ===========================================================================
-# Test Group 4: Conversation isolation (Q&A)
-# ===========================================================================
-
-echo ""
-bold "4. Conversation isolation"
-echo ""
-
-A_CONVOS=$(api GET "/query/conversations" "$TOKEN_A" | jq 'length')
-B_CONVOS=$(api GET "/query/conversations" "$TOKEN_B" | jq 'length')
-assert_eq "User B has no conversations" "0" "$B_CONVOS"
-
-# ===========================================================================
-# Test Group 5: Settings / jobs endpoints require auth
-# ===========================================================================
-
-echo ""
-bold "5. Protected endpoints"
-echo ""
-
-RESP=$(api GET "/settings" "$TOKEN_A")
-assert_contains "GET /settings with auth → returns data" "llm" "$RESP"
-
 RESP=$(api GET "/settings")
 CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
 assert_eq "GET /settings without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
-
-RESP=$(api GET "/jobs" "$TOKEN_A")
-assert_eq "GET /jobs with auth → returns array" "true" "$(echo "$RESP" | jq 'type == "array"')"
 
 RESP=$(api GET "/jobs")
 CODE=$(echo "$RESP" | jq -r '.error.code // empty' 2>/dev/null)
 assert_eq "GET /jobs without auth → UNAUTHORIZED" "UNAUTHORIZED" "$CODE"
 
+# ===========================================================================
+# Test Group 2: Source ingestion and ownership
+# ===========================================================================
+
+echo ""
+bold "2. Source ingestion and ownership"
+echo ""
+
+# -- User A ingests two sources --
+
+SRC_A1=$(api POST "/ingest/text" "$TOKEN_A" \
+    '{"content":"User A secret document number one with sensitive data","title":"A-Doc-1","auto_compile":false}')
+SRC_A1_ID=$(echo "$SRC_A1" | jq -r '.id')
+SRC_A1_UID=$(echo "$SRC_A1" | jq -r '.user_id')
+assert_eq "Ingest source 1 as User A → user_id matches" "$USER_A_ID" "$SRC_A1_UID"
+info "Source A1: id=$SRC_A1_ID  user_id=$SRC_A1_UID  title=$(echo "$SRC_A1" | jq -r '.title')"
+
+SRC_A2=$(api POST "/ingest/text" "$TOKEN_A" \
+    '{"content":"User A second document with more private info","title":"A-Doc-2","auto_compile":false}')
+SRC_A2_ID=$(echo "$SRC_A2" | jq -r '.id')
+SRC_A2_UID=$(echo "$SRC_A2" | jq -r '.user_id')
+assert_eq "Ingest source 2 as User A → user_id matches" "$USER_A_ID" "$SRC_A2_UID"
+info "Source A2: id=$SRC_A2_ID  user_id=$SRC_A2_UID  title=$(echo "$SRC_A2" | jq -r '.title')"
+
+# -- User B ingests one source --
+
+SRC_B1=$(api POST "/ingest/text" "$TOKEN_B" \
+    '{"content":"User B private note that A should never see","title":"B-Doc-1","auto_compile":false}')
+SRC_B1_ID=$(echo "$SRC_B1" | jq -r '.id')
+SRC_B1_UID=$(echo "$SRC_B1" | jq -r '.user_id')
+assert_eq "Ingest source 1 as User B → user_id matches" "$USER_B_ID" "$SRC_B1_UID"
+info "Source B1: id=$SRC_B1_ID  user_id=$SRC_B1_UID  title=$(echo "$SRC_B1" | jq -r '.title')"
+
+# ===========================================================================
+# Test Group 3: Source list isolation
+# ===========================================================================
+
+echo ""
+bold "3. Source list isolation"
+echo ""
+
+A_SOURCES=$(api GET "/ingest/sources" "$TOKEN_A")
+A_COUNT=$(echo "$A_SOURCES" | jq 'length')
+assert_eq "User A sees exactly 2 sources" "2" "$A_COUNT"
+info "User A sources: $(echo "$A_SOURCES" | jq -c '[.[] | {id: .id, title: .title}]')"
+
+B_SOURCES=$(api GET "/ingest/sources" "$TOKEN_B")
+B_COUNT=$(echo "$B_SOURCES" | jq 'length')
+assert_eq "User B sees exactly 1 source" "1" "$B_COUNT"
+info "User B sources: $(echo "$B_SOURCES" | jq -c '[.[] | {id: .id, title: .title}]')"
+
+# ===========================================================================
+# Test Group 4: Cross-user source access is blocked
+# ===========================================================================
+
+echo ""
+bold "4. Cross-user source access is blocked"
+echo ""
+
+# User A tries to read User B's source
+RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User A GET User B's source ($SRC_B1_ID) → 404" "Source not found" "$DETAIL"
+info "Response: $(echo "$RESP" | jq -c .)"
+
+# User B tries to read User A's source
+RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User B GET User A's source ($SRC_A1_ID) → 404" "Source not found" "$DETAIL"
+info "Response: $(echo "$RESP" | jq -c .)"
+
+# User A can read their OWN source
+RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User A GET own source ($SRC_A1_ID) → A-Doc-1" "A-Doc-1" "$TITLE"
+info "Response: id=$(echo "$RESP" | jq -r '.id')  title=$TITLE  user_id=$(echo "$RESP" | jq -r '.user_id')"
+
+# User B can read their OWN source
+RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User B GET own source ($SRC_B1_ID) → B-Doc-1" "B-Doc-1" "$TITLE"
+info "Response: id=$(echo "$RESP" | jq -r '.id')  title=$TITLE  user_id=$(echo "$RESP" | jq -r '.user_id')"
+
+# ===========================================================================
+# Test Group 5: Cross-user deletion is blocked
+# ===========================================================================
+
+echo ""
+bold "5. Cross-user deletion is blocked"
+echo ""
+
+# User B tries to delete User A's source
+RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_B")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User B DELETE User A's source ($SRC_A1_ID) → 404" "Source not found" "$DETAIL"
+info "Response: $(echo "$RESP" | jq -c .)"
+
+# Verify User A's source still exists
+RESP=$(api GET "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User A's source survives User B's delete attempt" "A-Doc-1" "$TITLE"
+info "Source still exists: id=$SRC_A1_ID  title=$TITLE"
+
+# User A tries to delete User B's source
+RESP=$(api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_A")
+DETAIL=$(echo "$RESP" | jq -r '.detail // empty')
+assert_eq "User A DELETE User B's source ($SRC_B1_ID) → 404" "Source not found" "$DETAIL"
+info "Response: $(echo "$RESP" | jq -c .)"
+
+# Verify User B's source still exists
+RESP=$(api GET "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
+TITLE=$(echo "$RESP" | jq -r '.title')
+assert_eq "User B's source survives User A's delete attempt" "B-Doc-1" "$TITLE"
+info "Source still exists: id=$SRC_B1_ID  title=$TITLE"
+
+# ===========================================================================
+# Test Group 6: Article isolation
+# ===========================================================================
+
+echo ""
+bold "6. Article isolation"
+echo ""
+
+A_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_A")
+A_ART_COUNT=$(echo "$A_ARTICLES" | jq 'length')
+info "User A article count: $A_ART_COUNT"
+
+B_ARTICLES=$(api GET "/wiki/articles" "$TOKEN_B")
+B_ART_COUNT=$(echo "$B_ARTICLES" | jq 'length')
+assert_eq "User B sees 0 of User A's articles" "0" "$B_ART_COUNT"
+info "User B article count: $B_ART_COUNT"
+
+# ===========================================================================
+# Test Group 7: Conversation isolation
+# ===========================================================================
+
+echo ""
+bold "7. Conversation isolation"
+echo ""
+
+A_CONVOS=$(api GET "/query/conversations" "$TOKEN_A")
+A_CONV_COUNT=$(echo "$A_CONVOS" | jq 'length')
+info "User A conversation count: $A_CONV_COUNT"
+
+B_CONVOS=$(api GET "/query/conversations" "$TOKEN_B")
+B_CONV_COUNT=$(echo "$B_CONVOS" | jq 'length')
+assert_eq "User B sees 0 of User A's conversations" "0" "$B_CONV_COUNT"
+info "User B conversation count: $B_CONV_COUNT"
+
+# ===========================================================================
+# Test Group 8: Protected endpoints require auth
+# ===========================================================================
+
+echo ""
+bold "8. Protected endpoints require auth"
+echo ""
+
+RESP=$(api GET "/settings" "$TOKEN_A")
+assert_contains "GET /settings with auth → returns LLM config" "default_provider" "$RESP"
+info "Provider: $(echo "$RESP" | jq -r '.llm.default_provider')"
+
+RESP=$(api GET "/jobs" "$TOKEN_A")
+assert_eq "GET /jobs with auth → returns array" "true" "$(echo "$RESP" | jq 'type == "array"')"
+info "Job count: $(echo "$RESP" | jq 'length')"
+
 RESP=$(api GET "/lint/reports" "$TOKEN_A")
 assert_eq "GET /lint/reports with auth → returns array" "true" "$(echo "$RESP" | jq 'type == "array"')"
+info "Report count: $(echo "$RESP" | jq 'length')"
 
 # ===========================================================================
-# Test Group 6: WebSocket auth (cannot impersonate via query param)
+# Test Group 9: WebSocket auth (source code verification)
 # ===========================================================================
 
 echo ""
-bold "6. WebSocket auth"
+bold "9. WebSocket auth (source code verification)"
 echo ""
 
-# We can't do a full WebSocket test from bash, but we can verify the
-# endpoint exists and the old query param pattern is gone from the source.
 if grep -qF 'query_params.get("user_id")' src/wikimind/api/routes/ws.py 2>/dev/null; then
-    assert_eq "WebSocket no longer reads user_id from query params" "gone" "still present"
+    assert_eq "ws.py does NOT read user_id from query params" "gone" "still present"
 else
-    assert_eq "WebSocket no longer reads user_id from query params" "gone" "gone"
+    assert_eq "ws.py does NOT read user_id from query params" "gone" "gone"
 fi
+info "ws.py uses get_ws_user_id() for JWT-based auth"
 
 if grep -q 'get_ws_user_id' src/wikimind/api/deps.py 2>/dev/null; then
-    assert_eq "get_ws_user_id helper exists in deps.py" "true" "true"
+    assert_eq "get_ws_user_id helper exists in deps.py" "found" "found"
 else
-    assert_eq "get_ws_user_id helper exists in deps.py" "true" "false"
+    assert_eq "get_ws_user_id helper exists in deps.py" "found" "missing"
 fi
 
 # ===========================================================================
-# Cleanup: delete test sources (as the owning user)
+# Cleanup: delete test data via API, then remove users from DB
 # ===========================================================================
 
 echo ""
 bold "Cleanup"
 echo ""
 
-api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_A" > /dev/null 2>&1
-api DELETE "/ingest/sources/$SRC_A2_ID" "$TOKEN_A" > /dev/null 2>&1
-api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_B" > /dev/null 2>&1
+# Delete sources via API (as the owning user)
+RESP=$(api DELETE "/ingest/sources/$SRC_A1_ID" "$TOKEN_A")
+info "Deleted source A1 ($SRC_A1_ID): $(echo "$RESP" | jq -c .)"
 
-# Remove test users
+RESP=$(api DELETE "/ingest/sources/$SRC_A2_ID" "$TOKEN_A")
+info "Deleted source A2 ($SRC_A2_ID): $(echo "$RESP" | jq -c .)"
+
+RESP=$(api DELETE "/ingest/sources/$SRC_B1_ID" "$TOKEN_B")
+info "Deleted source B1 ($SRC_B1_ID): $(echo "$RESP" | jq -c .)"
+
+# Verify sources are gone
+A_FINAL=$(api GET "/ingest/sources" "$TOKEN_A" | jq 'length')
+B_FINAL=$(api GET "/ingest/sources" "$TOKEN_B" | jq 'length')
+info "User A remaining sources: $A_FINAL"
+info "User B remaining sources: $B_FINAL"
+
+# Remove test users from database
 docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wikimind -d wikimind -q -c "
     DELETE FROM \"user\" WHERE id IN ('${USER_A_ID}', '${USER_B_ID}');
 " 2>/dev/null
-
-echo "  Cleaned up test data"
+info "Deleted User A ($USER_A_ID) from database"
+info "Deleted User B ($USER_B_ID) from database"
 
 # ===========================================================================
 # Summary

--- a/src/wikimind/api/deps.py
+++ b/src/wikimind/api/deps.py
@@ -5,7 +5,8 @@ When auth is disabled (single-user mode), user_id defaults to
 ``ANONYMOUS_USER_ID`` so every record has a non-null owner.
 """
 
-from fastapi import Depends, HTTPException, Request
+import jwt
+from fastapi import Depends, HTTPException, Request, WebSocket
 
 from wikimind.config import get_settings
 
@@ -26,3 +27,36 @@ async def require_user_id(user_id: str = Depends(get_current_user_id)) -> str:
     if settings.auth.enabled and user_id == ANONYMOUS_USER_ID:
         raise HTTPException(status_code=401, detail="Authentication required")
     return user_id
+
+
+async def get_ws_user_id(websocket: WebSocket) -> str:
+    """Extract user_id from JWT cookie on WebSocket upgrade.
+
+    Falls back to ANONYMOUS_USER_ID when auth is disabled.
+
+    Uses the same JWT decoding logic as :class:`wikimind.middleware.auth.AuthMiddleware`:
+    reads the session cookie (``settings.auth.cookie_name``), then falls back to a
+    ``token`` query parameter (for clients that cannot set cookies on the WS upgrade).
+    """
+    settings = get_settings()
+    if not settings.auth.enabled:
+        return ANONYMOUS_USER_ID
+
+    token = websocket.cookies.get(settings.auth.cookie_name)
+    if not token:
+        # Allow passing the JWT as a query parameter (NOT user_id) for clients
+        # that cannot attach cookies to the WebSocket upgrade request.
+        token = websocket.query_params.get("token")
+
+    if not token:
+        return ANONYMOUS_USER_ID
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.auth.jwt_secret_key,
+            algorithms=[settings.auth.jwt_algorithm],
+        )
+        return payload.get("sub") or ANONYMOUS_USER_ID
+    except jwt.InvalidTokenError:
+        return ANONYMOUS_USER_ID

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -7,7 +7,7 @@ deletion). The JWT is stored in an HttpOnly cookie.
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.api.deps import ANONYMOUS_USER_ID, require_user_id
 from wikimind.config import get_settings

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -380,6 +380,9 @@ async def delete_account(
             delete(ContradictionFinding).where(ContradictionFinding.article_a_id.in_(article_ids))  # type: ignore[attr-defined]
         )
         await session.execute(
+            delete(ContradictionFinding).where(ContradictionFinding.article_b_id.in_(article_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
             delete(OrphanFinding).where(OrphanFinding.article_id.in_(article_ids))  # type: ignore[attr-defined]
         )
         await session.execute(

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from wikimind.api.deps import ANONYMOUS_USER_ID, get_current_user_id
+from wikimind.api.deps import ANONYMOUS_USER_ID, require_user_id
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.services.user import UserService, get_user_service
@@ -131,11 +131,9 @@ async def logout() -> JSONResponse:
 @router.delete("/account")
 async def delete_account(
     session: AsyncSession = Depends(get_session),
-    user_id: str = Depends(get_current_user_id),
+    user_id: str = Depends(require_user_id),
     service: UserService = Depends(get_user_service),
 ) -> dict:
     """Delete the current user's account and all owned data."""
-    if user_id == ANONYMOUS_USER_ID:
-        raise HTTPException(status_code=400, detail="Cannot delete the anonymous account")
     await service.delete_account(session, user_id)
     return {"deleted": user_id}

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -19,12 +19,31 @@ import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import delete, select
 
-from wikimind.api.deps import ANONYMOUS_USER_ID
+from wikimind.api.deps import ANONYMOUS_USER_ID, get_current_user_id
 from wikimind.config import Settings, get_settings
 from wikimind.database import get_session
-from wikimind.models import User
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    ArticleSource,
+    Backlink,
+    Concept,
+    ContradictionFinding,
+    Conversation,
+    CostLog,
+    Job,
+    LintReport,
+    OrphanFinding,
+    Query,
+    Source,
+    StructuralFinding,
+    SyncLog,
+    User,
+    UserApiKey,
+    UserPreference,
+)
 
 router = APIRouter()
 
@@ -268,17 +287,37 @@ async def callback(
 
 @router.get("/me")
 async def me(request: Request, session: AsyncSession = Depends(get_session)) -> dict:
-    """Return current user profile."""
+    """Return current user profile.
+
+    If the JWT is valid but no matching user row exists, auto-provision a
+    minimal account using the ``sub`` and ``email`` claims from the token.
+    This handles the case where a user authenticates for the first time via
+    a pre-signed JWT (API testing, service accounts) without going through
+    the full OAuth callback.
+    """
     settings = get_settings()
     if not request.state.user_id:
         if not settings.auth.enabled:
-            # Auth disabled — return a stub user so the frontend knows
-            # it can skip the login flow.
             return {"id": ANONYMOUS_USER_ID, "email": "", "name": "Anonymous", "avatar_url": None}
         raise HTTPException(status_code=401)
-    user = await session.get(User, request.state.user_id)
+
+    user_id = request.state.user_id
+    user = await session.get(User, user_id)
+
     if not user:
-        raise HTTPException(status_code=404)
+        # Auto-provision: create a minimal user record from JWT claims.
+        email = getattr(request.state, "user_email", None) or f"{user_id}@jwt.local"
+        user = User(
+            id=user_id,
+            email=email,
+            name=user_id,
+            auth_provider="jwt",
+            auth_provider_id=user_id,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
     return {
         "id": user.id,
         "email": user.email,
@@ -298,3 +337,88 @@ async def logout() -> JSONResponse:
         domain=settings.auth.cookie_domain,
     )
     return response
+
+
+@router.delete("/account")
+async def delete_account(
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> dict:
+    """Delete the current user's account and all owned data.
+
+    Removes every record owned by this user across all tables, then
+    deletes the user row itself. Order matters: child rows with
+    foreign keys to articles/conversations must be deleted first.
+    """
+    if user_id == ANONYMOUS_USER_ID:
+        raise HTTPException(status_code=400, detail="Cannot delete the anonymous account")
+
+    user = await session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Collect IDs for join-table / child-table cleanup
+    article_ids = [
+        row[0] for row in (await session.execute(select(Article.id).where(Article.user_id == user_id))).all()
+    ]
+    report_ids = [
+        row[0] for row in (await session.execute(select(LintReport.id).where(LintReport.user_id == user_id))).all()
+    ]
+    conv_ids = [
+        row[0] for row in (await session.execute(select(Conversation.id).where(Conversation.user_id == user_id))).all()
+    ]
+
+    # 1. Delete child rows that reference articles
+    if article_ids:
+        await session.execute(
+            delete(ArticleConcept).where(ArticleConcept.article_id.in_(article_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
+            delete(ArticleSource).where(ArticleSource.article_id.in_(article_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
+            delete(ContradictionFinding).where(ContradictionFinding.article_a_id.in_(article_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
+            delete(OrphanFinding).where(OrphanFinding.article_id.in_(article_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
+            delete(StructuralFinding).where(StructuralFinding.article_id.in_(article_ids))  # type: ignore[attr-defined]
+        )
+
+    # 2. Delete lint findings that reference reports
+    if report_ids:
+        await session.execute(
+            delete(ContradictionFinding).where(ContradictionFinding.report_id.in_(report_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
+            delete(OrphanFinding).where(OrphanFinding.report_id.in_(report_ids))  # type: ignore[attr-defined]
+        )
+        await session.execute(
+            delete(StructuralFinding).where(StructuralFinding.report_id.in_(report_ids))  # type: ignore[attr-defined]
+        )
+
+    # 3. Delete queries that reference conversations
+    if conv_ids:
+        await session.execute(
+            delete(Query).where(Query.conversation_id.in_(conv_ids))  # type: ignore[attr-defined]
+        )
+
+    # 4. Delete all user-owned rows
+    await session.execute(delete(Backlink).where(Backlink.user_id == user_id))
+    await session.execute(delete(Article).where(Article.user_id == user_id))
+    await session.execute(delete(Source).where(Source.user_id == user_id))
+    await session.execute(delete(Concept).where(Concept.user_id == user_id))
+    await session.execute(delete(Conversation).where(Conversation.user_id == user_id))
+    await session.execute(delete(Job).where(Job.user_id == user_id))
+    await session.execute(delete(CostLog).where(CostLog.user_id == user_id))
+    await session.execute(delete(SyncLog).where(SyncLog.user_id == user_id))
+    await session.execute(delete(LintReport).where(LintReport.user_id == user_id))
+    await session.execute(delete(UserApiKey).where(UserApiKey.user_id == user_id))
+    await session.execute(delete(UserPreference).where(UserPreference.user_id == user_id))
+
+    # 5. Delete the user
+    await session.delete(user)
+    await session.commit()
+
+    return {"deleted": user_id}

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -19,31 +19,13 @@ import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import delete, select
+from sqlmodel import select
 
 from wikimind.api.deps import ANONYMOUS_USER_ID, get_current_user_id
 from wikimind.config import Settings, get_settings
 from wikimind.database import get_session
-from wikimind.models import (
-    Article,
-    ArticleConcept,
-    ArticleSource,
-    Backlink,
-    Concept,
-    ContradictionFinding,
-    Conversation,
-    CostLog,
-    Job,
-    LintReport,
-    OrphanFinding,
-    Query,
-    Source,
-    StructuralFinding,
-    SyncLog,
-    User,
-    UserApiKey,
-    UserPreference,
-)
+from wikimind.models import User
+from wikimind.services.user import UserService, get_user_service
 
 router = APIRouter()
 
@@ -286,37 +268,20 @@ async def callback(
 
 
 @router.get("/me")
-async def me(request: Request, session: AsyncSession = Depends(get_session)) -> dict:
-    """Return current user profile.
-
-    If the JWT is valid but no matching user row exists, auto-provision a
-    minimal account using the ``sub`` and ``email`` claims from the token.
-    This handles the case where a user authenticates for the first time via
-    a pre-signed JWT (API testing, service accounts) without going through
-    the full OAuth callback.
-    """
+async def me(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    service: UserService = Depends(get_user_service),
+) -> dict:
+    """Return current user profile, auto-provisioning if needed."""
     settings = get_settings()
     if not request.state.user_id:
         if not settings.auth.enabled:
             return {"id": ANONYMOUS_USER_ID, "email": "", "name": "Anonymous", "avatar_url": None}
         raise HTTPException(status_code=401)
 
-    user_id = request.state.user_id
-    user = await session.get(User, user_id)
-
-    if not user:
-        # Auto-provision: create a minimal user record from JWT claims.
-        email = getattr(request.state, "user_email", None) or f"{user_id}@jwt.local"
-        user = User(
-            id=user_id,
-            email=email,
-            name=user_id,
-            auth_provider="jwt",
-            auth_provider_id=user_id,
-        )
-        session.add(user)
-        await session.commit()
-        await session.refresh(user)
+    email = getattr(request.state, "user_email", None)
+    user = await service.get_or_create(session, request.state.user_id, email=email)
 
     return {
         "id": user.id,
@@ -343,85 +308,10 @@ async def logout() -> JSONResponse:
 async def delete_account(
     session: AsyncSession = Depends(get_session),
     user_id: str = Depends(get_current_user_id),
+    service: UserService = Depends(get_user_service),
 ) -> dict:
-    """Delete the current user's account and all owned data.
-
-    Removes every record owned by this user across all tables, then
-    deletes the user row itself. Order matters: child rows with
-    foreign keys to articles/conversations must be deleted first.
-    """
+    """Delete the current user's account and all owned data."""
     if user_id == ANONYMOUS_USER_ID:
         raise HTTPException(status_code=400, detail="Cannot delete the anonymous account")
-
-    user = await session.get(User, user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-
-    # Collect IDs for join-table / child-table cleanup
-    article_ids = [
-        row[0] for row in (await session.execute(select(Article.id).where(Article.user_id == user_id))).all()
-    ]
-    report_ids = [
-        row[0] for row in (await session.execute(select(LintReport.id).where(LintReport.user_id == user_id))).all()
-    ]
-    conv_ids = [
-        row[0] for row in (await session.execute(select(Conversation.id).where(Conversation.user_id == user_id))).all()
-    ]
-
-    # 1. Delete child rows that reference articles
-    if article_ids:
-        await session.execute(
-            delete(ArticleConcept).where(ArticleConcept.article_id.in_(article_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(ArticleSource).where(ArticleSource.article_id.in_(article_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(ContradictionFinding).where(ContradictionFinding.article_a_id.in_(article_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(ContradictionFinding).where(ContradictionFinding.article_b_id.in_(article_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(OrphanFinding).where(OrphanFinding.article_id.in_(article_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(StructuralFinding).where(StructuralFinding.article_id.in_(article_ids))  # type: ignore[attr-defined]
-        )
-
-    # 2. Delete lint findings that reference reports
-    if report_ids:
-        await session.execute(
-            delete(ContradictionFinding).where(ContradictionFinding.report_id.in_(report_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(OrphanFinding).where(OrphanFinding.report_id.in_(report_ids))  # type: ignore[attr-defined]
-        )
-        await session.execute(
-            delete(StructuralFinding).where(StructuralFinding.report_id.in_(report_ids))  # type: ignore[attr-defined]
-        )
-
-    # 3. Delete queries that reference conversations
-    if conv_ids:
-        await session.execute(
-            delete(Query).where(Query.conversation_id.in_(conv_ids))  # type: ignore[attr-defined]
-        )
-
-    # 4. Delete all user-owned rows
-    await session.execute(delete(Backlink).where(Backlink.user_id == user_id))
-    await session.execute(delete(Article).where(Article.user_id == user_id))
-    await session.execute(delete(Source).where(Source.user_id == user_id))
-    await session.execute(delete(Concept).where(Concept.user_id == user_id))
-    await session.execute(delete(Conversation).where(Conversation.user_id == user_id))
-    await session.execute(delete(Job).where(Job.user_id == user_id))
-    await session.execute(delete(CostLog).where(CostLog.user_id == user_id))
-    await session.execute(delete(SyncLog).where(SyncLog.user_id == user_id))
-    await session.execute(delete(LintReport).where(LintReport.user_id == user_id))
-    await session.execute(delete(UserApiKey).where(UserApiKey.user_id == user_id))
-    await session.execute(delete(UserPreference).where(UserPreference.user_id == user_id))
-
-    # 5. Delete the user
-    await session.delete(user)
-    await session.commit()
-
+    await service.delete_account(session, user_id)
     return {"deleted": user_id}

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -1,201 +1,26 @@
 """OAuth2 authentication routes — Google and GitHub login flows.
 
-Provides ``/auth/login/{provider}`` to redirect users to the OAuth2
-provider's authorization page, ``/auth/callback`` to handle the code
-exchange, JWT issuance, and HttpOnly cookie setting, ``/auth/me`` to
-return the current user's profile, and ``/auth/logout`` to clear the
-session cookie.
-
-The JWT is stored in an HttpOnly cookie (not exposed to JavaScript).
-After the OAuth callback sets the cookie, the browser is redirected to
-``/callback`` on the frontend where the SPA calls ``/auth/me``
-(cookie sent automatically) to confirm the session.
+Thin route handlers that delegate to :class:`UserService` for all
+business logic (token exchange, user upsert, JWT creation, account
+deletion). The JWT is stored in an HttpOnly cookie.
 """
 
-from datetime import UTC, datetime, timedelta
-
-import httpx
-import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
 from wikimind.api.deps import ANONYMOUS_USER_ID, get_current_user_id
-from wikimind.config import Settings, get_settings
+from wikimind.config import get_settings
 from wikimind.database import get_session
-from wikimind.models import User
 from wikimind.services.user import UserService, get_user_service
 
 router = APIRouter()
 
 
-# ---------------------------------------------------------------------------
-# OAuth2 token exchange helpers
-# ---------------------------------------------------------------------------
-
-
-async def _exchange_google_token(code: str, settings: Settings, redirect_uri: str) -> dict:
-    """Exchange a Google authorization code for an access token."""
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            "https://oauth2.googleapis.com/token",
-            data={
-                "code": code,
-                "client_id": settings.auth.google_client_id,
-                "client_secret": settings.auth.google_client_secret,
-                "redirect_uri": redirect_uri,
-                "grant_type": "authorization_code",
-            },
-        )
-        resp.raise_for_status()
-        return resp.json()
-
-
-async def _exchange_github_token(code: str, settings: Settings) -> dict:
-    """Exchange a GitHub authorization code for an access token."""
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            "https://github.com/login/oauth/access_token",
-            json={
-                "client_id": settings.auth.github_client_id,
-                "client_secret": settings.auth.github_client_secret,
-                "code": code,
-            },
-            headers={"Accept": "application/json"},
-        )
-        resp.raise_for_status()
-        return resp.json()
-
-
-# ---------------------------------------------------------------------------
-# OAuth2 user-info helpers
-# ---------------------------------------------------------------------------
-
-
-async def _fetch_google_userinfo(access_token: str) -> dict:
-    """Fetch the authenticated user's profile from Google."""
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            "https://www.googleapis.com/oauth2/v2/userinfo",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-        resp.raise_for_status()
-        return resp.json()
-
-
-async def _fetch_github_userinfo(access_token: str) -> dict:
-    """Fetch the authenticated user's profile from GitHub.
-
-    GitHub's ``/user`` endpoint may not include a public email, so we
-    also hit ``/user/emails`` and pick the primary verified address.
-    """
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
-    }
-    async with httpx.AsyncClient() as client:
-        user_resp = await client.get("https://api.github.com/user", headers=headers)
-        user_resp.raise_for_status()
-        user_data = user_resp.json()
-
-        if not user_data.get("email"):
-            email_resp = await client.get("https://api.github.com/user/emails", headers=headers)
-            email_resp.raise_for_status()
-            emails = email_resp.json()
-            primary = next((e for e in emails if e.get("primary") and e.get("verified")), None)
-            if primary:
-                user_data["email"] = primary["email"]
-
-        return user_data
-
-
-# ---------------------------------------------------------------------------
-# User upsert + JWT creation
-# ---------------------------------------------------------------------------
-
-
-async def _upsert_user(session: AsyncSession, provider: str, user_info: dict) -> User:
-    """Find or create a user by (auth_provider, auth_provider_id)."""
-    if provider == "google":
-        provider_id = str(user_info["id"])
-        email = user_info["email"]
-        name = user_info.get("name")
-        avatar_url = user_info.get("picture")
-    else:
-        provider_id = str(user_info["id"])
-        email = user_info["email"]
-        name = user_info.get("name") or user_info.get("login")
-        avatar_url = user_info.get("avatar_url")
-
-    # Look up by provider identity first, then fall back to email.
-    # This handles the case where a user logs in with Google first and
-    # GitHub second using the same email — they get the same User record.
-    result = await session.execute(
-        select(User).where(User.auth_provider == provider, User.auth_provider_id == provider_id)
-    )
-    user = result.scalar_one_or_none()
-
-    if not user and email:
-        result = await session.execute(select(User).where(User.email == email))
-        user = result.scalar_one_or_none()
-
-    if user:
-        user.name = name
-        user.avatar_url = avatar_url
-        user.updated_at = datetime.now(UTC).replace(tzinfo=None)
-        session.add(user)
-    else:
-        user = User(
-            email=email,
-            name=name,
-            avatar_url=avatar_url,
-            auth_provider=provider,
-            auth_provider_id=provider_id,
-        )
-        session.add(user)
-
-    await session.commit()
-    await session.refresh(user)
-    return user
-
-
-def _create_jwt(user: User, settings: Settings) -> str:
-    """Create a signed JWT for the given user."""
-    now = datetime.now(UTC)
-    payload = {
-        "sub": user.id,
-        "email": user.email,
-        "exp": now + timedelta(minutes=settings.auth.jwt_expiry_minutes),
-        "iat": now,
-    }
-    return jwt.encode(
-        payload,
-        settings.auth.jwt_secret_key,
-        algorithm=settings.auth.jwt_algorithm,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _callback_url(request: Request) -> str:
-    """Build the OAuth callback URL from the request's Host header.
-
-    ``request.url_for()`` uses the ASGI scope's server address which
-    ignores reverse proxies (Vite dev proxy, nginx, Fly.io).  Reading
-    the ``Host`` header directly produces the correct origin in all
-    environments.
-    """
+    """Build the OAuth callback URL from the request's Host header."""
     host = request.headers.get("host", request.url.netloc)
     return f"{request.url.scheme}://{host}/auth/callback"
-
-
-# ---------------------------------------------------------------------------
-# Route handlers
-# ---------------------------------------------------------------------------
 
 
 @router.get("/login/{provider}")
@@ -229,30 +54,29 @@ async def login(provider: str, request: Request) -> RedirectResponse:
 
 @router.get("/callback", name="auth_callback")
 async def callback(
-    code: str, state: str, request: Request, session: AsyncSession = Depends(get_session)
+    code: str,
+    state: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    service: UserService = Depends(get_user_service),
 ) -> RedirectResponse:
-    """Handle OAuth2 callback — exchange code for token, upsert user, return JWT."""
+    """Handle OAuth2 callback — exchange code for token, upsert user, set cookie."""
     settings = get_settings()
     provider = state
-    # Google requires the exact redirect_uri used in the authorize request
     callback_url = _callback_url(request)
 
     if provider == "google":
-        token_resp = await _exchange_google_token(code, settings, callback_url)
-        user_info = await _fetch_google_userinfo(token_resp["access_token"])
+        token_resp = await service.exchange_google_token(code, settings, callback_url)
+        user_info = await service.fetch_google_userinfo(token_resp["access_token"])
     elif provider == "github":
-        token_resp = await _exchange_github_token(code, settings)
-        user_info = await _fetch_github_userinfo(token_resp["access_token"])
+        token_resp = await service.exchange_github_token(code, settings)
+        user_info = await service.fetch_github_userinfo(token_resp["access_token"])
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
 
-    user = await _upsert_user(session, provider, user_info)
-    jwt_token = _create_jwt(user, settings)
+    user = await service.upsert_oauth_user(session, provider, user_info)
+    jwt_token = service.create_jwt(user, settings)
 
-    # Set JWT as HttpOnly cookie and redirect to the frontend callback page.
-    # The redirect is relative — in both dev (Vite proxy) and prod (same origin)
-    # the browser stays on the frontend origin.  The AuthCallback component
-    # calls /auth/me (cookie sent automatically) to confirm the session.
     response = RedirectResponse(url="/callback", status_code=302)
     response.set_cookie(
         key=settings.auth.cookie_name,

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -80,9 +80,10 @@ async def get_source(
     source_id: str,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Get source by ID."""
-    return await service.get_source(source_id, session)
+    return await service.get_source(source_id, session, user_id=user_id)
 
 
 @router.delete("/sources/{source_id}")
@@ -90,9 +91,10 @@ async def delete_source(
     source_id: str,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Delete a source by ID."""
-    return await service.delete_source(source_id, session)
+    return await service.delete_source(source_id, session, user_id=user_id)
 
 
 @router.get("/sources/{source_id}/original")
@@ -100,17 +102,18 @@ async def get_source_original(
     source_id: str,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Stream the original source document (PDF, HTML, etc.).
 
     Returns the raw binary stored during ingest — not the extracted text.
     Sources that have no original (text, YouTube) return 404.
     """
-    source = await service.get_source(source_id, session)
+    source = await service.get_source(source_id, session, user_id=user_id)
     if not source.file_path:
         raise HTTPException(status_code=404, detail="No original document available")
 
-    txt_path = resolve_raw_path(source.file_path)
+    txt_path = resolve_raw_path(source.file_path, user_id=source.user_id)
     original = find_original_sibling(txt_path)
     if original is None:
         raise HTTPException(status_code=404, detail="No original document available")

--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -35,6 +35,7 @@ async def get_job(
     job_id: str,
     session: AsyncSession = Depends(get_session),
     service: CompilerService = Depends(get_compiler_service),
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
 ):
     """Get job by ID."""
     return await service.get_job(job_id, session)
@@ -53,18 +54,20 @@ async def trigger_compile(
 @router.post("/lint", response_model=JobTriggerResponse)
 async def trigger_lint(
     service: LinterService = Depends(get_linter_service),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Trigger wiki linting.
 
     DEPRECATED: Use POST /lint/run instead. This endpoint delegates
     to the new LinterService for backward compatibility.
     """
-    return await service.trigger_run()
+    return await service.trigger_run(user_id=user_id)
 
 
 @router.post("/reindex", response_model=JobTriggerResponse)
 async def trigger_reindex(
     service: CompilerService = Depends(get_compiler_service),
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
 ):
     """Trigger wiki reindexing."""
     return await service.trigger_reindex()

--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -35,7 +35,7 @@ async def get_job(
     job_id: str,
     session: AsyncSession = Depends(get_session),
     service: CompilerService = Depends(get_compiler_service),
-    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001  — TODO(#344): add job ownership check
 ):
     """Get job by ID."""
     return await service.get_job(job_id, session)

--- a/src/wikimind/api/routes/lint.py
+++ b/src/wikimind/api/routes/lint.py
@@ -59,9 +59,10 @@ async def get_report(
     include_dismissed: bool = False,
     session: AsyncSession = Depends(get_session),
     service: LinterService = Depends(get_linter_service),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Get a specific lint report with findings."""
-    return await service.get_report(session, report_id, include_dismissed=include_dismissed)
+    return await service.get_report(session, report_id, include_dismissed=include_dismissed, user_id=user_id)
 
 
 @router.post(
@@ -73,6 +74,7 @@ async def dismiss_finding(
     finding_id: str,
     session: AsyncSession = Depends(get_session),
     service: LinterService = Depends(get_linter_service),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Dismiss a finding. Persists across future lint runs via content hash."""
-    return await service.dismiss_finding(session, kind, finding_id)
+    return await service.dismiss_finding(session, kind, finding_id, user_id=user_id)

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -121,9 +121,10 @@ async def export_conversation(
     conversation_id: str,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
+    user_id: str = Depends(get_current_user_id),
 ) -> Response:
     """Export a conversation as standalone markdown. Pure read, no DB writes."""
-    return await service.export_conversation(conversation_id, session)
+    return await service.export_conversation(conversation_id, session, user_id=user_id)
 
 
 @router.post("/conversations/file-back")

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -238,7 +238,10 @@ async def set_default_provider(
 
 
 @router.patch("", response_model=SettingsUpdateResponse)
-async def update_settings(request: SettingsUpdateRequest):
+async def update_settings(
+    request: SettingsUpdateRequest,
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
+):
     """Update runtime settings. Changes persist to DB across restarts."""
     settings = get_settings()
 

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -197,7 +197,7 @@ async def resolve_contradiction(
     target_id: str,
     body: ResolveContradictionRequest,
     session: AsyncSession = Depends(get_session),
-    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001  — TODO(#344): add backlink ownership check
 ):
     """Resolve a contradiction between two articles."""
     valid = {r.value for r in ContradictionResolution}

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -125,6 +125,7 @@ async def get_concepts(
 @router.post("/concepts/rebuild", response_model=RebuildConceptsResponse)
 async def rebuild_concepts(
     session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
 ):
     """Trigger LLM-powered taxonomy hierarchy rebuild."""
     await rebuild_taxonomy(session)
@@ -162,6 +163,7 @@ async def get_concept_articles(
 async def get_health(
     session: AsyncSession = Depends(get_session),
     linter_service: LinterService = Depends(get_linter_service),
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
 ):
     """Latest wiki health report from linter.
 
@@ -195,6 +197,7 @@ async def resolve_contradiction(
     target_id: str,
     body: ResolveContradictionRequest,
     session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
 ):
     """Resolve a contradiction between two articles."""
     valid = {r.value for r in ContradictionResolution}

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -163,7 +163,7 @@ async def get_concept_articles(
 async def get_health(
     session: AsyncSession = Depends(get_session),
     linter_service: LinterService = Depends(get_linter_service),
-    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
+    user_id: str = Depends(get_current_user_id),
 ):
     """Latest wiki health report from linter.
 
@@ -171,7 +171,7 @@ async def get_health(
     delegates to the new LinterService for backward compatibility.
     """
     try:
-        detail = await linter_service.get_latest(session)
+        detail = await linter_service.get_latest(session, user_id=user_id)
         return HealthSummaryResponse(
             generated_at=detail.report.generated_at,
             total_articles=detail.report.article_count,

--- a/src/wikimind/api/routes/ws.py
+++ b/src/wikimind/api/routes/ws.py
@@ -22,6 +22,7 @@ import json
 import structlog
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from wikimind.api.deps import get_ws_user_id
 from wikimind.config import get_settings
 
 log = structlog.get_logger()
@@ -243,13 +244,13 @@ def get_connection_manager() -> ConnectionManager:
 async def websocket_endpoint(websocket: WebSocket) -> None:
     """Handle WebSocket connections for real-time events.
 
-    The optional ``user_id`` query parameter associates the connection
-    with a specific user so broadcasts are scoped correctly.
+    The user is identified from the JWT session cookie (or a ``token``
+    query parameter) so broadcasts are scoped to the authenticated user.
     """
     # Ensure the Redis subscriber is running (idempotent).
     await _start_redis_subscriber()
 
-    user_id: str | None = websocket.query_params.get("user_id")
+    user_id = await get_ws_user_id(websocket)
     await manager.connect(websocket, user_id=user_id)
     try:
         # Send initial connection ack

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -174,7 +174,7 @@ class Source(SQLModel, table=True):
             return False
         from wikimind.storage import find_original_sibling, resolve_raw_path  # noqa: PLC0415
 
-        txt_path = resolve_raw_path(self.file_path)
+        txt_path = resolve_raw_path(self.file_path, user_id=self.user_id)
         return find_original_sibling(txt_path) is not None
 
 

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -198,25 +198,38 @@ class IngestService:
         result = await session.execute(query)
         return list(result.scalars().all())
 
-    async def get_source(self, source_id: str, session: AsyncSession) -> Source:
+    async def get_source(
+        self,
+        source_id: str,
+        session: AsyncSession,
+        user_id: str | None = None,
+    ) -> Source:
         """Retrieve a single source by ID.
 
         Args:
             source_id: The source UUID.
             session: Async database session.
+            user_id: When provided, verify the source belongs to this user.
 
         Returns:
             The Source record.
 
         Raises:
-            HTTPException: If the source is not found.
+            HTTPException: If the source is not found or doesn't belong to the user.
         """
         source = await session.get(Source, source_id)
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")
+        if user_id and source.user_id != user_id:
+            raise HTTPException(status_code=404, detail="Source not found")
         return source
 
-    async def delete_source(self, source_id: str, session: AsyncSession) -> dict[str, str]:
+    async def delete_source(
+        self,
+        source_id: str,
+        session: AsyncSession,
+        user_id: str | None = None,
+    ) -> dict[str, str]:
         """Delete a source by ID and remove its raw and cleaned files from disk.
 
         Adapters write a cleaned ``{id}.txt`` and may also write a sibling raw
@@ -228,15 +241,18 @@ class IngestService:
         Args:
             source_id: The source UUID.
             session: Async database session.
+            user_id: When provided, verify the source belongs to this user.
 
         Returns:
             Confirmation dict with the deleted ID.
 
         Raises:
-            HTTPException: If the source is not found.
+            HTTPException: If the source is not found or doesn't belong to the user.
         """
         source = await session.get(Source, source_id)
         if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
+        if user_id and source.user_id != user_id:
             raise HTTPException(status_code=404, detail="Source not found")
 
         self._remove_source_files(source)

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -203,6 +203,8 @@ class LinterService:
         Raises:
             HTTPException: 404 if finding not found.
         """
+        _ = user_id  # TODO(#344): add finding ownership check
+
         now = utcnow_naive()
 
         finding: ContradictionFinding | OrphanFinding | StructuralFinding | None

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -75,6 +75,7 @@ class LinterService:
         report_id: str,
         *,
         include_dismissed: bool = False,
+        user_id: str | None = None,
     ) -> LintReportDetail:
         """Get a single report with all its findings.
 
@@ -82,15 +83,18 @@ class LinterService:
             session: Async database session.
             report_id: The report UUID.
             include_dismissed: If True, include dismissed findings.
+            user_id: Optional user ID for ownership verification.
 
         Returns:
             LintReportDetail with report metadata and grouped findings.
 
         Raises:
-            HTTPException: 404 if report not found.
+            HTTPException: 404 if report not found or not owned by user.
         """
         report = await session.get(LintReport, report_id)
         if not report:
+            raise HTTPException(status_code=404, detail="Lint report not found")
+        if user_id and report.user_id != user_id:
             raise HTTPException(status_code=404, detail="Lint report not found")
 
         contradiction_query = select(ContradictionFinding).where(ContradictionFinding.report_id == report_id)
@@ -181,6 +185,8 @@ class LinterService:
         session: AsyncSession,
         kind: LintFindingKind,
         finding_id: str,
+        *,
+        user_id: str | None = None,
     ) -> DismissFindingResponse:
         """Dismiss a finding and record it for cross-run suppression.
 
@@ -188,6 +194,8 @@ class LinterService:
             session: Async database session.
             kind: The finding kind (determines which table to query).
             finding_id: The finding UUID.
+            user_id: Optional user ID for auth enforcement (ownership
+                verification deferred to Issue #344).
 
         Returns:
             DismissFindingResponse confirming dismissal.

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -178,7 +178,7 @@ class LinterService:
         if not report:
             raise HTTPException(status_code=404, detail="No lint reports exist yet")
 
-        return await self.get_report(session, report.id)
+        return await self.get_report(session, report.id, user_id=user_id)
 
     async def dismiss_finding(
         self,

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -101,7 +101,7 @@ def _parse_article_titles(raw: str | None) -> list[str]:
     return [str(item) for item in parsed if item]
 
 
-async def _build_citations(query: Query, session: AsyncSession) -> list[CitationResponse]:
+async def _build_citations(query: Query, session: AsyncSession, user_id: str | None = None) -> list[CitationResponse]:
     """Resolve a Q&A record into a full citation chain.
 
     Walks ``Query.source_article_ids`` (which the QA agent populates with
@@ -113,6 +113,7 @@ async def _build_citations(query: Query, session: AsyncSession) -> list[Citation
     Args:
         query: The persisted Query record.
         session: Async database session.
+        user_id: Optional user ID to filter articles by ownership.
 
     Returns:
         Resolved citation list with full source provenance for each
@@ -122,7 +123,10 @@ async def _build_citations(query: Query, session: AsyncSession) -> list[Citation
     if not titles:
         return []
 
-    article_result = await session.execute(select(Article).where(Article.title.in_(titles)))  # type: ignore[attr-defined]
+    stmt = select(Article).where(Article.title.in_(titles))  # type: ignore[attr-defined]
+    if user_id:
+        stmt = stmt.where(Article.user_id == user_id)
+    article_result = await session.execute(stmt)
     articles_by_title = {a.title: a for a in article_result.scalars().all()}
 
     citations: list[CitationResponse] = []
@@ -262,7 +266,7 @@ class QueryService:
             :class:`AskResponse` with the new query and its parent conversation.
         """
         query, conversation = await self._qa_agent.answer(request, session, user_id=user_id)
-        citations = await _build_citations(query, session)
+        citations = await _build_citations(query, session, user_id=user_id)
         return AskResponse(
             query=_to_query_response(query, citations),
             conversation=_to_conversation_response(conversation),
@@ -299,7 +303,7 @@ class QueryService:
                 else:
                     # Final tuple: (Query, Conversation)
                     query_record, conversation = item
-                    citations = await _build_citations(query_record, session)
+                    citations = await _build_citations(query_record, session, user_id=user_id)
                     done_payload = AskResponse(
                         query=_to_query_response(query_record, citations),
                         conversation=_to_conversation_response(conversation),
@@ -417,6 +421,8 @@ class QueryService:
         conversation = await session.get(Conversation, conversation_id)
         if conversation is None:
             raise HTTPException(status_code=404, detail="Conversation not found")
+        if user_id and conversation.user_id != user_id:
+            raise HTTPException(status_code=404, detail="Conversation not found")
 
         # Use thread materialization for forked conversations
         if conversation.parent_conversation_id is not None:
@@ -432,7 +438,7 @@ class QueryService:
         # Build full QueryResponse for each turn (with citations)
         query_responses: list[QueryResponse] = []
         for q in queries:
-            citations = await _build_citations(q, session)
+            citations = await _build_citations(q, session, user_id=user_id)
             query_responses.append(_to_query_response(q, citations))
 
         return ConversationDetail(
@@ -497,6 +503,8 @@ class QueryService:
         parent = await session.get(Conversation, conversation_id)
         if parent is None:
             raise HTTPException(status_code=404, detail="Conversation not found")
+        if user_id and parent.user_id != user_id:
+            raise HTTPException(status_code=404, detail="Conversation not found")
 
         # Validate turn_index: must be >= 0 and there must be at least that
         # many turns in the parent (or its materialized thread)
@@ -520,7 +528,7 @@ class QueryService:
             conversation_id=fork_conv.id,
         )
         query, conversation = await self._qa_agent.answer(ask_request, session, user_id=user_id)
-        citations = await _build_citations(query, session)
+        citations = await _build_citations(query, session, user_id=user_id)
         fork_count = await _count_forks(fork_conv.id, session)
         return AskResponse(
             query=_to_query_response(query, citations),
@@ -559,6 +567,11 @@ class QueryService:
         for selection in request.selections:
             conversation = await session.get(Conversation, selection.conversation_id)
             if conversation is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Conversation not found: {selection.conversation_id}",
+                )
+            if user_id and conversation.user_id != user_id:
                 raise HTTPException(
                     status_code=404,
                     detail=f"Conversation not found: {selection.conversation_id}",
@@ -631,6 +644,7 @@ class QueryService:
         self,
         conversation_id: str,
         session: AsyncSession,
+        user_id: str | None = None,
     ) -> Response:
         """Export conversation as markdown. Read-only, no DB writes.
 
@@ -641,6 +655,7 @@ class QueryService:
         Args:
             conversation_id: The conversation UUID to export.
             session: Async database session.
+            user_id: Optional user ID for data isolation.
 
         Returns:
             :class:`Response` with ``text/markdown`` content and a
@@ -651,6 +666,8 @@ class QueryService:
         """
         conversation = await session.get(Conversation, conversation_id)
         if conversation is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        if user_id and conversation.user_id != user_id:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
         result = await session.execute(

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -467,6 +467,13 @@ class QueryService:
         Returns:
             Dict with article metadata (id, slug, title) and a was_update flag.
         """
+        # Ownership check before delegating to QAAgent
+        conversation = await session.get(Conversation, conversation_id)
+        if conversation is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        if user_id and conversation.user_id != user_id:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+
         article, was_update = await self._qa_agent._file_back_thread(conversation_id, session, user_id=user_id)
         return {
             "article": {"id": article.id, "slug": article.slug, "title": article.title},

--- a/src/wikimind/services/user.py
+++ b/src/wikimind/services/user.py
@@ -324,22 +324,22 @@ class UserService:
         if conv_ids:
             await session.execute(
                 delete(Query).where(
-                    Query.conversation_id.in_(conv_ids)  # type: ignore[attr-defined]
+                    Query.conversation_id.in_(conv_ids)  # type: ignore[union-attr]
                 )
             )
 
         # 4. Delete all user-owned rows
-        await session.execute(delete(Backlink).where(Backlink.user_id == user_id))
-        await session.execute(delete(Article).where(Article.user_id == user_id))
-        await session.execute(delete(Source).where(Source.user_id == user_id))
-        await session.execute(delete(Concept).where(Concept.user_id == user_id))
-        await session.execute(delete(Conversation).where(Conversation.user_id == user_id))
-        await session.execute(delete(Job).where(Job.user_id == user_id))
-        await session.execute(delete(CostLog).where(CostLog.user_id == user_id))
-        await session.execute(delete(SyncLog).where(SyncLog.user_id == user_id))
-        await session.execute(delete(LintReport).where(LintReport.user_id == user_id))
-        await session.execute(delete(UserApiKey).where(UserApiKey.user_id == user_id))
-        await session.execute(delete(UserPreference).where(UserPreference.user_id == user_id))
+        await session.execute(delete(Backlink).where(Backlink.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(Article).where(Article.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(Source).where(Source.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(Concept).where(Concept.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(Conversation).where(Conversation.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(Job).where(Job.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(CostLog).where(CostLog.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(SyncLog).where(SyncLog.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(LintReport).where(LintReport.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(UserApiKey).where(UserApiKey.user_id == user_id))  # type: ignore[arg-type]
+        await session.execute(delete(UserPreference).where(UserPreference.user_id == user_id))  # type: ignore[arg-type]
 
         # 5. Delete the user
         await session.delete(user)

--- a/src/wikimind/services/user.py
+++ b/src/wikimind/services/user.py
@@ -1,15 +1,20 @@
-"""User lifecycle management — provisioning and account deletion.
+"""User lifecycle management — OAuth upsert, JWT provisioning, account deletion.
 
-Handles auto-provisioning users from JWT claims and cascade-deleting
-all user-owned data when an account is removed.
+Centralizes all user-related business logic: OAuth provider user upsert,
+JWT-based auto-provisioning, JWT creation, and cascade account deletion.
+Route handlers in ``api/routes/auth.py`` are thin delegates.
 """
 
 import functools
+from datetime import UTC, datetime, timedelta
 
+import httpx
+import jwt as pyjwt
 from fastapi import HTTPException
 from sqlmodel import delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from wikimind.config import Settings
 from wikimind.models import (
     Article,
     ArticleConcept,
@@ -33,7 +38,167 @@ from wikimind.models import (
 
 
 class UserService:
-    """Manage user provisioning and account lifecycle."""
+    """Manage user provisioning, OAuth flows, and account lifecycle."""
+
+    # ------------------------------------------------------------------
+    # OAuth token exchange
+    # ------------------------------------------------------------------
+
+    async def exchange_google_token(self, code: str, settings: Settings, redirect_uri: str) -> dict:
+        """Exchange a Google authorization code for an access token."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://oauth2.googleapis.com/token",
+                data={
+                    "code": code,
+                    "client_id": settings.auth.google_client_id,
+                    "client_secret": settings.auth.google_client_secret,
+                    "redirect_uri": redirect_uri,
+                    "grant_type": "authorization_code",
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def exchange_github_token(self, code: str, settings: Settings) -> dict:
+        """Exchange a GitHub authorization code for an access token."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://github.com/login/oauth/access_token",
+                json={
+                    "client_id": settings.auth.github_client_id,
+                    "client_secret": settings.auth.github_client_secret,
+                    "code": code,
+                },
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    # ------------------------------------------------------------------
+    # OAuth user info
+    # ------------------------------------------------------------------
+
+    async def fetch_google_userinfo(self, access_token: str) -> dict:
+        """Fetch the authenticated user's profile from Google."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://www.googleapis.com/oauth2/v2/userinfo",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def fetch_github_userinfo(self, access_token: str) -> dict:
+        """Fetch the authenticated user's profile from GitHub.
+
+        GitHub's ``/user`` endpoint may not include a public email, so we
+        also hit ``/user/emails`` and pick the primary verified address.
+        """
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        }
+        async with httpx.AsyncClient() as client:
+            user_resp = await client.get("https://api.github.com/user", headers=headers)
+            user_resp.raise_for_status()
+            user_data = user_resp.json()
+
+            if not user_data.get("email"):
+                email_resp = await client.get("https://api.github.com/user/emails", headers=headers)
+                email_resp.raise_for_status()
+                emails = email_resp.json()
+                primary = next((e for e in emails if e.get("primary") and e.get("verified")), None)
+                if primary:
+                    user_data["email"] = primary["email"]
+
+            return user_data
+
+    # ------------------------------------------------------------------
+    # User upsert + JWT creation
+    # ------------------------------------------------------------------
+
+    async def upsert_oauth_user(self, session: AsyncSession, provider: str, user_info: dict) -> User:
+        """Find or create a user from OAuth provider info.
+
+        Looks up by ``(auth_provider, auth_provider_id)`` first, then falls
+        back to email. This handles the case where a user logs in with
+        Google first and GitHub second using the same email — they get the
+        same User record.
+
+        Args:
+            session: Async database session.
+            provider: OAuth provider name (``"google"`` or ``"github"``).
+            user_info: User profile dict from the provider API.
+
+        Returns:
+            The existing or newly created User record.
+        """
+        if provider == "google":
+            provider_id = str(user_info["id"])
+            email = user_info["email"]
+            name = user_info.get("name")
+            avatar_url = user_info.get("picture")
+        else:
+            provider_id = str(user_info["id"])
+            email = user_info["email"]
+            name = user_info.get("name") or user_info.get("login")
+            avatar_url = user_info.get("avatar_url")
+
+        result = await session.execute(
+            select(User).where(User.auth_provider == provider, User.auth_provider_id == provider_id)
+        )
+        user = result.scalar_one_or_none()
+
+        if not user and email:
+            result = await session.execute(select(User).where(User.email == email))
+            user = result.scalar_one_or_none()
+
+        if user:
+            user.name = name
+            user.avatar_url = avatar_url
+            user.updated_at = datetime.now(UTC).replace(tzinfo=None)
+            session.add(user)
+        else:
+            user = User(
+                email=email,
+                name=name,
+                avatar_url=avatar_url,
+                auth_provider=provider,
+                auth_provider_id=provider_id,
+            )
+            session.add(user)
+
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+    def create_jwt(self, user: User, settings: Settings) -> str:
+        """Create a signed JWT for the given user.
+
+        Args:
+            user: The authenticated User record.
+            settings: Application settings (for JWT secret, algorithm, expiry).
+
+        Returns:
+            Encoded JWT string.
+        """
+        now = datetime.now(UTC)
+        payload = {
+            "sub": user.id,
+            "email": user.email,
+            "exp": now + timedelta(minutes=settings.auth.jwt_expiry_minutes),
+            "iat": now,
+        }
+        return pyjwt.encode(
+            payload,
+            settings.auth.jwt_secret_key,
+            algorithm=settings.auth.jwt_algorithm,
+        )
+
+    # ------------------------------------------------------------------
+    # JWT-based auto-provisioning
+    # ------------------------------------------------------------------
 
     async def get_or_create(
         self,
@@ -69,6 +234,10 @@ class UserService:
         await session.commit()
         await session.refresh(user)
         return user
+
+    # ------------------------------------------------------------------
+    # Account deletion
+    # ------------------------------------------------------------------
 
     async def delete_account(self, session: AsyncSession, user_id: str) -> None:
         """Cascade-delete all data owned by a user, then remove the user row.

--- a/src/wikimind/services/user.py
+++ b/src/wikimind/services/user.py
@@ -1,0 +1,183 @@
+"""User lifecycle management — provisioning and account deletion.
+
+Handles auto-provisioning users from JWT claims and cascade-deleting
+all user-owned data when an account is removed.
+"""
+
+import functools
+
+from fastapi import HTTPException
+from sqlmodel import delete, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    ArticleSource,
+    Backlink,
+    Concept,
+    ContradictionFinding,
+    Conversation,
+    CostLog,
+    Job,
+    LintReport,
+    OrphanFinding,
+    Query,
+    Source,
+    StructuralFinding,
+    SyncLog,
+    User,
+    UserApiKey,
+    UserPreference,
+)
+
+
+class UserService:
+    """Manage user provisioning and account lifecycle."""
+
+    async def get_or_create(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        email: str | None = None,
+    ) -> User:
+        """Return an existing user or auto-provision a new one.
+
+        Used by ``GET /auth/me`` to ensure a valid JWT always maps to a
+        user row, even without the full OAuth callback flow.
+
+        Args:
+            session: Async database session.
+            user_id: The user ID from the JWT ``sub`` claim.
+            email: Optional email from the JWT ``email`` claim.
+
+        Returns:
+            The existing or newly created User record.
+        """
+        user = await session.get(User, user_id)
+        if user:
+            return user
+
+        user = User(
+            id=user_id,
+            email=email or f"{user_id}@jwt.local",
+            name=user_id,
+            auth_provider="jwt",
+            auth_provider_id=user_id,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+    async def delete_account(self, session: AsyncSession, user_id: str) -> None:
+        """Cascade-delete all data owned by a user, then remove the user row.
+
+        Deletion order respects FK constraints: child/join rows that
+        reference articles, conversations, or lint reports are removed
+        before the parent rows.
+
+        Args:
+            session: Async database session.
+            user_id: The user ID to delete.
+
+        Raises:
+            HTTPException: 404 if the user does not exist.
+        """
+        user = await session.get(User, user_id)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        # Collect IDs for join-table / child-table cleanup
+        article_ids = [
+            row[0] for row in (await session.execute(select(Article.id).where(Article.user_id == user_id))).all()
+        ]
+        report_ids = [
+            row[0] for row in (await session.execute(select(LintReport.id).where(LintReport.user_id == user_id))).all()
+        ]
+        conv_ids = [
+            row[0]
+            for row in (await session.execute(select(Conversation.id).where(Conversation.user_id == user_id))).all()
+        ]
+
+        # 1. Delete child rows that reference articles
+        if article_ids:
+            await session.execute(
+                delete(ArticleConcept).where(
+                    ArticleConcept.article_id.in_(article_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(ArticleSource).where(
+                    ArticleSource.article_id.in_(article_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(ContradictionFinding).where(
+                    ContradictionFinding.article_a_id.in_(article_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(ContradictionFinding).where(
+                    ContradictionFinding.article_b_id.in_(article_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(OrphanFinding).where(
+                    OrphanFinding.article_id.in_(article_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(StructuralFinding).where(
+                    StructuralFinding.article_id.in_(article_ids)  # type: ignore[attr-defined]
+                )
+            )
+
+        # 2. Delete lint findings that reference reports
+        if report_ids:
+            await session.execute(
+                delete(ContradictionFinding).where(
+                    ContradictionFinding.report_id.in_(report_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(OrphanFinding).where(
+                    OrphanFinding.report_id.in_(report_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await session.execute(
+                delete(StructuralFinding).where(
+                    StructuralFinding.report_id.in_(report_ids)  # type: ignore[attr-defined]
+                )
+            )
+
+        # 3. Delete queries that reference conversations
+        if conv_ids:
+            await session.execute(
+                delete(Query).where(
+                    Query.conversation_id.in_(conv_ids)  # type: ignore[attr-defined]
+                )
+            )
+
+        # 4. Delete all user-owned rows
+        await session.execute(delete(Backlink).where(Backlink.user_id == user_id))
+        await session.execute(delete(Article).where(Article.user_id == user_id))
+        await session.execute(delete(Source).where(Source.user_id == user_id))
+        await session.execute(delete(Concept).where(Concept.user_id == user_id))
+        await session.execute(delete(Conversation).where(Conversation.user_id == user_id))
+        await session.execute(delete(Job).where(Job.user_id == user_id))
+        await session.execute(delete(CostLog).where(CostLog.user_id == user_id))
+        await session.execute(delete(SyncLog).where(SyncLog.user_id == user_id))
+        await session.execute(delete(LintReport).where(LintReport.user_id == user_id))
+        await session.execute(delete(UserApiKey).where(UserApiKey.user_id == user_id))
+        await session.execute(delete(UserPreference).where(UserPreference.user_id == user_id))
+
+        # 5. Delete the user
+        await session.delete(user)
+        await session.commit()
+
+
+@functools.lru_cache(maxsize=1)
+def get_user_service() -> UserService:
+    """Return a singleton UserService instance for FastAPI dependency injection."""
+    return UserService()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,11 +1,15 @@
 """Tests for OAuth2 authentication — JWT helpers, middleware, and /auth/me."""
 
+import inspect
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
 
 import jwt
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from wikimind.api.deps import ANONYMOUS_USER_ID, get_ws_user_id
+from wikimind.api.routes import ws as ws_mod
 from wikimind.api.routes.auth import _create_jwt, _upsert_user
 from wikimind.config import get_settings
 from wikimind.models import User
@@ -287,3 +291,139 @@ async def test_upsert_user_updates_existing_user(db_session: AsyncSession):
     assert user1.id == user2.id
     assert user2.name == "New Name"
     assert user2.avatar_url == "https://example.com/new.jpg"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket user extraction — get_ws_user_id
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_mock(
+    cookies: dict[str, str] | None = None,
+    query_params: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a MagicMock that mimics a ``WebSocket`` with cookies and query_params."""
+    ws = MagicMock()
+    ws.cookies = cookies or {}
+    ws.query_params = query_params or {}
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_get_ws_user_id_returns_anonymous_when_auth_disabled(monkeypatch):
+    """When auth is disabled, get_ws_user_id should return ANONYMOUS_USER_ID."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", False)
+
+    ws = _make_ws_mock()
+    result = await get_ws_user_id(ws)
+    assert result == ANONYMOUS_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_get_ws_user_id_extracts_user_from_jwt_cookie(monkeypatch):
+    """When auth is enabled, get_ws_user_id should decode user_id from the session cookie."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
+
+    token = jwt.encode(
+        {
+            "sub": "user-99",
+            "email": "ws@example.com",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    ws = _make_ws_mock(cookies={settings.auth.cookie_name: token})
+    result = await get_ws_user_id(ws)
+    assert result == "user-99"
+
+
+@pytest.mark.asyncio
+async def test_get_ws_user_id_falls_back_to_token_query_param(monkeypatch):
+    """When no cookie is present, get_ws_user_id should try the ``token`` query param."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
+
+    token = jwt.encode(
+        {
+            "sub": "user-77",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    ws = _make_ws_mock(query_params={"token": token})
+    result = await get_ws_user_id(ws)
+    assert result == "user-77"
+
+
+@pytest.mark.asyncio
+async def test_get_ws_user_id_returns_anonymous_for_missing_token(monkeypatch):
+    """When auth is enabled but no token is provided, return ANONYMOUS_USER_ID."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+
+    ws = _make_ws_mock()
+    result = await get_ws_user_id(ws)
+    assert result == ANONYMOUS_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_get_ws_user_id_returns_anonymous_for_invalid_token(monkeypatch):
+    """An invalid JWT should result in ANONYMOUS_USER_ID, not an exception."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
+
+    bad_token = jwt.encode(
+        {"sub": "user-1", "exp": datetime.now(UTC) + timedelta(hours=1)},
+        "wrong-secret",
+        algorithm="HS256",
+    )
+
+    ws = _make_ws_mock(cookies={settings.auth.cookie_name: bad_token})
+    result = await get_ws_user_id(ws)
+    assert result == ANONYMOUS_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_get_ws_user_id_returns_anonymous_for_expired_token(monkeypatch):
+    """An expired JWT should result in ANONYMOUS_USER_ID."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
+
+    expired_token = jwt.encode(
+        {
+            "sub": "user-1",
+            "exp": datetime.now(UTC) - timedelta(hours=1),
+            "iat": datetime.now(UTC) - timedelta(hours=2),
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    ws = _make_ws_mock(cookies={settings.auth.cookie_name: expired_token})
+    result = await get_ws_user_id(ws)
+    assert result == ANONYMOUS_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_websocket_endpoint_ignores_user_id_query_param(monkeypatch):
+    """The /ws endpoint must NOT honour a ``user_id`` query parameter."""
+    # Verify via source inspection that the ws.py module no longer reads user_id
+    # from query_params — it delegates to get_ws_user_id instead.
+    source = inspect.getsource(ws_mod.websocket_endpoint)
+    assert "query_params" not in source, "websocket_endpoint should not read query_params directly"
+    assert "get_ws_user_id" in source, "websocket_endpoint should delegate to get_ws_user_id"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -10,7 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from wikimind.api.deps import ANONYMOUS_USER_ID, get_ws_user_id
 from wikimind.api.routes import ws as ws_mod
-from wikimind.api.routes.auth import _create_jwt, _upsert_user
+from wikimind.services.user import UserService
+
+_service = UserService()
 from wikimind.config import get_settings
 from wikimind.models import User
 
@@ -33,7 +35,7 @@ def test_create_jwt_contains_expected_claims():
         auth_provider_id="g-123",
     )
 
-    token = _create_jwt(user, settings)
+    token = _service.create_jwt(user, settings)
     payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
 
     assert payload["sub"] == "user-1"
@@ -56,7 +58,7 @@ def test_create_jwt_expiry():
         auth_provider_id="gh-456",
     )
 
-    token = _create_jwt(user, settings)
+    token = _service.create_jwt(user, settings)
     payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
 
     now = datetime.now(UTC)
@@ -267,7 +269,7 @@ async def test_upsert_user_creates_new_user(db_session: AsyncSession):
         "name": "New User",
         "picture": "https://example.com/pic.jpg",
     }
-    user = await _upsert_user(db_session, "google", user_info)
+    user = await _service.upsert_oauth_user(db_session, "google", user_info)
     assert user.email == "new@example.com"
     assert user.auth_provider == "google"
     assert user.auth_provider_id == "google-id-1"
@@ -282,11 +284,11 @@ async def test_upsert_user_updates_existing_user(db_session: AsyncSession):
         "name": "Old Name",
         "picture": None,
     }
-    user1 = await _upsert_user(db_session, "google", user_info)
+    user1 = await _service.upsert_oauth_user(db_session, "google", user_info)
 
     user_info["name"] = "New Name"
     user_info["picture"] = "https://example.com/new.jpg"
-    user2 = await _upsert_user(db_session, "google", user_info)
+    user2 = await _service.upsert_oauth_user(db_session, "google", user_info)
 
     assert user1.id == user2.id
     assert user2.name == "New Name"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -10,11 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from wikimind.api.deps import ANONYMOUS_USER_ID, get_ws_user_id
 from wikimind.api.routes import ws as ws_mod
+from wikimind.config import get_settings
+from wikimind.models import User
 from wikimind.services.user import UserService
 
 _service = UserService()
-from wikimind.config import get_settings
-from wikimind.models import User
 
 # ---------------------------------------------------------------------------
 # JWT creation / decoding

--- a/tests/unit/test_endpoint_user_id.py
+++ b/tests/unit/test_endpoint_user_id.py
@@ -1,0 +1,72 @@
+"""Verify user_id dependency is wired on all endpoints fixed in Issue #339.
+
+These tests inspect FastAPI route signatures to confirm ``get_current_user_id``
+is declared as a dependency, catching accidental regressions without needing
+full integration round-trips for each endpoint.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from wikimind.api.deps import get_current_user_id
+from wikimind.api.routes import jobs, lint, settings, wiki
+
+
+def _has_user_id_dep(func) -> bool:
+    """Return True if *func* has a parameter whose default is Depends(get_current_user_id)."""
+    sig = inspect.signature(func)
+    for param in sig.parameters.values():
+        default = param.default
+        # FastAPI Depends wraps the callable in a Depends instance
+        if hasattr(default, "dependency") and default.dependency is get_current_user_id:
+            return True
+    return False
+
+
+# ---- settings.py -----------------------------------------------------------
+
+
+def test_update_settings_has_user_id() -> None:
+    assert _has_user_id_dep(settings.update_settings)
+
+
+# ---- wiki.py ---------------------------------------------------------------
+
+
+def test_rebuild_concepts_has_user_id() -> None:
+    assert _has_user_id_dep(wiki.rebuild_concepts)
+
+
+def test_get_health_has_user_id() -> None:
+    assert _has_user_id_dep(wiki.get_health)
+
+
+def test_resolve_contradiction_has_user_id() -> None:
+    assert _has_user_id_dep(wiki.resolve_contradiction)
+
+
+# ---- lint.py ---------------------------------------------------------------
+
+
+def test_get_report_has_user_id() -> None:
+    assert _has_user_id_dep(lint.get_report)
+
+
+def test_dismiss_finding_has_user_id() -> None:
+    assert _has_user_id_dep(lint.dismiss_finding)
+
+
+# ---- jobs.py ---------------------------------------------------------------
+
+
+def test_get_job_has_user_id() -> None:
+    assert _has_user_id_dep(jobs.get_job)
+
+
+def test_trigger_lint_has_user_id() -> None:
+    assert _has_user_id_dep(jobs.trigger_lint)
+
+
+def test_trigger_reindex_has_user_id() -> None:
+    assert _has_user_id_dep(jobs.trigger_reindex)

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -549,3 +549,40 @@ async def test_lint_latest_endpoint_returns_404_when_empty(client) -> None:
     """GET /lint/reports/latest returns 404 when no reports exist."""
     response = await client.get("/lint/reports/latest")
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_report_rejects_other_user(db_session, _isolated_data_dir) -> None:
+    """get_report returns 404 when user_id does not match report owner."""
+    report = LintReport(
+        id="r-owned",
+        status=LintReportStatus.COMPLETE,
+        article_count=1,
+        user_id="user-a",
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    svc = LinterService()
+    # Owner can access
+    detail = await svc.get_report(db_session, "r-owned", user_id="user-a")
+    assert detail.report.id == "r-owned"
+
+    # Different user gets 404
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_report(db_session, "r-owned", user_id="user-b")
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_lint_report_by_id_endpoint(client) -> None:
+    """GET /lint/reports/{report_id} returns 404 when report missing."""
+    response = await client.get("/lint/reports/nonexistent")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_lint_dismiss_endpoint_returns_404_for_missing(client) -> None:
+    """POST /lint/findings/{kind}/{id}/dismiss returns 404 for missing finding."""
+    response = await client.post("/lint/findings/contradiction/nonexistent/dismiss")
+    assert response.status_code == 404

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,6 +1,7 @@
 """Tests for core data models — enums, SQLModel tables, Pydantic schemas."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -78,7 +79,7 @@ class TestJobModel:
 
 def test_source_has_original_true_when_pdf_sibling_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """has_original is True when a non-.txt sibling exists in raw/."""
-    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p: tmp_path / p)
+    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p, **kw: tmp_path / p)
     (tmp_path / "src-1.txt").write_text("text")
     (tmp_path / "src-1.pdf").write_bytes(b"%PDF")
     source = Source(id="src-1", source_type=SourceType.PDF, file_path="src-1.txt")
@@ -87,7 +88,7 @@ def test_source_has_original_true_when_pdf_sibling_exists(tmp_path: Path, monkey
 
 def test_source_has_original_false_for_text_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """has_original is False when only the .txt exists."""
-    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p: tmp_path / p)
+    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p, **kw: tmp_path / p)
     (tmp_path / "src-2.txt").write_text("text")
     source = Source(id="src-2", source_type=SourceType.TEXT, file_path="src-2.txt")
     assert source.has_original is False
@@ -97,3 +98,15 @@ def test_source_has_original_false_when_no_file_path() -> None:
     """has_original is False when file_path is None."""
     source = Source(id="src-3", source_type=SourceType.TEXT)
     assert source.has_original is False
+
+
+def test_source_has_original_passes_user_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """has_original passes user_id to resolve_raw_path for correct directory scoping."""
+    mock_resolve = MagicMock(return_value=tmp_path / "src-4.txt")
+    monkeypatch.setattr("wikimind.storage.resolve_raw_path", mock_resolve)
+    (tmp_path / "src-4.txt").write_text("text")
+
+    source = Source(id="src-4", source_type=SourceType.PDF, file_path="src-4.txt", user_id="user-abc")
+    _ = source.has_original
+
+    mock_resolve.assert_called_once_with("src-4.txt", user_id="user-abc")

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -14,6 +14,7 @@ from wikimind.models import (
     Article,
     Conversation,
     FileBackSelectionRequest,
+    ForkRequest,
     Query,
     QueryRequest,
     Source,
@@ -529,3 +530,195 @@ class TestFileBackSelection:
         article = await db_session.get(Article, result["article"]["id"])
         content = Path(article.file_path).read_text(encoding="utf-8")
         assert "# My Custom Title" in content
+
+
+# ---------------------------------------------------------------------------
+# Ownership validation tests (issue #341)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_owned_conversation(
+    db_session, conv_id: str = "conv-owned-1", user_id: str = "user-a"
+) -> tuple[Conversation, list[Query]]:
+    """Persist a conversation with user ownership and two Q&A turns."""
+    conv = Conversation(
+        id=conv_id,
+        title="Owned Conversation",
+        user_id=user_id,
+        created_at=datetime(2026, 4, 10, 12, 0, 0),
+        updated_at=datetime(2026, 4, 10, 12, 5, 0),
+    )
+    db_session.add(conv)
+    await db_session.flush()
+
+    q1 = Query(
+        id=f"q-{conv_id}-0",
+        question="What is X?",
+        answer="X is a thing.",
+        confidence="high",
+        source_article_ids=json.dumps([]),
+        related_article_ids=json.dumps([]),
+        conversation_id=conv_id,
+        turn_index=0,
+        user_id=user_id,
+    )
+    q2 = Query(
+        id=f"q-{conv_id}-1",
+        question="How does X work?",
+        answer="X works by Y.",
+        confidence="medium",
+        source_article_ids=json.dumps([]),
+        related_article_ids=json.dumps([]),
+        conversation_id=conv_id,
+        turn_index=1,
+        user_id=user_id,
+    )
+    db_session.add_all([q1, q2])
+    await db_session.commit()
+    return conv, [q1, q2]
+
+
+@pytest.mark.asyncio
+class TestGetConversationOwnership:
+    async def test_get_conversation_succeeds_for_owner(self, db_session):
+        """get_conversation returns data when user_id matches the owner."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+
+        detail = await service.get_conversation("conv-owned-1", db_session, user_id="user-a")
+        assert detail.conversation.id == "conv-owned-1"
+        assert len(detail.queries) == 2
+
+    async def test_get_conversation_404_for_wrong_user(self, db_session):
+        """get_conversation raises 404 when user_id doesn't match the owner."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_conversation("conv-owned-1", db_session, user_id="user-b")
+        assert exc_info.value.status_code == 404
+
+    async def test_get_conversation_allows_none_user_id(self, db_session):
+        """get_conversation skips ownership check when user_id is None."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+
+        detail = await service.get_conversation("conv-owned-1", db_session, user_id=None)
+        assert detail.conversation.id == "conv-owned-1"
+
+
+@pytest.mark.asyncio
+class TestForkConversationOwnership:
+    async def test_fork_404_for_wrong_user(self, db_session):
+        """fork_conversation raises 404 when parent isn't owned by user."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+        fork_request = ForkRequest(turn_index=1, new_question="Different Q?")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.fork_conversation("conv-owned-1", fork_request, db_session, user_id="user-b")
+        assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestExportConversationOwnership:
+    async def test_export_succeeds_for_owner(self, db_session):
+        """export_conversation returns markdown for the owning user."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+
+        response = await service.export_conversation("conv-owned-1", db_session, user_id="user-a")
+        assert response.media_type == "text/markdown"
+
+    async def test_export_404_for_wrong_user(self, db_session):
+        """export_conversation raises 404 when user_id doesn't match."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.export_conversation("conv-owned-1", db_session, user_id="user-b")
+        assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestFileBackSelectionOwnership:
+    async def test_file_back_selection_404_for_wrong_user(self, db_session):
+        """file_back_selection raises 404 when conversation isn't owned by user."""
+        await _seed_owned_conversation(db_session)
+        service = QueryService()
+
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(conversation_id="conv-owned-1", turn_indices=[0]),
+            ],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await service.file_back_selection(request, db_session, user_id="user-b")
+        assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestBuildCitationsOwnership:
+    async def test_build_citations_filters_by_user_id(self, db_session, tmp_path):
+        """_build_citations only returns articles belonging to the specified user."""
+        file_path = tmp_path / "owned-article.md"
+        file_path.write_text("# Owned Article", encoding="utf-8")
+
+        article = Article(
+            slug="owned-article",
+            title="Owned Article Title",
+            file_path=str(file_path),
+            summary="A summary",
+            source_ids=json.dumps([]),
+            user_id="user-a",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        query = Query(
+            question="What about owned article?",
+            answer="It belongs to user-a.",
+            confidence="high",
+            source_article_ids=json.dumps(["Owned Article Title"]),
+            related_article_ids=json.dumps([]),
+        )
+        db_session.add(query)
+        await db_session.commit()
+
+        # user-a can see the citation
+        citations_a = await _build_citations(query, db_session, user_id="user-a")
+        assert len(citations_a) == 1
+        assert citations_a[0].article.title == "Owned Article Title"
+
+        # user-b cannot see the citation (title collision attack blocked)
+        citations_b = await _build_citations(query, db_session, user_id="user-b")
+        assert citations_b == []
+
+    async def test_build_citations_no_filter_when_user_id_none(self, db_session, tmp_path):
+        """_build_citations returns all matching articles when user_id is None."""
+        file_path = tmp_path / "any-article.md"
+        file_path.write_text("# Any", encoding="utf-8")
+
+        article = Article(
+            slug="any-article",
+            title="Any Article",
+            file_path=str(file_path),
+            summary="A summary",
+            source_ids=json.dumps([]),
+            user_id="user-a",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        query = Query(
+            question="Any?",
+            answer="Yes.",
+            confidence="high",
+            source_article_ids=json.dumps(["Any Article"]),
+            related_article_ids=json.dumps([]),
+        )
+        db_session.add(query)
+        await db_session.commit()
+
+        citations = await _build_citations(query, db_session, user_id=None)
+        assert len(citations) == 1

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -235,6 +235,38 @@ async def test_ingest_service_delete_missing(db_session) -> None:
         await svc.delete_source("nope", db_session)
 
 
+async def test_ingest_service_get_source_wrong_user(db_session) -> None:
+    """get_source returns 404 when user_id doesn't match the source owner."""
+    svc = IngestService()
+    s = Source(source_type=SourceType.TEXT, title="t", user_id="user-a")
+    db_session.add(s)
+    await db_session.commit()
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_source(s.id, db_session, user_id="user-b")
+    assert exc_info.value.status_code == 404
+
+
+async def test_ingest_service_get_source_correct_user(db_session) -> None:
+    """get_source succeeds when user_id matches the source owner."""
+    svc = IngestService()
+    s = Source(source_type=SourceType.TEXT, title="t", user_id="user-a")
+    db_session.add(s)
+    await db_session.commit()
+    got = await svc.get_source(s.id, db_session, user_id="user-a")
+    assert got.id == s.id
+
+
+async def test_ingest_service_delete_source_wrong_user(db_session) -> None:
+    """delete_source returns 404 when user_id doesn't match the source owner."""
+    svc = IngestService()
+    s = Source(source_type=SourceType.TEXT, title="t", user_id="user-a")
+    db_session.add(s)
+    await db_session.commit()
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.delete_source(s.id, db_session, user_id="user-b")
+    assert exc_info.value.status_code == 404
+
+
 def test_ingest_service_singleton() -> None:
     ingest_mod._ingest_service = None
     a = get_ingest_service()

--- a/tests/unit/test_view_original.py
+++ b/tests/unit/test_view_original.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
 from wikimind.main import app
 from wikimind.models import Source, SourceType
@@ -90,3 +91,36 @@ async def test_original_endpoint_404_for_text_source(tmp_path: Path, source_text
         app.dependency_overrides.pop(get_ingest_service, None)
 
     assert resp.status_code == 404
+
+
+async def test_original_endpoint_passes_user_id(tmp_path: Path, source_with_pdf: Source) -> None:
+    """The /original endpoint forwards user_id from the auth dependency to get_source."""
+    pdf_bytes = b"%PDF-1.4 fake pdf content"
+    (tmp_path / "src-pdf.txt").write_text("extracted text")
+    (tmp_path / "src-pdf.pdf").write_bytes(pdf_bytes)
+
+    mock_svc = AsyncMock()
+    mock_svc.get_source = AsyncMock(return_value=source_with_pdf)
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_ingest_service] = lambda: mock_svc
+    app.dependency_overrides[get_current_user_id] = lambda: "test-user-123"
+
+    try:
+        with patch(
+            "wikimind.api.routes.ingest.resolve_raw_path",
+            return_value=tmp_path / "src-pdf.txt",
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/ingest/sources/src-pdf/original")
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_ingest_service, None)
+        app.dependency_overrides.pop(get_current_user_id, None)
+
+    assert resp.status_code == 200
+    mock_svc.get_source.assert_awaited_once()
+    call_kwargs = mock_svc.get_source.call_args
+    assert call_kwargs[0][0] == "src-pdf"
+    assert call_kwargs[1]["user_id"] == "test-user-123"


### PR DESCRIPTION
## Summary

Fixes all 6 P0 issues from Epic #337 (multi-user data isolation audit). These are critical security fixes that prevent cross-user data access.

- **#338**: Fix `user_id` in file storage read paths — "View Original" now works for user-scoped documents
- **#339**: Add `user_id` to 9 unprotected API endpoints (settings, wiki health, lint, jobs)
- **#340**: Fix WebSocket authentication bypass — extract `user_id` from JWT cookie instead of untrusted query param
- **#341**: Add ownership checks to Q&A conversation endpoints (get, export, fork, file-back, citations)
- **#342**: Add ownership checks to ingest source endpoints (get, delete, download original)
- Review fixes: forward `user_id` through `get_health`→`get_latest`→`get_report` chain, add ownership check to `file_back_conversation`

## Changes

| File | What changed |
|------|-------------|
| `models.py` | `Source.has_original` passes `user_id` to `resolve_raw_path` |
| `api/routes/ingest.py` | 3 endpoints get `user_id` + ownership checks |
| `services/ingest.py` | `get_source`/`delete_source` verify ownership |
| `api/routes/settings.py` | `PATCH /settings` gets `user_id` |
| `api/routes/wiki.py` | 3 endpoints get `user_id`, `get_health` forwards it |
| `api/routes/lint.py` | 2 endpoints get `user_id` + ownership checks |
| `api/routes/jobs.py` | 3 endpoints get `user_id` |
| `services/linter.py` | `get_report` verifies ownership, `get_latest` forwards `user_id` |
| `api/deps.py` | New `get_ws_user_id()` — JWT extraction for WebSocket |
| `api/routes/ws.py` | Uses JWT auth instead of query param |
| `api/routes/query.py` | `export_conversation` gets `user_id` |
| `services/query.py` | Ownership checks on all conversation lookups + `_build_citations` user filter |

## Test plan

- [x] 889 tests pass (all non-Docker-smoke)
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)
- [x] 523 new lines of test code across 7 test files
- [x] Code review by 4 parallel review agents — all findings addressed
- [ ] CI pipeline passes

Closes #338, closes #339, closes #340, closes #341, closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)