### PR TITLE
feat: add OpenAI-compatible provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,13 +17,14 @@
 # These work both with the WIKIMIND_ prefix and without (CI/CD friendly).
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
+# OPENAI_COMPATIBLE_API_KEY=...
 # GOOGLE_API_KEY=...
 
 # ----------------------------------------------------------------------------
 # LLM Provider Selection (optional)
 # ----------------------------------------------------------------------------
 # If multiple keys are set, choose the default.
-# WIKIMIND_LLM__DEFAULT_PROVIDER=anthropic   # anthropic | openai | google | ollama
+# WIKIMIND_LLM__DEFAULT_PROVIDER=anthropic   # anthropic | openai | openai_compatible | google | ollama
 
 # Allow falling back to other configured providers when the default fails
 # WIKIMIND_LLM__FALLBACK_ENABLED=true
@@ -42,8 +43,34 @@
 # ----------------------------------------------------------------------------
 # WIKIMIND_LLM__ANTHROPIC__MODEL=claude-sonnet-4-5
 # WIKIMIND_LLM__OPENAI__MODEL=gpt-4o
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL=gpt-4o-mini
 # WIKIMIND_LLM__GOOGLE__MODEL=gemini-2.0-flash
 # WIKIMIND_LLM__OLLAMA__MODEL=llama3.2
+
+# ----------------------------------------------------------------------------
+# OpenAI-Compatible Endpoints (optional)
+# ----------------------------------------------------------------------------
+# Use this for OpenRouter, Together, Fireworks, LM Studio, vLLM, LocalAI, or
+# any endpoint that supports the OpenAI Chat Completions API.
+# The provider auto-enables only when both OPENAI_COMPATIBLE_API_KEY and
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL are set.
+#
+# OpenRouter example:
+# OPENAI_COMPATIBLE_API_KEY=sk-or-...
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL=https://openrouter.ai/api/v1
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL=openai/gpt-4o-mini
+# WIKIMIND_LLM__DEFAULT_PROVIDER=openai_compatible
+#
+# Optional compatibility switches for endpoints with partial API support:
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_JSON_RESPONSE_FORMAT=true
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_STREAM_USAGE=true
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_REASONING_EFFORT=true
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__REASONING_FORMAT=openai
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__MAX_TOKENS_FIELD=max_tokens
+#
+# Optional attribution headers used by gateways such as OpenRouter:
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__SITE_URL=https://wikimind.local
+# WIKIMIND_LLM__OPENAI_COMPATIBLE__APP_NAME=WikiMind
 
 # Local Ollama endpoint (if using local models)
 # WIKIMIND_LLM__OLLAMA_BASE_URL=http://localhost:11434
@@ -210,7 +237,9 @@
 # Authentication (OAuth2 / SSO)
 # ----------------------------------------------------------------------------
 # Set WIKIMIND_AUTH__ENABLED=true to require login. When disabled (default),
-# WikiMind runs in single-user mode with no authentication.
+# WikiMind runs in single-user mode with no authentication. The JWT secret is
+# also used to encrypt API keys stored through the Settings UI (BYOK), so set a
+# stable random value if you plan to save provider keys in the app.
 # WIKIMIND_AUTH__ENABLED=false
 # WIKIMIND_AUTH__JWT_SECRET_KEY=change-me-to-a-random-string
 # WIKIMIND_AUTH__JWT_EXPIRY_MINUTES=1440

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,6 @@ docs/site/
 
 # Serena MCP tool — auto-generated per-worktree config + cache + memories
 .serena/
+.codex
+.codex/
 .venv

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".env.example",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 231
       }
     ],
     "Makefile": [
@@ -206,14 +206,32 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 382
+        "line_number": 416
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 406
+        "line_number": 441
+      }
+    ],
+    "src/wikimind/engine/providers/openai.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wikimind/engine/providers/openai.py",
+        "hashed_secret": "7d3bbb5cbbc497d78ad547d8d39cbea2b3b8b69e",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "src/wikimind/engine/providers/openai_compatible.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wikimind/engine/providers/openai_compatible.py",
+        "hashed_secret": "c356a8a72867a70c73614c8cc7c9fdc75bbc279d",
+        "is_verified": false,
+        "line_number": 242
       }
     ],
     "tests/integration/test_postgres_integration.py": [
@@ -247,7 +265,7 @@
         "filename": "tests/unit/test_api_keys.py",
         "hashed_secret": "9cea46b39bd44a1ef9f3e71bfe9e45c24d3300f6",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 210
       }
     ],
     "tests/unit/test_db_compat.py": [
@@ -259,6 +277,22 @@
         "line_number": 19
       }
     ],
+    "tests/unit/test_llm_router.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_llm_router.py",
+        "hashed_secret": "c356a8a72867a70c73614c8cc7c9fdc75bbc279d",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_llm_router.py",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 181
+      }
+    ],
     "tests/unit/test_postgres_engine.py": [
       {
         "type": "Basic Auth Credentials",
@@ -267,7 +301,16 @@
         "is_verified": false,
         "line_number": 29
       }
+    ],
+    "tests/unit/test_user_preference.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_user_preference.py",
+        "hashed_secret": "687faefb2094ef89b1685ebfe27a55a6c453f5f7",
+        "is_verified": false,
+        "line_number": 213
+      }
     ]
   },
-  "generated_at": "2026-04-26T16:02:18Z"
+  "generated_at": "2026-04-30T13:58:14Z"
 }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ make check-env
 # 2. Configure at least one LLM provider — copy .env.example and edit
 cp .env.example .env
 # Add: OPENAI_API_KEY=sk-... (or ANTHROPIC_API_KEY, GOOGLE_API_KEY)
+# For OpenRouter/other OpenAI-compatible gateways, see .env.example.
 # Providers auto-enable when their key is detected.
 
 # 3. Start the local gateway (FastAPI on :7842)
@@ -186,6 +187,8 @@ WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
 ```
 
 When disabled (default), WikiMind runs in single-user mode with no login required.
+Keep `WIKIMIND_AUTH__JWT_SECRET_KEY` set if users store API keys through the
+Settings UI, because BYOK encryption derives from that secret.
 
 ## Architecture
 
@@ -214,13 +217,25 @@ wikimind/
 All configuration lives in `.env` (gitignored). See `.env.example` for the full list of options.
 
 The most common case: just set ONE LLM API key and the provider will auto-enable.
+If you save API keys through the Settings UI instead of environment variables,
+also set `WIKIMIND_AUTH__JWT_SECRET_KEY`; it is used to encrypt stored keys.
 
 ```bash
 # In .env:
 OPENAI_API_KEY=sk-...
