### PR TITLE
ci: align coverage thresholds and fix test policy drift (#362)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,3 @@
-# ===============================================================
-# 🧪  PyTest & Coverage — Quality Gate
-# ===============================================================
-#
-#   - runs the full test-suite across Python 3.11 and 3.12
-#   - measures branch + line coverage (fails < 60%)
-#   - uploads the HTML coverage report as a build artifact
-#   - executes on every push / PR to *main*
-# ---------------------------------------------------------------
-
 name: Tests & Coverage
 
 on:
@@ -17,6 +7,7 @@ on:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
+      - "Makefile"
       - "uv.lock"
       - ".github/workflows/test.yml"
   pull_request:
@@ -26,6 +17,7 @@ on:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
+      - "Makefile"
       - "uv.lock"
       - ".github/workflows/test.yml"
 
@@ -46,8 +38,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We pin to a single Python version. The matrix is preserved as a
-        # 1-element list so we can re-add 3.11/3.13 cheaply if needed.
         python: ["3.12"]
 
     env:
@@ -55,17 +45,11 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
     steps:
-      # -----------------------------------------------------------
-      # 0️⃣  Checkout
-      # -----------------------------------------------------------
       - name: ⬇️  Checkout code
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # -----------------------------------------------------------
-      # 1️⃣  Set up Python + uv
-      # -----------------------------------------------------------
       - name: 🐍  Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -76,30 +60,19 @@ jobs:
         with:
           enable-cache: true
 
-      # -----------------------------------------------------------
-      # 2️⃣  Install dependencies (pinned by uv.lock)
-      # -----------------------------------------------------------
       - name: 📦  Install dependencies
         run: uv sync --frozen --extra dev
 
-      # -----------------------------------------------------------
-      # 3️⃣  Run the tests with coverage (fail under 40%)
-      # -----------------------------------------------------------
       - name: 🧪  Run pytest
         run: |
           uv run pytest \
             -m "not e2e" \
             --cov=wikimind \
-            --cov-branch \
             --cov-report=term-missing \
             --cov-report=html:htmlcov \
             --cov-report=xml:coverage.xml \
-            --cov-fail-under=40 \
             -v
 
-      # -----------------------------------------------------------
-      # 4️⃣  Upload coverage artifacts (HTML report)
-      # -----------------------------------------------------------
       - name: 📤  Upload HTML coverage
         if: always() && matrix.python == '3.12'
         uses: actions/upload-artifact@v4
@@ -109,9 +82,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      # -----------------------------------------------------------
-      # 5️⃣  Upload coverage to Codecov (main branch only)
-      # -----------------------------------------------------------
       - name: 📈  Codecov upload
         if: matrix.python == '3.12' && github.event_name == 'push'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,14 @@
+#
+# ===============================================================
+# 🧪  PyTest & Coverage — Quality Gate
+# ===============================================================
+#
+#   - runs the backend test suite on the pinned CI Python version
+#   - measures branch + line coverage via `pyproject.toml` (fails < 80%)
+#   - uploads the HTML coverage report as a build artifact
+#   - executes on every push / PR to `main` when backend test inputs change
+# ---------------------------------------------------------------
+
 name: Tests & Coverage
 
 on:
@@ -38,6 +49,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # We pin to a single Python version. The matrix is preserved as a
+        # 1-element list so we can re-add 3.11/3.13 cheaply if needed.
         python: ["3.12"]
 
     env:
@@ -45,11 +58,17 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
     steps:
+      # -----------------------------------------------------------
+      # 0️⃣  Checkout
+      # -----------------------------------------------------------
       - name: ⬇️  Checkout code
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
+      # -----------------------------------------------------------
+      # 1️⃣  Set up Python + uv
+      # -----------------------------------------------------------
       - name: 🐍  Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -60,9 +79,15 @@ jobs:
         with:
           enable-cache: true
 
+      # -----------------------------------------------------------
+      # 2️⃣  Install dependencies (pinned by uv.lock)
+      # -----------------------------------------------------------
       - name: 📦  Install dependencies
         run: uv sync --frozen --extra dev
 
+      # -----------------------------------------------------------
+      # 3️⃣  Run the tests with coverage
+      # -----------------------------------------------------------
       - name: 🧪  Run pytest
         run: |
           uv run pytest \
@@ -73,6 +98,9 @@ jobs:
             --cov-report=xml:coverage.xml \
             -v
 
+      # -----------------------------------------------------------
+      # 4️⃣  Upload coverage artifacts (HTML report)
+      # -----------------------------------------------------------
       - name: 📤  Upload HTML coverage
         if: always() && matrix.python == '3.12'
         uses: actions/upload-artifact@v4
@@ -82,6 +110,9 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      # -----------------------------------------------------------
+      # 5️⃣  Upload coverage to Codecov (main branch only)
+      # -----------------------------------------------------------
       - name: 📈  Codecov upload
         if: matrix.python == '3.12' && github.event_name == 'push'
         uses: codecov/codecov-action@v4

--- a/Makefile
+++ b/Makefile
@@ -201,8 +201,8 @@ security: bandit vulture ## Run security and dead-code checks
 verify: lint format-check typecheck pyright docstyle coverage-check desktop-verify extension-verify ## Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop + extension)
 
 .PHONY: coverage-check
-coverage-check: ## Run tests and fail if coverage is under 80%
-	$(BIN)/pytest --cov=wikimind --cov-report=term-missing --cov-fail-under=80
+coverage-check: ## Run non-E2E tests with coverage (policy is configured in pyproject.toml)
+	$(BIN)/pytest -m "not e2e" --cov=wikimind --cov-report=term-missing --cov-report=html
 
 .PHONY: frontend-install
 frontend-install: ## Install frontend dependencies

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make doc-coverage` | Measure docstring coverage (fails if below fail-under threshold) |
 | `make security` | Run security and dead-code checks |
 | `make verify` | Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop + extension) |
-| `make coverage-check` | Run tests and fail if coverage is under 80% |
+| `make coverage-check` | Run non-E2E tests with coverage (policy is configured in pyproject.toml) |
 | `make frontend-install` | Install frontend dependencies |
 | `make frontend-dev` | Start Vite dev server on :5173 |
 | `make frontend-build` | Build frontend production bundle |

--- a/docs/docs/development/ci-cd.md
+++ b/docs/docs/development/ci-cd.md
@@ -4,7 +4,7 @@ WikiMind uses GitHub Actions for continuous integration and deployment.
 
 ## CI Pipeline
 
-The CI pipeline runs on every pull request and push to `main`.
+WikiMind splits CI across multiple GitHub Actions workflows. For test policy, the relevant workflow is `test.yml`, which runs on pushes to `main` and pull requests targeting `main` when backend test inputs change.
 
 ### Quality Gates
 
@@ -17,7 +17,7 @@ The following checks must pass before merging:
 | Type check | `make typecheck` | mypy static type checking |
 | Pyright | `make pyright` | basedpyright type checking |
 | Docstyle | `make docstyle` | pydocstyle docstring checks |
-| Tests | `make coverage-check` | pytest with 80% coverage threshold |
+| Tests | `make coverage-check` | pytest coverage gate for non-E2E tests with an 80% threshold |
 | Frontend | `make frontend-verify` | ESLint + TypeScript + build |
 | Desktop | `make desktop-verify` | Electron typecheck + build |
 | Doc sync | `make check-docs` | Verify generated docs are in sync |
@@ -32,6 +32,8 @@ WIKIMIND_LLM__DEFAULT_PROVIDER=mock
 ```
 
 The mock provider returns deterministic JSON responses for compile, Q&A, and lint operations.
+
+The test workflow currently runs on Python 3.12, excludes `@pytest.mark.e2e` tests from the default coverage gate, enforces branch coverage via `pyproject.toml`, uploads `htmlcov/` as an artifact, and uploads `coverage.xml` to Codecov on pushes to `main`.
 
 ## Pre-Commit Hooks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,10 +253,11 @@ markers = [
 # ---------- Coverage ----------
 [tool.coverage.run]
 source = ["wikimind"]
+branch = true
 omit = ["*/tests/*", "*/conftest.py"]
 
 [tool.coverage.report]
-fail_under = 40
+fail_under = 80
 show_missing = true
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
## Summary
- align the backend coverage policy around an 80% threshold
- move branch coverage configuration into `pyproject.toml`
- update `test.yml`, `Makefile`, and CI docs to match the current contract
- include `Makefile` in workflow path filters so CI reruns when test policy changes

## Testing
- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev pytest -m 'not e2e' --cov=wikimind --cov-report=term-missing --cov-report=html -q`

Closes #362