### PR TITLE
fix: auto-generate JWT secret for BYOK in single-user mode (#383)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -206,14 +206,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 382
+        "line_number": 412
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 406
+        "line_number": 436
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -269,5 +269,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-26T16:02:18Z"
+  "generated_at": "2026-04-30T00:18:43Z"
 }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import re
+import secrets
 from functools import lru_cache
 from pathlib import Path
 
@@ -349,6 +350,34 @@ class Settings(BaseSettings):
         )
 
 
+def _ensure_jwt_secret(settings: Settings) -> None:
+    """Auto-generate a stable JWT secret when auth is disabled (single-user mode).
+
+    When ``auth.enabled`` is False and no ``jwt_secret_key`` is configured,
+    BYOK key encryption would fail because there's no secret to derive the
+    Fernet key from.  This helper loads a persisted secret from the data
+    directory (``{data_dir}/.jwt_secret``), or generates and saves one if
+    it doesn't exist.  The secret survives server restarts so encrypted
+    BYOK keys remain readable.
+    """
+    if settings.auth.enabled or settings.auth.jwt_secret_key:
+        return
+
+    secret_path = Path(settings.data_dir) / ".jwt_secret"
+    if secret_path.exists():
+        stored = secret_path.read_text().strip()
+        if stored:
+            settings.auth.jwt_secret_key = stored
+            log.info("loaded auto-generated JWT secret", path=str(secret_path))
+            return
+
+    generated = secrets.token_hex(32)
+    secret_path.parent.mkdir(parents=True, exist_ok=True)
+    secret_path.write_text(generated)
+    settings.auth.jwt_secret_key = generated
+    log.info("generated JWT secret for single-user BYOK", path=str(secret_path))
+
+
 def _reconcile_providers(settings: Settings) -> None:
     """Auto-enable providers with keys; warn about enabled ones without."""
     for name, (_field, raw_env) in _PROVIDER_KEY_FIELDS.items():
@@ -366,6 +395,7 @@ def get_settings() -> Settings:
     """Load and return application settings (cached singleton)."""
     settings = Settings()
     settings.ensure_dirs()
+    _ensure_jwt_secret(settings)
     _reconcile_providers(settings)
     return settings
 

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -226,8 +226,10 @@ class TestAPIRoutes:
         )
         assert resp.status_code == 400
 
-    async def test_set_key_without_jwt_secret(self, client: AsyncClient, monkeypatch):
-        """PUT returns 500 with descriptive error when JWT_SECRET_KEY is missing."""
+    async def test_set_key_works_without_explicit_jwt_secret(
+        self, client: AsyncClient, monkeypatch
+    ):
+        """PUT succeeds when JWT_SECRET_KEY is not set — auto-generated in single-user mode."""
         monkeypatch.setenv("WIKIMIND_AUTH__JWT_SECRET_KEY", "")
         get_settings.cache_clear()
         try:
@@ -235,8 +237,8 @@ class TestAPIRoutes:
                 "/api/settings/api-keys/openai",
                 json={"api_key": "sk-test-key-1234"},  # pragma: allowlist secret
             )
-            assert resp.status_code == 500
-            assert "JWT_SECRET_KEY" in resp.json()["detail"]
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
         finally:
             get_settings.cache_clear()
 

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -226,9 +226,7 @@ class TestAPIRoutes:
         )
         assert resp.status_code == 400
 
-    async def test_set_key_works_without_explicit_jwt_secret(
-        self, client: AsyncClient, monkeypatch
-    ):
+    async def test_set_key_works_without_explicit_jwt_secret(self, client: AsyncClient, monkeypatch):
         """PUT succeeds when JWT_SECRET_KEY is not set — auto-generated in single-user mode."""
         monkeypatch.setenv("WIKIMIND_AUTH__JWT_SECRET_KEY", "")
         get_settings.cache_clear()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,7 @@
 import keyring
 import pytest
 
-from wikimind.config import Settings, _reconcile_providers, get_settings
+from wikimind.config import Settings, _ensure_jwt_secret, _reconcile_providers, get_settings
 
 
 @pytest.fixture(autouse=True)
@@ -231,3 +231,53 @@ class TestDatabaseUrlRewrite:
     def test_sqlite_default_when_no_env(self):
         s = Settings()
         assert "sqlite+aiosqlite" in s.database_url
