### PR TITLE
fix: scope CostLog by user_id + store relative file paths (#344, #345)

### DIFF
--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -295,7 +295,7 @@ class LLMRouter:
         except Exception:
             log.debug("Failed to set budget flag in Redis", flag=flag_name)
 
-    async def _check_budget(self, user_id: str | None = None) -> None:
+    async def _check_budget(self, user_id: str) -> None:
         """Check monthly budget and emit warnings if thresholds are exceeded."""
         current_month = utcnow_naive()
         month_key = (current_month.year, current_month.month)
@@ -353,7 +353,7 @@ class LLMRouter:
         model: str,
         task_type: TaskType,
         response: CompletionResponse,
-        user_id: str | None = None,
+        user_id: str,
     ) -> None:
         """Write a CostLog entry in an independent session."""
         cost_entry = CostLog(
@@ -412,9 +412,6 @@ class LLMRouter:
                 instance = await self._get_provider_instance(provider, api_key_override=user_key)
                 response = await instance.complete(request, model)
 
-                # Log cost in independent session
-                await self._log_cost(provider, model, request.task_type, response, user_id=user_id)
-
                 log.info(
                     "LLM call complete",
                     provider=provider,
@@ -422,13 +419,19 @@ class LLMRouter:
                     latency_ms=response.latency_ms,
                 )
 
-                def _log_budget_error(t: asyncio.Task) -> None:
-                    if not t.cancelled():
-                        exc = t.exception()
-                        if exc:
-                            log.warning("budget check failed", error=str(exc))
+                # Cost logging and budget checks require user_id (#381)
+                if user_id:
+                    await self._log_cost(provider, model, request.task_type, response, user_id=user_id)
 
-                task = asyncio.create_task(self._check_budget(user_id=user_id))
+                    def _log_budget_error(t: asyncio.Task) -> None:
+                        if not t.cancelled():
+                            exc = t.exception()
+                            if exc:
+                                log.warning("budget check failed", error=str(exc))
+
+                    task = asyncio.create_task(self._check_budget(user_id=user_id))
+                else:
+                    log.warning("LLM call without user_id — cost not logged")
                 task.add_done_callback(_log_budget_error)
                 return response
 
@@ -505,15 +508,17 @@ class LLMRouter:
                     temperature=temperature,
                 )
 
-                # Log cost in independent session
-                await self._log_cost(provider, model, task_type, response, user_id=user_id)
-
                 log.info(
                     "LLM multimodal call complete",
                     provider=provider,
                     cost_usd=response.cost_usd,
                     latency_ms=response.latency_ms,
                 )
+
+                if user_id:
+                    await self._log_cost(provider, model, task_type, response, user_id=user_id)
+                else:
+                    log.warning("LLM multimodal call without user_id — cost not logged")
                 return response
 
             except Exception as e:  # TODO: narrow once provider error hierarchy is unified

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -295,7 +295,7 @@ class LLMRouter:
         except Exception:
             log.debug("Failed to set budget flag in Redis", flag=flag_name)
 
-    async def _check_budget(self, user_id: str) -> None:
+    async def _check_budget(self, user_id: str | None = None) -> None:
         """Check monthly budget and emit warnings if thresholds are exceeded."""
         current_month = utcnow_naive()
         month_key = (current_month.year, current_month.month)
@@ -353,7 +353,7 @@ class LLMRouter:
         model: str,
         task_type: TaskType,
         response: CompletionResponse,
