### PR TITLE
fix: pass user_id to ConceptCompiler for BYOK key resolution

### DIFF
--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -223,7 +223,7 @@ async def maybe_trigger_concept_pages(
         return []
     from wikimind.engine.concept_compiler import ConceptCompiler  # noqa: PLC0415
 
-    compiler = ConceptCompiler()
+    compiler = ConceptCompiler(user_id=user_id)
     compiled: list[str] = []
     for concept in eligible:
         try:


### PR DESCRIPTION
## Summary

- `maybe_trigger_concept_pages()` correctly filters concepts by `user_id` but constructed `ConceptCompiler()` without passing it
- The LLM router call at `concept_compiler.py:205` used `user_id=None`, so BYOK key lookup would fail for authenticated users

One-line fix: `ConceptCompiler()` → `ConceptCompiler(user_id=user_id)`

## Test plan
- [x] 915 tests pass
- [x] `make lint` clean
- [x] `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)