+WIKIMIND_AUTH__JWT_SECRET_KEY=<random-hex-or-token>
 ```
 
 For more advanced configuration (model selection, fallback chain, monthly budget), see `.env.example`.
+
+OpenAI-compatible gateways such as OpenRouter can be used through a separate configurable provider:
+
+```bash
+OPENAI_COMPATIBLE_API_KEY=sk-or-...
+WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL=https://openrouter.ai/api/v1
+WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL=openai/gpt-4o-mini
+WIKIMIND_LLM__DEFAULT_PROVIDER=openai_compatible
+```
 
 ## Tech stack
 
@@ -229,7 +244,7 @@ For more advanced configuration (model selection, fallback chain, monthly budget
 | Backend gateway | Python 3.11+ / FastAPI |
 | Job queue | ARQ + asyncio (in-process for dev, ARQ + Redis for prod) |
 | Database | SQLite via SQLModel + aiosqlite |
-| LLM providers | Anthropic Claude, OpenAI GPT, Google Gemini, Ollama |
+| LLM providers | Anthropic Claude, OpenAI GPT, OpenAI-compatible endpoints, Google Gemini, Ollama |
 | PDF extraction | [docling-serve](https://github.com/docling-project/docling-serve) sidecar; pymupdf (fitz) fallback |
 | Document ingest | trafilatura (URLs), youtube-transcript-api (YouTube) |
 | Logging | structlog (JSON in prod, console in dev) |

--- a/alembic/versions/0004_add_openai_compatible_provider_enum_value.py
+++ b/alembic/versions/0004_add_openai_compatible_provider_enum_value.py
@@ -1,0 +1,39 @@
+"""Add OpenAI-compatible provider enum value.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-26
+
+Adds the Provider.OPENAI_COMPATIBLE value for PostgreSQL deployments that
+materialize SQLModel enums as native Postgres enum types. SQLite and varchar
+backends need no schema change.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: str = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the OPENAI_COMPATIBLE enum value when the native enum exists."""
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+
+    enum_exists = conn.execute(
+        sa.text("SELECT 1 FROM pg_type WHERE typname = 'provider'"),
+    ).scalar()
+    if enum_exists:
+        conn.execute(sa.text("ALTER TYPE provider ADD VALUE IF NOT EXISTS 'OPENAI_COMPATIBLE'"))
+
+
+def downgrade() -> None:
+    """No-op: PostgreSQL cannot safely remove enum values in-place."""

--- a/apps/web/src/api/settings.ts
+++ b/apps/web/src/api/settings.ts
@@ -4,6 +4,7 @@ export interface ProviderInfo {
   enabled: boolean;
   model: string;
   configured: boolean;
+  base_url?: string | null;
 }
 
 export interface SettingsResponse {
@@ -75,6 +76,13 @@ export function setDefaultProvider(provider: string): Promise<{ provider: string
 export function updateSettings(updates: {
   monthly_budget_usd?: number;
   fallback_enabled?: boolean;
+  openai_compatible_base_url?: string;
+  openai_compatible_model?: string;
+  openai_compatible_supports_json_response_format?: boolean;
+  openai_compatible_supports_stream_usage?: boolean;
+  openai_compatible_supports_reasoning_effort?: boolean;
+  openai_compatible_max_tokens_field?: "max_tokens" | "max_completion_tokens";
+  openai_compatible_reasoning_format?: "none" | "openai" | "openrouter";
 }): Promise<{ status: string }> {
   return apiFetch("/settings", {
     method: "PATCH",

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -4,7 +4,7 @@ import { Button } from "../shared/Button";
 import { Card } from "../shared/Card";
 import { Spinner } from "../shared/Spinner";
 import { ApiError } from "../../api/client";
-import { setApiKey, testProvider, setDefaultProvider, completeOnboarding } from "../../api/settings";
+import { setApiKey, testProvider, setDefaultProvider, completeOnboarding, updateSettings } from "../../api/settings";
 import { ingestUrl } from "../../api/sources";
 import { useWebSocketStore } from "../../store/websocket";
 import type { WSEvent } from "../../types/api";
@@ -163,6 +163,8 @@ function ConfigureLLMStep({
 }) {
   const [provider, setProvider] = useState("anthropic");
   const [apiKey, setApiKeyValue] = useState("");
+  const [openAIBaseUrl, setOpenAIBaseUrl] = useState("");
+  const [openAIModel, setOpenAIModel] = useState("openai/gpt-4o-mini");
   const [testState, setTestState] = useState<
     "idle" | "saving" | "testing" | "success" | "error"
   >("idle");
@@ -174,12 +176,20 @@ function ConfigureLLMStep({
     setTestState("saving");
     setErrorMsg("");
     try {
-      await setApiKey(provider, apiKey);
+      const customOpenAIEndpoint = provider === "openai" && openAIBaseUrl.trim() !== "";
+      const providerToConfigure = customOpenAIEndpoint ? "openai_compatible" : provider;
+      if (customOpenAIEndpoint) {
+        await updateSettings({
+          openai_compatible_base_url: openAIBaseUrl.trim(),
+          openai_compatible_model: openAIModel.trim() || "openai/gpt-4o-mini",
+        });
+      }
+      await setApiKey(providerToConfigure, apiKey);
       queryClient.invalidateQueries({ queryKey: ["settings"] });
       setTestState("testing");
-      const result = await testProvider(provider);
+      const result = await testProvider(providerToConfigure);
       if (result.status === "ok") {
-        await setDefaultProvider(provider);
+        await setDefaultProvider(providerToConfigure);
         queryClient.invalidateQueries({ queryKey: ["settings"] });
         setTestState("success");
       } else {
@@ -215,9 +225,44 @@ function ConfigureLLMStep({
         className="mb-4 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-brand-500 focus:outline-none"
       >
         <option value="anthropic">Anthropic</option>
-        <option value="openai">OpenAI</option>
+        <option value="openai">OpenAI / compatible</option>
         <option value="google">Google</option>
       </select>
+
+      {provider === "openai" && (
+        <div className="mb-4 rounded-md border border-slate-200 bg-slate-50 p-3">
+          <label className="mb-1 block text-sm font-medium text-slate-700">
+            Custom base URL
+          </label>
+          <input
+            type="url"
+            value={openAIBaseUrl}
+            onChange={(e) => {
+              setOpenAIBaseUrl(e.target.value);
+              if (testState !== "idle") setTestState("idle");
+            }}
+            placeholder="https://openrouter.ai/api/v1"
+            className="mb-3 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          />
+          {openAIBaseUrl.trim() !== "" && (
+            <>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                Model
+              </label>
+              <input
+                type="text"
+                value={openAIModel}
+                onChange={(e) => {
+                  setOpenAIModel(e.target.value);
+                  if (testState !== "idle") setTestState("idle");
+                }}
+                placeholder="openai/gpt-4o-mini"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              />
+            </>
+          )}
+        </div>
+      )}
 
       <label className="mb-1 block text-sm font-medium text-slate-700">
         API Key

--- a/apps/web/src/components/settings/ApiKeyModal.tsx
+++ b/apps/web/src/components/settings/ApiKeyModal.tsx
@@ -1,26 +1,64 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "../shared/Button";
-import { setApiKey } from "../../api/settings";
+import { setApiKey, updateSettings } from "../../api/settings";
+import type { ProviderInfo } from "../../api/settings";
 
 interface ApiKeyModalProps {
   provider: string;
+  providerInfo?: ProviderInfo;
   onClose: () => void;
 }
 
-export function ApiKeyModal({ provider, onClose }: ApiKeyModalProps) {
+export function ApiKeyModal({ provider, providerInfo, onClose }: ApiKeyModalProps) {
   const [value, setValue] = useState("");
+  const [baseUrl, setBaseUrl] = useState(providerInfo?.base_url ?? "");
+  const [model, setModel] = useState(providerInfo?.model ?? "");
   const queryClient = useQueryClient();
 
+  const isOpenAICompatible = provider === "openai_compatible";
+  const trimmedBaseUrl = baseUrl.trim();
+  const trimmedModel = model.trim();
+  const trimmedKey = value.trim();
+  const settingsChanged =
+    isOpenAICompatible &&
+    (trimmedBaseUrl !== (providerInfo?.base_url ?? "") || trimmedModel !== (providerInfo?.model ?? ""));
+
   const mutation = useMutation({
-    mutationFn: () => setApiKey(provider, value),
+    mutationFn: async () => {
+      if (isOpenAICompatible) {
+        const settingsUpdate: {
+          openai_compatible_base_url?: string;
+          openai_compatible_model?: string;
+        } = {};
+
+        if (trimmedBaseUrl !== (providerInfo?.base_url ?? "")) {
+          settingsUpdate.openai_compatible_base_url = trimmedBaseUrl;
+        }
+        if (trimmedModel !== (providerInfo?.model ?? "")) {
+          settingsUpdate.openai_compatible_model = trimmedModel;
+        }
+        if (Object.keys(settingsUpdate).length > 0) {
+          await updateSettings(settingsUpdate);
+        }
+      }
+      if (trimmedKey) {
+        await setApiKey(provider, trimmedKey);
+      }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["settings"] });
       onClose();
     },
   });
+  const canSave =
+    !mutation.isPending &&
+    (isOpenAICompatible
+      ? Boolean(trimmedBaseUrl && trimmedModel && (trimmedKey || (providerInfo?.configured && settingsChanged)))
+      : Boolean(trimmedKey));
 
-  const displayName = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const displayName =
+    provider === "openai_compatible" ? "OpenAI-compatible" : provider.charAt(0).toUpperCase() + provider.slice(1);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -37,13 +75,38 @@ export function ApiKeyModal({ provider, onClose }: ApiKeyModalProps) {
           className="mb-4 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
         />
 
+        {isOpenAICompatible && (
+          <div className="mb-4 rounded-md border border-slate-200 bg-slate-50 p-3">
+            <label className="mb-1 block text-sm font-medium text-slate-700">
+              Base URL
+            </label>
+            <input
+              type="url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://openrouter.ai/api/v1"
+              className="mb-3 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+            <label className="mb-1 block text-sm font-medium text-slate-700">
+              Model
+            </label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="openai/gpt-4o-mini"
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+        )}
+
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>
           <Button
             variant="primary"
-            disabled={value.trim() === "" || mutation.isPending}
+            disabled={!canSave}
             onClick={() => mutation.mutate()}
           >
             {mutation.isPending ? "Saving..." : "Save"}

--- a/apps/web/src/components/settings/ProviderCard.tsx
+++ b/apps/web/src/components/settings/ProviderCard.tsx
@@ -21,6 +21,12 @@ type TestState =
 
 const NO_KEY_PROVIDERS = new Set(["ollama", "mock"]);
 
+function formatProviderName(name: string): string {
+  if (name === "openai_compatible") return "OpenAI-compatible";
+  if (name === "openai") return "OpenAI";
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
 function HealthDot({ state }: { state: TestState; enabled: boolean }) {
   if (state.kind === "testing") {
     return (
@@ -87,7 +93,7 @@ export function ProviderCard({ name, info, isDefault, onSetKey }: ProviderCardPr
 
       <div className="mb-3 flex items-center gap-2.5">
         <HealthDot state={testState} enabled={info.enabled} />
-        <span className="text-base font-semibold text-slate-800 capitalize">{name}</span>
+        <span className="text-base font-semibold text-slate-800">{formatProviderName(name)}</span>
       </div>
 
       <div className="mb-3 flex items-center gap-2">

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -150,6 +150,7 @@ export function SettingsView() {
       {apiKeyModalProvider !== null && (
         <ApiKeyModal
           provider={apiKeyModalProvider}
+          providerInfo={settings.llm.providers[apiKeyModalProvider]}
           onClose={() => setApiKeyModalProvider(null)}
         />
       )}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,7 @@ const API_PREFIXES = [
   "/jobs",
   "/lint",
   "/settings",
+  "/api",
   "/health",
   "/images",
 ];

--- a/docs/adr/adr-026-byok-api-key-encryption.md
+++ b/docs/adr/adr-026-byok-api-key-encryption.md
@@ -26,7 +26,8 @@ Requirements:
   the `cryptography` library)
 - **Key derivation**: PBKDF2-HMAC-SHA256 with 100,000 iterations (OWASP 2023
   minimum for SHA-256)
-- **Key material**: `JWT_SECRET_KEY` (already required for authentication) +
+- **Key material**: `JWT_SECRET_KEY` (required for authentication and BYOK
+  key storage) +
   a 16-byte random per-row salt
 - **Storage**: `UserApiKey` table with `encrypted_key` (Fernet ciphertext,
   base64) and `salt` (hex-encoded)

--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -23,6 +23,10 @@ WIKIMIND_AUTH__ENABLED=true
 WIKIMIND_AUTH__JWT_SECRET_KEY=your-random-secret-here
 ```
 
+`WIKIMIND_AUTH__JWT_SECRET_KEY` is also required when authentication is disabled
+if you store provider API keys through the Settings UI. WikiMind uses that
+secret to encrypt BYOK keys at rest.
+
 !!! warning "Generate a strong secret"
     The JWT secret key must be a random string. Generate one with:
     ```bash

--- a/docs/docs/configuration/llm-providers.md
+++ b/docs/docs/configuration/llm-providers.md
@@ -8,6 +8,7 @@ WikiMind supports multiple LLM providers with automatic selection, fallback, and
 |---|---|---|---|
 | Anthropic | claude-sonnet-4-5 | `ANTHROPIC_API_KEY` | Default provider |
 | OpenAI | gpt-4o | `OPENAI_API_KEY` | |
+| OpenAI-compatible | gpt-4o-mini | `OPENAI_COMPATIBLE_API_KEY` | Custom Chat Completions base URL |
 | Google Gemini | gemini-2.0-flash | `GOOGLE_API_KEY` | |
 | Ollama | llama3.2 | -- | Local, no key needed |
 | Mock | mock-1 | -- | CI/testing only |
@@ -70,8 +71,48 @@ Override the default model for any provider:
 ```bash
 WIKIMIND_LLM__ANTHROPIC__MODEL=claude-haiku-4-5-20251001
 WIKIMIND_LLM__OPENAI__MODEL=gpt-4o-mini
+WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL=openai/gpt-4o-mini
 WIKIMIND_LLM__GOOGLE__MODEL=gemini-2.0-flash
 WIKIMIND_LLM__OLLAMA__MODEL=mistral
+```
+
+## OpenAI-Compatible Endpoints
+
+Use `openai_compatible` for OpenRouter, Together, Fireworks, LM Studio,
+vLLM, LocalAI, or any endpoint that supports the OpenAI Chat Completions API.
+It is separate from the official `openai` provider so cost logs and article
+provenance show that a gateway/custom endpoint was used.
+
+OpenRouter example:
+
+```bash
+OPENAI_COMPATIBLE_API_KEY=sk-or-...
+WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL=https://openrouter.ai/api/v1
+WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL=openai/gpt-4o-mini
+WIKIMIND_LLM__DEFAULT_PROVIDER=openai_compatible
+```
+
+Optional compatibility switches:
+
+```bash
+WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_JSON_RESPONSE_FORMAT=true
+WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_STREAM_USAGE=true
+WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_REASONING_EFFORT=true
+WIKIMIND_LLM__OPENAI_COMPATIBLE__REASONING_FORMAT=openai
+WIKIMIND_LLM__OPENAI_COMPATIBLE__MAX_TOKENS_FIELD=max_tokens
+```
+
+For gateways with OpenRouter-style reasoning payloads, set:
+
+```bash
+WIKIMIND_LLM__OPENAI_COMPATIBLE__REASONING_FORMAT=openrouter
+```
+
+For OpenRouter attribution headers:
+
+```bash
+WIKIMIND_LLM__OPENAI_COMPATIBLE__SITE_URL=https://wikimind.local
+WIKIMIND_LLM__OPENAI_COMPATIBLE__APP_NAME=WikiMind
 ```
 
 ## Ollama (Local Models)
@@ -112,6 +153,7 @@ Current pricing (USD per 1M tokens):
 | Anthropic | claude-haiku-4-5-20251001 | $0.80 | $4.00 |
 | OpenAI | gpt-4o | $2.50 | $10.00 |
 | OpenAI | gpt-4o-mini | $0.15 | $0.60 |
+| OpenAI-compatible | * | $0.00 | $0.00 |
 | Google | gemini-2.0-flash | $0.10 | $0.40 |
 | Ollama | * | $0.00 | $0.00 |
 

--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -19,6 +19,7 @@ Set at least one API key. The provider auto-enables when a key is detected.
 |---|---|
 | `ANTHROPIC_API_KEY` | Anthropic API key |
 | `OPENAI_API_KEY` | OpenAI API key |
+| `OPENAI_COMPATIBLE_API_KEY` | API key for a custom OpenAI-compatible endpoint |
 | `GOOGLE_API_KEY` | Google Gemini API key |
 
 !!! tip
@@ -28,7 +29,7 @@ Set at least one API key. The provider auto-enables when a key is detected.
 
 | Variable | Default | Description |
 |---|---|---|
-| `WIKIMIND_LLM__DEFAULT_PROVIDER` | `anthropic` | Default LLM provider (`anthropic`, `openai`, `google`, `ollama`, `mock`) |
+| `WIKIMIND_LLM__DEFAULT_PROVIDER` | `anthropic` | Default LLM provider (`anthropic`, `openai`, `openai_compatible`, `google`, `ollama`, `mock`) |
 | `WIKIMIND_LLM__FALLBACK_ENABLED` | `true` | Fall back to other providers when the default fails |
 | `WIKIMIND_LLM__MONTHLY_BUDGET_USD` | `50.0` | Monthly spending ceiling across all providers (USD) |
 | `WIKIMIND_LLM__BUDGET_WARNING_PCT` | `0.8` | Budget warning threshold (fraction 0.0-1.0) |
@@ -44,6 +45,16 @@ Each provider has `model` and `enabled` settings:
 | `WIKIMIND_LLM__ANTHROPIC__ENABLED` | auto | Enabled when API key detected |
 | `WIKIMIND_LLM__OPENAI__MODEL` | `gpt-4o` | OpenAI model name |
 | `WIKIMIND_LLM__OPENAI__ENABLED` | auto | Enabled when API key detected |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL` | `gpt-4o-mini` | OpenAI-compatible endpoint model name |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__ENABLED` | auto | Enabled when API key and base URL are detected |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL` | -- | Custom Chat Completions base URL |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_JSON_RESPONSE_FORMAT` | `true` | Send OpenAI JSON response format for JSON requests |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_STREAM_USAGE` | `true` | Request usage metadata in streaming responses |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_REASONING_EFFORT` | `true` | Allow explicit reasoning effort payloads when requested |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__REASONING_FORMAT` | `openai` | Reasoning payload style (`none`, `openai`, or `openrouter`) |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__MAX_TOKENS_FIELD` | `max_tokens` | Token limit field (`max_tokens` or `max_completion_tokens`) |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__SITE_URL` | -- | Optional attribution site URL for gateways such as OpenRouter |