-        user_id: str,
+        user_id: str | None = None,
     ) -> None:
         """Write a CostLog entry in an independent session."""
         cost_entry = CostLog(
@@ -412,6 +412,9 @@ class LLMRouter:
                 instance = await self._get_provider_instance(provider, api_key_override=user_key)
                 response = await instance.complete(request, model)
 
+                # Log cost in independent session
+                await self._log_cost(provider, model, request.task_type, response, user_id=user_id)
+
                 log.info(
                     "LLM call complete",
                     provider=provider,
@@ -419,19 +422,13 @@ class LLMRouter:
                     latency_ms=response.latency_ms,
                 )
 
-                # Cost logging and budget checks require user_id (#381)
-                if user_id:
-                    await self._log_cost(provider, model, request.task_type, response, user_id=user_id)
+                def _log_budget_error(t: asyncio.Task) -> None:
+                    if not t.cancelled():
+                        exc = t.exception()
+                        if exc:
+                            log.warning("budget check failed", error=str(exc))
 
-                    def _log_budget_error(t: asyncio.Task) -> None:
-                        if not t.cancelled():
-                            exc = t.exception()
-                            if exc:
-                                log.warning("budget check failed", error=str(exc))
-
-                    task = asyncio.create_task(self._check_budget(user_id=user_id))
-                else:
-                    log.warning("LLM call without user_id — cost not logged")
+                task = asyncio.create_task(self._check_budget(user_id=user_id))
                 task.add_done_callback(_log_budget_error)
                 return response
 
@@ -508,17 +505,15 @@ class LLMRouter:
                     temperature=temperature,
                 )
 
+                # Log cost in independent session
+                await self._log_cost(provider, model, task_type, response, user_id=user_id)
+
                 log.info(
                     "LLM multimodal call complete",
                     provider=provider,
                     cost_usd=response.cost_usd,
                     latency_ms=response.latency_ms,
                 )
-
-                if user_id:
-                    await self._log_cost(provider, model, task_type, response, user_id=user_id)
-                else:
-                    log.warning("LLM multimodal call without user_id — cost not logged")
                 return response
 
             except Exception as e:  # TODO: narrow once provider error hierarchy is unified

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -295,7 +295,7 @@ class LLMRouter:
         except Exception:
             log.debug("Failed to set budget flag in Redis", flag=flag_name)
 
-    async def _check_budget(self) -> None:
+    async def _check_budget(self, user_id: str | None = None) -> None:
         """Check monthly budget and emit warnings if thresholds are exceeded."""
         current_month = utcnow_naive()
         month_key = (current_month.year, current_month.month)
@@ -318,9 +318,11 @@ class LLMRouter:
         else:
             start_of_month = current_month.replace(day=1, hour=0, minute=0, second=0)
             async with get_session_factory()() as session:
-                result = await session.execute(
-                    select(func.sum(CostLog.cost_usd)).where(CostLog.created_at >= start_of_month)
+                stmt = select(func.sum(CostLog.cost_usd)).where(
+                    CostLog.created_at >= start_of_month,
+                    CostLog.user_id == user_id,
                 )
+                result = await session.execute(stmt)
                 spend = result.scalar() or 0.0
             self._cached_spend = spend
             self._cache_expires_at = now + self.settings.llm.budget_check_cache_seconds
@@ -351,6 +353,7 @@ class LLMRouter:
         model: str,
         task_type: TaskType,
         response: CompletionResponse,
+        user_id: str | None = None,
     ) -> None:
         """Write a CostLog entry in an independent session."""
         cost_entry = CostLog(
@@ -361,6 +364,7 @@ class LLMRouter:
             output_tokens=response.output_tokens,
             cost_usd=response.cost_usd,
             latency_ms=response.latency_ms,
+            user_id=user_id,
         )
         try:
             async with get_session_factory()() as cost_session:
@@ -409,7 +413,7 @@ class LLMRouter:
                 response = await instance.complete(request, model)
 
                 # Log cost in independent session
-                await self._log_cost(provider, model, request.task_type, response)
+                await self._log_cost(provider, model, request.task_type, response, user_id=user_id)
 
                 log.info(
                     "LLM call complete",
@@ -424,7 +428,7 @@ class LLMRouter:
                         if exc:
                             log.warning("budget check failed", error=str(exc))
 
-                task = asyncio.create_task(self._check_budget())
+                task = asyncio.create_task(self._check_budget(user_id=user_id))
                 task.add_done_callback(_log_budget_error)
                 return response
 
@@ -502,7 +506,7 @@ class LLMRouter:
                 )
 
                 # Log cost in independent session
