### PR TITLE
ci: add auth and postgres regression lanes (#364)

### DIFF
--- a/.github/workflows/auth-multiuser.yml
+++ b/.github/workflows/auth-multiuser.yml
@@ -1,0 +1,65 @@
+name: Auth & Multi-user
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - ".github/workflows/auth-multiuser.yml"
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - ".github/workflows/auth-multiuser.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  auth-and-multiuser:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: auth-and-multiuser
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      WIKIMIND_LLM__MOCK__ENABLED: "true"
+      WIKIMIND_LLM__DEFAULT_PROVIDER: "mock"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run auth and multi-user regression tests
+        run: make test-auth-multiuser

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -41,7 +41,7 @@ jobs:
         image: postgres:16-alpine
         env:
           POSTGRES_USER: wikimind
-          POSTGRES_PASSWORD: wikimind
+          POSTGRES_PASSWORD: wikimind # pragma: allowlist secret
           POSTGRES_DB: wikimind
         ports:
           - 5432:5432
@@ -54,8 +54,8 @@ jobs:
     env:
       PYTHONUNBUFFERED: "1"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
-      WIKIMIND_DATABASE_URL: "postgresql+asyncpg://wikimind:wikimind@localhost:5432/wikimind"
-      WIKIMIND_TEST_POSTGRES_URL: "postgresql+asyncpg://wikimind:wikimind@localhost:5432/wikimind"
+      WIKIMIND_DATABASE_URL: "postgresql+asyncpg://wikimind:wikimind@localhost:5432/wikimind" # pragma: allowlist secret
+      WIKIMIND_TEST_POSTGRES_URL: "postgresql+asyncpg://wikimind:wikimind@localhost:5432/wikimind" # pragma: allowlist secret
 
     steps:
       - name: Checkout code

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -1,0 +1,80 @@
+name: Postgres integration
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - ".github/workflows/postgres-integration.yml"
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - ".github/workflows/postgres-integration.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  postgres-integration:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: postgres-integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: wikimind
+          POSTGRES_PASSWORD: wikimind
+          POSTGRES_DB: wikimind
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U wikimind -d wikimind"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      WIKIMIND_DATABASE_URL: "postgresql+asyncpg://wikimind:wikimind@localhost:5432/wikimind"
+      WIKIMIND_TEST_POSTGRES_URL: "postgresql+asyncpg://wikimind:wikimind@localhost:5432/wikimind"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run Postgres integration tests
+        run: make test-postgres-integration

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,15 @@ serve: ## Run production server on :7842 (gunicorn)
 	$(BIN)/gunicorn wikimind.main:app -w 2 -k uvicorn.workers.UvicornWorker --bind 127.0.0.1:7842
 
 DEV_PG_URL := postgresql+asyncpg://wikimind:wikimind@localhost:5433/wikimind
+AUTH_MULTIUSER_TESTS := \
+	tests/unit/test_auth.py \
+	tests/unit/test_endpoint_user_id.py \
+	tests/unit/test_linter_user_scoping.py \
+	tests/unit/test_wikilink_user_scoping.py \
+	tests/unit/test_user_scoping.py \
+	tests/unit/test_query_service.py \
+	tests/unit/test_services.py
+POSTGRES_INTEGRATION_TESTS := tests/integration/test_postgres_integration.py
 
 .PHONY: pg-up
 pg-up: ## Start local Postgres (docker-compose.dev.yml, port 5433)
@@ -323,6 +332,18 @@ test-unit: ## Run unit tests only
 .PHONY: test-integration
 test-integration: ## Run integration tests only
 	$(BIN)/pytest tests/integration -v
+
+.PHONY: test-auth-multiuser
+test-auth-multiuser: ## Run focused auth and multi-user regression tests
+	WIKIMIND_LLM__MOCK__ENABLED=$${WIKIMIND_LLM__MOCK__ENABLED:-true} \
+	WIKIMIND_LLM__DEFAULT_PROVIDER=$${WIKIMIND_LLM__DEFAULT_PROVIDER:-mock} \
+	$(BIN)/pytest $(AUTH_MULTIUSER_TESTS) -q
+
+.PHONY: test-postgres-integration
+test-postgres-integration: ## Run PostgreSQL-backed integration regression tests
+	WIKIMIND_DATABASE_URL=$${WIKIMIND_DATABASE_URL:-$(DEV_PG_URL)} \
+	WIKIMIND_TEST_POSTGRES_URL=$${WIKIMIND_TEST_POSTGRES_URL:-$${WIKIMIND_DATABASE_URL:-$(DEV_PG_URL)}} \
+	$(BIN)/pytest $(POSTGRES_INTEGRATION_TESTS) -m postgres -v
 
 .PHONY: coverage
 coverage: ## Run tests with coverage report and HTML output

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make test` | Run unit + integration tests with pytest |
 | `make test-unit` | Run unit tests only |
 | `make test-integration` | Run integration tests only |
+| `make test-auth-multiuser` | Run focused auth and multi-user regression tests |
+| `make test-postgres-integration` | Run PostgreSQL-backed integration regression tests |
 | `make coverage` | Run tests with coverage report and HTML output |
 | `make test-matrix` | Show how to run the LLM × document type benchmark |
 

--- a/docs/docs/development/ci-cd.md
+++ b/docs/docs/development/ci-cd.md
@@ -6,6 +6,11 @@ WikiMind uses GitHub Actions for continuous integration and deployment.
 
 The CI pipeline runs on every pull request and push to `main`.
 
+In addition to the broad lint, unit, and e2e workflows, CI now has two focused backend regression lanes:
+
+- `auth-and-multiuser` runs the auth, endpoint dependency, and ownership/isolation regression subset via `make test-auth-multiuser`
+- `postgres-integration` provisions PostgreSQL and runs the dedicated Postgres regression suite via `make test-postgres-integration`
+
 ### Quality Gates
 
 The following checks must pass before merging:
@@ -18,6 +23,8 @@ The following checks must pass before merging:
 | Pyright | `make pyright` | basedpyright type checking |
 | Docstyle | `make docstyle` | pydocstyle docstring checks |
 | Tests | `make coverage-check` | pytest with 80% coverage threshold |
+| Auth & multi-user | `make test-auth-multiuser` | Focused auth, dependency wiring, and user-isolation regressions |
+| Postgres integration | `make test-postgres-integration` | PostgreSQL-backed integration regression suite |
 | Frontend | `make frontend-verify` | ESLint + TypeScript + build |
 | Desktop | `make desktop-verify` | Electron typecheck + build |
 | Doc sync | `make check-docs` | Verify generated docs are in sync |

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -580,10 +580,16 @@ async def _backfill_concepts_from_articles(engine) -> None:
                 concept_id = str(uuid.uuid4())
                 await conn.execute(
                     sa_text(
-                        "INSERT INTO concept (id, name, description, article_count, created_at) "
-                        "VALUES (:id, :name, :desc, 0, :created_at)"
+                        "INSERT INTO concept (id, name, description, article_count, created_at, concept_kind) "
+                        "VALUES (:id, :name, :desc, 0, :created_at, :concept_kind)"
                     ),
-                    {"id": concept_id, "name": normalized, "desc": raw_name, "created_at": utcnow_naive().isoformat()},
+                    {
+                        "id": concept_id,
+                        "name": normalized,
+                        "desc": raw_name,
+                        "created_at": utcnow_naive(),
+                        "concept_kind": "topic",
+                    },
                 )
 
         # Recalculate article counts


### PR DESCRIPTION
## Summary
- add dedicated `Auth & Multi-user` and `Postgres integration` workflows
- add focused `make test-auth-multiuser` and `make test-postgres-integration` targets
- document the new backend regression lanes in CI docs
- fix Postgres concept backfill inserts in `database.py` so the Postgres suite passes

## Testing
- `uv sync --frozen --extra dev`
- `make test-auth-multiuser`
- `make test-postgres-integration`

Closes #364