+| `WIKIMIND_LLM__OPENAI_COMPATIBLE__APP_NAME` | -- | Optional attribution app title for gateways such as OpenRouter |
 | `WIKIMIND_LLM__GOOGLE__MODEL` | `gemini-2.0-flash` | Google Gemini model name |
 | `WIKIMIND_LLM__GOOGLE__ENABLED` | auto | Enabled when API key detected |
 | `WIKIMIND_LLM__OLLAMA__MODEL` | `llama3.2` | Ollama model name |
@@ -155,7 +166,7 @@ See the [Authentication](auth.md) page for detailed setup.
 | Variable | Default | Description |
 |---|---|---|
 | `WIKIMIND_AUTH__ENABLED` | `false` | Enable multi-user authentication |
-| `WIKIMIND_AUTH__JWT_SECRET_KEY` | -- | Secret key for JWT signing (required when auth enabled) |
+| `WIKIMIND_AUTH__JWT_SECRET_KEY` | -- | Secret key for JWT signing and BYOK API-key encryption (required for auth and Settings UI key storage) |
 | `WIKIMIND_AUTH__JWT_ALGORITHM` | `HS256` | JWT algorithm |
 | `WIKIMIND_AUTH__JWT_EXPIRY_MINUTES` | `1440` | JWT expiry (24 hours) |
 | `WIKIMIND_AUTH__COOKIE_NAME` | `wikimind_session` | Session cookie name |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -70,7 +70,7 @@ Feed --> Compile --> Query --> Answer files back --> Wiki gets smarter --> Repea
 | Backend gateway | Python 3.11+ / FastAPI |
 | Job queue | ARQ + asyncio (in-process for dev, ARQ + Redis for prod) |
 | Database | SQLite (dev) / PostgreSQL (prod) via SQLModel |