-                await self._log_cost(provider, model, task_type, response)
+                await self._log_cost(provider, model, task_type, response, user_id=user_id)
 
                 log.info(
                     "LLM multimodal call complete",

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -459,6 +459,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                 output_tokens=resp.output_tokens,
                 cost_usd=resp.cost_usd,
                 latency_ms=resp.latency_ms,
+                user_id=user_id,
             )
             session.add(cost_entry)
             await session.commit()

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -627,7 +627,7 @@ class QueryService:
         article = Article(
             slug=slug,
             title=effective_title,
-            file_path=str(file_path),
+            file_path=f"qa-answers/{slug}.md",
             summary=(selected_turns[0].query.answer[:200] if selected_turns else None),
             confidence=None,
             page_type=PageType.ANSWER,

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -22,6 +22,7 @@ from wikimind.models import (
     TurnSelection,
 )
 from wikimind.services.query import QueryService, _build_citations, _sanitize_filename
+from wikimind.storage import resolve_wiki_path
 
 
 async def _seed(db_session, tmp_path: Path) -> tuple[Query, Article, Source]:
@@ -422,7 +423,8 @@ class TestFileBackSelection:
         # Verify the article was created on disk
         article = await db_session.get(Article, article_data["id"])
         assert article is not None
-        content = Path(article.file_path).read_text(encoding="utf-8")
+        resolved = resolve_wiki_path(article.file_path)
+        content = resolved.read_text(encoding="utf-8")
         assert "## Q1: Q1 from thread 1" in content
         assert "## Q2: Q3 from thread 1" in content
         # Q2 from thread 1 (turn_index=1) should NOT be present
@@ -446,7 +448,8 @@ class TestFileBackSelection:
         assert article_data["title"] == "Merged Research"
 
         article = await db_session.get(Article, article_data["id"])
-        content = Path(article.file_path).read_text(encoding="utf-8")
+        resolved = resolve_wiki_path(article.file_path)
+        content = resolved.read_text(encoding="utf-8")
         assert "# Merged Research" in content
         assert "## Q1: Q1 from thread 1" in content
         assert "## Q2: Q1 from thread 2" in content
@@ -528,7 +531,8 @@ class TestFileBackSelection:
 
         assert result["article"]["title"] == "My Custom Title"
         article = await db_session.get(Article, result["article"]["id"])
-        content = Path(article.file_path).read_text(encoding="utf-8")
+        resolved = resolve_wiki_path(article.file_path)
+        content = resolved.read_text(encoding="utf-8")
         assert "# My Custom Title" in content
 
 

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -34,6 +34,7 @@ from wikimind.services.wiki_index import (
     generate_meta_health_page,
     regenerate_index_md,
 )
+from wikimind.storage import resolve_wiki_path
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -322,10 +323,12 @@ class TestFileBackSelectionPathScoping:
         )
         article_info = result["article"]
 
-        # Verify the article's file was written under wiki/alice/qa-answers/
+        # Verify the article stores a relative path and resolves under wiki/alice/
         art_result = await db_session.execute(select(Article).where(Article.id == article_info["id"]))
         article = art_result.scalar_one()
-        assert "alice" in article.file_path or "/alice/" in article.file_path
+        assert article.file_path.startswith("qa-answers/")
+        resolved = resolve_wiki_path(article.file_path, user_id="alice")
+        assert "/alice/" in str(resolved)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two remaining multi-user scoping gaps from Epic #337:

- **CostLog budget check (#344):** `_log_cost()` created entries without `user_id`, and `_check_budget()` summed all users' costs globally. Now both are scoped per-user. Also fixed the streaming Q&A path in `qa_agent.py` which had the same issue.
- **Relative file paths (#345):** `query.py` `file_back_selection` stored absolute paths (`/data/wiki/user123/qa-answers/abc.md`). Changed to relative `qa-answers/{slug}.md`, consistent with `qa_agent.py`.

## Test plan

- [x] `make lint` — passes
- [x] `make typecheck` — passes  
- [x] `make test` — 915 passed (20 Docker smoke errors are pre-existing, unrelated)
- [ ] Manual: compile an article, check CostLog row has `user_id` populated
- [ ] Manual: file back a Q&A answer, check `Article.file_path` is relative not absolute

Closes #344, closes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)