### PR TITLE
fix: scope P1 engine/service queries by user_id (Epic #337)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         curl \
+        gosu \
         libmupdf-dev \
         libsqlite3-0 \
     && pip install --upgrade pip setuptools wheel \
@@ -113,8 +114,6 @@ RUN chmod +x docker-entrypoint.sh
 RUN useradd --create-home --uid 1000 wikimind \
     && mkdir -p /home/wikimind/.wikimind \
     && chown -R wikimind:wikimind /home/wikimind /app
-USER wikimind
-
 ENV WIKIMIND_DATA_DIR=/home/wikimind/.wikimind \
     WIKIMIND_SERVER__HOST=0.0.0.0
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Fix volume ownership — Fly.io volumes may retain root ownership across deploys
+# Fix volume ownership — Fly.io volumes may retain root ownership across deploys.
+# Fast-path: skip chown -R if the data dir is already owned by wikimind (UID 1000).
 if [ "$(id -u)" = "0" ]; then
-    chown -R wikimind:wikimind "${WIKIMIND_DATA_DIR:-/home/wikimind/.wikimind}"
+    _data_dir="${WIKIMIND_DATA_DIR:-/home/wikimind/.wikimind}"
+    if [ "$(stat -c '%u' "$_data_dir" 2>/dev/null)" != "1000" ]; then
+        chown -R wikimind:wikimind "$_data_dir"
+    fi
     exec gosu wikimind "$0" "$@"
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Fix volume ownership — Fly.io volumes may retain root ownership across deploys
+if [ "$(id -u)" = "0" ]; then
+    chown -R wikimind:wikimind "${WIKIMIND_DATA_DIR:-/data}"
+    exec gosu wikimind "$0" "$@"
+fi
+
 # Run Alembic migrations when using PostgreSQL.
 # SQLite uses create_all() at startup — no Alembic needed.
 # Check both WIKIMIND_DATABASE_URL (explicit) and DATABASE_URL (Fly.io/Railway auto-set).

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Fix volume ownership — Fly.io volumes may retain root ownership across deploys
 if [ "$(id -u)" = "0" ]; then
-    chown -R wikimind:wikimind "${WIKIMIND_DATA_DIR:-/data}"
+    chown -R wikimind:wikimind "${WIKIMIND_DATA_DIR:-/home/wikimind/.wikimind}"
     exec gosu wikimind "$0" "$@"
 fi
 

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -125,10 +125,10 @@ async def get_concepts(
 @router.post("/concepts/rebuild", response_model=RebuildConceptsResponse)
 async def rebuild_concepts(
     session: AsyncSession = Depends(get_session),
-    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
+    user_id: str = Depends(get_current_user_id),
 ):
     """Trigger LLM-powered taxonomy hierarchy rebuild."""
-    await rebuild_taxonomy(session)
+    await rebuild_taxonomy(session, user_id=user_id)
     return RebuildConceptsResponse(status="ok")
 
 

--- a/src/wikimind/engine/backlink_enforcer.py
+++ b/src/wikimind/engine/backlink_enforcer.py
@@ -76,6 +76,7 @@ async def ensure_bidirectional(backlink: Backlink, session: AsyncSession) -> boo
             target_article_id=backlink.source_article_id,
             relation_type=backlink.relation_type,
             context=backlink.context,
+            user_id=backlink.user_id,
         )
     )
     await session.flush()

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -337,6 +337,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             result.backlink_suggestions,
             session,
             relation_types=self._last_typed_suggestions,
+            user_id=source.user_id,
         )
 
         relative_path = await self._write_article_file(result, source, slug, resolved, unresolved)
@@ -368,7 +369,12 @@ Compile this into a wiki article following the JSON schema exactly."""
             session.add(ArticleConcept(article_id=article.id, concept_name=concept_name))
         await session.commit()
 
-        await self._persist_resolved_backlinks(article.id, resolved, session)
+        await self._persist_resolved_backlinks(
+            article.id,
+            resolved,
+            session,
+            user_id=source.user_id,
+        )
 
         try:
             await upsert_concepts(result.concepts, session)
@@ -424,6 +430,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             session,
             exclude_article_id=existing.id,
             relation_types=self._last_typed_suggestions,
+            user_id=source.user_id,
         )
 
         relative_path = await self._write_article_file(result, source, existing.slug, resolved, unresolved)
@@ -468,7 +475,12 @@ Compile this into a wiki article following the JSON schema exactly."""
             session.add(ArticleConcept(article_id=existing.id, concept_name=concept_name))
         await session.commit()
 
-        await self._persist_resolved_backlinks(existing.id, resolved, session)
+        await self._persist_resolved_backlinks(
+            existing.id,
+            resolved,
+            session,
+            user_id=source.user_id,
+        )
 
         try:
             await upsert_concepts(result.concepts, session)
@@ -516,6 +528,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         source_article_id: str,
         resolved: list[ResolvedBacklink],
         session: AsyncSession,
+        user_id: str | None = None,
     ) -> None:
         """Insert one Backlink row per resolved candidate with relation_type."""
         for rb in resolved:
@@ -528,6 +541,7 @@ Compile this into a wiki article following the JSON schema exactly."""
                 target_article_id=rb.target_id,
                 context=rb.candidate_text,
                 relation_type=rel,
+                user_id=user_id,
             )
             session.add(bl)
             try:

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -377,9 +377,9 @@ Compile this into a wiki article following the JSON schema exactly."""
         )
 
         try:
-            await upsert_concepts(result.concepts, session)
-            await update_article_counts(session)
-            await maybe_trigger_taxonomy_rebuild(session)
+            await upsert_concepts(result.concepts, session, user_id=source.user_id)
+            await update_article_counts(session, user_id=source.user_id)
+            await maybe_trigger_taxonomy_rebuild(session, user_id=source.user_id)
             # Concept page generation must use its own session to avoid
             # identity-map conflicts when both the source compiler and
             # concept compiler create Backlinks for overlapping article
@@ -394,12 +394,13 @@ Compile this into a wiki article following the JSON schema exactly."""
                 "compile",
                 article.title,
                 extra={"source_id": source.id, "article_slug": article.slug},
+                user_id=source.user_id,
             )
         except OSError:
             log.warning("activity log write failed", op="compile", article_id=article.id)
 
         try:
-            await regenerate_index_md(session)
+            await regenerate_index_md(session, user_id=source.user_id)
         except (OSError, SQLAlchemyError):
             log.warning("index.md regeneration failed", article_id=article.id)
 
@@ -483,9 +484,16 @@ Compile this into a wiki article following the JSON schema exactly."""
         )
 
         try:
-            await upsert_concepts(result.concepts, session)
-            await update_article_counts(session)
-            await maybe_trigger_taxonomy_rebuild(session)
+            await upsert_concepts(
+                result.concepts,
+                session,
+                user_id=source.user_id,
+            )
+            await update_article_counts(session, user_id=source.user_id)
+            await maybe_trigger_taxonomy_rebuild(
+                session,
+                user_id=source.user_id,
+            )
             # Concept page generation must use its own session to avoid
             # identity-map conflicts (same pattern as _create_article,
             # issue #152).  Added here so recompiling an existing source
@@ -504,12 +512,13 @@ Compile this into a wiki article following the JSON schema exactly."""
                 "compile",
                 existing.title,
                 extra={"source_id": source.id, "article_slug": existing.slug},
+                user_id=source.user_id,
             )
         except OSError:
             log.warning("activity log write failed", op="compile", article_id=existing.id)
 
         try:
-            await regenerate_index_md(session)
+            await regenerate_index_md(session, user_id=source.user_id)
         except (OSError, SQLAlchemyError):
             log.warning("index.md regeneration failed", article_id=existing.id)
 

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -385,7 +385,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             # concept compiler create Backlinks for overlapping article
             # pairs (issue #152 — greenlet_spawn error).
             async with get_session_factory()() as concept_session:
-                await maybe_trigger_concept_pages(concept_session)
+                await maybe_trigger_concept_pages(concept_session, user_id=source.user_id)
         except (SQLAlchemyError, RuntimeError, ValueError):
             log.warning("taxonomy upsert failed", article_id=article.id)
 
@@ -499,7 +499,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             # issue #152).  Added here so recompiling an existing source
             # also updates concept pages (issue #162).
             async with get_session_factory()() as concept_session:
-                await maybe_trigger_concept_pages(concept_session)
+                await maybe_trigger_concept_pages(concept_session, user_id=source.user_id)
         except (SQLAlchemyError, RuntimeError, ValueError):
             log.warning(
                 "taxonomy upsert failed",

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -294,9 +294,7 @@ class ConceptCompiler:
             session.add(ArticleSource(article_id=article.id, source_id=sid))
         await session.commit()
         await self._create_synthesizes_links(article.id, source_ids, session, user_id=article.user_id)
-        await self._create_related_to_links(
-            article, compilation.related_concepts, session, user_id=article.user_id
-        )
+        await self._create_related_to_links(article, compilation.related_concepts, session, user_id=article.user_id)
         return article
 
     async def _find_existing_concept_article(self, concept_name: str, session: AsyncSession) -> Article | None:

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -293,8 +293,10 @@ class ConceptCompiler:
         for sid in source_ids:
             session.add(ArticleSource(article_id=article.id, source_id=sid))
         await session.commit()
-        await self._create_synthesizes_links(article.id, source_ids, session)
-        await self._create_related_to_links(article, compilation.related_concepts, session)
+        await self._create_synthesizes_links(article.id, source_ids, session, user_id=article.user_id)
+        await self._create_related_to_links(
+            article, compilation.related_concepts, session, user_id=article.user_id
+        )
         return article
 
     async def _find_existing_concept_article(self, concept_name: str, session: AsyncSession) -> Article | None:
@@ -372,7 +374,11 @@ provider: {self._last_provider_used or "unknown"}
         return relative_path
 
     async def _create_synthesizes_links(
-        self, concept_article_id: str, source_article_ids: list[str], session: AsyncSession
+        self,
+        concept_article_id: str,
+        source_article_ids: list[str],
+        session: AsyncSession,
+        user_id: str | None = None,
     ) -> None:
         for source_id in source_article_ids:
             # Guard against duplicate Backlinks (issue #152).
@@ -389,6 +395,7 @@ provider: {self._last_provider_used or "unknown"}
                 target_article_id=source_id,
                 relation_type=RelationType.SYNTHESIZES,
                 context="Concept page synthesizes from source article",
+                user_id=user_id,
             )
             session.add(bl)
             try:
@@ -397,7 +404,11 @@ provider: {self._last_provider_used or "unknown"}
                 await session.rollback()
 
     async def _create_related_to_links(
-        self, concept_article: Article, related_concepts: list[str], session: AsyncSession
+        self,
+        concept_article: Article,
+        related_concepts: list[str],
+        session: AsyncSession,
+        user_id: str | None = None,
     ) -> None:
         if not related_concepts:
             return
@@ -427,6 +438,7 @@ provider: {self._last_provider_used or "unknown"}
                     target_article_id=tgt_id,
                     relation_type=RelationType.RELATED_TO,
                     context=f"Related: {concept_article.title} <-> {target.title}",
+                    user_id=user_id,
                 )
                 session.add(bl)
                 try:

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -96,13 +96,26 @@ def _extract_claims(article: Article) -> list[str]:
     return claims
 
 
-async def _get_articles_for_concept(session: AsyncSession, concept_name: str) -> list[Article]:
-    """Load articles tagged with the given concept via the ArticleConcept join table."""
-    result = await session.execute(
+async def _get_articles_for_concept(
+    session: AsyncSession,
+    concept_name: str,
+    user_id: str | None = None,
+) -> list[Article]:
+    """Load articles tagged with the given concept via the ArticleConcept join table.
+
+    Args:
+        session: Async database session.
+        concept_name: The concept name to look up.
+        user_id: Optional user ID to scope results to a single user's articles.
+    """
+    stmt = (
         select(Article)
         .join(ArticleConcept, ArticleConcept.article_id == Article.id)  # type: ignore[arg-type]
         .where(ArticleConcept.concept_name == concept_name)
     )
+    if user_id is not None:
+        stmt = stmt.where(Article.user_id == user_id)
+    result = await session.execute(stmt)
     return list(result.scalars().all())
 
 
@@ -158,6 +171,7 @@ async def _create_contradiction_backlink(
     article_a_id: str,
     article_b_id: str,
     context: str,
+    user_id: str | None = None,
 ) -> None:
     """Create a ``contradicts`` typed Backlink for an article pair (bidirectional)."""
     for src, tgt in [(article_a_id, article_b_id), (article_b_id, article_a_id)]:
@@ -175,6 +189,7 @@ async def _create_contradiction_backlink(
                 target_article_id=tgt,
                 relation_type=RelationType.CONTRADICTS,
                 context=context,
+                user_id=user_id,
             )
         )
     await session.flush()
@@ -233,6 +248,7 @@ async def _run_batch(
     settings: Settings,
     report_id: str,
     session: AsyncSession,
+    user_id: str | None = None,
 ) -> list[ContradictionFinding]:
     """Run a batched LLM call for multiple pairs.
 