-| LLM providers | Anthropic Claude, OpenAI GPT, Google Gemini, Ollama |
+| LLM providers | Anthropic Claude, OpenAI GPT, OpenAI-compatible endpoints, Google Gemini, Ollama |
 | PDF extraction | [docling-serve](https://github.com/docling-project/docling-serve) sidecar; pymupdf fallback |
 | Document ingest | trafilatura (URLs), youtube-transcript-api (YouTube) |
 | Frontend | React 18 + TypeScript + Vite + TanStack Query + Zustand + Tailwind CSS |

--- a/docs/docs/overview/features.md
+++ b/docs/docs/overview/features.md
@@ -34,6 +34,7 @@ WikiMind supports multiple LLM providers with automatic fallback:
 |---|---|---|
 | Anthropic | claude-sonnet-4-5 | Default provider |
 | OpenAI | gpt-4o | |
+| OpenAI-compatible | gpt-4o-mini | Custom Chat Completions base URL |
 | Google | gemini-2.0-flash | |
 | Ollama | llama3.2 | Local, no API key needed |
 

--- a/docs/docs/overview/quick-start.md
+++ b/docs/docs/overview/quick-start.md
@@ -6,7 +6,7 @@ Get WikiMind running locally in 5 minutes.
 
 - **Python 3.11+** (3.12 recommended)
 - **Node.js 20+** (for the React frontend, optional)
-- An LLM API key (any one of: Anthropic, OpenAI, Google, or a local Ollama instance)
+- An LLM API key (Anthropic, OpenAI, Google, OpenAI-compatible, or a local Ollama instance)
 
 ## 1. Clone and set up
 
@@ -42,6 +42,15 @@ GOOGLE_API_KEY=...
 ```
 
 That is all you need. WikiMind auto-detects which providers have keys configured and enables them automatically.
+
+!!! tip "Using OpenRouter or another OpenAI-compatible endpoint"
+    Configure the separate `openai_compatible` provider:
+    ```bash
+    OPENAI_COMPATIBLE_API_KEY=sk-or-...
+    WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL=https://openrouter.ai/api/v1
+    WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL=openai/gpt-4o-mini
+    WIKIMIND_LLM__DEFAULT_PROVIDER=openai_compatible
+    ```
 
 !!! tip "Using Ollama (no API key needed)"
     If you have [Ollama](https://ollama.ai) running locally, enable it explicitly:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2843,6 +2843,11 @@ components:
         configured:
           type: boolean
           title: Configured
+        base_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Url
       type: object
       required:
       - enabled
@@ -3042,6 +3047,41 @@ components:
           - type: boolean
           - type: 'null'
           title: Fallback Enabled
+        openai_compatible_base_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Openai Compatible Base Url
+        openai_compatible_model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Openai Compatible Model
+        openai_compatible_supports_json_response_format:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Openai Compatible Supports Json Response Format
+        openai_compatible_supports_stream_usage:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Openai Compatible Supports Stream Usage
+        openai_compatible_supports_reasoning_effort:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Openai Compatible Supports Reasoning Effort
+        openai_compatible_max_tokens_field:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Openai Compatible Max Tokens Field
+        openai_compatible_reasoning_format:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Openai Compatible Reasoning Format
       type: object
       title: SettingsUpdateRequest
       description: Request to update settings.

--- a/src/wikimind/api/routes/api_keys.py
+++ b/src/wikimind/api/routes/api_keys.py
@@ -25,7 +25,7 @@ from wikimind.services.api_keys import (
 router = APIRouter()
 
 # Providers that accept user-supplied API keys (Ollama and Mock don't use keys)
-_BYOK_PROVIDERS = {Provider.ANTHROPIC, Provider.OPENAI, Provider.GOOGLE}
+_BYOK_PROVIDERS = {Provider.ANTHROPIC, Provider.OPENAI, Provider.OPENAI_COMPATIBLE, Provider.GOOGLE}
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/api/routes/export.py
+++ b/src/wikimind/api/routes/export.py
@@ -86,7 +86,7 @@ async def export_article(
         return HTMLResponse(content=html, media_type="text/html")
 
     if format == ExportFormat.LINKEDIN:
-        text = await service.export_linkedin(article.title, content)
+        text = await service.export_linkedin(article.title, content, user_id=user_id)
         return ExportResponse(
             format=ExportFormat.LINKEDIN,
             content=text,
@@ -95,7 +95,7 @@ async def export_article(
         )
 
     # slides
-    text = await service.export_slides(article.title, content)
+    text = await service.export_slides(article.title, content, user_id=user_id)
     return ExportResponse(
         format=ExportFormat.SLIDES,
         content=text,

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -19,6 +19,8 @@ from wikimind.services.api_keys import get_user_api_key
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
+    from wikimind.config import Settings
+
 router = APIRouter()
 
 
@@ -28,6 +30,13 @@ class SettingsUpdateRequest(BaseModel):
     monthly_budget_usd: float | None = None
     default_provider: str | None = None
     fallback_enabled: bool | None = None
+    openai_compatible_base_url: str | None = None
+    openai_compatible_model: str | None = None
+    openai_compatible_supports_json_response_format: bool | None = None
+    openai_compatible_supports_stream_usage: bool | None = None
+    openai_compatible_supports_reasoning_effort: bool | None = None
+    openai_compatible_max_tokens_field: str | None = None
+    openai_compatible_reasoning_format: str | None = None
 
 
 class DefaultProviderRequest(BaseModel):
@@ -42,6 +51,7 @@ class ProviderDetail(BaseModel):
     enabled: bool
     model: str
     configured: bool
+    base_url: str | None = None
 
 
 class LLMSettingsResponse(BaseModel):
@@ -129,6 +139,70 @@ class OnboardingCompleteRequest(BaseModel):
     """Request to mark onboarding as complete."""
 
 
+_OPENAI_COMPATIBLE_PREF_MAP = {
+    "llm.openai_compatible.base_url": "base_url",
+    "llm.openai_compatible.model": "model",
+    "llm.openai_compatible.supports_json_response_format": "supports_json_response_format",
+    "llm.openai_compatible.supports_stream_usage": "supports_stream_usage",
+    "llm.openai_compatible.supports_reasoning_effort": "supports_reasoning_effort",
+    "llm.openai_compatible.max_tokens_field": "max_tokens_field",
+    "llm.openai_compatible.reasoning_format": "reasoning_format",
+}
+_OPENAI_COMPATIBLE_TOKEN_FIELDS = {"max_tokens", "max_completion_tokens"}
+_OPENAI_COMPATIBLE_REASONING_FORMATS = {"none", "openai", "openrouter"}
+_OPENAI_COMPATIBLE_RUNTIME_REQUEST_FIELDS = (
+    "openai_compatible_base_url",
+    "openai_compatible_model",
+    "openai_compatible_supports_json_response_format",
+    "openai_compatible_supports_stream_usage",
+    "openai_compatible_supports_reasoning_effort",
+    "openai_compatible_max_tokens_field",
+    "openai_compatible_reasoning_format",
+)
+
+
+async def apply_runtime_llm_preferences() -> None:
+    """Apply persisted LLM runtime preferences to the in-memory settings singleton."""
+    settings = get_settings()
+    async with get_session_factory()() as session:
+        result = await session.execute(select(UserPreference))
+        for pref in result.scalars().all():
+            if pref.key == "llm.default_provider":
+                settings.llm.default_provider = pref.value
+            elif pref.key == "llm.monthly_budget_usd":
+                settings.llm.monthly_budget_usd = float(pref.value)
+            elif pref.key == "llm.fallback_enabled":
+                settings.llm.fallback_enabled = pref.value.lower() == "true"
+            elif pref.key in _OPENAI_COMPATIBLE_PREF_MAP:
+                field_name = _OPENAI_COMPATIBLE_PREF_MAP[pref.key]
+                current_value = getattr(settings.llm.openai_compatible, field_name)
+                value = pref.value.lower() == "true" if isinstance(current_value, bool) else pref.value
+                setattr(settings.llm.openai_compatible, field_name, value)
+
+    cfg = settings.llm.openai_compatible
+    cfg.enabled = bool((cfg.enabled or get_api_key(Provider.OPENAI_COMPATIBLE.value)) and cfg.base_url and cfg.model)
+
+
+def _has_required_provider_config(provider: Provider) -> bool:
+    """Return whether non-secret runtime config exists for a provider."""
+    if provider != Provider.OPENAI_COMPATIBLE:
+        return True
+    cfg = get_settings().llm.openai_compatible
+    return bool(cfg.base_url and cfg.model)
+
+
+def _refresh_openai_compatible_enabled(settings: Settings) -> None:
+    """Refresh derived enabled state after runtime config changes."""
+    cfg = settings.llm.openai_compatible
+    cfg.enabled = bool((cfg.enabled or get_api_key(Provider.OPENAI_COMPATIBLE.value)) and cfg.base_url and cfg.model)
+    get_llm_router()._provider_cache.pop(Provider.OPENAI_COMPATIBLE, None)
+
+
+def _has_openai_compatible_runtime_update(request: SettingsUpdateRequest) -> bool:
+    """Return true when a request changes global OpenAI-compatible runtime config."""
+    return any(getattr(request, field_name) is not None for field_name in _OPENAI_COMPATIBLE_RUNTIME_REQUEST_FIELDS)
+
+
 # ---------------------------------------------------------------------------
 # DB preference helpers
 # ---------------------------------------------------------------------------
@@ -152,6 +226,113 @@ async def _set_preference(key: str, value: str) -> None:
         await session.commit()
 
 
+async def _update_openai_compatible_base_url(request: SettingsUpdateRequest, settings: Settings) -> bool:
+    """Persist the configured OpenAI-compatible base URL if present."""
+    if request.openai_compatible_base_url is None:
+        return False
+
+    base_url = request.openai_compatible_base_url.strip().rstrip("/")
+    if base_url and not base_url.startswith(("http://", "https://")):
+        raise HTTPException(status_code=400, detail="OpenAI-compatible base URL must start with http:// or https://")
+
+    await _set_preference("llm.openai_compatible.base_url", base_url)
+    settings.llm.openai_compatible.base_url = base_url
+    return True
+
+
+async def _update_openai_compatible_model(request: SettingsUpdateRequest, settings: Settings) -> bool:
+    """Persist the configured OpenAI-compatible model if present."""
+    if request.openai_compatible_model is None:
+        return False
+
+    model = request.openai_compatible_model.strip()
+    if not model:
+        raise HTTPException(status_code=400, detail="OpenAI-compatible model must not be empty")
+
+    await _set_preference("llm.openai_compatible.model", model)
+    settings.llm.openai_compatible.model = model
+    return True
+
+
+async def _update_openai_compatible_bools(request: SettingsUpdateRequest, settings: Settings) -> bool:
+    """Persist OpenAI-compatible boolean capability flags."""
+    updated = False
+    cfg = settings.llm.openai_compatible
+    bool_updates = {
+        "supports_json_response_format": request.openai_compatible_supports_json_response_format,
+        "supports_stream_usage": request.openai_compatible_supports_stream_usage,
+        "supports_reasoning_effort": request.openai_compatible_supports_reasoning_effort,
+    }
+    for field_name, value in bool_updates.items():
+        if value is None:
+            continue
+        await _set_preference(f"llm.openai_compatible.{field_name}", str(value).lower())
+        setattr(cfg, field_name, value)
+        updated = True
+    return updated
+
+
+async def _update_openai_compatible_max_tokens_field(request: SettingsUpdateRequest, settings: Settings) -> bool:
+    """Persist the max-tokens field selection if present."""
+    if request.openai_compatible_max_tokens_field is None:
+        return False
+
+    max_tokens_field = request.openai_compatible_max_tokens_field.strip()
+    if max_tokens_field not in _OPENAI_COMPATIBLE_TOKEN_FIELDS:
+        raise HTTPException(
+            status_code=400,
+            detail="OpenAI-compatible max token field must be max_tokens or max_completion_tokens",
+        )
+
+    await _set_preference("llm.openai_compatible.max_tokens_field", max_tokens_field)
+    settings.llm.openai_compatible.max_tokens_field = max_tokens_field
+    return True
+
+
+async def _update_openai_compatible_reasoning_format(
+    request: SettingsUpdateRequest,
+    settings: Settings,
+) -> bool:
+    """Persist the reasoning payload style if present."""
+    if request.openai_compatible_reasoning_format is None:
+        return False
+
+    reasoning_format = request.openai_compatible_reasoning_format.strip()
+    if reasoning_format not in _OPENAI_COMPATIBLE_REASONING_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail="OpenAI-compatible reasoning format must be none, openai, or openrouter",
+        )
+
+    await _set_preference("llm.openai_compatible.reasoning_format", reasoning_format)
+    if reasoning_format == "none":
+        settings.llm.openai_compatible.reasoning_format = "none"
+    elif reasoning_format == "openai":
+        settings.llm.openai_compatible.reasoning_format = "openai"
+    else:
+        settings.llm.openai_compatible.reasoning_format = "openrouter"
+    return True
+
+
+async def _update_openai_compatible_settings(request: SettingsUpdateRequest, settings: Settings) -> bool:
+    """Persist runtime OpenAI-compatible settings and update the singleton."""
+    updated = False
+
+    if settings.auth.enabled and _has_openai_compatible_runtime_update(request):
+        raise HTTPException(
+            status_code=403,
+            detail="OpenAI-compatible runtime settings are global and cannot be changed by users when auth is enabled",
+        )
+
+    updated = await _update_openai_compatible_base_url(request, settings) or updated
+    updated = await _update_openai_compatible_model(request, settings) or updated
+    updated = await _update_openai_compatible_bools(request, settings) or updated
+    updated = await _update_openai_compatible_max_tokens_field(request, settings) or updated
+    updated = await _update_openai_compatible_reasoning_format(request, settings) or updated
+
+    return updated
+
+
 @router.get("", response_model=AllSettingsResponse)
 async def get_all_settings(
     session: AsyncSession = Depends(get_session),
@@ -173,10 +354,12 @@ async def get_all_settings(
         has_system_key = bool(get_api_key(p.value))
         has_user_key = bool(await get_user_api_key(session, user_id, p)) if not has_system_key else False
         config_enabled = getattr(settings.llm, p.value).enabled
+        has_required_config = _has_required_provider_config(p)
         providers[p.value] = ProviderDetail(
-            enabled=config_enabled or has_user_key,
+            enabled=(config_enabled or has_user_key) and has_required_config,
             model=getattr(settings.llm, p.value).model,
             configured=has_system_key or has_user_key,
+            base_url=getattr(settings.llm, p.value).base_url if p == Provider.OPENAI_COMPATIBLE else None,
         )
 
     return AllSettingsResponse(
@@ -221,6 +404,11 @@ async def set_default_provider(
             status_code=400,
             detail=f"Provider {request.provider} is not enabled",
         )
+    if not _has_required_provider_config(Provider(request.provider)):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Provider {request.provider} is missing required configuration",
+        )
 
     # Providers that need API keys
     no_key_providers = {Provider.OLLAMA.value, Provider.MOCK.value}
@@ -261,6 +449,9 @@ async def update_settings(
         )
         settings.llm.fallback_enabled = request.fallback_enabled
 
+    if await _update_openai_compatible_settings(request, settings):
+        _refresh_openai_compatible_enabled(settings)
+
     if request.default_provider is not None:
         valid_providers = [p.value for p in Provider]
         if request.default_provider not in valid_providers:
@@ -293,7 +484,7 @@ async def test_llm_connection(
                     "content": ('Respond with the json object: {"status": "ok"}'),
                 }
             ],
-            max_tokens=10,
+            max_tokens=32,
             task_type=TaskType.QA,
             preferred_provider=Provider(provider),
         )

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -15,6 +15,7 @@ import os
 import re
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 import keyring
 import keyring.errors
@@ -64,6 +65,21 @@ class OpenAIConfig(LLMProviderConfig):
     enabled: bool = False
 
 
+class OpenAICompatibleConfig(LLMProviderConfig):
+    """OpenAI Chat Completions-compatible endpoint defaults."""
+
+    model: str = "gpt-4o-mini"
+    enabled: bool = False
+    base_url: str = ""
+    supports_json_response_format: bool = True
+    supports_stream_usage: bool = True
+    supports_reasoning_effort: bool = True
+    max_tokens_field: str = "max_tokens"
+    reasoning_format: Literal["none", "openai", "openrouter"] = "openai"
+    site_url: str = ""
+    app_name: str = ""
+
+
 class GoogleConfig(LLMProviderConfig):
     """Google Gemini provider defaults."""
 
@@ -100,6 +116,7 @@ class LLMConfig(BaseModel):
     budget_check_cache_seconds: int = 60
     anthropic: AnthropicConfig = Field(default_factory=AnthropicConfig)
     openai: OpenAIConfig = Field(default_factory=OpenAIConfig)
+    openai_compatible: OpenAICompatibleConfig = Field(default_factory=OpenAICompatibleConfig)
     google: GoogleConfig = Field(default_factory=GoogleConfig)
     ollama: OllamaConfig = Field(default_factory=OllamaConfig)
     ollama_base_url: str = "http://localhost:11434"
@@ -206,6 +223,7 @@ class AuthConfig(BaseModel):
 _PROVIDER_KEY_FIELDS: dict[str, tuple[str, str]] = {
     "anthropic": ("anthropic_api_key", "ANTHROPIC_API_KEY"),
     "openai": ("openai_api_key", "OPENAI_API_KEY"),
+    "openai_compatible": ("openai_compatible_api_key", "OPENAI_COMPATIBLE_API_KEY"),
     "google": ("google_api_key", "GOOGLE_API_KEY"),
 }
 
@@ -279,6 +297,7 @@ class Settings(BaseSettings):
     # API keys — SecretStr prevents accidental logging
     anthropic_api_key: SecretStr | None = None
     openai_api_key: SecretStr | None = None
+    openai_compatible_api_key: SecretStr | None = None
     google_api_key: SecretStr | None = None
     aws_access_key_id: SecretStr | None = None
     aws_secret_access_key: SecretStr | None = None
@@ -334,6 +353,7 @@ class Settings(BaseSettings):
         return {
             "anthropic_api_key": self._has_provider_key("anthropic"),
             "openai_api_key": self._has_provider_key("openai"),
+            "openai_compatible_api_key": self._has_provider_key("openai_compatible"),
             "google_api_key": self._has_provider_key("google"),
             "keyring_backend": type(keyring.get_keyring()).__name__,
         }
@@ -354,11 +374,24 @@ def _reconcile_providers(settings: Settings) -> None:
     for name, (_field, raw_env) in _PROVIDER_KEY_FIELDS.items():
         cfg = getattr(settings.llm, name)
         has_key = settings._has_provider_key(name)
-        if has_key and not cfg.enabled:
+        missing_runtime = name == "openai_compatible" and not cfg.base_url
+        if has_key and not cfg.enabled and not missing_runtime:
             cfg.enabled = True
             log.info("auto-enabled provider (key detected)", provider=name)
+        elif has_key and missing_runtime:
+            log.warning(
+                "provider key detected but required base URL is missing",
+                provider=name,
+                hint="set WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL",
+            )
         elif not has_key and cfg.enabled:
             log.warning("provider enabled but no API key", provider=name, hint=f"set {raw_env}")
+        elif name == "openai_compatible" and cfg.enabled and not cfg.base_url:
+            log.warning(
+                "provider enabled but required base URL is missing",
+                provider=name,
+                hint="set WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL",
+            )
 
 
 @lru_cache(maxsize=1)
@@ -377,6 +410,7 @@ def get_settings() -> Settings:
 _ENV_MAP: dict[str, str] = {
     "anthropic": "anthropic_api_key",
     "openai": "openai_api_key",
+    "openai_compatible": "openai_compatible_api_key",
     "google": "google_api_key",
     "aws_access_key": "aws_access_key_id",
     "aws_secret_key": "aws_secret_access_key",
@@ -401,6 +435,7 @@ def get_api_key(provider: str) -> str | None:
     raw_env_map: dict[str, str] = {
         "anthropic": "ANTHROPIC_API_KEY",
         "openai": "OPENAI_API_KEY",
+        "openai_compatible": "OPENAI_COMPATIBLE_API_KEY",
         "google": "GOOGLE_API_KEY",
         "aws_access_key": "AWS_ACCESS_KEY_ID",
         "aws_secret_key": "AWS_SECRET_ACCESS_KEY",

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -11,7 +11,6 @@ import functools
 import json
 import re
 import time
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -27,7 +26,7 @@ from wikimind.models import CompletionRequest, CompletionResponse, CostLog, Prov
 from wikimind.services.api_keys import get_user_api_key
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from wikimind.engine.provider_base import StreamSession
 
 log = structlog.get_logger()
 
@@ -63,63 +62,12 @@ async def _get_budget_redis():
 
 
 # ---------------------------------------------------------------------------
-# Pricing (USD per 1M tokens) -- update as providers change pricing
-# ---------------------------------------------------------------------------
-
-PRICING = {
-    Provider.ANTHROPIC: {
-        "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
-        "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
-    },
-    Provider.OPENAI: {
-        "gpt-4o": {"input": 2.50, "output": 10.00},
-        "gpt-4o-mini": {"input": 0.15, "output": 0.60},
-    },
-    Provider.GOOGLE: {
-        "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
-    },
-    Provider.OLLAMA: {
-        "*": {"input": 0.0, "output": 0.0},  # Free -- local
-    },
-    Provider.MOCK: {
-        "*": {"input": 0.0, "output": 0.0},  # Free -- deterministic
-    },
-}
-
-
-def _calc_cost(provider: Provider, model: str, input_tokens: int, output_tokens: int) -> float:
-    """Calculate the USD cost of an LLM call based on token counts."""
-    provider_pricing = PRICING.get(provider, {})
-    model_pricing = provider_pricing.get(model) or provider_pricing.get("*", {"input": 0, "output": 0})
-    return (input_tokens * model_pricing["input"] + output_tokens * model_pricing["output"]) / 1_000_000
-
-
-# ---------------------------------------------------------------------------
-# StreamSession -- wraps a streaming LLM response
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class StreamSession:
-    """Wraps a streaming LLM response. Async-iterate for text chunks.
-
-    After iteration completes, ``result`` is populated with token counts
-    and cost information from the provider.
-    """
-
-    _chunks: AsyncIterator[str]
-    result: CompletionResponse | None = field(default=None, init=True)
-
-    def __aiter__(self) -> AsyncIterator[str]:  # noqa: D105
-        return self._chunks
-
-
-# ---------------------------------------------------------------------------
 # Provider imports -- each provider lives in its own file under providers/
 # ---------------------------------------------------------------------------
 
 from wikimind.engine.providers import (  # noqa: E402
     AnthropicProvider,
+    ConfiguredOpenAICompatibleProvider,
     GoogleProvider,
     MockProvider,
     OllamaProvider,
@@ -201,6 +149,8 @@ class LLMRouter:
             return False
         if provider in (Provider.OLLAMA, Provider.MOCK):
             return True  # No API key needed
+        if provider == Provider.OPENAI_COMPATIBLE:
+            return bool(get_api_key(provider.value) and cfg.model and cfg.base_url)
         return bool(get_api_key(provider.value))
 
     async def _get_provider_instance(
@@ -223,6 +173,8 @@ class LLMRouter:
             instance = AnthropicProvider(api_key_override=api_key_override)
         elif provider == Provider.OPENAI:
             instance = OpenAIProvider(api_key_override=api_key_override)
+        elif provider == Provider.OPENAI_COMPATIBLE:
+            instance = ConfiguredOpenAICompatibleProvider(api_key_override=api_key_override)
         elif provider == Provider.GOOGLE:
             instance = GoogleProvider(api_key_override=api_key_override)
         elif provider == Provider.OLLAMA:

--- a/src/wikimind/engine/provider_base.py
+++ b/src/wikimind/engine/provider_base.py
@@ -1,0 +1,58 @@
+"""Shared provider helpers that do not depend on the LLM router."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from wikimind.models import CompletionResponse, Provider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+# Pricing (USD per 1M tokens) -- update as providers change pricing.
+PRICING = {
+    Provider.ANTHROPIC: {
+        "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
+        "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
+    },
+    Provider.OPENAI: {
+        "gpt-4o": {"input": 2.50, "output": 10.00},
+        "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    },
+    Provider.OPENAI_COMPATIBLE: {
+        "*": {"input": 0.0, "output": 0.0},
+    },
+    Provider.GOOGLE: {
+        "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
+    },
+    Provider.OLLAMA: {
+        "*": {"input": 0.0, "output": 0.0},
+    },
+    Provider.MOCK: {
+        "*": {"input": 0.0, "output": 0.0},
+    },
+}
+
+
+def _calc_cost(provider: Provider, model: str, input_tokens: int, output_tokens: int) -> float:
+    """Calculate the USD cost of an LLM call based on token counts."""
+    provider_pricing = PRICING.get(provider, {})
+    model_pricing = provider_pricing.get(model) or provider_pricing.get("*", {"input": 0, "output": 0})
+    return (input_tokens * model_pricing["input"] + output_tokens * model_pricing["output"]) / 1_000_000
+
+
+@dataclass
+class StreamSession:
+    """Wrap a streaming LLM response.
+
+    Async-iterate for text chunks. After iteration completes, ``result`` is
+    populated with token counts and cost information from the provider.
+    """
+
+    _chunks: AsyncIterator[str]
+    result: CompletionResponse | None = field(default=None, init=True)
+
+    def __aiter__(self) -> AsyncIterator[str]:  # noqa: D105
+        return self._chunks

--- a/src/wikimind/engine/providers/__init__.py
+++ b/src/wikimind/engine/providers/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from wikimind.engine.llm_router import StreamSession
+    from wikimind.engine.provider_base import StreamSession
     from wikimind.models import CompletionRequest, CompletionResponse
 
 from wikimind.engine.providers.anthropic import AnthropicProvider
@@ -18,6 +18,10 @@ from wikimind.engine.providers.mock import (
 )
 from wikimind.engine.providers.ollama import OllamaProvider
 from wikimind.engine.providers.openai import OpenAIProvider
+from wikimind.engine.providers.openai_compatible import (
+    ConfiguredOpenAICompatibleProvider,
+    OpenAICompatibleProvider,
+)
 
 
 @runtime_checkable
@@ -55,9 +59,11 @@ __all__ = [
     "_MOCK_LINT_RESPONSE",
     "_MOCK_QA_RESPONSE",
     "AnthropicProvider",
+    "ConfiguredOpenAICompatibleProvider",
     "GoogleProvider",
     "MockProvider",
     "OllamaProvider",
+    "OpenAICompatibleProvider",
     "OpenAIProvider",
     "ProviderProtocol",
 ]

--- a/src/wikimind/engine/providers/anthropic.py
+++ b/src/wikimind/engine/providers/anthropic.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import anthropic
 
 from wikimind.config import get_api_key
-from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.engine.provider_base import StreamSession, _calc_cost
 from wikimind.models import CompletionRequest, CompletionResponse, Provider
 
 if TYPE_CHECKING:

--- a/src/wikimind/engine/providers/google.py
+++ b/src/wikimind/engine/providers/google.py
@@ -10,7 +10,7 @@ from google import genai
 from google.genai import types
 
 from wikimind.config import get_api_key
-from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.engine.provider_base import StreamSession, _calc_cost
 from wikimind.models import CompletionRequest, CompletionResponse, Provider
 
 if TYPE_CHECKING:

--- a/src/wikimind/engine/providers/mock.py
+++ b/src/wikimind/engine/providers/mock.py
@@ -6,7 +6,7 @@ import json
 import time
 from typing import TYPE_CHECKING, Any
 
-from wikimind.engine.llm_router import StreamSession
+from wikimind.engine.provider_base import StreamSession
 from wikimind.models import CompletionRequest, CompletionResponse, Provider, TaskType
 
 if TYPE_CHECKING:

--- a/src/wikimind/engine/providers/ollama.py
+++ b/src/wikimind/engine/providers/ollama.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import ollama
 
-from wikimind.engine.llm_router import StreamSession
+from wikimind.engine.provider_base import StreamSession
 from wikimind.models import CompletionRequest, CompletionResponse, Provider
 
 if TYPE_CHECKING:

--- a/src/wikimind/engine/providers/openai.py
+++ b/src/wikimind/engine/providers/openai.py
@@ -1,173 +1,23 @@
-"""OpenAI LLM provider."""
+"""Official OpenAI LLM provider."""
 
 from __future__ import annotations
 
-import time
-from typing import TYPE_CHECKING, Any
-
-import openai
-
-from wikimind.config import get_api_key
-from wikimind.engine.llm_router import StreamSession, _calc_cost
-from wikimind.models import CompletionRequest, CompletionResponse, Provider
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+from wikimind.engine.providers.openai_compatible import OpenAICompatibleProvider
+from wikimind.models import Provider
 
 
-class OpenAIProvider:
-    """OpenAI LLM provider."""
+class OpenAIProvider(OpenAICompatibleProvider):
+    """Official OpenAI provider using the default OpenAI API endpoint."""
 
-    def __init__(self, api_key_override: str | None = None):
-        api_key = api_key_override or get_api_key("openai")
-        if not api_key:
-            msg = "OpenAI API key not configured"
-            raise ValueError(msg)
-        self.client = openai.AsyncOpenAI(api_key=api_key)
-
-    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
-        """Complete a request using OpenAI."""
-        start = time.monotonic()
-
-        messages = [{"role": "system", "content": request.system}]
-        messages.extend(request.messages)
-
-        kwargs: dict[str, object] = {
-            "model": model,
-            "max_tokens": request.max_tokens,
-            "temperature": request.temperature,
-            "messages": messages,
-        }
-        if request.response_format == "json":
-            kwargs["response_format"] = {"type": "json_object"}
-
-        response = await self.client.chat.completions.create(**kwargs)  # type: ignore[call-overload]
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.choices[0].message.content
-        input_tokens = response.usage.prompt_tokens
-        output_tokens = response.usage.completion_tokens
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.OPENAI,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
+    def __init__(self, api_key_override: str | None = None) -> None:
+        super().__init__(
+            provider=Provider.OPENAI,
+            api_key_name="openai",
+            api_key_override=api_key_override,
+            base_url=None,
+            supports_json_response_format=True,
+            supports_stream_usage=True,
+            supports_reasoning_effort=True,
+            max_tokens_field="max_tokens",
+            reasoning_format="openai",
         )
-
-    async def complete_multimodal(
-        self,
-        system: str,
-        content_parts: list[dict[str, Any]],
-        model: str,
-        max_tokens: int = 4096,
-        temperature: float = 0.3,
-    ) -> CompletionResponse:
-        """Complete a multimodal request with text and images using OpenAI.
-
-        Translates the Anthropic-style content blocks to OpenAI's
-        ``image_url`` format before calling the API.
-
-        Args:
-            system: System prompt.
-            content_parts: List of content blocks in Anthropic format.
-            model: Model name to use.
-            max_tokens: Maximum output tokens.
-            temperature: Sampling temperature.
-
-        Returns:
-            CompletionResponse with the LLM's text output.
-        """
-        start = time.monotonic()
-
-        # Translate Anthropic content blocks to OpenAI format
-        openai_parts: list[dict[str, Any]] = []
-        for part in content_parts:
-            if part["type"] == "text":
-                openai_parts.append({"type": "text", "text": part["text"]})
-            elif part["type"] == "image":
-                media_type = part["source"]["media_type"]
-                data = part["source"]["data"]
-                openai_parts.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:{media_type};base64,{data}"},
-                    }
-                )
-
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": openai_parts},
-        ]
-
-        response = await self.client.chat.completions.create(
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=messages,  # type: ignore[arg-type]
-        )
-
-        latency_ms = int((time.monotonic() - start) * 1000)
-        content = response.choices[0].message.content or ""
-        input_tokens = response.usage.prompt_tokens if response.usage else 0
-        output_tokens = response.usage.completion_tokens if response.usage else 0
-
-        return CompletionResponse(
-            content=content,
-            provider_used=Provider.OPENAI,
-            model_used=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
-            latency_ms=latency_ms,
-        )
-
-    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
-        """Stream a completion request using OpenAI."""
-        messages: list[dict[str, str]] = [{"role": "system", "content": request.system}]
-        messages.extend(request.messages)
-        start = time.monotonic()
-
-        kwargs: dict[str, object] = {
-            "model": model,
-            "max_tokens": request.max_tokens,
-            "temperature": request.temperature,
-            "messages": messages,
-            "stream": True,
-            "stream_options": {"include_usage": True},
-        }
-        if request.response_format == "json":
-            kwargs["response_format"] = {"type": "json_object"}
-
-        async def _generate() -> AsyncIterator[str]:
-            full_text_parts: list[str] = []
-            input_tokens = 0
-            output_tokens = 0
-            response_stream = await self.client.chat.completions.create(
-                **kwargs  # type: ignore[call-overload]
-            )
-            async for chunk in response_stream:
-                if chunk.usage:
-                    input_tokens = chunk.usage.prompt_tokens or 0
-                    output_tokens = chunk.usage.completion_tokens or 0
-                if chunk.choices and chunk.choices[0].delta.content:
-                    text = chunk.choices[0].delta.content
-                    full_text_parts.append(text)
-                    yield text
-
-            latency_ms = int((time.monotonic() - start) * 1000)
-            session.result = CompletionResponse(
-                content="".join(full_text_parts),
-                provider_used=Provider.OPENAI,
-                model_used=model,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cost_usd=_calc_cost(Provider.OPENAI, model, input_tokens, output_tokens),
-                latency_ms=latency_ms,
-            )
-
-        session = StreamSession(_chunks=_generate())
-        return session

--- a/src/wikimind/engine/providers/openai_compatible.py
+++ b/src/wikimind/engine/providers/openai_compatible.py
@@ -1,0 +1,261 @@
+"""OpenAI-compatible Chat Completions provider helpers."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+import openai
+
+from wikimind.config import get_api_key, get_settings
+from wikimind.engine.provider_base import StreamSession, _calc_cost
+from wikimind.models import CompletionRequest, CompletionResponse, Provider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+MaxTokensField = Literal["max_tokens", "max_completion_tokens"]
+ReasoningFormat = Literal["none", "openai", "openrouter"]
+
+
+class OpenAICompatibleProvider:
+    """Provider for OpenAI Chat Completions-compatible endpoints."""
+
+    def __init__(
+        self,
+        *,
+        provider: Provider = Provider.OPENAI_COMPATIBLE,
+        api_key_name: str = "openai_compatible",
+        api_key_override: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        supports_json_response_format: bool = True,
+        supports_stream_usage: bool = True,
+        supports_reasoning_effort: bool = True,
+        max_tokens_field: MaxTokensField = "max_tokens",
+        reasoning_format: ReasoningFormat = "openai",
+    ) -> None:
+        api_key = api_key_override or get_api_key(api_key_name)
+        if not api_key:
+            msg = f"{provider.value} API key not configured"
+            raise ValueError(msg)
+        if provider == Provider.OPENAI_COMPATIBLE and not base_url:
+            msg = "OpenAI-compatible base URL not configured"
+            raise ValueError(msg)
+        if max_tokens_field not in {"max_tokens", "max_completion_tokens"}:
+            msg = "max_tokens_field must be 'max_tokens' or 'max_completion_tokens'"
+            raise ValueError(msg)
+        if reasoning_format not in {"none", "openai", "openrouter"}:
+            msg = "reasoning_format must be 'none', 'openai', or 'openrouter'"
+            raise ValueError(msg)
+
+        self.provider = provider
+        self.supports_json_response_format = supports_json_response_format
+        self.supports_stream_usage = supports_stream_usage
+        self.supports_reasoning_effort = supports_reasoning_effort
+        self.max_tokens_field: MaxTokensField = max_tokens_field
+        self.reasoning_format: ReasoningFormat = reasoning_format
+        self.client = openai.AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            default_headers=default_headers or None,
+        )
+
+    async def complete(self, request: CompletionRequest, model: str) -> CompletionResponse:
+        """Complete a request using an OpenAI-compatible endpoint."""
+        start = time.monotonic()
+
+        messages = [{"role": "system", "content": request.system}]
+        messages.extend(request.messages)
+
+        kwargs: dict[str, object] = {
+            "model": model,
+            self.max_tokens_field: request.max_tokens,
+            "temperature": request.temperature,
+            "messages": messages,
+        }
+        if request.response_format == "json" and self.supports_json_response_format:
+            kwargs["response_format"] = {"type": "json_object"}
+        self._add_reasoning_kwargs(kwargs, request)
+
+        response = await self.client.chat.completions.create(**kwargs)  # type: ignore[call-overload]
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.choices[0].message.content or ""
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+        output_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=self.provider,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=self._calc_response_cost(model, input_tokens, output_tokens, usage),
+            latency_ms=latency_ms,
+        )
+
+    async def complete_multimodal(
+        self,
+        system: str,
+        content_parts: list[dict[str, Any]],
+        model: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+    ) -> CompletionResponse:
+        """Complete a multimodal request with text and images."""
+        start = time.monotonic()
+
+        openai_parts: list[dict[str, Any]] = []
+        for part in content_parts:
+            if part["type"] == "text":
+                openai_parts.append({"type": "text", "text": part["text"]})
+            elif part["type"] == "image":
+                media_type = part["source"]["media_type"]
+                data = part["source"]["data"]
+                openai_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{media_type};base64,{data}"},
+                    }
+                )
+
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": openai_parts},
+        ]
+
+        kwargs: dict[str, object] = {
+            "model": model,
+            self.max_tokens_field: max_tokens,
+            "temperature": temperature,
+            "messages": messages,
+        }
+        response = await self.client.chat.completions.create(**kwargs)  # type: ignore[call-overload]
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        content = response.choices[0].message.content or ""
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+        output_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+
+        return CompletionResponse(
+            content=content,
+            provider_used=self.provider,
+            model_used=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=self._calc_response_cost(model, input_tokens, output_tokens, usage),
+            latency_ms=latency_ms,
+        )
+
+    async def stream(self, request: CompletionRequest, model: str) -> StreamSession:
+        """Stream a completion request using an OpenAI-compatible endpoint."""
+        messages: list[dict[str, str]] = [{"role": "system", "content": request.system}]
+        messages.extend(request.messages)
+        start = time.monotonic()
+
+        kwargs: dict[str, object] = {
+            "model": model,
+            self.max_tokens_field: request.max_tokens,
+            "temperature": request.temperature,
+            "messages": messages,
+            "stream": True,
+        }
+        if self.supports_stream_usage:
+            kwargs["stream_options"] = {"include_usage": True}
+        if request.response_format == "json" and self.supports_json_response_format:
+            kwargs["response_format"] = {"type": "json_object"}
+        self._add_reasoning_kwargs(kwargs, request)
+
+        async def _generate() -> AsyncIterator[str]:
+            full_text_parts: list[str] = []
+            input_tokens = 0
+            output_tokens = 0
+            usage = None
+            response_stream = await self.client.chat.completions.create(**kwargs)  # type: ignore[call-overload]
+            async for chunk in response_stream:
+                usage = getattr(chunk, "usage", None) or usage
+                if usage:
+                    input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                    output_tokens = getattr(usage, "completion_tokens", 0) or 0
+                choices = getattr(chunk, "choices", None) or []
+                text = getattr(choices[0].delta, "content", None) if choices else None
+                if text:
+                    full_text_parts.append(text)
+                    yield text
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            session.result = CompletionResponse(
+                content="".join(full_text_parts),
+                provider_used=self.provider,
+                model_used=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=self._calc_response_cost(model, input_tokens, output_tokens, usage),
+                latency_ms=latency_ms,
+            )
+
+        session = StreamSession(_chunks=_generate())
+        return session
+
+    def _add_reasoning_kwargs(self, kwargs: dict[str, object], request: CompletionRequest) -> None:
+        """Add provider-specific reasoning controls when explicitly requested."""
+        effort = request.reasoning_effort
+        if not effort or effort == "none" or not self.supports_reasoning_effort:
+            return
+        if self.reasoning_format == "openrouter":
+            kwargs["extra_body"] = {"reasoning": {"effort": effort}}
+        elif self.reasoning_format == "openai":
+            kwargs["reasoning_effort"] = effort
+
+    def _calc_response_cost(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        usage: object | None,
+    ) -> float:
+        """Use provider-reported cost when present, otherwise static pricing."""
+        for attr in ("cost", "total_cost"):
+            raw_cost = getattr(usage, attr, None)
+            if isinstance(raw_cost, (int, float)):
+                return float(raw_cost)
+            if isinstance(raw_cost, str):
+                try:
+                    return float(raw_cost)
+                except ValueError:
+                    continue
+        return _calc_cost(self.provider, model, input_tokens, output_tokens)
+
+
+class ConfiguredOpenAICompatibleProvider(OpenAICompatibleProvider):
+    """OpenAI-compatible provider configured from ``settings.llm.openai_compatible``."""
+
+    def __init__(self, api_key_override: str | None = None) -> None:
+        settings = get_settings()
+        cfg = settings.llm.openai_compatible
+        headers = self._default_headers(cfg.site_url, cfg.app_name)
+        super().__init__(
+            provider=Provider.OPENAI_COMPATIBLE,
+            api_key_name="openai_compatible",
+            api_key_override=api_key_override,
+            base_url=cfg.base_url or None,
+            default_headers=headers,
+            supports_json_response_format=cfg.supports_json_response_format,
+            supports_stream_usage=cfg.supports_stream_usage,
+            supports_reasoning_effort=cfg.supports_reasoning_effort,
+            max_tokens_field=cast("MaxTokensField", cfg.max_tokens_field),
+            reasoning_format=cfg.reasoning_format,
+        )
+
+    @staticmethod
+    def _default_headers(site_url: str, app_name: str) -> dict[str, str]:
+        """Build optional attribution headers for compatible gateways."""
+        headers: dict[str, str] = {}
+        if site_url:
+            headers["HTTP-Referer"] = site_url
+        if app_name:
+            headers["X-Title"] = app_name
+        return headers

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -399,7 +399,13 @@ conversation context contradicts the wiki, prefer the wiki."""
         if ctx.no_context_result is not None:
             result = ctx.no_context_result
         else:
-            result = await self._query_llm(request.question, ctx.wiki_context, ctx.prior_turns, session)
+            result = await self._query_llm(
+                request.question,
+                ctx.wiki_context,
+                ctx.prior_turns,
+                session,
+                user_id=user_id,
+            )
 
         return await self._persist_query(request, result, ctx, session, user_id=user_id)
 
@@ -440,7 +446,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             return
 
         assert ctx.completion_request is not None
-        stream_session = await self.router.stream_complete(ctx.completion_request)
+        stream_session = await self.router.stream_complete(ctx.completion_request, user_id=user_id)
         full_text_parts: list[str] = []
         async for chunk_text in stream_session:
             full_text_parts.append(chunk_text)
@@ -544,11 +550,12 @@ conversation context contradicts the wiki, prefer the wiki."""
         context: list[dict],
         prior_turns: list[Query],
         session: AsyncSession,
+        user_id: str | None = None,
     ) -> QueryResult:
         """Build the LLM prompt (with optional conversation context) and call the router."""
         request_obj = self._build_completion_request(question, context, prior_turns)
 
-        response = await self.router.complete(request_obj, session=session)
+        response = await self.router.complete(request_obj, session=session, user_id=user_id)
 
         try:
             data = self.router.parse_json_response(response)

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -215,7 +215,7 @@ class PDFAdapter:
         # step that merges LLM descriptions for diagrams/charts/covers
         # back into the extracted text.
         try:
-            clean_text = await self._enhance_with_vision(file_bytes, clean_text, source.id)
+            clean_text = await self._enhance_with_vision(file_bytes, clean_text, source.id, user_id=source.user_id)
         except Exception:  # TODO: narrow once provider error hierarchy is unified
             log.warning("Vision enhancement failed — using extracted text as-is", source_id=source.id)
 
@@ -359,6 +359,7 @@ class PDFAdapter:
         images: list[bytes],
         page_indices: list[int],
         max_per_batch: int,
+        user_id: str | None = None,
     ) -> dict[int, str]:
         """Send rendered page images to the multimodal LLM for description.
 
@@ -370,6 +371,7 @@ class PDFAdapter:
             images: PNG bytes for each sparse page (parallel to page_indices).
             page_indices: Zero-based page indices corresponding to each image.
             max_per_batch: Maximum images per LLM call.
+            user_id: Optional user ID for BYOK key resolution.
 
         Returns:
             A dict mapping page index to its LLM-generated description.
@@ -428,6 +430,7 @@ class PDFAdapter:
                 task_type=TaskType.INGEST,
                 max_tokens=4096,
                 temperature=0.2,
+                user_id=user_id,
             )
 
             # Parse the response — assign descriptions to page indices.
@@ -487,6 +490,7 @@ class PDFAdapter:
         file_bytes: bytes,
         clean_text: str,
         source_id: str,
+        user_id: str | None = None,
     ) -> str:
         """Apply vision enhancement to PDF text extraction.
 
@@ -498,6 +502,7 @@ class PDFAdapter:
             file_bytes: Raw PDF binary contents.
             clean_text: The text already extracted (fitz or docling).
             source_id: Source ID for progress logging.
+            user_id: Optional user ID for BYOK key resolution.
 
         Returns:
             Enhanced text with LLM descriptions for sparse pages merged in.
@@ -531,6 +536,7 @@ class PDFAdapter:
             images,
             sparse,
             settings.vision_max_pages_per_batch,
+            user_id=user_id,
         )
 
         # Append vision descriptions to the original clean_text (which may

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -20,6 +20,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from wikimind.api.routes import admin, api_keys, auth, export, ingest, jobs, lint, query, wiki, ws
 from wikimind.api.routes import settings as settings_router
+from wikimind.api.routes.settings import apply_runtime_llm_preferences
 from wikimind.api.routes.ws import _start_redis_subscriber, stop_redis_subscriber
 from wikimind.config import get_settings
 from wikimind.database import close_db, get_session_factory, init_db
@@ -30,7 +31,7 @@ from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
 from wikimind.middleware.request_logging import RequestLoggingMiddleware
 from wikimind.middleware.security_headers import SecurityHeadersMiddleware
-from wikimind.models import Article, IngestStatus, Source, UserPreference
+from wikimind.models import Article, IngestStatus, Source
 
 log = structlog.get_logger()
 
@@ -89,20 +90,6 @@ class SPAFallbackMiddleware:
         await self._app(scope, receive, send)
 
 
-async def _apply_db_preferences() -> None:
-    """Apply persisted user preferences to the in-memory settings singleton."""
-    async with get_session_factory()() as session:
-        result = await session.execute(select(UserPreference))
-        for pref in result.scalars().all():
-            settings = get_settings()
-            if pref.key == "llm.default_provider":
-                settings.llm.default_provider = pref.value
-            elif pref.key == "llm.monthly_budget_usd":
-                settings.llm.monthly_budget_usd = float(pref.value)
-            elif pref.key == "llm.fallback_enabled":
-                settings.llm.fallback_enabled = pref.value.lower() == "true"
-
-
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     """Startup and shutdown lifecycle."""
@@ -126,7 +113,7 @@ async def lifespan(_app: FastAPI):
 
     log.info("WikiMind gateway starting", port=settings.gateway_port)
     await init_db()
-    await _apply_db_preferences()
+    await apply_runtime_llm_preferences()
     log.info("Database initialized")
 
     # Reset sources stuck in PROCESSING from a prior crash/restart.

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -8,6 +8,7 @@ Pydantic models carry data through the ingest → compile → query pipeline.
 import uuid
 from datetime import date, datetime
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, computed_field
 from sqlalchemy import Column, String, UniqueConstraint
@@ -99,6 +100,7 @@ class Provider(StrEnum):
 
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
+    OPENAI_COMPATIBLE = "openai_compatible"
     GOOGLE = "google"
     OLLAMA = "ollama"
     MOCK = "mock"
@@ -1120,6 +1122,7 @@ class CompletionRequest(BaseModel):
     response_format: str = "json"  # text | json
     task_type: TaskType = TaskType.COMPILE
     preferred_provider: Provider | None = None
+    reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"] | None = None
 
 
 class CompletionResponse(BaseModel):

--- a/src/wikimind/services/export.py
+++ b/src/wikimind/services/export.py
@@ -262,12 +262,13 @@ class ExportService:
         body_html = _markdown_to_html(markdown_content)
         return _PDF_HTML_TEMPLATE.format(title=_escape_html(title), body=body_html)
 
-    async def export_linkedin(self, title: str, markdown_content: str) -> str:
+    async def export_linkedin(self, title: str, markdown_content: str, user_id: str | None = None) -> str:
         """Rewrite article content as a LinkedIn post via LLM.
 
         Args:
             title: Article title for context.
             markdown_content: Raw article markdown content.
+            user_id: Optional user ID for BYOK key resolution.
 
         Returns:
             LinkedIn post text (plain text, under 300 words).
@@ -285,15 +286,16 @@ class ExportService:
             response_format="text",
             task_type=TaskType.EXPORT,
         )
-        response = await self._llm.complete(request)
+        response = await self._llm.complete(request, user_id=user_id)
         return response.content.strip()
 
-    async def export_slides(self, title: str, markdown_content: str) -> str:
+    async def export_slides(self, title: str, markdown_content: str, user_id: str | None = None) -> str:
         """Generate Marp-compatible slide deck from article content via LLM.
 
         Args:
             title: Article title for context.
             markdown_content: Raw article markdown content.
+            user_id: Optional user ID for BYOK key resolution.
 
         Returns:
             Marp markdown slide deck.
@@ -311,7 +313,7 @@ class ExportService:
             response_format="text",
             task_type=TaskType.EXPORT,
         )
-        response = await self._llm.complete(request)
+        response = await self._llm.complete(request, user_id=user_id)
         return response.content.strip()
 
 

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -160,7 +160,7 @@ async def test_multi_turn_conversation_includes_prior_context_in_prompt(
     # Capture every CompletionRequest passed to router.complete
     captured_requests: list = []
 
-    async def _fake_complete(request, session):
+    async def _fake_complete(request, session, **kwargs):
         captured_requests.append(request)
         return '{"answer": "fake answer", "confidence": "high", "sources": [], "related_articles": [], "follow_up_questions": []}'
 

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -182,6 +182,15 @@ class TestAPIRoutes:
         assert "sk-a" in data["key_hint"]
         assert "cdef" in data["key_hint"]
 
+    async def test_set_openai_compatible_key(self, client: AsyncClient):
+        """PUT accepts the configurable OpenAI-compatible provider."""
+        resp = await client.put(
+            "/api/settings/api-keys/openai_compatible",
+            json={"api_key": "sk-or-test-1234567890abcdef"},  # pragma: allowlist secret
+        )
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "openai_compatible"
+
     async def test_list_keys_empty(self, client: AsyncClient):
         """GET /api/settings/api-keys returns empty list when none configured."""
         resp = await client.get("/api/settings/api-keys")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -31,11 +31,17 @@ def _clean_env(monkeypatch):
 class TestNestedEnvVars:
     """Verify the env_nested_delimiter='__' machinery works with the new factories."""
 
-    def test_default_provider_is_anthropic(self):
+    def test_default_provider_is_anthropic(self, monkeypatch):
+        monkeypatch.delenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL", raising=False)
+        monkeypatch.delenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL", raising=False)
+        monkeypatch.delenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__ENABLED", raising=False)
         s = Settings()
         assert s.llm.default_provider == "anthropic"
         assert s.llm.openai.model == "gpt-4o"  # default preserved
         assert s.llm.openai.enabled is False
+        assert s.llm.openai_compatible.base_url == ""
+        assert s.llm.openai_compatible.supports_reasoning_effort is True
+        assert s.llm.openai_compatible.reasoning_format == "openai"
 
     def test_nested_env_var_override(self, monkeypatch):
         monkeypatch.setenv("WIKIMIND_LLM__DEFAULT_PROVIDER", "openai")
@@ -50,6 +56,19 @@ class TestNestedEnvVars:
         monkeypatch.setenv("WIKIMIND_LLM__OPENAI__MODEL", "gpt-4o-mini")
         s = Settings()
         assert s.llm.openai.model == "gpt-4o-mini"
+
+    def test_openai_compatible_nested_env_vars(self, monkeypatch):
+        monkeypatch.setenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL", "https://openrouter.ai/api/v1")
+        monkeypatch.setenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__MODEL", "openai/gpt-4o-mini")
+        monkeypatch.setenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_STREAM_USAGE", "false")
+        monkeypatch.setenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__SUPPORTS_REASONING_EFFORT", "false")
+        monkeypatch.setenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__REASONING_FORMAT", "openrouter")
+        s = Settings()
+        assert s.llm.openai_compatible.base_url == "https://openrouter.ai/api/v1"
+        assert s.llm.openai_compatible.model == "openai/gpt-4o-mini"
+        assert s.llm.openai_compatible.supports_stream_usage is False
+        assert s.llm.openai_compatible.supports_reasoning_effort is False
+        assert s.llm.openai_compatible.reasoning_format == "openrouter"
 
 
 class TestAutoEnableProviders:
@@ -80,11 +99,25 @@ class TestAutoEnableProviders:
         _reconcile_providers(s)
         assert s.llm.google.enabled is True
 
+    def test_openai_compatible_auto_enables_with_key_and_base_url(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "openrouter-test")
+        monkeypatch.setenv("WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL", "https://openrouter.ai/api/v1")
+        s = Settings()
+        _reconcile_providers(s)
+        assert s.llm.openai_compatible.enabled is True
+
+    def test_openai_compatible_does_not_auto_enable_without_base_url(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "openrouter-test")
+        s = Settings()
+        _reconcile_providers(s)
+        assert s.llm.openai_compatible.enabled is False
+
     def test_no_auto_enable_when_no_keys(self):
         s = Settings()
         _reconcile_providers(s)
         assert s.llm.anthropic.enabled is False
         assert s.llm.openai.enabled is False
+        assert s.llm.openai_compatible.enabled is False
         assert s.llm.google.enabled is False
         assert s.llm.ollama.enabled is False
 
@@ -105,6 +138,7 @@ class TestSecurityStatus:
         status = s.get_security_status()
         assert status["anthropic_api_key"] is False
         assert status["openai_api_key"] is False
+        assert status["openai_compatible_api_key"] is False
         assert status["google_api_key"] is False
         assert "keyring_backend" in status
 

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -114,7 +114,7 @@ async def test_compile_chunked_path(db_session) -> None:
     doc = _doc(tokens=100_000, chunks=chunks)
     chunk_result = _result()
 
-    async def fake_compile(d, sess):
+    async def fake_compile(d, sess, user_id=None):
         # Avoid infinite recursion: only return for sub-chunks
         if d.estimated_tokens < 80_000:
             return chunk_result

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from google.genai import types as genai_types
 
-from wikimind.engine.llm_router import StreamSession, _calc_cost
+from wikimind.engine.provider_base import StreamSession, _calc_cost
 from wikimind.engine.providers import google as google_provider_mod
 from wikimind.engine.providers.google import GoogleProvider
 from wikimind.models import CompletionRequest, CompletionResponse, Provider, TaskType

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -18,14 +19,14 @@ from wikimind.engine.llm_router import (
     MockProvider,
     OllamaProvider,
     OpenAIProvider,
-    StreamSession,
-    _calc_cost,
     _sanitize_json_control_chars,
     get_llm_router,
 )
+from wikimind.engine.provider_base import StreamSession, _calc_cost
 from wikimind.engine.providers import anthropic as anthropic_provider_mod
 from wikimind.engine.providers import ollama as ollama_provider_mod
-from wikimind.engine.providers import openai as openai_provider_mod
+from wikimind.engine.providers import openai_compatible as openai_compatible_provider_mod
+from wikimind.engine.providers.openai_compatible import OpenAICompatibleProvider
 from wikimind.models import (
     CompilationResult,
     CompletionRequest,
@@ -92,6 +93,14 @@ def test_calc_cost_ollama_wildcard() -> None:
     assert _calc_cost(Provider.OLLAMA, "llama3", 1000, 1000) == 0
 
 
+def test_providers_package_imports_without_router_cycle() -> None:
+    """Provider modules should be importable without re-entering the router."""
+    providers = importlib.import_module("wikimind.engine.providers")
+    compatible = importlib.import_module("wikimind.engine.providers.openai_compatible")
+
+    assert providers.OpenAICompatibleProvider is compatible.OpenAICompatibleProvider
+
+
 def test_anthropic_provider_missing_key() -> None:
     with patch.object(anthropic_provider_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
         AnthropicProvider()
@@ -117,7 +126,7 @@ async def test_anthropic_provider_complete() -> None:
 
 
 def test_openai_provider_missing_key() -> None:
-    with patch.object(openai_provider_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
+    with patch.object(openai_compatible_provider_mod, "get_api_key", return_value=None), pytest.raises(ValueError):
         OpenAIProvider()
 
 
@@ -130,8 +139,8 @@ async def test_openai_provider_complete_json() -> None:
     create = AsyncMock(return_value=fake_response)
     fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
     with (
-        patch.object(openai_provider_mod, "get_api_key", return_value="key"),
-        patch.object(openai_provider_mod.openai, "AsyncOpenAI", return_value=fake_client),
+        patch.object(openai_compatible_provider_mod, "get_api_key", return_value="key"),
+        patch.object(openai_compatible_provider_mod.openai, "AsyncOpenAI", return_value=fake_client),
     ):
         provider = OpenAIProvider()
         resp = await provider.complete(_req(response_format="json"), "gpt-4o-mini")
@@ -140,6 +149,137 @@ async def test_openai_provider_complete_json() -> None:
     assert resp.provider_used == Provider.OPENAI
     kwargs = create.call_args.kwargs
     assert kwargs["response_format"] == {"type": "json_object"}
+
+
+async def test_openai_compatible_provider_uses_custom_endpoint_and_flags() -> None:
+    fake_choice = SimpleNamespace(message=SimpleNamespace(content="ok"))
+    fake_response = SimpleNamespace(
+        choices=[fake_choice],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7),
+    )
+    create = AsyncMock(return_value=fake_response)
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    headers = {"X-Title": "WikiMind"}
+    with (
+        patch.object(openai_compatible_provider_mod, "get_api_key", return_value="key"),
+        patch.object(openai_compatible_provider_mod.openai, "AsyncOpenAI", return_value=fake_client) as client_cls,
+    ):
+        provider = OpenAICompatibleProvider(
+            provider=Provider.OPENAI_COMPATIBLE,
+            api_key_name="openai_compatible",
+            base_url="https://openrouter.ai/api/v1",
+            default_headers=headers,
+            supports_json_response_format=False,
+            supports_stream_usage=False,
+            max_tokens_field="max_completion_tokens",
+        )
+        resp = await provider.complete(_req(response_format="json"), "openai/gpt-4o-mini")
+
+    assert resp.content == "ok"
+    assert resp.provider_used == Provider.OPENAI_COMPATIBLE
+    client_cls.assert_called_once_with(
+        api_key="key",
+        base_url="https://openrouter.ai/api/v1",
+        default_headers=headers,
+    )
+    kwargs = create.call_args.kwargs
+    assert kwargs["max_completion_tokens"] == 64
+    assert "max_tokens" not in kwargs
+    assert "response_format" not in kwargs
+
+
+def test_openai_compatible_default_headers_use_openrouter_title() -> None:
+    headers = openai_compatible_provider_mod.ConfiguredOpenAICompatibleProvider._default_headers(
+        site_url="https://wikimind.example",
+        app_name="WikiMind",
+    )
+
+    assert headers == {
+        "HTTP-Referer": "https://wikimind.example",
+        "X-Title": "WikiMind",
+    }
+    assert "X-OpenRouter-Title" not in headers
+
+
+async def test_openai_compatible_provider_sends_openrouter_reasoning() -> None:
+    fake_choice = SimpleNamespace(message=SimpleNamespace(content="ok"))
+    fake_response = SimpleNamespace(
+        choices=[fake_choice],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7),
+    )
+    create = AsyncMock(return_value=fake_response)
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    with (
+        patch.object(openai_compatible_provider_mod, "get_api_key", return_value="key"),
+        patch.object(openai_compatible_provider_mod.openai, "AsyncOpenAI", return_value=fake_client),
+    ):
+        provider = OpenAICompatibleProvider(
+            provider=Provider.OPENAI_COMPATIBLE,
+            api_key_name="openai_compatible",
+            base_url="https://openrouter.ai/api/v1",
+            reasoning_format="openrouter",
+        )
+        await provider.complete(_req(reasoning_effort="high"), "anthropic/claude-3.7-sonnet:thinking")
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["extra_body"] == {"reasoning": {"effort": "high"}}
+    assert "reasoning" not in kwargs
+    assert "reasoning_effort" not in kwargs
+
+
+async def test_openai_compatible_provider_sends_openai_reasoning_effort() -> None:
+    fake_choice = SimpleNamespace(message=SimpleNamespace(content="ok"))
+    fake_response = SimpleNamespace(
+        choices=[fake_choice],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7),
+    )
+    create = AsyncMock(return_value=fake_response)
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    with (
+        patch.object(openai_compatible_provider_mod, "get_api_key", return_value="key"),
+        patch.object(openai_compatible_provider_mod.openai, "AsyncOpenAI", return_value=fake_client),
+    ):
+        provider = OpenAICompatibleProvider(
+            provider=Provider.OPENAI_COMPATIBLE,
+            api_key_name="openai_compatible",
+            base_url="https://example.com/v1",
+            reasoning_format="openai",
+        )
+        await provider.complete(_req(reasoning_effort="medium"), "gpt-5")
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["reasoning_effort"] == "medium"
+    assert "reasoning" not in kwargs
+    assert "extra_body" not in kwargs
+
+
+async def test_openai_compatible_provider_omits_reasoning_when_disabled_or_unset() -> None:
+    fake_choice = SimpleNamespace(message=SimpleNamespace(content="ok"))
+    fake_response = SimpleNamespace(
+        choices=[fake_choice],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7),
+    )
+    create = AsyncMock(return_value=fake_response)
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    with (
+        patch.object(openai_compatible_provider_mod, "get_api_key", return_value="key"),
+        patch.object(openai_compatible_provider_mod.openai, "AsyncOpenAI", return_value=fake_client),
+    ):
+        provider = OpenAICompatibleProvider(
+            provider=Provider.OPENAI_COMPATIBLE,
+            api_key_name="openai_compatible",
+            base_url="https://example.com/v1",
+            supports_reasoning_effort=False,
+            reasoning_format="openrouter",
+        )
+        await provider.complete(_req(reasoning_effort="high"), "non-reasoning-model")
+        await provider.complete(_req(), "non-reasoning-model")
+
+    for call in create.call_args_list:
+        kwargs = call.kwargs
+        assert "reasoning" not in kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "extra_body" not in kwargs
 
 
 async def test_ollama_provider_complete() -> None:
@@ -178,6 +318,7 @@ def _router_with_settings(default="anthropic", **provider_overrides):
     cfgs = {
         "anthropic": SimpleNamespace(enabled=True, model="claude-sonnet-4-5"),
         "openai": SimpleNamespace(enabled=True, model="gpt-4o-mini"),
+        "openai_compatible": SimpleNamespace(enabled=False, model="gpt-4o-mini", base_url=""),
         "google": SimpleNamespace(enabled=False, model="gemini-2.0-flash"),
         "ollama": SimpleNamespace(enabled=True, model="llama3"),
     }
@@ -225,6 +366,24 @@ def test_is_provider_available_ollama_no_key_needed() -> None:
     assert router._is_provider_available(Provider.OLLAMA) is True
 
 
+def test_is_provider_available_openai_compatible_requires_key_and_base_url() -> None:
+    router = _router_with_settings(
+        openai_compatible=SimpleNamespace(
+            enabled=True,
+            model="openai/gpt-4o-mini",
+            base_url="https://openrouter.ai/api/v1",
+        ),
+    )
+    with patch.object(llm_router_mod, "get_api_key", return_value="key"):
+        assert router._is_provider_available(Provider.OPENAI_COMPATIBLE) is True
+
+    router = _router_with_settings(
+        openai_compatible=SimpleNamespace(enabled=True, model="openai/gpt-4o-mini", base_url="")
+    )
+    with patch.object(llm_router_mod, "get_api_key", return_value="key"):
+        assert router._is_provider_available(Provider.OPENAI_COMPATIBLE) is False
+
+
 def test_get_model_returns_unknown_for_missing_cfg() -> None:
     router = _router_with_settings()
     # Force an unknown attribute by removing a provider attribute
@@ -238,15 +397,18 @@ async def test_get_provider_instance_dispatch() -> None:
         patch.object(llm_router_mod, "get_api_key", return_value="k"),
         patch.object(llm_router_mod, "AnthropicProvider") as ant,
         patch.object(llm_router_mod, "OpenAIProvider") as opn,
+        patch.object(llm_router_mod, "ConfiguredOpenAICompatibleProvider") as opc,
         patch.object(llm_router_mod, "GoogleProvider") as ggl,
         patch.object(llm_router_mod, "OllamaProvider") as oll,
     ):
         ant.return_value = "a"
         opn.return_value = "o"
+        opc.return_value = "oc"
         ggl.return_value = "g"
         oll.return_value = "l"
         assert await router._get_provider_instance(Provider.ANTHROPIC) == "a"
         assert await router._get_provider_instance(Provider.OPENAI) == "o"
+        assert await router._get_provider_instance(Provider.OPENAI_COMPATIBLE) == "oc"
         assert await router._get_provider_instance(Provider.GOOGLE) == "g"
         assert await router._get_provider_instance(Provider.OLLAMA) == "l"
 

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -31,7 +31,7 @@ from wikimind.errors import WikiMindError
 from wikimind.middleware import logging_config
 from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import _sanitize_event_dict
-from wikimind.models import Conversation, Query
+from wikimind.models import CompletionResponse, Conversation, Provider, Query
 
 # ----- ws ConnectionManager -----
 
@@ -104,6 +104,34 @@ async def test_settings_test_llm_error(client) -> None:
     resp = await client.post("/settings/llm/test", params={"provider": "anthropic"})
     assert resp.status_code == 200
     assert resp.json()["status"] in ("ok", "error")
+
+
+async def test_settings_test_llm_uses_provider_safe_token_budget(client) -> None:
+    seen = {}
+    settings = get_settings()
+
+    class _Router:
+        def __init__(self) -> None:
+            self.settings = settings
+
+        async def complete(self, request, user_id=None):
+            seen["request"] = request
+            return CompletionResponse(
+                content='{"status":"ok"}',
+                provider_used=Provider.OPENAI_COMPATIBLE,
+                model_used="test-model",
+                input_tokens=1,
+                output_tokens=1,
+                cost_usd=0.0,
+                latency_ms=5,
+            )
+
+    with patch("wikimind.api.routes.settings.get_llm_router", return_value=_Router()):
+        resp = await client.post("/settings/llm/test", params={"provider": "openai_compatible"})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert seen["request"].max_tokens >= 16
 
 
 async def test_settings_get_cost(client, async_engine) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -38,6 +38,7 @@ class TestEnums:
     def test_provider_values(self):
         assert Provider.ANTHROPIC == "anthropic"
         assert Provider.OPENAI == "openai"
+        assert Provider.OPENAI_COMPATIBLE == "openai_compatible"
         assert Provider.OLLAMA == "ollama"
 
     def test_job_status_values(self):

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException
 from wikimind._datetime import utcnow_naive
 from wikimind.config import QAConfig, get_settings
 from wikimind.engine import qa_agent as qa_mod
-from wikimind.engine.llm_router import StreamSession
+from wikimind.engine.provider_base import StreamSession
 from wikimind.engine.qa_agent import QAAgent
 from wikimind.models import (
     Article,

--- a/tests/unit/test_user_preference.py
+++ b/tests/unit/test_user_preference.py
@@ -8,8 +8,10 @@ Covers:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jwt
 import pytest
 
 from wikimind.api.routes import settings as settings_mod
@@ -148,6 +150,94 @@ async def test_patch_fallback(client) -> None:
 
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+async def test_patch_openai_compatible_runtime_config(client) -> None:
+    """Patching OpenAI-compatible endpoint config updates runtime settings."""
+    session_factory, _ = _make_session_with_pref(None)
+    settings = settings_mod.get_settings()
+    original_base_url = settings.llm.openai_compatible.base_url
+    original_model = settings.llm.openai_compatible.model
+    original_supports_reasoning = settings.llm.openai_compatible.supports_reasoning_effort
+    original_reasoning_format = settings.llm.openai_compatible.reasoning_format
+    try:
+        with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+            resp = await client.patch(
+                "/settings",
+                json={
+                    "openai_compatible_base_url": "https://openrouter.ai/api/v1/",
+                    "openai_compatible_model": "openai/gpt-4o-mini",
+                    "openai_compatible_supports_reasoning_effort": True,
+                    "openai_compatible_reasoning_format": "openrouter",
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        assert settings.llm.openai_compatible.base_url == "https://openrouter.ai/api/v1"
+        assert settings.llm.openai_compatible.model == "openai/gpt-4o-mini"
+        assert settings.llm.openai_compatible.supports_reasoning_effort is True
+        assert settings.llm.openai_compatible.reasoning_format == "openrouter"
+    finally:
+        settings.llm.openai_compatible.base_url = original_base_url
+        settings.llm.openai_compatible.model = original_model
+        settings.llm.openai_compatible.supports_reasoning_effort = original_supports_reasoning
+        settings.llm.openai_compatible.reasoning_format = original_reasoning_format
+
+
+async def test_patch_openai_compatible_rejects_invalid_base_url(client) -> None:
+    """OpenAI-compatible base URLs must be absolute HTTP(S) URLs."""
+    resp = await client.patch("/settings", json={"openai_compatible_base_url": "openrouter.ai/api/v1"})
+    assert resp.status_code == 400
+    assert "base URL" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"openai_compatible_base_url": "https://attacker.example/v1"},
+        {"openai_compatible_model": "attacker/model"},
+        {"openai_compatible_supports_json_response_format": False},
+        {"openai_compatible_supports_stream_usage": False},
+        {"openai_compatible_supports_reasoning_effort": True},
+        {"openai_compatible_max_tokens_field": "max_completion_tokens"},
+        {"openai_compatible_reasoning_format": "openrouter"},
+    ],
+)
+async def test_patch_openai_compatible_runtime_config_rejected_when_auth_enabled(
+    client,
+    monkeypatch,
+    payload,
+) -> None:
+    """Authenticated users cannot change global OpenAI-compatible runtime config."""
+    settings = settings_mod.get_settings()
+    secret = "test-secret-key-32-bytes-minimum"
+    monkeypatch.setattr(settings.auth, "enabled", True)
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", secret)
+    token = jwt.encode(
+        {
+            "sub": "user-1",
+            "email": "user@example.com",
+            "exp": datetime.now(UTC) + timedelta(minutes=5),
+        },
+        secret,
+        algorithm=settings.auth.jwt_algorithm,
+    )
+
+    resp = await client.patch(
+        "/settings",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 403
+    assert "runtime settings are global" in resp.json()["detail"]
+
+
+async def test_patch_openai_compatible_rejects_invalid_reasoning_format(client) -> None:
+    """OpenAI-compatible reasoning format must be one of the supported payload styles."""
+    resp = await client.patch("/settings", json={"openai_compatible_reasoning_format": "custom"})
+    assert resp.status_code == 400
+    assert "reasoning format" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a generic OpenAI Chat Completions provider that works with any OpenAI-compatible endpoint (OpenRouter, Together, LM Studio, vLLM, Ollama via /v1, etc.).

Based on @Gondavar's work in #336, rebased on main with BYOK overlap commits dropped (already merged via #360).

- **New provider:** `openai_compatible` with configurable `base_url`, `model`, and compatibility switches
- **Refactored OpenAI provider:** now a thin 23-line subclass of `OpenAICompatibleProvider`
- **Extracted `provider_base.py`:** `StreamSession` and `_calc_cost` moved out of `llm_router.py`
- **Runtime config:** PATCH endpoint for base_url/model, persisted via `UserPreference`
- **Frontend:** OpenAI-compatible card in Settings, onboarding wizard support, API key modal with base_url/model fields
- **Alembic migration:** adds `openai_compatible` to Provider enum

## Changes

- 3 new files, 42 modified
- 937 tests pass, lint clean, typecheck clean

## Test plan

- [x] All 937 tests pass locally
- [x] `make lint` — passes
- [x] Manually tested: provider shows in Settings UI, test connection works against Ollama
- [ ] CI checks

Supersedes #336.
Original author: @Gondavar

🤖 Generated with [Claude Code](https://claude.com/claude-code)