### PR TITLE
ci: add full-verify workflow and pin basedpyright tooling (#365)

### DIFF
--- a/.github/workflows/full-verify.yml
+++ b/.github/workflows/full-verify.yml
@@ -1,0 +1,80 @@
+# ===============================================================
+# ✅  Full Verify — Required Merge Gate
+# ===============================================================
+#
+#   - mirrors local `make verify` as closely as practical
+#   - installs the same Python toolchain plus the Node prerequisites
+#     needed by `pyright`, `desktop-verify`, and `extension-verify`
+#   - keeps the authoritative command in one place by invoking
+#     `make verify` instead of reimplementing its steps in YAML
+# ---------------------------------------------------------------
+
+name: Full Verify
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  full-verify:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: full-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🐍  Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: 📦  Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: ⚙️  Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            apps/desktop/package-lock.json
+            apps/web-extension/package-lock.json
+
+      - name: 📦  Install root Node tooling
+        run: npm ci
+
+      - name: 📦  Install Python dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: 📦  Install desktop dependencies
+        working-directory: apps/desktop
+        run: npm ci
+
+      - name: 📦  Install extension dependencies
+        working-directory: apps/web-extension
+        run: npm ci
+
+      - name: ✅  Run full verify
+        run: make verify

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@
 #
 #   - runs ruff (linter + formatter check) and mypy in parallel
 #   - ruff catches import ordering, style violations, bugbear
+#   - ruff scope matches `make lint` / `make format-check` (`src/` + `tests/`)
 #   - mypy enforces strict type checking with pydantic plugin
 #   - fast — should complete in under 2 minutes
 # ---------------------------------------------------------------
@@ -15,16 +16,20 @@ on:
     branches: ["main"]
     paths:
       - "src/**"
+      - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "Makefile"
       - ".github/workflows/lint.yml"
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
     paths:
       - "src/**"
+      - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "Makefile"
       - ".github/workflows/lint.yml"
 
 concurrency:
@@ -67,10 +72,10 @@ jobs:
         run: uv sync --frozen --extra lint
 
       - name: 🔍  Ruff lint
-        run: uv run ruff check src/
+        run: uv run ruff check src/ tests/
 
       - name: 🎨  Ruff format check
-        run: uv run ruff format --check src/
+        run: uv run ruff format --check src/ tests/
 
   # -----------------------------------------------------------
   # Job 2 — Mypy: strict type checking

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ check-env: check-venv ## Verify Python version, venv hygiene, and required tools
 	@test -f $(BIN)/ruff && echo "✓ ruff: $$($(BIN)/ruff --version)" || echo "✗ ruff not found (run: make install-dev)"
 	@test -f $(BIN)/mypy && echo "✓ mypy: $$($(BIN)/mypy --version)" || echo "✗ mypy not found (run: make install-dev)"
 	@test -f $(BIN)/pylint && echo "✓ pylint: $$($(BIN)/pylint --version | head -1)" || echo "✗ pylint not found (run: make install-dev)"
-	@command -v npx >/dev/null 2>&1 && echo "✓ basedpyright: $$(npx basedpyright --version 2>/dev/null | head -1)" || echo "✗ basedpyright not found (requires Node.js + npx)"
+	@test -x node_modules/.bin/basedpyright && echo "✓ basedpyright: $$(./node_modules/.bin/basedpyright --version | head -1)" || echo "✗ basedpyright not found (run: npm install)"
 	@test -f $(BIN)/pydocstyle && echo "✓ pydocstyle: $$($(BIN)/pydocstyle --version)" || echo "✗ pydocstyle not found (run: make install-dev)"
 	@test -f $(BIN)/pytest && echo "✓ pytest: $$($(BIN)/pytest --version)" || echo "✗ pytest not found (run: make install-dev)"
 
@@ -168,8 +168,8 @@ typecheck: ## Run mypy type checking
 	$(BIN)/mypy src/wikimind
 
 .PHONY: pyright
-pyright: ## Run basedpyright type checking (requires Node.js)
-	@npx basedpyright src/wikimind
+pyright: ## Run basedpyright type checking (requires `npm install` at repo root)
+	@./node_modules/.bin/basedpyright src/wikimind
 
 .PHONY: pylint
 pylint: ## Run pylint static analysis (fails under 9.0/10)
@@ -198,7 +198,7 @@ doc-coverage: ## Measure docstring coverage (fails if below fail-under threshold
 security: bandit vulture ## Run security and dead-code checks
 
 .PHONY: verify
-verify: lint format-check typecheck pyright docstyle coverage-check desktop-verify extension-verify ## Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop + extension)
+verify: lint format-check typecheck pyright docstyle coverage-check desktop-verify extension-verify ## Run the required full-verify suite (Python + desktop + extension; excludes frontend/doc-sync)
 
 .PHONY: coverage-check
 coverage-check: ## Run tests and fail if coverage is under 80%

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make format` | Format source code with ruff |
 | `make format-check` | Check formatting without modifying files |
 | `make typecheck` | Run mypy type checking |
-| `make pyright` | Run basedpyright type checking (requires Node.js) |
+| `make pyright` | Run basedpyright type checking (requires `npm install` at repo root) |
 | `make pylint` | Run pylint static analysis (fails under 9.0/10) |
 | `make docstyle` | Run pydocstyle docstring checks |
 | `make bandit` | Run bandit security scanner |
@@ -264,7 +264,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make dead-code` | Alias for vulture — find unused functions, imports, variables |
 | `make doc-coverage` | Measure docstring coverage (fails if below fail-under threshold) |
 | `make security` | Run security and dead-code checks |
-| `make verify` | Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop + extension) |
+| `make verify` | Run the required full-verify suite (Python + desktop + extension; excludes frontend/doc-sync) |
 | `make coverage-check` | Run tests and fail if coverage is under 80% |
 | `make frontend-install` | Install frontend dependencies |
 | `make frontend-dev` | Start Vite dev server on :5173 |

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make dead-code` | Alias for vulture — find unused functions, imports, variables |
 | `make doc-coverage` | Measure docstring coverage (fails if below fail-under threshold) |
 | `make security` | Run security and dead-code checks |
-| `make verify` | Run the required full-verify suite (lint + format + mypy + pyright + docstyle + coverage + desktop + extension; excludes frontend/doc-sync) |
+| `make verify` | Run the required full-verify suite (Python + desktop + extension; excludes frontend/doc-sync) |
 | `make coverage-check` | Run non-E2E tests with coverage (policy is configured in pyproject.toml) |
 | `make frontend-install` | Install frontend dependencies |
 | `make frontend-dev` | Start Vite dev server on :5173 |

--- a/docs/docs/development/ci-cd.md
+++ b/docs/docs/development/ci-cd.md
@@ -6,6 +6,9 @@ WikiMind uses GitHub Actions for continuous integration and deployment.
 
 The CI pipeline runs on every pull request and push to `main`.
 
+`Full Verify` is the required merge gate. It runs `make verify` in CI so the authoritative verification sequence stays in the `Makefile` instead of being duplicated in workflow YAML.
+It also installs the repo-root Node tooling manifest so `basedpyright` is pinned in-version-controlled metadata instead of being fetched ad hoc via `npx`.
+
 ### Quality Gates
 
 The following checks must pass before merging:
@@ -18,9 +21,16 @@ The following checks must pass before merging:
 | Pyright | `make pyright` | basedpyright type checking |
 | Docstyle | `make docstyle` | pydocstyle docstring checks |
 | Tests | `make coverage-check` | pytest with 80% coverage threshold |
-| Frontend | `make frontend-verify` | ESLint + TypeScript + build |
 | Desktop | `make desktop-verify` | Electron typecheck + build |
+| Extension | `make extension-verify` | Browser extension typecheck + build |
+| Frontend | `make frontend-verify` | ESLint + TypeScript + build |
 | Doc sync | `make check-docs` | Verify generated docs are in sync |
+
+### Required vs supplemental workflows
+
+- Required: `Full Verify` runs `make verify` and therefore covers `make lint`, `make format-check`, `make typecheck`, `make pyright`, `make docstyle`, `make coverage-check`, `make desktop-verify`, and `make extension-verify`.
+- Supplemental: `Lint & Static Analysis`, `Tests & Coverage`, `Pre-commit Checks`, and the docs/smoke/e2e workflows still provide faster or more specialized feedback, but they are not the canonical definition of the full verify suite.
+- Intentional scope difference: `make verify` does not include `make frontend-verify` or `make check-docs`, so those remain separate CI checks rather than being folded into the required gate.
 
 ### Mock Provider for CI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "@wikimind/tooling",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wikimind/tooling",
+      "version": "0.1.0",
+      "devDependencies": {
+        "basedpyright": "1.31.4"
+      }
+    },
+    "node_modules/basedpyright": {
+      "version": "1.31.4",
+      "resolved": "https://registry.npmjs.org/basedpyright/-/basedpyright-1.31.4.tgz",
+      "integrity": "sha512-XEOnntpRezNC4tj+6cZXT/Zy7QcxTZox2tr11I7MvIFHUQcuPNUzLyCxP2eNjuPtBaw01C66CeGaNjOSnPOFSA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "basedpyright": "index.js",
+        "basedpyright-langserver": "langserver.index.js",
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@wikimind/tooling",
+  "private": true,
+  "version": "0.1.0",
+  "devDependencies": {
+    "basedpyright": "1.31.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add a required `Full Verify` workflow that runs `make verify`
- widen `lint.yml` so Ruff checks `tests/` as well as `src/`
- pin `basedpyright` in a repo-root Node manifest and lockfile
- update `make pyright` and CI docs to use the pinned local toolchain

## Testing
- `npm ci`
- `./node_modules/.bin/basedpyright --version`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/full-verify.yml"); YAML.load_file(".github/workflows/lint.yml")'`
- `make -n verify`
- `git diff --check`

Closes #365