+
+
+class TestEnsureJwtSecret:
+    """Auto-generate JWT secret for BYOK when auth is disabled (issue #383)."""
+
+    def test_generates_secret_when_auth_disabled_and_no_key(self, tmp_path):
+        """When auth.enabled=False and jwt_secret_key is empty, a secret is generated."""
+        s = Settings(data_dir=str(tmp_path))
+        s.auth.enabled = False
+        s.auth.jwt_secret_key = ""
+        _ensure_jwt_secret(s)
+        assert s.auth.jwt_secret_key != ""
+        assert len(s.auth.jwt_secret_key) == 64  # token_hex(32) → 64 hex chars
+
+    def test_persists_secret_to_file(self, tmp_path):
+        """The generated secret is saved to {data_dir}/.jwt_secret."""
+        s = Settings(data_dir=str(tmp_path))
+        s.auth.enabled = False
+        s.auth.jwt_secret_key = ""
+        _ensure_jwt_secret(s)
+        secret_file = tmp_path / ".jwt_secret"
+        assert secret_file.exists()
+        assert secret_file.read_text() == s.auth.jwt_secret_key
+
+    def test_loads_existing_secret(self, tmp_path):
+        """If .jwt_secret already exists, the stored value is reused."""
+        secret_file = tmp_path / ".jwt_secret"
+        secret_file.write_text("my-persisted-secret-value")
+        s = Settings(data_dir=str(tmp_path))
+        s.auth.enabled = False
+        s.auth.jwt_secret_key = ""
+        _ensure_jwt_secret(s)
+        assert s.auth.jwt_secret_key == "my-persisted-secret-value"
+
+    def test_skips_when_auth_enabled(self, tmp_path):
+        """No auto-generation when auth is explicitly enabled."""
+        s = Settings(data_dir=str(tmp_path))
+        s.auth.enabled = True
+        s.auth.jwt_secret_key = ""
+        _ensure_jwt_secret(s)
+        assert s.auth.jwt_secret_key == ""
+
+    def test_skips_when_key_already_set(self, tmp_path):
+        """No auto-generation when jwt_secret_key is already configured."""
+        s = Settings(data_dir=str(tmp_path))
+        s.auth.enabled = False
+        s.auth.jwt_secret_key = "explicit-secret"
+        _ensure_jwt_secret(s)
+        assert s.auth.jwt_secret_key == "explicit-secret"
+        assert not (tmp_path / ".jwt_secret").exists()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -263,7 +263,7 @@ class TestEnsureJwtSecret:
         s.auth.enabled = False
         s.auth.jwt_secret_key = ""
         _ensure_jwt_secret(s)
-        assert s.auth.jwt_secret_key == "my-persisted-secret-value"
+        assert s.auth.jwt_secret_key == "my-persisted-secret-value"  # pragma: allowlist secret
 
     def test_skips_when_auth_enabled(self, tmp_path):
         """No auto-generation when auth is explicitly enabled."""
@@ -277,7 +277,7 @@ class TestEnsureJwtSecret:
         """No auto-generation when jwt_secret_key is already configured."""
         s = Settings(data_dir=str(tmp_path))
         s.auth.enabled = False
-        s.auth.jwt_secret_key = "explicit-secret"
+        s.auth.jwt_secret_key = "explicit-secret"  # pragma: allowlist secret
         _ensure_jwt_secret(s)
-        assert s.auth.jwt_secret_key == "explicit-secret"
+        assert s.auth.jwt_secret_key == "explicit-secret"  # pragma: allowlist secret
         assert not (tmp_path / ".jwt_secret").exists()


### PR DESCRIPTION
## Summary

BYOK key save via the Settings UI fails with a 500 when `JWT_SECRET_KEY` isn't configured — which is always the case for new users in single-user mode (the default). This blocks the entire onboarding flow.

- When auth is disabled and no JWT secret is set, auto-generate a stable secret and persist it to `{data_dir}/.jwt_secret`
- Secret survives server restarts so encrypted BYOK keys remain readable
- Users who enable auth can still override with `WIKIMIND_AUTH__JWT_SECRET_KEY`

## Test plan

- [x] `make lint` — passes
- [x] `make typecheck` — passes
- [x] 55 relevant tests pass (test_config.py + test_api_keys.py)
- [ ] Manual: start fresh (`make dev` with no `.env`), go to Settings, click "Set Key" on any provider — should succeed instead of 500
- [ ] Manual: restart server, verify saved key is still usable

Closes #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)