@@ -283,10 +299,17 @@ async def _run_batch(
                             article_b_claim=claim_b,
                             llm_confidence=c.get("confidence", "medium"),
                             shared_concept_id=concept_id,
+                            user_id=user_id,
                         )
                     )
                     ctx = f"{claim_a} vs {claim_b}"
-                    await _create_contradiction_backlink(session, art_a.id, art_b.id, ctx)
+                    await _create_contradiction_backlink(
+                        session,
+                        art_a.id,
+                        art_b.id,
+                        ctx,
+                        user_id=user_id,
+                    )
             return findings
 
         except (RuntimeError, json.JSONDecodeError, ValueError, KeyError):
@@ -301,7 +324,16 @@ async def _run_batch(
     # Fallback: per-pair calls
     fallback_findings: list[ContradictionFinding] = []
     for art_a, art_b, _ca, _cb in pairs_with_claims:
-        pair_findings = await _compare_article_pair(art_a, art_b, concept_id, router, settings, report_id, session)
+        pair_findings = await _compare_article_pair(
+            art_a,
+            art_b,
+            concept_id,
+            router,
+            settings,
+            report_id,
+            session,
+            user_id=user_id,
+        )
         fallback_findings.extend(pair_findings)
     return fallback_findings
 
@@ -314,24 +346,37 @@ async def _run_batch(
 async def _collect_work(
     session: AsyncSession,
     cfg: LinterConfig,
+    user_id: str | None = None,
 ) -> list[tuple[str | None, str, list[tuple[Article, Article]]]]:
-    """Build the list of (concept_id, concept_name, pairs) work items."""
-    concept_result = await session.execute(
+    """Build the list of (concept_id, concept_name, pairs) work items.
+
+    Args:
+        session: Async database session.
+        cfg: Linter configuration.
+        user_id: Optional user ID to scope queries to a single user's data.
+    """
+    concept_stmt = (
         select(Concept)
         .order_by(Concept.article_count.desc())  # type: ignore[attr-defined]
         .limit(cfg.max_concepts_per_run)
     )
+    if user_id is not None:
+        concept_stmt = concept_stmt.where(Concept.user_id == user_id)
+    concept_result = await session.execute(concept_stmt)
     concepts = list(concept_result.scalars().all())
 
     all_work: list[tuple[str | None, str, list[tuple[Article, Article]]]] = []
 
     if not concepts:
         log.info("No concepts found, falling back to top-N article comparison")
-        article_result = await session.execute(
+        article_stmt = (
             select(Article)
             .order_by(Article.updated_at.desc())  # type: ignore[attr-defined]
             .limit(cfg.max_contradiction_pairs_per_concept * 2)
         )
+        if user_id is not None:
+            article_stmt = article_stmt.where(Article.user_id == user_id)
+        article_result = await session.execute(article_stmt)
         articles = list(article_result.scalars().all())
         pairs = list(itertools.combinations(articles, 2))
         if len(pairs) > cfg.max_contradiction_pairs_per_concept:
@@ -340,7 +385,7 @@ async def _collect_work(
     else:
         for concept_obj in concepts:
             cid, cname = concept_obj.id, concept_obj.name
-            articles = await _get_articles_for_concept(session, cname)
+            articles = await _get_articles_for_concept(session, cname, user_id=user_id)
             if len(articles) < 2:
                 continue
             pairs = list(itertools.combinations(articles, 2))
@@ -357,6 +402,7 @@ def _findings_from_cached(
     article_a: Article,
     article_b: Article,
     concept_id: str | None,
+    user_id: str | None = None,
 ) -> list[ContradictionFinding]:
     """Convert cached pair data into ContradictionFinding objects."""
     results: list[ContradictionFinding] = []
@@ -375,6 +421,7 @@ def _findings_from_cached(
                 article_b_claim=claim_b,
                 llm_confidence=c.get("confidence", "medium"),
                 shared_concept_id=concept_id,
+                user_id=user_id,
             )
         )
     return results
@@ -401,6 +448,7 @@ async def _process_uncached_pairs(
     report: LintReport,
     session: AsyncSession,
     checked: int,
+    user_id: str | None = None,
 ) -> tuple[list[ContradictionFinding], int]:
     """Process uncached pairs via batch or per-pair LLM calls.
 
@@ -412,7 +460,15 @@ async def _process_uncached_pairs(
     if cfg.contradiction_batch_enabled and len(uncached_pairs) > 1:
         for batch_start in range(0, len(uncached_pairs), cfg.contradiction_batch_size):
             batch = uncached_pairs[batch_start : batch_start + cfg.contradiction_batch_size]
-            batch_findings = await _run_batch(batch, concept_id, router, settings, report.id, session)
+            batch_findings = await _run_batch(
+                batch,
+                concept_id,
+                router,
+                settings,
+                report.id,
+                session,
+                user_id=user_id,
+            )
             findings.extend(batch_findings)
 
             for _idx, (art_a, art_b, _ca, _cb) in enumerate(batch):
@@ -427,7 +483,16 @@ async def _process_uncached_pairs(
                 await session.flush()
     else:
         for art_a, art_b, _ca, _cb in uncached_pairs:
-            new_findings = await _compare_article_pair(art_a, art_b, concept_id, router, settings, report.id, session)
+            new_findings = await _compare_article_pair(
+                art_a,
+                art_b,
+                concept_id,
+                router,
+                settings,
+                report.id,
+                session,
+                user_id=user_id,
+            )
             findings.extend(new_findings)
             if cfg.enable_pair_cache:
                 await _save_pair_cache(session, art_a, art_b, _cache_data_from_findings(new_findings))
@@ -449,12 +514,21 @@ async def detect_contradictions(
     router: LLMRouter,
     settings: Settings,
     report: LintReport,
+    user_id: str | None = None,
 ) -> list[ContradictionFinding]:
-    """For each concept, LLM-compare article pairs within that concept bucket."""
+    """For each concept, LLM-compare article pairs within that concept bucket.
+
+    Args:
+        session: Async database session.
+        router: LLM router for making completion requests.
+        settings: Application settings with linter config.
+        report: The parent LintReport to attach findings to.
+        user_id: Optional user ID to scope queries to a single user's data.
+    """
     cfg = settings.linter
     findings: list[ContradictionFinding] = []
 
-    all_work = await _collect_work(session, cfg)
+    all_work = await _collect_work(session, cfg, user_id=user_id)
 
     total_pairs = sum(len(pairs) for _, _, pairs in all_work)
     report.total_pairs = total_pairs
@@ -481,11 +555,24 @@ async def detect_contradictions(
                         a=article_a.title[:30],
                         b=article_b.title[:30],
                     )
-                    cached_findings = _findings_from_cached(cached, report.id, article_a, article_b, concept_id)
+                    cached_findings = _findings_from_cached(
+                        cached,
+                        report.id,
+                        article_a,
+                        article_b,
+                        concept_id,
+                        user_id=user_id,
+                    )
                     findings.extend(cached_findings)
                     for f in cached_findings:
                         ctx = f"{f.article_a_claim} vs {f.article_b_claim}"
-                        await _create_contradiction_backlink(session, article_a.id, article_b.id, ctx)
+                        await _create_contradiction_backlink(
+                            session,
+                            article_a.id,
+                            article_b.id,
+                            ctx,
+                            user_id=user_id,
+                        )
                     checked += 1
                     report.checked_pairs = checked
                     session.add(report)
@@ -505,7 +592,14 @@ async def detect_contradictions(
 
         # Process uncached pairs: batch or per-pair
         new_findings, checked = await _process_uncached_pairs(
-            uncached_pairs, concept_id, router, settings, report, session, checked
+            uncached_pairs,
+            concept_id,
+            router,
+            settings,
+            report,
+            session,
+            checked,
+            user_id=user_id,
         )
         findings.extend(new_findings)
 
@@ -525,6 +619,7 @@ async def _compare_article_pair(
     settings: Settings,
     report_id: str,
     session: AsyncSession | None = None,
+    user_id: str | None = None,
 ) -> list[ContradictionFinding]:
     """Compare a single article pair via LLM and return any findings."""
     cfg = settings.linter
@@ -583,11 +678,18 @@ async def _compare_article_pair(
             article_b_claim=claim_b,
             llm_confidence=c.get("confidence", "medium"),
             shared_concept_id=concept_id,
+            user_id=user_id,
         )
         findings.append(finding)
 
         if session is not None:
             ctx = f"{claim_a} vs {claim_b}"
-            await _create_contradiction_backlink(session, article_a.id, article_b.id, ctx)
+            await _create_contradiction_backlink(
+                session,
+                article_a.id,
+                article_b.id,
+                ctx,
+                user_id=user_id,
+            )
 
     return findings

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -60,17 +60,26 @@ async def detect_orphans(
         log.info("Orphan detection disabled (enable_orphan_detection=False)")
         return []
 
-    sql = (
-        "SELECT a.id, a.title FROM article a "
-        "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id "
-        "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id "
-        "WHERE bl_in.target_article_id IS NULL "
-        "AND bl_out.source_article_id IS NULL"
-    )
+    sql = "SELECT a.id, a.title FROM article a "
     params: dict[str, str] = {}
     if user_id is not None:
-        sql += " AND a.user_id = :uid"
+        sql += (
+            "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id"
+            " AND bl_in.user_id = :uid "
+            "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id"
+            " AND bl_out.user_id = :uid "
+            "WHERE bl_in.target_article_id IS NULL "
+            "AND bl_out.source_article_id IS NULL "
+            "AND a.user_id = :uid"
+        )
         params["uid"] = user_id
+    else:
+        sql += (
+            "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id "
+            "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id "
+            "WHERE bl_in.target_article_id IS NULL "
+            "AND bl_out.source_article_id IS NULL"
+        )
 
     result = await session.execute(text(sql), params)
     rows = result.fetchall()

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -40,6 +40,7 @@ async def detect_orphans(
     session: AsyncSession,
     settings: Settings,
     report_id: str,
+    user_id: str | None = None,
 ) -> list[OrphanFinding]:
     """Find articles with zero inbound AND zero outbound backlinks.
 
@@ -50,6 +51,7 @@ async def detect_orphans(
         session: Async database session.
         settings: Application settings with linter config.
         report_id: The parent LintReport ID.
+        user_id: Optional user ID to scope the check to a single user's articles.
 
     Returns:
         List of OrphanFinding instances ready for persistence.
@@ -58,15 +60,19 @@ async def detect_orphans(
         log.info("Orphan detection disabled (enable_orphan_detection=False)")
         return []
 
-    result = await session.execute(
-        text(
-            "SELECT a.id, a.title FROM article a "
-            "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id "
-            "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id "
-            "WHERE bl_in.target_article_id IS NULL "
-            "AND bl_out.source_article_id IS NULL"
-        )
+    sql = (
+        "SELECT a.id, a.title FROM article a "
+        "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id "
+        "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id "
+        "WHERE bl_in.target_article_id IS NULL "
+        "AND bl_out.source_article_id IS NULL"
     )
+    params: dict[str, str] = {}
+    if user_id is not None:
+        sql += " AND a.user_id = :uid"
+        params["uid"] = user_id
+
+    result = await session.execute(text(sql), params)
     rows = result.fetchall()
 
     findings: list[OrphanFinding] = []
@@ -80,6 +86,7 @@ async def detect_orphans(
                 content_hash=_content_hash(article_id),
                 article_id=article_id,
                 article_title=article_title,
+                user_id=user_id,
             )
         )
 

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -64,18 +64,18 @@ async def detect_orphans(
 
     # Build LEFT JOINs for inbound/outbound backlinks, scoped by user_id
     # when provided so another user's backlinks don't mask orphans.
-    inbound_join = Backlink.target_article_id == Article.id  # type: ignore[arg-type]
-    outbound_join = Backlink.source_article_id == Article.id  # type: ignore[arg-type]
+    inbound_join = Backlink.target_article_id == Article.id
+    outbound_join = Backlink.source_article_id == Article.id
     if user_id is not None:
-        inbound_join = inbound_join & (Backlink.user_id == user_id)  # type: ignore[assignment]
-        outbound_join = outbound_join & (Backlink.user_id == user_id)  # type: ignore[assignment]
+        inbound_join = inbound_join & (Backlink.user_id == user_id)
+        outbound_join = outbound_join & (Backlink.user_id == user_id)
 
     bl_in = select(Backlink.target_article_id).where(inbound_join).correlate(Article)
     bl_out = select(Backlink.source_article_id).where(outbound_join).correlate(Article)
 
     stmt = select(Article.id, Article.title).where(
-        ~bl_in.exists(),  # type: ignore[union-attr]
-        ~bl_out.exists(),  # type: ignore[union-attr]
+        ~bl_in.exists(),
+        ~bl_out.exists(),
     )
     if user_id is not None:
         stmt = stmt.where(Article.user_id == user_id)

--- a/src/wikimind/engine/linter/orphans.py
+++ b/src/wikimind/engine/linter/orphans.py
@@ -1,4 +1,4 @@
-"""Orphan detection — pure SQL check for articles with no backlinks.
+"""Orphan detection — find articles with no backlinks.
 
 Identifies articles with zero inbound AND zero outbound backlinks.
 Gated by ``settings.linter.enable_orphan_detection`` (default False)
@@ -11,9 +11,11 @@ import hashlib
 from typing import TYPE_CHECKING
 
 import structlog
-from sqlalchemy import text
+from sqlmodel import select
 
 from wikimind.models import (
+    Article,
+    Backlink,
     LintFindingKind,
     LintSeverity,
     OrphanFinding,
@@ -60,33 +62,29 @@ async def detect_orphans(
         log.info("Orphan detection disabled (enable_orphan_detection=False)")
         return []
 
-    sql = "SELECT a.id, a.title FROM article a "
-    params: dict[str, str] = {}
+    # Build LEFT JOINs for inbound/outbound backlinks, scoped by user_id
+    # when provided so another user's backlinks don't mask orphans.
+    inbound_join = Backlink.target_article_id == Article.id  # type: ignore[arg-type]
+    outbound_join = Backlink.source_article_id == Article.id  # type: ignore[arg-type]
     if user_id is not None:
-        sql += (
-            "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id"
-            " AND bl_in.user_id = :uid "
-            "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id"
-            " AND bl_out.user_id = :uid "
-            "WHERE bl_in.target_article_id IS NULL "
-            "AND bl_out.source_article_id IS NULL "
-            "AND a.user_id = :uid"
-        )
-        params["uid"] = user_id
-    else:
-        sql += (
-            "LEFT JOIN backlink bl_in ON bl_in.target_article_id = a.id "
-            "LEFT JOIN backlink bl_out ON bl_out.source_article_id = a.id "
-            "WHERE bl_in.target_article_id IS NULL "
-            "AND bl_out.source_article_id IS NULL"
-        )
+        inbound_join = inbound_join & (Backlink.user_id == user_id)  # type: ignore[assignment]
+        outbound_join = outbound_join & (Backlink.user_id == user_id)  # type: ignore[assignment]
 
-    result = await session.execute(text(sql), params)
-    rows = result.fetchall()
+    bl_in = select(Backlink.target_article_id).where(inbound_join).correlate(Article)
+    bl_out = select(Backlink.source_article_id).where(outbound_join).correlate(Article)
+
+    stmt = select(Article.id, Article.title).where(
+        ~bl_in.exists(),  # type: ignore[union-attr]
+        ~bl_out.exists(),  # type: ignore[union-attr]
+    )
+    if user_id is not None:
+        stmt = stmt.where(Article.user_id == user_id)
+
+    result = await session.execute(stmt)
+    rows = result.all()
 
     findings: list[OrphanFinding] = []
-    for row in rows:
-        article_id, article_title = row
+    for article_id, article_title in rows:
         findings.append(
             OrphanFinding(
                 report_id=report_id,

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -125,7 +125,11 @@ async def _check_in_progress(
     session: AsyncSession,
     user_id: str | None,
 ) -> LintReport | None:
-    """Return an existing in-progress report for this user, if any."""
+    """Return an existing in-progress report for this user, if any.
+
+    When user_id is None (system/admin call), ANY in-progress report
+    blocks — this is intentional to prevent concurrent global runs.
+    """
     stmt = select(LintReport).where(LintReport.status == LintReportStatus.IN_PROGRESS)
     if user_id is not None:
         stmt = stmt.where(LintReport.user_id == user_id)

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -139,8 +139,13 @@ async def run_lint(
     settings = get_settings()
     router = get_llm_router()
 
-    # Guard against concurrent runs
-    existing = await session.execute(select(LintReport).where(LintReport.status == LintReportStatus.IN_PROGRESS))
+    # Guard against concurrent runs (scoped to user when provided)
+    guard_stmt = select(LintReport).where(
+        LintReport.status == LintReportStatus.IN_PROGRESS
+    )
+    if user_id is not None:
+        guard_stmt = guard_stmt.where(LintReport.user_id == user_id)
+    existing = await session.execute(guard_stmt)
     in_progress = existing.scalars().first()
     if in_progress:
         log.info("Lint run already in progress", report_id=in_progress.id)

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -45,12 +45,24 @@ def _structural_content_hash(article_id: str, violation_type: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-async def run_enforcer_checks(session: AsyncSession, report: LintReport) -> list[StructuralFinding]:
+async def run_enforcer_checks(
+    session: AsyncSession,
+    report: LintReport,
+    user_id: str | None = None,
+) -> list[StructuralFinding]:
     """Run the backlink enforcer on all articles and return StructuralFinding rows.
 
     Phase 3 of the lint pipeline — runs after contradictions and orphans.
+
+    Args:
+        session: Async database session.
+        report: The parent LintReport.
+        user_id: Optional user ID to scope the check to a single user's articles.
     """
-    result = await session.execute(select(Article))
+    stmt = select(Article)
+    if user_id is not None:
+        stmt = stmt.where(Article.user_id == user_id)
+    result = await session.execute(stmt)
     articles = list(result.scalars().all())
 
     findings: list[StructuralFinding] = []
@@ -70,6 +82,7 @@ async def run_enforcer_checks(session: AsyncSession, report: LintReport) -> list
                 violation_type=violation.violation_type,
                 auto_repaired=violation.auto_repaired,
                 detail=violation.detail,
+                user_id=user_id,
             )
             findings.append(finding)
 
@@ -152,13 +165,24 @@ async def run_lint(
 
     try:
         # Phase 1: Contradictions
-        contradictions = await detect_contradictions(session, router, settings, report)
+        contradictions = await detect_contradictions(
+            session,
+            router,
+            settings,
+            report,
+            user_id=user_id,
+        )
 
         # Phase 2: Orphans
-        orphans = await detect_orphans(session, settings, report.id)
+        orphans = await detect_orphans(
+            session,
+            settings,
+            report.id,
+            user_id=user_id,
+        )
 
         # Phase 3: Structural integrity (backlink enforcer)
-        structurals = await run_enforcer_checks(session, report)
+        structurals = await run_enforcer_checks(session, report, user_id=user_id)
 
         # Apply dismiss suppression
         await _apply_dismiss_suppression(session, contradictions, orphans, structurals)

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -121,6 +121,18 @@ async def _apply_dismiss_suppression(
             finding.dismissed_at = now
 
 
+async def _check_in_progress(
+    session: AsyncSession,
+    user_id: str | None,
+) -> LintReport | None:
+    """Return an existing in-progress report for this user, if any."""
+    stmt = select(LintReport).where(LintReport.status == LintReportStatus.IN_PROGRESS)
+    if user_id is not None:
+        stmt = stmt.where(LintReport.user_id == user_id)
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
 async def run_lint(
     session: AsyncSession,
     job_id: str | None = None,
@@ -139,14 +151,7 @@ async def run_lint(
     settings = get_settings()
     router = get_llm_router()
 
-    # Guard against concurrent runs (scoped to user when provided)
-    guard_stmt = select(LintReport).where(
-        LintReport.status == LintReportStatus.IN_PROGRESS
-    )
-    if user_id is not None:
-        guard_stmt = guard_stmt.where(LintReport.user_id == user_id)
-    existing = await session.execute(guard_stmt)
-    in_progress = existing.scalars().first()
+    in_progress = await _check_in_progress(session, user_id)
     if in_progress:
         log.info("Lint run already in progress", report_id=in_progress.id)
         return in_progress

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -357,12 +357,13 @@ conversation context contradicts the wiki, prefer the wiki."""
         await session.commit()
 
         try:
-            append_log_entry("query", request.question[:120])
+            append_log_entry("query", request.question[:120], user_id=user_id)
             if filed_article is not None:
                 append_log_entry(
                     "filed",
                     filed_article.title,
                     extra={"conversation_id": ctx.conversation.id},
+                    user_id=user_id,
                 )
         except OSError:
             log.warning("activity log write failed", op="query")

--- a/src/wikimind/engine/wikilink_resolver.py
+++ b/src/wikimind/engine/wikilink_resolver.py
@@ -55,6 +55,7 @@ async def resolve_backlink_candidates(
     session: AsyncSession,
     exclude_article_id: str | None = None,
     relation_types: dict[str, str] | None = None,
+    user_id: str | None = None,
 ) -> tuple[list[ResolvedBacklink], list[str]]:
     """Resolve wikilink candidates against the Article table.
 
@@ -70,6 +71,8 @@ async def resolve_backlink_candidates(
         relation_types: Optional mapping of candidate text (lowered) to
             relation type string. When provided, resolved backlinks
             carry the relation type through. Defaults to references.
+        user_id: When provided, only articles belonging to this user are
+            considered for resolution. Prevents cross-user link leakage.
 
     Returns:
         A tuple ``(resolved, unresolved)``. Resolved contains one
@@ -85,10 +88,12 @@ async def resolve_backlink_candidates(
     if not cleaned:
         return [], []
 
-    # Load every Article once. For a single-user personal wiki this is
-    # fine — we expect O(hundreds) of articles at most. If this ever
-    # becomes a bottleneck, narrow the SELECT to (id, title, created_at).
-    result = await session.execute(select(Article).order_by(Article.created_at))  # type: ignore[arg-type]
+    # Load articles for resolution. When user_id is provided, only that
+    # user's articles are considered — prevents cross-user link leakage.
+    stmt = select(Article).order_by(Article.created_at)  # type: ignore[arg-type]
+    if user_id is not None:
+        stmt = stmt.where(Article.user_id == user_id)
+    result = await session.execute(stmt)
     all_articles: list[Article] = list(result.scalars().all())
     if exclude_article_id is not None:
         all_articles = [a for a in all_articles if a.id != exclude_article_id]

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -74,7 +74,12 @@ async def _sweep_single_article(
     # Deduplicate while preserving order
     unique_candidates = list(dict.fromkeys(matches))
 
-    resolved, _unresolved = await resolve_backlink_candidates(unique_candidates, session, exclude_article_id=article.id)
+    resolved, _unresolved = await resolve_backlink_candidates(
+        unique_candidates,
+        session,
+        exclude_article_id=article.id,
+        user_id=article.user_id,
+    )
 
     if not resolved:
         return False
@@ -114,6 +119,7 @@ async def _sweep_single_article(
                 source_article_id=article.id,
                 target_article_id=rb.target_id,
                 context=rb.candidate_text,
+                user_id=article.user_id,
             )
             session.add(bl)
 

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -110,7 +110,12 @@ def _try_embed_article(article: Article) -> None:
         embedding_service = get_embedding_service()
         if embedding_service is not None:
             content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text(encoding="utf-8")
-            embedding_service.embed_article(article.id, article.title, content)
+            embedding_service.embed_article(
+                article.id,
+                article.title,
+                content,
+                user_id=article.user_id,
+            )
             log.info("Article embedded", article_id=article.id)
     except (RuntimeError, ValueError, OSError) as embed_err:
         log.warning(

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -112,16 +112,17 @@ async def lifespan(_app: FastAPI):
     settings.ensure_dirs()
 
     # Verify write permissions to data directories (fail fast before DB init)
-    for subdir in ("wiki", "raw"):
-        test_dir = Path(settings.data_dir) / subdir
-        test_dir.mkdir(parents=True, exist_ok=True)
-        test_file = test_dir / ".write-test"
-        try:
-            test_file.write_text("ok")
-            test_file.unlink()
-        except PermissionError:
-            log.critical("No write permission", path=str(test_dir))
-            raise SystemExit(1) from None
+    if settings.storage_backend == "local":
+        for subdir in ("wiki", "raw"):
+            test_dir = Path(settings.data_dir) / subdir
+            test_dir.mkdir(parents=True, exist_ok=True)
+            test_file = test_dir / ".write-test"
+            try:
+                test_file.write_text("ok")
+                test_file.unlink()
+            except PermissionError:
+                log.critical("No write permission", path=str(test_dir))
+                raise SystemExit(1) from None
 
     log.info("WikiMind gateway starting", port=settings.gateway_port)
     await init_db()

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -111,6 +111,18 @@ async def lifespan(_app: FastAPI):
     settings = get_settings()
     settings.ensure_dirs()
 
+    # Verify write permissions to data directories (fail fast before DB init)
+    for subdir in ("wiki", "raw"):
+        test_dir = Path(settings.data_dir) / subdir
+        test_dir.mkdir(parents=True, exist_ok=True)
+        test_file = test_dir / ".write-test"
+        try:
+            test_file.write_text("ok")
+            test_file.unlink()
+        except PermissionError:
+            log.critical("No write permission", path=str(test_dir))
+            raise SystemExit(1) from None
+
     log.info("WikiMind gateway starting", port=settings.gateway_port)
     await init_db()
     await _apply_db_preferences()

--- a/src/wikimind/services/activity_log.py
+++ b/src/wikimind/services/activity_log.py
@@ -17,7 +17,12 @@ log = structlog.get_logger()
 _LOG_HEADER = "# Activity Log\n\n"
 
 
-def append_log_entry(op: str, title: str, extra: dict | None = None) -> None:
+def append_log_entry(
+    op: str,
+    title: str,
+    extra: dict | None = None,
+    user_id: str | None = None,
+) -> None:
     """Append an entry to wiki/log.md.
 
     Line format::
@@ -33,8 +38,11 @@ def append_log_entry(op: str, title: str, extra: dict | None = None) -> None:
         title: Human-readable subject of the entry.
         extra: Optional dict of supplementary key/value pairs written as
             indented detail lines beneath the heading.
+        user_id: Optional user ID for path scoping.
     """
     wiki_dir = Path(get_settings().data_dir) / "wiki"
+    if user_id:
+        wiki_dir = wiki_dir / user_id
     wiki_dir.mkdir(parents=True, exist_ok=True)
     log_path = wiki_dir / "log.md"
 

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -172,7 +172,13 @@ class EmbeddingService:
         embeddings = model.encode(texts, show_progress_bar=False)
         return [e.tolist() for e in embeddings]
 
-    def embed_article(self, article_id: str, title: str, content: str) -> int:
+    def embed_article(
+        self,
+        article_id: str,
+        title: str,
+        content: str,
+        user_id: str | None = None,
+    ) -> int:
         """Chunk and embed an article's content into ChromaDB.
 
         Any existing embeddings for the article are deleted first so
@@ -182,6 +188,7 @@ class EmbeddingService:
             article_id: UUID of the article.
             title: Article title (stored as metadata).
             content: Full markdown content of the article.
+            user_id: Optional user ID stored as metadata for per-user filtering.
 
         Returns:
             Number of chunks embedded.
@@ -201,6 +208,7 @@ class EmbeddingService:
                 "article_id": article_id,
                 "article_title": title,
                 "chunk_index": i,
+                **({"user_id": user_id} if user_id else {}),
             }
             for i in range(len(chunks))
         ]
@@ -220,12 +228,18 @@ class EmbeddingService:
         )
         return len(chunks)
 
-    def search(self, query: str, limit: int = 20) -> list[SemanticSearchResult]:
+    def search(
+        self,
+        query: str,
+        limit: int = 20,
+        user_id: str | None = None,
+    ) -> list[SemanticSearchResult]:
         """Query ChromaDB for semantically similar chunks.
 
         Args:
             query: Natural language search query.
             limit: Maximum number of results.
+            user_id: Optional user ID to filter results by ownership.
 
         Returns:
             Ranked list of :class:`SemanticSearchResult`.
@@ -234,11 +248,14 @@ class EmbeddingService:
             return []
 
         query_embedding = self._encode([query])
-        results = self._collection.query(
-            query_embeddings=query_embedding,
-            n_results=min(limit, self._collection.count()),
-            include=["documents", "metadatas", "distances"],
-        )
+        query_kwargs: dict[str, Any] = {
+            "query_embeddings": query_embedding,
+            "n_results": min(limit, self._collection.count()),
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if user_id:
+            query_kwargs["where"] = {"user_id": user_id}
+        results = self._collection.query(**query_kwargs)
 
         search_results: list[SemanticSearchResult] = []
         if not results["ids"] or not results["ids"][0]:

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -248,9 +248,10 @@ class EmbeddingService:
             return []
 
         query_embedding = self._encode([query])
+        n_results = limit if user_id else min(limit, self._collection.count())
         query_kwargs: dict[str, Any] = {
             "query_embeddings": query_embedding,
-            "n_results": min(limit, self._collection.count()),
+            "n_results": n_results,
             "include": ["documents", "metadatas", "distances"],
         }
         if user_id:

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -134,6 +134,7 @@ class IngestService:
                 "ingest",
                 source.title or "untitled",
                 extra={"source_type": source.source_type, "source_url": source.source_url},
+                user_id=source.user_id,
             )
         except OSError:
             log.warning("activity log write failed", op="ingest", source_id=source.id)

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -611,7 +611,10 @@ class QueryService:
         markdown = serialize_selected_turns_to_markdown(selected_turns, title=request.title)
 
         settings = get_settings()
-        wiki_dir = Path(settings.data_dir) / "wiki" / "qa-answers"
+        wiki_dir = Path(settings.data_dir) / "wiki"
+        if user_id:
+            wiki_dir = wiki_dir / user_id
+        wiki_dir = wiki_dir / "qa-answers"
         wiki_dir.mkdir(parents=True, exist_ok=True)
 
         now = utcnow_naive()

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -199,15 +199,25 @@ async def _concept_source_set_changed(concept: Concept, session: AsyncSession) -
     return current_ids != previous_ids
 
 
-async def maybe_trigger_concept_pages(session: AsyncSession) -> list[str]:
+async def maybe_trigger_concept_pages(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> list[str]:
     """Generate concept pages for concepts with enough source articles.
 
     Skips concepts whose source set has not changed since the last
     compilation, avoiding unnecessary LLM calls (issue #162).
+
+    Args:
+        session: Async database session.
+        user_id: Optional user ID for data isolation.
     """
     settings = get_settings()
     min_sources = settings.taxonomy.concept_page_min_sources
-    result = await session.execute(select(Concept).where(Concept.article_count >= min_sources))
+    stmt = select(Concept).where(Concept.article_count >= min_sources)
+    if user_id:
+        stmt = stmt.where(Concept.user_id == user_id)
+    result = await session.execute(stmt)
     eligible = list(result.scalars().all())
     if not eligible:
         return []

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -66,6 +66,7 @@ def _parse_concept_ids(raw: str | None) -> list[str]:
 async def upsert_concepts(
     concept_names: list[str],
     session: AsyncSession,
+    user_id: str | None = None,
 ) -> list[Concept]:
     """Create or retrieve Concept rows for the given names.
 
@@ -76,6 +77,7 @@ async def upsert_concepts(
     Args:
         concept_names: Raw concept names from the compiler.
         session: Async database session.
+        user_id: Optional user ID for data isolation.
 
     Returns:
         List of Concept rows (one per unique normalized name).
@@ -89,7 +91,10 @@ async def upsert_concepts(
         if not normalized:
             continue
 
-        result = await session.execute(select(Concept).where(Concept.name == normalized))
+        stmt = select(Concept).where(Concept.name == normalized)
+        if user_id:
+            stmt = stmt.where(Concept.user_id == user_id)
+        result = await session.execute(stmt)
         existing = result.scalar_one_or_none()
 
         if existing is not None:
@@ -102,6 +107,7 @@ async def upsert_concepts(
             concept = Concept(
                 name=normalized,
                 description=raw_name,
+                user_id=user_id,
             )
             session.add(concept)
             await session.flush()
@@ -111,7 +117,10 @@ async def upsert_concepts(
     return concepts
 
 
-async def update_article_counts(session: AsyncSession) -> None:
+async def update_article_counts(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> None:
     """Recalculate ``Concept.article_count`` from the ArticleConcept join table.
 
     Queries the join table for article counts per concept name, normalizes
@@ -120,22 +129,29 @@ async def update_article_counts(session: AsyncSession) -> None:
 
     Args:
         session: Async database session.
+        user_id: Optional user ID for data isolation.
     """
     # Count references per normalized concept name from join table — only
     # source articles count toward the threshold for concept page generation (#155).
     counts: dict[str, int] = {}
-    ac_result = await session.execute(
+    ac_stmt = (
         select(ArticleConcept)
         .join(Article, ArticleConcept.article_id == Article.id)  # type: ignore[arg-type]
         .where(Article.page_type == PageType.SOURCE)
     )
+    if user_id:
+        ac_stmt = ac_stmt.where(Article.user_id == user_id)
+    ac_result = await session.execute(ac_stmt)
     for ac in ac_result.scalars().all():
         normalized = slugify(ac.concept_name)
         if normalized:
             counts[normalized] = counts.get(normalized, 0) + 1
 
-    # Apply counts to all concepts
-    concepts_result = await session.execute(select(Concept))
+    # Apply counts to all concepts (scoped by user_id)
+    concept_stmt = select(Concept)
+    if user_id:
+        concept_stmt = concept_stmt.where(Concept.user_id == user_id)
+    concepts_result = await session.execute(concept_stmt)
     for concept in concepts_result.scalars().all():
         concept.article_count = counts.get(concept.name, 0)
         session.add(concept)
@@ -215,11 +231,15 @@ async def maybe_trigger_concept_pages(session: AsyncSession) -> list[str]:
     return compiled
 
 
-async def maybe_trigger_taxonomy_rebuild(session: AsyncSession) -> bool:
+async def maybe_trigger_taxonomy_rebuild(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> bool:
     """Trigger a taxonomy rebuild if unparented concepts exceed the threshold.
 
     Args:
         session: Async database session.
+        user_id: Optional user ID for data isolation.
 
     Returns:
         True if a rebuild was triggered, False otherwise.
@@ -227,18 +247,24 @@ async def maybe_trigger_taxonomy_rebuild(session: AsyncSession) -> bool:
     settings = get_settings()
     threshold = settings.taxonomy.rebuild_threshold
 
-    result = await session.execute(
-        select(Concept).where(Concept.parent_id.is_(None))  # type: ignore[union-attr]
+    stmt = select(Concept).where(
+        Concept.parent_id.is_(None)  # type: ignore[union-attr]
     )
+    if user_id:
+        stmt = stmt.where(Concept.user_id == user_id)
+    result = await session.execute(stmt)
     unparented = list(result.scalars().all())
 
     if len(unparented) >= threshold:
-        await rebuild_taxonomy(session)
+        await rebuild_taxonomy(session, user_id=user_id)
         return True
     return False
 
 
-async def rebuild_taxonomy(session: AsyncSession) -> None:
+async def rebuild_taxonomy(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> None:
     """Use LLM to infer concept hierarchy and rewrite all parent_ids.
 
     Fetches all concepts, asks the LLM to organize them, validates
@@ -246,11 +272,15 @@ async def rebuild_taxonomy(session: AsyncSession) -> None:
 
     Args:
         session: Async database session.
+        user_id: Optional user ID for data isolation.
     """
     settings = get_settings()
     max_depth = settings.taxonomy.max_hierarchy_depth
 
-    result = await session.execute(select(Concept))
+    concept_stmt = select(Concept)
+    if user_id:
+        concept_stmt = concept_stmt.where(Concept.user_id == user_id)
+    result = await session.execute(concept_stmt)
     all_concepts = list(result.scalars().all())
 
     if not all_concepts:

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -469,7 +469,11 @@ class WikiService:
             embedding_service = get_embedding_service()
             if embedding_service is not None:
                 try:
-                    semantic_results = embedding_service.search(q, limit=limit)
+                    semantic_results = embedding_service.search(
+                        q,
+                        limit=limit,
+                        user_id=user_id,
+                    )
                     merged = _merge_hybrid_scores(keyword_scores_map, semantic_results)
                 except (RuntimeError, ValueError, OSError):
                     log.warning("Semantic search failed, falling back to keyword-only")
@@ -626,7 +630,11 @@ class WikiService:
             user_id=user_id,
         )
 
-    async def get_health(self, session: AsyncSession) -> dict:
+    async def get_health(
+        self,
+        session: AsyncSession,
+        user_id: str | None = None,
+    ) -> dict:
         """Return the latest wiki health report from the linter.
 
         If no linter run has been performed yet, returns a stub report
@@ -634,17 +642,24 @@ class WikiService:
 
         Args:
             session: Async database session.
+            user_id: Optional user ID for path scoping.
 
         Returns:
             Health report dict.
         """
         settings = get_settings()
-        health_path = Path(settings.data_dir) / "wiki" / "_meta" / "health.json"
+        health_dir = Path(settings.data_dir) / "wiki"
+        if user_id:
+            health_dir = health_dir / user_id
+        health_path = health_dir / "_meta" / "health.json"
 
         if health_path.exists():
             return json.loads(health_path.read_text())
 
-        articles_result = await session.execute(select(Article))
+        article_stmt = select(Article)
+        if user_id:
+            article_stmt = article_stmt.where(Article.user_id == user_id)
+        articles_result = await session.execute(article_stmt)
         articles = articles_result.scalars().all()
 
         return {

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -227,7 +227,8 @@ async def _fetch_health_data(
     backlink_stmt = select(Backlink)
     if user_id:
         backlink_stmt = backlink_stmt.where(
-            Backlink.source_article_id.in_(article_ids)  # type: ignore[attr-defined]
+            Backlink.source_article_id.in_(article_ids),  # type: ignore[attr-defined]
+            Backlink.target_article_id.in_(article_ids),  # type: ignore[attr-defined]
         )
     backlinks_result = await session.execute(backlink_stmt)
     backlinks: list[Backlink] = list(backlinks_result.scalars().all())

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -172,7 +172,10 @@ def _build_index_lines(
     return lines
 
 
-async def regenerate_index_md(session: AsyncSession) -> str:
+async def regenerate_index_md(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> str:
     """Regenerate the wiki/index.md content catalog from the database.
 
     Reads all Articles + their concepts, groups by concept, writes a
@@ -182,16 +185,22 @@ async def regenerate_index_md(session: AsyncSession) -> str:
 
     Args:
         session: Async database session.
+        user_id: Optional user ID for data isolation.
 
     Returns:
         The wiki-relative path string of the written file.
     """
     settings = get_settings()
     wiki_dir = Path(settings.data_dir) / "wiki"
+    if user_id:
+        wiki_dir = wiki_dir / user_id
     wiki_dir.mkdir(parents=True, exist_ok=True)
     index_path = wiki_dir / "index.md"
 
-    articles_result = await session.execute(select(Article))
+    article_stmt = select(Article)
+    if user_id:
+        article_stmt = article_stmt.where(Article.user_id == user_id)
+    articles_result = await session.execute(article_stmt)
     articles: list[Article] = list(articles_result.scalars().all())
 
     concept_articles, uncategorized = await _group_articles_by_concept(articles, session)
@@ -202,7 +211,34 @@ async def regenerate_index_md(session: AsyncSession) -> str:
     return "index.md"
 
 
-async def generate_meta_health_page(session: AsyncSession) -> str:
+async def _fetch_health_data(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> tuple[list[Article], list[Backlink]]:
+    """Fetch articles and backlinks for the health page, scoped by user_id."""
+    article_stmt = select(Article)
+    if user_id:
+        article_stmt = article_stmt.where(Article.user_id == user_id)
+    articles_result = await session.execute(article_stmt)
+    articles: list[Article] = list(articles_result.scalars().all())
+
+    # Filter backlinks to only those between this user's articles
+    article_ids = {a.id for a in articles}
+    backlink_stmt = select(Backlink)
+    if user_id:
+        backlink_stmt = backlink_stmt.where(
+            Backlink.source_article_id.in_(article_ids)  # type: ignore[attr-defined]
+        )
+    backlinks_result = await session.execute(backlink_stmt)
+    backlinks: list[Backlink] = list(backlinks_result.scalars().all())
+
+    return articles, backlinks
+
+
+async def generate_meta_health_page(
+    session: AsyncSession,
+    user_id: str | None = None,
+) -> str:
     """Generate a meta page with wiki health statistics.
 
     Creates ``wiki/meta/wiki-health.md`` with deterministic summary
@@ -211,24 +247,24 @@ async def generate_meta_health_page(session: AsyncSession) -> str:
 
     Args:
         session: Async database session.
+        user_id: Optional user ID for data isolation.
 
     Returns:
         The wiki-relative path string of the written meta page file.
     """
     settings = get_settings()
-    meta_dir = Path(settings.data_dir) / "wiki" / "meta"
+    meta_dir = Path(settings.data_dir) / "wiki"
+    if user_id:
+        meta_dir = meta_dir / user_id
+    meta_dir = meta_dir / "meta"
     meta_dir.mkdir(parents=True, exist_ok=True)
     health_path = meta_dir / "wiki-health.md"
 
-    articles_result = await session.execute(select(Article))
-    articles: list[Article] = list(articles_result.scalars().all())
+    articles, backlinks = await _fetch_health_data(session, user_id=user_id)
 
     type_counts: Counter[str] = Counter()
     for article in articles:
         type_counts[article.page_type] += 1
-
-    backlinks_result = await session.execute(select(Backlink))
-    backlinks: list[Backlink] = list(backlinks_result.scalars().all())
 
     relation_counts: Counter[str] = Counter()
     for bl in backlinks:

--- a/tests/smoke/test_docker_smoke.py
+++ b/tests/smoke/test_docker_smoke.py
@@ -439,9 +439,20 @@ class TestContainerBasics:
             assert resp.status_code == 200
 
     def test_non_root_user(self, container_url: str):
-        """The container should run as non-root (wikimind user)."""
+        """The application process should run as non-root (wikimind user).
+
+        The container starts as root (for volume chown), then drops to
+        wikimind via gosu. Check the gunicorn worker's effective user.
+        """
         result = subprocess.run(
-            ["docker", "exec", CONTAINER_NAME, "whoami"],
+            [
+                "docker",
+                "exec",
+                CONTAINER_NAME,
+                "sh",
+                "-c",
+                "ps -o user= -p $(pgrep -f 'gunicorn.*worker' | head -1) 2>/dev/null || id -un",
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/tests/smoke/test_docker_smoke.py
+++ b/tests/smoke/test_docker_smoke.py
@@ -442,7 +442,9 @@ class TestContainerBasics:
         """The application process should run as non-root (wikimind user).
 
         The container starts as root (for volume chown), then drops to
-        wikimind via gosu. Check the gunicorn worker's effective user.
+        wikimind via gosu. PID 1 should be the gunicorn master running
+        as the wikimind user. We check /proc/1/status which is always
+        available on Linux — no dependency on ps or pgrep.
         """
         result = subprocess.run(
             [
@@ -451,14 +453,15 @@ class TestContainerBasics:
                 CONTAINER_NAME,
                 "sh",
                 "-c",
-                "ps -o user= -p $(pgrep -f 'gunicorn.*worker' | head -1) 2>/dev/null || id -un",
+                "awk '/^Uid:/{print $2}' /proc/1/status",
             ],
             capture_output=True,
             text=True,
             check=False,
         )
         if result.returncode == 0:
-            assert result.stdout.strip() == "wikimind"
+            uid = result.stdout.strip()
+            assert uid != "0", "PID 1 is running as root (UID 0), expected wikimind"
 
     def test_data_dir_writable(self, container_url: str):
         """The data directory should be writable by the container user."""

--- a/tests/unit/test_concept_recompilation.py
+++ b/tests/unit/test_concept_recompilation.py
@@ -293,4 +293,4 @@ class TestReplaceArticleTriggersConceptPages:
             await compiler._replace_article_in_place(existing, result, source, db_session)
 
         # The key assertion: maybe_trigger_concept_pages was called.
-        mock_trigger.assert_called_once_with(mock_concept_session)
+        mock_trigger.assert_called_once_with(mock_concept_session, user_id=source.user_id)

--- a/tests/unit/test_linter_user_scoping.py
+++ b/tests/unit/test_linter_user_scoping.py
@@ -1,0 +1,362 @@
+"""Tests for linter engine user_id scoping (Epic #337, Issue #10).
+
+Verifies that detect_orphans, detect_contradictions, and run_enforcer_checks
+return only the specified user's data when user_id is provided.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wikimind.config import get_settings
+from wikimind.engine.linter.contradictions import detect_contradictions
+from wikimind.engine.linter.orphans import detect_orphans
+from wikimind.engine.linter.runner import run_enforcer_checks, run_lint
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    Concept,
+    LintReport,
+    LintReportStatus,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_article(
+    tmp_path: Path,
+    *,
+    article_id: str = "a1",
+    slug: str = "test-article",
+    title: str = "Test Article",
+    user_id: str | None = None,
+    claims: list[str] | None = None,
+) -> Article:
+    """Create an Article with a real .md file containing claims."""
+    wiki_dir = tmp_path / "wikimind" / "wiki"
+    if user_id:
+        wiki_dir = wiki_dir / user_id
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    file_path = wiki_dir / f"{slug}.md"
+    body_lines = [f"# {title}", ""]
+    if claims:
+        body_lines.append("## Key Claims")
+        for c in claims:
+            body_lines.append(f"- {c}")
+    else:
+        body_lines.append("Some body content here.")
+    file_path.write_text("\n".join(body_lines), encoding="utf-8")
+
+    return Article(
+        id=article_id,
+        slug=slug,
+        title=title,
+        file_path=f"{slug}.md",
+        user_id=user_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# detect_orphans — user_id scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_orphans_scoped_by_user_id(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Orphan detection with user_id only returns that user's orphaned articles."""
+    settings = get_settings()
+    settings.linter.enable_orphan_detection = True
+
+    # Create orphan articles for two different users
+    art_alice = _make_article(
+        tmp_path,
+        article_id="alice-art",
+        slug="alice-art",
+        title="Alice Article",
+        user_id="alice",
+    )
+    art_bob = _make_article(
+        tmp_path,
+        article_id="bob-art",
+        slug="bob-art",
+        title="Bob Article",
+        user_id="bob",
+    )
+    db_session.add(art_alice)
+    db_session.add(art_bob)
+    await db_session.commit()
+
+    # Scoped to alice — should only find alice's orphan
+    findings_alice = await detect_orphans(db_session, settings, report_id="r1", user_id="alice")
+    assert len(findings_alice) == 1
+    assert findings_alice[0].article_id == "alice-art"
+    assert findings_alice[0].user_id == "alice"
+
+    # Scoped to bob — should only find bob's orphan
+    findings_bob = await detect_orphans(db_session, settings, report_id="r1", user_id="bob")
+    assert len(findings_bob) == 1
+    assert findings_bob[0].article_id == "bob-art"
+    assert findings_bob[0].user_id == "bob"
+
+
+@pytest.mark.asyncio
+async def test_detect_orphans_no_user_id_returns_all(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Orphan detection without user_id returns all orphaned articles."""
+    settings = get_settings()
+    settings.linter.enable_orphan_detection = True
+
+    art_alice = _make_article(
+        tmp_path,
+        article_id="alice-art",
+        slug="alice-art",
+        title="Alice Article",
+        user_id="alice",
+    )
+    art_bob = _make_article(
+        tmp_path,
+        article_id="bob-art",
+        slug="bob-art",
+        title="Bob Article",
+        user_id="bob",
+    )
+    db_session.add(art_alice)
+    db_session.add(art_bob)
+    await db_session.commit()
+
+    findings = await detect_orphans(db_session, settings, report_id="r1")
+    assert len(findings) == 2
+
+
+# ---------------------------------------------------------------------------
+# detect_contradictions — user_id scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_scoped_by_user_id(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Contradiction detection with user_id only processes that user's articles."""
+    # Create concepts for two users
+    concept_alice = Concept(id="c-alice", name="testing", article_count=2, user_id="alice")
+    concept_bob = Concept(id="c-bob", name="testing-bob", article_count=2, user_id="bob")
+    db_session.add(concept_alice)
+    db_session.add(concept_bob)
+
+    # Alice's articles
+    art_a1 = _make_article(
+        tmp_path,
+        article_id="a1",
+        slug="alice-art-a",
+        title="Alice A",
+        user_id="alice",
+        claims=["The sky is blue"],
+    )
+    art_a2 = _make_article(
+        tmp_path,
+        article_id="a2",
+        slug="alice-art-b",
+        title="Alice B",
+        user_id="alice",
+        claims=["The sky is green"],
+    )
+    # Bob's articles
+    art_b1 = _make_article(
+        tmp_path,
+        article_id="b1",
+        slug="bob-art-a",
+        title="Bob A",
+        user_id="bob",
+        claims=["Water is wet"],
+    )
+    art_b2 = _make_article(
+        tmp_path,
+        article_id="b2",
+        slug="bob-art-b",
+        title="Bob B",
+        user_id="bob",
+        claims=["Water is dry"],
+    )
+    db_session.add(art_a1)
+    db_session.add(art_a2)
+    db_session.add(art_b1)
+    db_session.add(art_b2)
+    await db_session.commit()
+
+    db_session.add(ArticleConcept(article_id="a1", concept_name="testing"))
+    db_session.add(ArticleConcept(article_id="a2", concept_name="testing"))
+    db_session.add(ArticleConcept(article_id="b1", concept_name="testing-bob"))
+    db_session.add(ArticleConcept(article_id="b2", concept_name="testing-bob"))
+    await db_session.commit()
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(
+        return_value={
+            "contradictions": [
+                {
+                    "description": "Color contradiction",
+                    "article_a_claim": "The sky is blue",
+                    "article_b_claim": "The sky is green",
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+
+    settings = get_settings()
+
+    # Run for alice only
+    report = LintReport(id="r-alice", user_id="alice")
+    db_session.add(report)
+    await db_session.flush()
+
+    findings = await detect_contradictions(db_session, mock_router, settings, report, user_id="alice")
+
+    # LLM should be called exactly once (one alice concept pair)
+    assert mock_router.complete.call_count == 1
+    assert len(findings) == 1
+    assert findings[0].user_id == "alice"
+    assert findings[0].article_a_id == "a1"
+    assert findings[0].article_b_id == "a2"
+
+
+# ---------------------------------------------------------------------------
+# run_enforcer_checks — user_id scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_enforcer_checks_scoped_by_user_id(db_session, _isolated_data_dir, tmp_path) -> None:
+    """run_enforcer_checks with user_id only processes that user's articles."""
+    art_alice = _make_article(
+        tmp_path,
+        article_id="alice-art",
+        slug="alice-art",
+        title="Alice Article",
+        user_id="alice",
+    )
+    art_bob = _make_article(
+        tmp_path,
+        article_id="bob-art",
+        slug="bob-art",
+        title="Bob Article",
+        user_id="bob",
+    )
+    db_session.add(art_alice)
+    db_session.add(art_bob)
+    await db_session.commit()
+
+    report = LintReport(id="r1", user_id="alice")
+    db_session.add(report)
+    await db_session.flush()
+
+    with patch(
+        "wikimind.engine.linter.runner.enforce_backlinks",
+        new_callable=AsyncMock,
+    ) as mock_enforce:
+        mock_enforce.return_value = MagicMock(violations=[])
+
+        await run_enforcer_checks(db_session, report, user_id="alice")
+
+        # Only alice's article should be checked
+        assert mock_enforce.call_count == 1
+        mock_enforce.assert_called_once_with("alice-art", db_session)
+        assert report.checked_articles == 1
+
+
+# ---------------------------------------------------------------------------
+# run_lint end-to-end — user_id scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_lint_scopes_article_count_by_user_id(db_session, _isolated_data_dir, tmp_path) -> None:
+    """run_lint with user_id counts only that user's articles."""
+    art_alice = _make_article(
+        tmp_path,
+        article_id="alice-art",
+        slug="alice-art",
+        title="Alice Article",
+        user_id="alice",
+        claims=["Claim A"],
+    )
+    art_bob = _make_article(
+        tmp_path,
+        article_id="bob-art",
+        slug="bob-art",
+        title="Bob Article",
+        user_id="bob",
+        claims=["Claim B"],
+    )
+    db_session.add(art_alice)
+    db_session.add(art_bob)
+    await db_session.commit()
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+
+    with (
+        patch(
+            "wikimind.engine.linter.runner.get_llm_router",
+            return_value=mock_router,
+        ),
+        patch(
+            "wikimind.engine.linter.runner.emit_linter_alert",
+            new_callable=AsyncMock,
+        ),
+    ):
+        report = await run_lint(db_session, user_id="alice")
+
+    assert report.status == LintReportStatus.COMPLETE
+    assert report.article_count == 1
+    assert report.user_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_run_lint_findings_carry_user_id(db_session, _isolated_data_dir, tmp_path) -> None:
+    """Findings from a user-scoped lint run carry the user_id."""
+    settings = get_settings()
+    settings.linter.enable_orphan_detection = True
+
+    art = _make_article(
+        tmp_path,
+        article_id="alice-art",
+        slug="alice-art",
+        title="Alice Article",
+        user_id="alice",
+    )
+    db_session.add(art)
+    await db_session.commit()
+
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=MagicMock())
+    mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
+
+    with (
+        patch(
+            "wikimind.engine.linter.runner.get_llm_router",
+            return_value=mock_router,
+        ),
+        patch(
+            "wikimind.engine.linter.runner.get_settings",
+            return_value=settings,
+        ),
+        patch(
+            "wikimind.engine.linter.runner.emit_linter_alert",
+            new_callable=AsyncMock,
+        ),
+    ):
+        report = await run_lint(db_session, user_id="alice")
+
+    assert report.status == LintReportStatus.COMPLETE
+    # The orphan detection found our article — verify user_id on findings
+    assert report.orphans_count == 1

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -1,0 +1,477 @@
+"""Tests for user_id scoping in service-layer queries, file paths, and ChromaDB."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlmodel import select
+
+from wikimind.config import get_settings
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    CompletionResponse,
+    Concept,
+    Conversation,
+    FileBackSelectionRequest,
+    Provider,
+    Query,
+    TurnSelection,
+)
+from wikimind.services.activity_log import append_log_entry
+from wikimind.services.embedding import _SEARCH_AVAILABLE
+from wikimind.services.query import QueryService
+from wikimind.services.taxonomy import (
+    rebuild_taxonomy,
+    update_article_counts,
+    upsert_concepts,
+)
+from wikimind.services.wiki_index import (
+    generate_meta_health_page,
+    regenerate_index_md,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Issue 3: Service-layer query scoping by user_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestUpsertConceptsUserScoping:
+    """Concepts should be scoped by user_id."""
+
+    async def test_creates_concept_with_user_id(self, db_session: AsyncSession) -> None:
+        concepts = await upsert_concepts(["ML"], db_session, user_id="alice")
+        assert len(concepts) == 1
+        assert concepts[0].user_id == "alice"
+
+    async def test_separate_concepts_per_user(self, db_session: AsyncSession) -> None:
+        alice = await upsert_concepts(["ML"], db_session, user_id="alice")
+        bob = await upsert_concepts(["ML"], db_session, user_id="bob")
+        # Same name, different users — separate rows
+        assert alice[0].id != bob[0].id
+
+    async def test_idempotent_within_same_user(self, db_session: AsyncSession) -> None:
+        first = await upsert_concepts(["ML"], db_session, user_id="alice")
+        second = await upsert_concepts(["ML"], db_session, user_id="alice")
+        assert first[0].id == second[0].id
+
+
+@pytest.mark.asyncio
+class TestUpdateArticleCountsUserScoping:
+    """Article counts should only include the specified user's articles."""
+
+    async def test_counts_only_own_articles(
+        self,
+        db_session: AsyncSession,
+        tmp_path: Path,
+    ) -> None:
+        # Create concepts for each user
+        await upsert_concepts(["ML"], db_session, user_id="alice")
+        await upsert_concepts(["ML"], db_session, user_id="bob")
+
+        # Create articles owned by different users
+        fp1 = tmp_path / "alice.md"
+        fp1.write_text("# Alice ML", encoding="utf-8")
+        art_alice = Article(
+            slug="alice-ml",
+            title="Alice ML",
+            file_path=str(fp1),
+            user_id="alice",
+        )
+        fp2 = tmp_path / "bob.md"
+        fp2.write_text("# Bob ML", encoding="utf-8")
+        art_bob = Article(
+            slug="bob-ml",
+            title="Bob ML",
+            file_path=str(fp2),
+            user_id="bob",
+        )
+        db_session.add_all([art_alice, art_bob])
+        await db_session.commit()
+        await db_session.refresh(art_alice)
+        await db_session.refresh(art_bob)
+
+        db_session.add(ArticleConcept(article_id=art_alice.id, concept_name="ml"))
+        db_session.add(ArticleConcept(article_id=art_bob.id, concept_name="ml"))
+        await db_session.commit()
+
+        # Update counts for alice only
+        await update_article_counts(db_session, user_id="alice")
+
+        result = await db_session.execute(select(Concept).where(Concept.user_id == "alice"))
+        alice_concept = result.scalar_one()
+        assert alice_concept.article_count == 1
+
+
+@pytest.mark.asyncio
+class TestRebuildTaxonomyUserScoping:
+    """Taxonomy rebuild should only process the specified user's concepts."""
+
+    async def test_rebuild_scopes_to_user(self, db_session: AsyncSession) -> None:
+        await upsert_concepts(["ml", "nlp"], db_session, user_id="alice")
+        await upsert_concepts(["biology"], db_session, user_id="bob")
+
+        llm_response = json.dumps(
+            [
+                {"name": "ml", "parent": None},
+                {"name": "nlp", "parent": "ml"},
+            ]
+        )
+        fake_resp = CompletionResponse(
+            content=llm_response,
+            provider_used=Provider.MOCK,
+            model_used="mock-1",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0,
+        )
+        mock_router = AsyncMock()
+        mock_router.complete = AsyncMock(return_value=fake_resp)
+        mock_router.parse_json_response = lambda r: json.loads(r.content)
+
+        with patch(
+            "wikimind.services.taxonomy.get_llm_router",
+            return_value=mock_router,
+        ):
+            await rebuild_taxonomy(db_session, user_id="alice")
+
+        # Bob's concept should be untouched
+        bob_result = await db_session.execute(select(Concept).where(Concept.user_id == "bob"))
+        bob_concept = bob_result.scalar_one()
+        assert bob_concept.parent_id is None
+        assert bob_concept.name == "biology"
+
+
+@pytest.mark.asyncio
+class TestRegenerateIndexUserScoping:
+    """Index regeneration should only include the specified user's articles."""
+
+    async def test_index_filters_by_user(self, db_session: AsyncSession) -> None:
+        a_alice = Article(
+            slug="alice-art",
+            title="Alice Article",
+            file_path="/wiki/alice-art.md",
+            user_id="alice",
+        )
+        a_bob = Article(
+            slug="bob-art",
+            title="Bob Article",
+            file_path="/wiki/bob-art.md",
+            user_id="bob",
+        )
+        db_session.add_all([a_alice, a_bob])
+        await db_session.commit()
+
+        await regenerate_index_md(db_session, user_id="alice")
+
+        settings = get_settings()
+        index_path = Path(settings.data_dir) / "wiki" / "alice" / "index.md"
+        assert index_path.exists()
+        content = index_path.read_text(encoding="utf-8")
+        assert "[[alice-art]]" in content
+        assert "[[bob-art]]" not in content
+
+    async def test_index_path_scoped_by_user(self, db_session: AsyncSession) -> None:
+        """Index file should be written under wiki/{user_id}/."""
+        await regenerate_index_md(db_session, user_id="user123")
+
+        settings = get_settings()
+        index_path = Path(settings.data_dir) / "wiki" / "user123" / "index.md"
+        assert index_path.exists()
+
+    async def test_index_no_user_uses_global_path(self, db_session: AsyncSession) -> None:
+        """Without user_id, index should be at wiki/index.md (global)."""
+        await regenerate_index_md(db_session)
+
+        settings = get_settings()
+        index_path = Path(settings.data_dir) / "wiki" / "index.md"
+        assert index_path.exists()
+
+
+@pytest.mark.asyncio
+class TestHealthPageUserScoping:
+    """Health page should scope path and queries by user_id."""
+
+    async def test_health_path_scoped_by_user(self, db_session: AsyncSession) -> None:
+        rel = await generate_meta_health_page(db_session, user_id="alice")
+        assert rel == "meta/wiki-health.md"
+
+        settings = get_settings()
+        health_path = Path(settings.data_dir) / "wiki" / "alice" / "meta" / "wiki-health.md"
+        assert health_path.exists()
+
+    async def test_health_filters_articles_by_user(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        a_alice = Article(
+            slug="alice-art",
+            title="Alice Article",
+            file_path="/wiki/alice-art.md",
+            user_id="alice",
+        )
+        a_bob = Article(
+            slug="bob-art",
+            title="Bob Article",
+            file_path="/wiki/bob-art.md",
+            user_id="bob",
+        )
+        db_session.add_all([a_alice, a_bob])
+        await db_session.commit()
+
+        await generate_meta_health_page(db_session, user_id="alice")
+
+        settings = get_settings()
+        health_path = Path(settings.data_dir) / "wiki" / "alice" / "meta" / "wiki-health.md"
+        content = health_path.read_text(encoding="utf-8")
+        # Total should be 1 (only Alice's article)
+        assert "| **Total** | **1** |" in content
+
+
+# ---------------------------------------------------------------------------
+# Issue 4: File system path scoping by user_id
+# ---------------------------------------------------------------------------
+
+
+class TestActivityLogPathScoping:
+    """Activity log path should include user_id when provided."""
+
+    def test_log_path_includes_user_id(self, tmp_path: Path) -> None:
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("ingest", "Test Source", user_id="alice")
+
+        log_path = tmp_path / "wiki" / "alice" / "log.md"
+        assert log_path.exists()
+        content = log_path.read_text(encoding="utf-8")
+        assert "ingest | Test Source" in content
+
+    def test_log_path_global_without_user_id(self, tmp_path: Path) -> None:
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("ingest", "Test Source")
+
+        log_path = tmp_path / "wiki" / "log.md"
+        assert log_path.exists()
+
+    def test_separate_logs_per_user(self, tmp_path: Path) -> None:
+        with patch("wikimind.services.activity_log.get_settings") as mock_settings:
+            mock_settings.return_value.data_dir = str(tmp_path)
+            append_log_entry("ingest", "Alice Source", user_id="alice")
+            append_log_entry("ingest", "Bob Source", user_id="bob")
+
+        alice_log = tmp_path / "wiki" / "alice" / "log.md"
+        bob_log = tmp_path / "wiki" / "bob" / "log.md"
+        assert alice_log.exists()
+        assert bob_log.exists()
+
+        alice_content = alice_log.read_text(encoding="utf-8")
+        bob_content = bob_log.read_text(encoding="utf-8")
+        assert "Alice Source" in alice_content
+        assert "Bob Source" not in alice_content
+        assert "Bob Source" in bob_content
+
+
+@pytest.mark.asyncio
+class TestFileBackSelectionPathScoping:
+    """file_back_selection should scope qa-answers path by user_id."""
+
+    async def test_qa_answers_path_includes_user_id(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        conv = Conversation(title="Test Conv", user_id="alice")
+        db_session.add(conv)
+        await db_session.commit()
+        await db_session.refresh(conv)
+
+        q = Query(
+            question="What is X?",
+            answer="X is Y.",
+            conversation_id=conv.id,
+            turn_index=0,
+            user_id="alice",
+        )
+        db_session.add(q)
+        await db_session.commit()
+        await db_session.refresh(q)
+
+        svc = QueryService()
+        request = FileBackSelectionRequest(
+            selections=[
+                TurnSelection(
+                    conversation_id=conv.id,
+                    turn_indices=[0],
+                ),
+            ],
+        )
+        result = await svc.file_back_selection(
+            request,
+            db_session,
+            user_id="alice",
+        )
+        article_info = result["article"]
+
+        # Verify the article's file was written under wiki/alice/qa-answers/
+        art_result = await db_session.execute(select(Article).where(Article.id == article_info["id"]))
+        article = art_result.scalar_one()
+        assert "alice" in article.file_path or "/alice/" in article.file_path
+
+
+# ---------------------------------------------------------------------------
+# Issue 12: ChromaDB user_id scoping
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingServiceUserScoping:
+    """Embedding service should include user_id in metadata and filter on search."""
+
+    @pytest.mark.skipif(
+        not _SEARCH_AVAILABLE,
+        reason="search extras not installed",
+    )
+    def test_embed_article_includes_user_id_metadata(self) -> None:
+        from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
+
+        with (
+            patch.object(EmbeddingService, "__init__", lambda self: None),
+            patch.object(
+                EmbeddingService,
+                "_encode",
+                return_value=[[0.1, 0.2]],
+            ),
+        ):
+            svc = EmbeddingService.__new__(EmbeddingService)
+            svc._chunk_size = 500
+            svc._chunk_overlap = 50
+            mock_collection = MagicMock()
+            mock_collection.count.return_value = 0
+            svc._collection = mock_collection
+
+            svc.embed_article(
+                "art-1",
+                "Test",
+                "Content here.",
+                user_id="alice",
+            )
+
+            call_args = mock_collection.add.call_args
+            metadatas = call_args.kwargs.get(
+                "metadatas",
+                call_args[1].get("metadatas"),
+            )
+            assert metadatas[0]["user_id"] == "alice"
+
+    @pytest.mark.skipif(
+        not _SEARCH_AVAILABLE,
+        reason="search extras not installed",
+    )
+    def test_embed_article_omits_user_id_when_none(self) -> None:
+        from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
+
+        with (
+            patch.object(EmbeddingService, "__init__", lambda self: None),
+            patch.object(
+                EmbeddingService,
+                "_encode",
+                return_value=[[0.1, 0.2]],
+            ),
+        ):
+            svc = EmbeddingService.__new__(EmbeddingService)
+            svc._chunk_size = 500
+            svc._chunk_overlap = 50
+            mock_collection = MagicMock()
+            mock_collection.count.return_value = 0
+            svc._collection = mock_collection
+
+            svc.embed_article("art-1", "Test", "Content here.")
+
+            call_args = mock_collection.add.call_args
+            metadatas = call_args.kwargs.get(
+                "metadatas",
+                call_args[1].get("metadatas"),
+            )
+            assert "user_id" not in metadatas[0]
+
+    @pytest.mark.skipif(
+        not _SEARCH_AVAILABLE,
+        reason="search extras not installed",
+    )
+    def test_search_passes_user_id_filter(self) -> None:
+        from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
+
+        with (
+            patch.object(EmbeddingService, "__init__", lambda self: None),
+            patch.object(
+                EmbeddingService,
+                "_encode",
+                return_value=[[0.1, 0.2]],
+            ),
+        ):
+            svc = EmbeddingService.__new__(EmbeddingService)
+            mock_collection = MagicMock()
+            mock_collection.count.return_value = 5
+            mock_collection.query.return_value = {
+                "ids": [["art-1_chunk_0"]],
+                "distances": [[0.2]],
+                "metadatas": [
+                    [
+                        {
+                            "article_id": "art-1",
+                            "article_title": "Test",
+                            "chunk_index": 0,
+                            "user_id": "alice",
+                        }
+                    ]
+                ],
+                "documents": [["Some text"]],
+            }
+            svc._collection = mock_collection
+            svc._min_score = 0.65
+
+            svc.search("query text", limit=5, user_id="alice")
+
+            call_kwargs = mock_collection.query.call_args.kwargs
+            assert call_kwargs["where"] == {"user_id": "alice"}
+
+    @pytest.mark.skipif(
+        not _SEARCH_AVAILABLE,
+        reason="search extras not installed",
+    )
+    def test_search_no_where_without_user_id(self) -> None:
+        from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
+
+        with (
+            patch.object(EmbeddingService, "__init__", lambda self: None),
+            patch.object(
+                EmbeddingService,
+                "_encode",
+                return_value=[[0.1, 0.2]],
+            ),
+        ):
+            svc = EmbeddingService.__new__(EmbeddingService)
+            mock_collection = MagicMock()
+            mock_collection.count.return_value = 5
+            mock_collection.query.return_value = {
+                "ids": [[]],
+                "distances": [[]],
+                "metadatas": [[]],
+                "documents": [[]],
+            }
+            svc._collection = mock_collection
+            svc._min_score = 0.65
+
+            svc.search("query text", limit=5)
+
+            call_kwargs = mock_collection.query.call_args.kwargs
+            assert "where" not in call_kwargs

--- a/tests/unit/test_wikilink_user_scoping.py
+++ b/tests/unit/test_wikilink_user_scoping.py
@@ -1,0 +1,189 @@
+"""Tests for user_id scoping in wikilink resolver and backlink enforcer.
+
+Verifies that:
+- resolve_backlink_candidates() only returns articles for the given user_id
+- The backlink enforcer creates inverse backlinks with correct user_id
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlmodel import select
+
+from wikimind.engine.backlink_enforcer import ensure_bidirectional
+from wikimind.engine.wikilink_resolver import resolve_backlink_candidates
+from wikimind.models import Article, Backlink, ConfidenceLevel, RelationType
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _make_article(
+    session: AsyncSession,
+    title: str,
+    user_id: str | None = None,
+    slug: str | None = None,
+) -> Article:
+    article = Article(
+        id=str(uuid.uuid4()),
+        slug=slug or title.lower().replace(" ", "-"),
+        title=title,
+        file_path=f"/tmp/{slug or title}.md",
+        confidence=ConfidenceLevel.SOURCED,
+        user_id=user_id,
+    )
+    session.add(article)
+    await session.commit()
+    await session.refresh(article)
+    return article
+
+
+# ---------------------------------------------------------------------------
+# resolve_backlink_candidates — user_id scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_filters_by_user_id(db_session: AsyncSession) -> None:
+    """Only articles belonging to the given user_id are resolved."""
+    user_a = "user-a"
+    user_b = "user-b"
+    art_a = await _make_article(db_session, "Machine Learning", user_id=user_a)
+    await _make_article(db_session, "Machine Learning", user_id=user_b, slug="ml-b")
+
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Machine Learning"],
+        db_session,
+        user_id=user_a,
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == art_a.id
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_resolver_other_user_article_is_unresolved(
+    db_session: AsyncSession,
+) -> None:
+    """An article from a different user is treated as unresolved."""
+    await _make_article(db_session, "Quantum Computing", user_id="user-b")
+
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Quantum Computing"],
+        db_session,
+        user_id="user-a",
+    )
+    assert resolved == []
+    assert unresolved == ["Quantum Computing"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_no_user_id_returns_all(db_session: AsyncSession) -> None:
+    """When user_id is None, all articles are considered (backward compat)."""
+    art_a = await _make_article(db_session, "React", user_id="user-a")
+    art_b = await _make_article(db_session, "Vue", user_id="user-b")
+
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["React", "Vue"],
+        db_session,
+    )
+    assert len(resolved) == 2
+    resolved_ids = {r.target_id for r in resolved}
+    assert art_a.id in resolved_ids
+    assert art_b.id in resolved_ids
+    assert unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_resolver_user_id_with_exclude(db_session: AsyncSession) -> None:
+    """user_id filtering and exclude_article_id work together."""
+    user = "user-x"
+    self_art = await _make_article(db_session, "Self", user_id=user)
+    other_art = await _make_article(db_session, "Other", user_id=user)
+
+    resolved, unresolved = await resolve_backlink_candidates(
+        ["Self", "Other"],
+        db_session,
+        exclude_article_id=self_art.id,
+        user_id=user,
+    )
+    assert len(resolved) == 1
+    assert resolved[0].target_id == other_art.id
+    assert unresolved == ["Self"]
+
+
+# ---------------------------------------------------------------------------
+# ensure_bidirectional — user_id propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_bidirectional_propagates_user_id(
+    db_session: AsyncSession,
+) -> None:
+    """Inverse backlink created by ensure_bidirectional carries the source user_id."""
+    user = "user-abc"
+    art_a = await _make_article(db_session, "Art A", user_id=user, slug="art-a")
+    art_b = await _make_article(db_session, "Art B", user_id=user, slug="art-b")
+
+    bl = Backlink(
+        source_article_id=art_a.id,
+        target_article_id=art_b.id,
+        relation_type=RelationType.CONTRADICTS,
+        context="claim conflict",
+        user_id=user,
+    )
+    db_session.add(bl)
+    await db_session.commit()
+
+    created = await ensure_bidirectional(bl, db_session)
+    await db_session.commit()
+
+    assert created is True
+
+    result = await db_session.execute(
+        select(Backlink).where(
+            Backlink.source_article_id == art_b.id,
+            Backlink.target_article_id == art_a.id,
+        )
+    )
+    inverse = result.scalars().first()
+    assert inverse is not None
+    assert inverse.user_id == user
+
+
+@pytest.mark.asyncio
+async def test_ensure_bidirectional_null_user_id(
+    db_session: AsyncSession,
+) -> None:
+    """Inverse backlink with null user_id is preserved (legacy compat)."""
+    art_a = await _make_article(db_session, "Art A", slug="art-a-legacy")
+    art_b = await _make_article(db_session, "Art B", slug="art-b-legacy")
+
+    bl = Backlink(
+        source_article_id=art_a.id,
+        target_article_id=art_b.id,
+        relation_type=RelationType.RELATED_TO,
+        context="related",
+        user_id=None,
+    )
+    db_session.add(bl)
+    await db_session.commit()
+
+    created = await ensure_bidirectional(bl, db_session)
+    await db_session.commit()
+
+    assert created is True
+
+    result = await db_session.execute(
+        select(Backlink).where(
+            Backlink.source_article_id == art_b.id,
+            Backlink.target_article_id == art_a.id,
+        )
+    )
+    inverse = result.scalars().first()
+    assert inverse is not None
+    assert inverse.user_id is None


### PR DESCRIPTION
## Summary

Implements all P1 issues from Epic #337 (multi-user data isolation). Threads `user_id` through the engine and service layers so that queries, file paths, and search indexes are properly scoped per user.

### Issues addressed
- **Issue 3**: Scope service-layer queries by `user_id` — taxonomy, wiki_index, query services
- **Issue 4**: Scope file system paths by `user_id` — activity log, QA answers, index, meta health
- **Issue 6**: Fix Fly.io volume permission vulnerability — gosu + startup write check
- **Issue 10**: Scope linter engine by `user_id` — orphans, contradictions, structural checks, runner
- **Issue 12**: Scope ChromaDB search index per user — metadata filtering on embed + search
- **Issue 17**: Scope wikilink resolver and backlink enforcer by `user_id`

### Key changes
- 25+ functions now accept and propagate `user_id` parameter
- All finding/backlink records carry `user_id` when created
- Orphan detection rewritten from raw SQL to ORM (correlated subqueries)
- ChromaDB embeddings include `user_id` metadata; search filters by it
- File paths use `wiki/{user_id}/` pattern for per-user isolation
- Docker entrypoint runs as root with gosu to fix volume permissions
- Startup health check verifies write permissions (guarded by `storage_backend`)
- Concurrent lint guard scoped per user (Alice's lint doesn't block Bob's)

## Test plan
- [x] 915 unit/integration tests pass (30 new tests across 3 test files)
- [x] `make lint` passes
- [x] `make format` passes  
- [x] `make typecheck` passes (only pre-existing frontmatter_validator error)
- [ ] Deploy to staging and verify multi-user isolation with test script
- [ ] Verify Fly.io volume permissions work after deploy

Closes part of #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)