### PR TITLE
ci: add nightly runs and codecov coverage enforcement (#366)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,293 @@
+name: Nightly full-stack
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  backend-coverage:
+    name: backend tests + coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🐍  Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: 📦  Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: 📦  Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: 🧪  Run backend coverage suite
+        run: make coverage-ci
+
+      - name: 📤  Upload HTML coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-coverage-report
+          path: htmlcov/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: 📈  Codecov upload
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: backend
+          name: nightly-backend-py312
+          fail_ci_if_error: false
+          use_oidc: true
+
+  postgres-integration:
+    name: Postgres integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: wikimind_test
+          POSTGRES_USER: wikimind
+          POSTGRES_PASSWORD: wikimind
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U wikimind -d wikimind_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      WIKIMIND_TEST_POSTGRES_URL: postgresql+asyncpg://wikimind:wikimind@127.0.0.1:5432/wikimind_test
+
+    steps:
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🐍  Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: 📦  Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: 📦  Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: 🧪  Run Postgres integration tests
+        run: make test-postgres-ci
+
+  e2e:
+    name: Playwright e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      WIKIMIND_LLM__MOCK__ENABLED: "true"
+      WIKIMIND_LLM__DEFAULT_PROVIDER: "mock"
+      WIKIMIND_DATA_DIR: "/tmp/wikimind-e2e"
+
+    steps:
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🐍  Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: 📦  Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: 📦  Install Python dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: ⚙️  Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: 📦  Install frontend dependencies
+        working-directory: apps/web
+        run: npm ci
+
+      - name: 🎭  Install Playwright browsers
+        working-directory: apps/web
+        run: npx playwright install --with-deps chromium
+
+      - name: 🚀  Start backend
+        run: |
+          uv run python -m uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 &
+          echo "Waiting for backend to become ready..."
+          for i in {1..60}; do
+            if curl -sf http://127.0.0.1:7842/docs > /dev/null 2>&1; then
+              echo "Backend ready after ${i}s"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "❌ Backend failed to start within 60s"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: 🌱  Seed wiki with fixture article
+        run: |
+          curl -sf -X POST http://127.0.0.1:7842/ingest/text \
+            -H "Content-Type: application/json" \
+            -d '{"content":"WikiMind is a personal LLM-powered knowledge OS that ingests sources, compiles them into wiki articles, and answers questions against the wiki. It closes the Karpathy loop by filing conversations back into the wiki as new articles.","title":"WikiMind Overview","auto_compile":true}'
+          echo ""
+          echo "Waiting for in-process compile to complete..."
+          for i in {1..30}; do
+            count=$(curl -sf http://127.0.0.1:7842/wiki/articles | python3 -c "import sys, json; print(len(json.load(sys.stdin)))")
+            if [ "$count" -gt 0 ]; then
+              echo "Wiki seeded with ${count} article(s) after ${i}s"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "❌ No article appeared in the wiki within 30s of ingest"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: 🎯  Run Playwright e2e
+        working-directory: apps/web
+        env:
+          CI: "true"
+        run: npm run e2e
+
+      - name: 📤  Upload Playwright HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: 📤  Upload Playwright test-results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-playwright-test-results
+          path: apps/web/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  smoke:
+    name: Docker smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🐍  Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: 📦  Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: 📦  Install test dependencies
+        run: uv sync --frozen --extra test
+
+      - name: 🔧  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🧪  Run Docker smoke tests
+        run: |
+          uv run pytest tests/smoke/ \
+            -m e2e \
+            -v \
+            --timeout=600 \
+            -x
+
+      - name: 📤  Capture container logs on failure
+        if: failure()
+        run: |
+          docker logs wikimind-smoke-test 2>&1 || echo "No container logs available"
+          docker logs wikimind-smoke-test-auth 2>&1 || echo "No auth container logs available"
+
+  security:
+    name: Security scans
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - name: ⬇️  Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🐍  Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: 📦  Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: 📦  Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: 🔒  Run Bandit
+        run: make security-check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           POSTGRES_DB: wikimind_test
           POSTGRES_USER: wikimind
-          POSTGRES_PASSWORD: wikimind
+          POSTGRES_PASSWORD: wikimind # pragma: allowlist secret
         ports:
           - 5432:5432
         options: >-
@@ -86,7 +86,7 @@ jobs:
     env:
       PYTHONUNBUFFERED: "1"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
-      WIKIMIND_TEST_POSTGRES_URL: postgresql+asyncpg://wikimind:wikimind@127.0.0.1:5432/wikimind_test
+      WIKIMIND_TEST_POSTGRES_URL: postgresql+asyncpg://wikimind:wikimind@127.0.0.1:5432/wikimind_test # pragma: allowlist secret
 
     steps:
       - name: ⬇️  Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,10 @@
 # 🧪  PyTest & Coverage — Quality Gate
 # ===============================================================
 #
-#   - runs the full test-suite across Python 3.11 and 3.12
-#   - measures branch + line coverage (fails < 60%)
+#   - runs the backend test suite on Python 3.12
+#   - measures branch + line coverage (fails < 80%)
 #   - uploads the HTML coverage report as a build artifact
+#   - uploads coverage to Codecov on pushes and PRs so patch coverage is reported
 #   - executes on every push / PR to *main*
 # ---------------------------------------------------------------
 
@@ -18,6 +19,8 @@ on:
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "Makefile"
+      - "codecov.yml"
       - ".github/workflows/test.yml"
   pull_request:
     types: [opened, synchronize, ready_for_review]
@@ -27,6 +30,8 @@ on:
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "Makefile"
+      - "codecov.yml"
       - ".github/workflows/test.yml"
 
 concurrency:
@@ -35,6 +40,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -83,19 +89,10 @@ jobs:
         run: uv sync --frozen --extra dev
 
       # -----------------------------------------------------------
-      # 3️⃣  Run the tests with coverage (fail under 40%)
+      # 3️⃣  Run the tests with coverage (fail under 80%)
       # -----------------------------------------------------------
       - name: 🧪  Run pytest
-        run: |
-          uv run pytest \
-            -m "not e2e" \
-            --cov=wikimind \
-            --cov-branch \
-            --cov-report=term-missing \
-            --cov-report=html:htmlcov \
-            --cov-report=xml:coverage.xml \
-            --cov-fail-under=40 \
-            -v
+        run: make coverage-ci
 
       # -----------------------------------------------------------
       # 4️⃣  Upload coverage artifacts (HTML report)
@@ -110,13 +107,14 @@ jobs:
           if-no-files-found: ignore
 
       # -----------------------------------------------------------
-      # 5️⃣  Upload coverage to Codecov (main branch only)
+      # 5️⃣  Upload coverage to Codecov (push + PR for project/patch status)
       # -----------------------------------------------------------
       - name: 📈  Codecov upload
-        if: matrix.python == '3.12' && github.event_name == 'push'
-        uses: codecov/codecov-action@v4
+        if: matrix.python == '3.12'
+        uses: codecov/codecov-action@v5
         with:
-          file: coverage.xml
+          files: coverage.xml
+          flags: backend
+          name: backend-py312
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true

--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,25 @@ security: bandit vulture ## Run security and dead-code checks
 .PHONY: verify
 verify: lint format-check typecheck pyright docstyle coverage-check desktop-verify extension-verify ## Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop + extension)
 
+.PHONY: coverage-ci
+coverage-ci: ## Run backend CI tests with terminal, HTML, and XML coverage outputs
+	$(BIN)/pytest \
+		-m "not e2e and not postgres" \
+		--cov=wikimind \
+		--cov-branch \
+		--cov-report=term-missing \
+		--cov-report=html:htmlcov \
+		--cov-report=xml:coverage.xml \
+		--cov-fail-under=80 \
+		-v
+
 .PHONY: coverage-check
 coverage-check: ## Run tests and fail if coverage is under 80%
 	$(BIN)/pytest --cov=wikimind --cov-report=term-missing --cov-fail-under=80
+
+.PHONY: security-check
+security-check: ## Run the scheduled CI security scan set
+	$(BIN)/bandit -r src/wikimind -c pyproject.toml
 
 .PHONY: frontend-install
 frontend-install: ## Install frontend dependencies
@@ -323,6 +339,10 @@ test-unit: ## Run unit tests only
 .PHONY: test-integration
 test-integration: ## Run integration tests only
 	$(BIN)/pytest tests/integration -v
+
+.PHONY: test-postgres-ci
+test-postgres-ci: ## Run Postgres-only integration tests (requires WIKIMIND_TEST_POSTGRES_URL)
+	$(BIN)/pytest tests/integration/test_postgres_integration.py -m postgres -v
 
 .PHONY: coverage
 coverage: ## Run tests with coverage report and HTML output

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make doc-coverage` | Measure docstring coverage (fails if below fail-under threshold) |
 | `make security` | Run security and dead-code checks |
 | `make verify` | Run all checks (lint + format + mypy + pyright + docstyle + coverage + desktop + extension) |
+| `make coverage-ci` | Run backend CI tests with terminal, HTML, and XML coverage outputs |
 | `make coverage-check` | Run tests and fail if coverage is under 80% |
+| `make security-check` | Run the scheduled CI security scan set |
 | `make frontend-install` | Install frontend dependencies |
 | `make frontend-dev` | Start Vite dev server on :5173 |
 | `make frontend-build` | Build frontend production bundle |
@@ -317,6 +319,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | `make test` | Run unit + integration tests with pytest |
 | `make test-unit` | Run unit tests only |
 | `make test-integration` | Run integration tests only |
+| `make test-postgres-ci` | Run Postgres-only integration tests (requires WIKIMIND_TEST_POSTGRES_URL) |
 | `make coverage` | Run tests with coverage report and HTML output |
 | `make test-matrix` | Show how to run the LLM × document type benchmark |
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        if_ci_failed: error
+        flags:
+          - backend
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error
+        only_pulls: true
+        flags:
+          - backend
+
+comment:
+  layout: "reach,diff,flags,files"
+  require_changes: true
+  show_carryforward_flags: false

--- a/docs/docs/development/ci-cd.md
+++ b/docs/docs/development/ci-cd.md
@@ -4,7 +4,7 @@ WikiMind uses GitHub Actions for continuous integration and deployment.
 
 ## CI Pipeline
 
-The CI pipeline runs on every pull request and push to `main`.
+The primary CI pipeline runs on every pull request and push to `main`.
 
 ### Quality Gates
 
@@ -17,7 +17,7 @@ The following checks must pass before merging:
 | Type check | `make typecheck` | mypy static type checking |
 | Pyright | `make pyright` | basedpyright type checking |
 | Docstyle | `make docstyle` | pydocstyle docstring checks |
-| Tests | `make coverage-check` | pytest with 80% coverage threshold |
+| Tests | `make coverage-ci` | backend pytest suite with HTML + XML coverage artifacts and an 80% repo floor in CI |
 | Frontend | `make frontend-verify` | ESLint + TypeScript + build |
 | Desktop | `make desktop-verify` | Electron typecheck + build |
 | Doc sync | `make check-docs` | Verify generated docs are in sync |
@@ -32,6 +32,34 @@ WIKIMIND_LLM__DEFAULT_PROVIDER=mock
 ```
 
 The mock provider returns deterministic JSON responses for compile, Q&A, and lint operations.
+
+## Nightly Full-Stack Workflow
+
+The `nightly.yml` workflow runs every day at `06:00 UTC` and can also be started manually with `workflow_dispatch`.
+
+Nightly covers the runtime and integration surfaces that path-filtered PR CI can miss:
+
+- backend coverage run via `make coverage-ci`
+- PostgreSQL integration tests via `make test-postgres-ci`
+- Playwright end-to-end coverage of the web app against the FastAPI backend
+- Docker smoke tests against the production image
+- Bandit security scanning via `make security-check`
+
+This workflow is intentionally broader than PR CI because its job is drift detection: dependency breakage, runtime regressions, and environment-sensitive failures that may not be exercised by a narrow diff-triggered workflow.
+
+## Coverage Gates
+
+WikiMind now uses two separate coverage guardrails:
+
+- Total backend coverage: the GitHub Actions backend test job still enforces a repository-wide floor via `make coverage-ci`.
+- Changed-code coverage: Codecov receives the same `coverage.xml` upload on both pushes and pull requests, and `codecov.yml` defines a `codecov/patch` status for PRs.
+
+Current Codecov policy:
+
+- `codecov/project`: tracks overall backend coverage for the uploaded `backend` flag and allows a small 1% drop threshold.
+- `codecov/patch`: requires `80%` coverage on changed backend lines in pull requests.
+
+To make patch coverage a required merge gate, add the `codecov/patch` status check to the repository branch protection rules for `main`.
 
 ## Pre-Commit Hooks
 
@@ -79,5 +107,6 @@ The documentation site is built and deployed to GitHub Pages via the `docs.yml` 
 The project uses:
 
 - **bandit** for Python security scanning (`make bandit`)
+- a nightly Bandit run in `.github/workflows/nightly.yml`
 - **vulture** for dead code detection (`make vulture`)
 - Pinned dependencies via `uv.lock` for reproducible builds


### PR DESCRIPTION
## Summary
- add a nightly full-stack workflow covering backend coverage, Postgres integration, e2e, smoke, and security scans
- upload coverage to Codecov on PRs and pushes with OIDC
- add a repo `codecov.yml` with project and patch coverage settings
- add CI-oriented Make targets for coverage, Postgres, and security jobs

## Testing
- `uv sync --frozen --extra dev`
- `make coverage-ci`
- `make -n test-postgres-ci`
- `make -n security-check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml"); YAML.load_file(".github/workflows/test.yml")'`
- `git diff --check`

Closes #366