### PR TITLE
refactor: make user_id NOT NULL on all database models

### DIFF
--- a/alembic/versions/0005_make_user_id_not_null_on_all_models.py
+++ b/alembic/versions/0005_make_user_id_not_null_on_all_models.py
@@ -44,7 +44,7 @@ def upgrade() -> None:
 
     # Backfill legacy NULL rows
     for table in _TABLES:
-        op.execute(sa.text(f"UPDATE {table} SET user_id = 'anonymous' WHERE user_id IS NULL"))
+        op.execute(sa.text(f"UPDATE {table} SET user_id = 'anonymous' WHERE user_id IS NULL"))  # noqa: S608 — table names from hardcoded list, not user input
 
     # Make columns NOT NULL
     if conn.dialect.name == "sqlite":

--- a/alembic/versions/0005_make_user_id_not_null_on_all_models.py
+++ b/alembic/versions/0005_make_user_id_not_null_on_all_models.py
@@ -1,0 +1,70 @@
+"""Make user_id NOT NULL on all data models.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-05-01
+
+Backfills NULL user_id rows with 'anonymous' (for legacy data), then
+alters each column to SET NOT NULL. Closes #393.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0005"
+down_revision: str = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES = [
+    "source",
+    "article",
+    "concept",
+    "backlink",
+    "conversation",
+    "query",
+    "job",
+    "costlog",
+    "synclog",
+    "userpreference",
+    "lintreport",
+    "contradictionfinding",
+    "orphanfinding",
+    "structuralfinding",
+]
+
+
+def upgrade() -> None:
+    """Backfill NULL user_id rows and make the column NOT NULL."""
+    conn = op.get_bind()
+
+    # Backfill legacy NULL rows
+    for table in _TABLES:
+        op.execute(sa.text(f"UPDATE {table} SET user_id = 'anonymous' WHERE user_id IS NULL"))
+
+    # Make columns NOT NULL
+    if conn.dialect.name == "sqlite":
+        # SQLite does not support ALTER COLUMN; use batch mode
+        for table in _TABLES:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.alter_column("user_id", existing_type=sa.String(), nullable=False)
+    else:
+        for table in _TABLES:
+            op.alter_column(table, "user_id", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    """Revert user_id columns back to nullable."""
+    conn = op.get_bind()
+
+    if conn.dialect.name == "sqlite":
+        for table in _TABLES:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.alter_column("user_id", existing_type=sa.String(), nullable=True)
+    else:
+        for table in _TABLES:
+            op.alter_column(table, "user_id", existing_type=sa.String(), nullable=True)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2032,9 +2032,7 @@ components:
           type: string
           title: Id
         user_id:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: User Id
         report_id:
           type: string
@@ -2087,6 +2085,7 @@ components:
           title: Shared Concept Id
       type: object
       required:
+      - user_id
       - report_id
       - description
       - content_hash
@@ -2557,9 +2556,7 @@ components:
           type: string
           title: Id
         user_id:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: User Id
         job_type:
           $ref: '#/components/schemas/JobType'
@@ -2608,6 +2605,7 @@ components:
           title: Result Summary
       type: object
       required:
+      - user_id
       - job_type
       title: Job
       description: Async job record.
@@ -2721,9 +2719,7 @@ components:
           type: string
           title: Id
         user_id:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: User Id
         generated_at:
           type: string
@@ -2790,6 +2786,8 @@ components:
           - type: 'null'
           title: Job Id
       type: object
+      required:
+      - user_id
       title: LintReport
       description: One run of the linter. All findings from a run FK back to this
         row via report_id.
@@ -2930,9 +2928,7 @@ components:
           type: string
           title: Id
         user_id:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: User Id
         report_id:
           type: string
@@ -2971,6 +2967,7 @@ components:
           title: Article Title
       type: object
       required:
+      - user_id
       - report_id
       - description
       - content_hash
@@ -3258,9 +3255,7 @@ components:
           type: string
           title: Id
         user_id:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: User Id
         source_type:
           $ref: '#/components/schemas/SourceType'
@@ -3326,6 +3321,7 @@ components:
           readOnly: true
       type: object
       required:
+      - user_id
       - source_type
       - has_original
       title: Source
@@ -3386,9 +3382,7 @@ components:
           type: string
           title: Id
         user_id:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: User Id
         report_id:
           type: string
@@ -3435,6 +3429,7 @@ components:
           default: ''
       type: object
       required:
+      - user_id
       - report_id
       - description
       - content_hash

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlmodel import func, select
 
 from wikimind._datetime import utcnow_naive
-from wikimind.api.deps import get_current_user_id
+from wikimind.api.deps import ANONYMOUS_USER_ID, get_current_user_id
 from wikimind.config import get_api_key, get_settings
 from wikimind.database import get_session, get_session_factory
 from wikimind.engine.llm_router import get_llm_router
@@ -217,14 +217,14 @@ async def _get_preference(key: str) -> str | None:
         return pref.value if pref else None
 
 
-async def _set_preference(key: str, value: str) -> None:
+async def _set_preference(key: str, value: str, user_id: str = ANONYMOUS_USER_ID) -> None:
     async with get_session_factory()() as session:
         pref = await session.get(UserPreference, key)
         if pref:
             pref.value = value
             pref.updated_at = utcnow_naive()
         else:
-            pref = UserPreference(key=key, value=value)
+            pref = UserPreference(key=key, value=value, user_id=user_id)
         session.add(pref)
         await session.commit()
 

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlmodel import func, select
 
 from wikimind._datetime import utcnow_naive
-from wikimind.api.deps import ANONYMOUS_USER_ID, get_current_user_id
+from wikimind.api.deps import get_current_user_id
 from wikimind.config import get_api_key, get_settings
 from wikimind.database import get_session, get_session_factory
 from wikimind.engine.llm_router import get_llm_router
@@ -217,7 +217,7 @@ async def _get_preference(key: str) -> str | None:
         return pref.value if pref else None
 
 
-async def _set_preference(key: str, value: str, user_id: str = ANONYMOUS_USER_ID) -> None:
+async def _set_preference(key: str, value: str, user_id: str) -> None:
     async with get_session_factory()() as session:
         pref = await session.get(UserPreference, key)
         if pref:
@@ -229,7 +229,9 @@ async def _set_preference(key: str, value: str, user_id: str = ANONYMOUS_USER_ID
         await session.commit()
 
 
-async def _update_openai_compatible_base_url(request: SettingsUpdateRequest, settings: Settings) -> bool:
+async def _update_openai_compatible_base_url(
+    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+) -> bool:
     """Persist the configured OpenAI-compatible base URL if present."""
     if request.openai_compatible_base_url is None:
         return False
@@ -238,12 +240,14 @@ async def _update_openai_compatible_base_url(request: SettingsUpdateRequest, set
     if base_url and not base_url.startswith(("http://", "https://")):
         raise HTTPException(status_code=400, detail="OpenAI-compatible base URL must start with http:// or https://")
 
-    await _set_preference("llm.openai_compatible.base_url", base_url)
+    await _set_preference("llm.openai_compatible.base_url", base_url, user_id)
     settings.llm.openai_compatible.base_url = base_url
     return True
 
 
-async def _update_openai_compatible_model(request: SettingsUpdateRequest, settings: Settings) -> bool:
+async def _update_openai_compatible_model(
+    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+) -> bool:
     """Persist the configured OpenAI-compatible model if present."""
     if request.openai_compatible_model is None:
         return False
@@ -252,12 +256,14 @@ async def _update_openai_compatible_model(request: SettingsUpdateRequest, settin
     if not model:
         raise HTTPException(status_code=400, detail="OpenAI-compatible model must not be empty")
 
-    await _set_preference("llm.openai_compatible.model", model)
+    await _set_preference("llm.openai_compatible.model", model, user_id)
     settings.llm.openai_compatible.model = model
     return True
 
 
-async def _update_openai_compatible_bools(request: SettingsUpdateRequest, settings: Settings) -> bool:
+async def _update_openai_compatible_bools(
+    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+) -> bool:
     """Persist OpenAI-compatible boolean capability flags."""
     updated = False
     cfg = settings.llm.openai_compatible
@@ -269,13 +275,15 @@ async def _update_openai_compatible_bools(request: SettingsUpdateRequest, settin
     for field_name, value in bool_updates.items():
         if value is None:
             continue
-        await _set_preference(f"llm.openai_compatible.{field_name}", str(value).lower())
+        await _set_preference(f"llm.openai_compatible.{field_name}", str(value).lower(), user_id)
         setattr(cfg, field_name, value)
         updated = True
     return updated
 
 
-async def _update_openai_compatible_max_tokens_field(request: SettingsUpdateRequest, settings: Settings) -> bool:
+async def _update_openai_compatible_max_tokens_field(
+    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+) -> bool:
     """Persist the max-tokens field selection if present."""
     if request.openai_compatible_max_tokens_field is None:
         return False
@@ -287,7 +295,7 @@ async def _update_openai_compatible_max_tokens_field(request: SettingsUpdateRequ
             detail="OpenAI-compatible max token field must be max_tokens or max_completion_tokens",
         )
 
-    await _set_preference("llm.openai_compatible.max_tokens_field", max_tokens_field)
+    await _set_preference("llm.openai_compatible.max_tokens_field", max_tokens_field, user_id)
     settings.llm.openai_compatible.max_tokens_field = max_tokens_field
     return True
 
@@ -295,6 +303,7 @@ async def _update_openai_compatible_max_tokens_field(request: SettingsUpdateRequ
 async def _update_openai_compatible_reasoning_format(
     request: SettingsUpdateRequest,
     settings: Settings,
+    user_id: str,
 ) -> bool:
     """Persist the reasoning payload style if present."""
     if request.openai_compatible_reasoning_format is None:
@@ -307,7 +316,7 @@ async def _update_openai_compatible_reasoning_format(
             detail="OpenAI-compatible reasoning format must be none, openai, or openrouter",
         )
 
-    await _set_preference("llm.openai_compatible.reasoning_format", reasoning_format)
+    await _set_preference("llm.openai_compatible.reasoning_format", reasoning_format, user_id)
     if reasoning_format == "none":
         settings.llm.openai_compatible.reasoning_format = "none"
     elif reasoning_format == "openai":
@@ -317,7 +326,9 @@ async def _update_openai_compatible_reasoning_format(
     return True
 
 
-async def _update_openai_compatible_settings(request: SettingsUpdateRequest, settings: Settings) -> bool:
+async def _update_openai_compatible_settings(
+    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+) -> bool:
     """Persist runtime OpenAI-compatible settings and update the singleton."""
     updated = False
 
@@ -327,11 +338,11 @@ async def _update_openai_compatible_settings(request: SettingsUpdateRequest, set
             detail="OpenAI-compatible runtime settings are global and cannot be changed by users when auth is enabled",
         )
 
-    updated = await _update_openai_compatible_base_url(request, settings) or updated
-    updated = await _update_openai_compatible_model(request, settings) or updated
-    updated = await _update_openai_compatible_bools(request, settings) or updated
-    updated = await _update_openai_compatible_max_tokens_field(request, settings) or updated
-    updated = await _update_openai_compatible_reasoning_format(request, settings) or updated
+    updated = await _update_openai_compatible_base_url(request, settings, user_id) or updated
+    updated = await _update_openai_compatible_model(request, settings, user_id) or updated
+    updated = await _update_openai_compatible_bools(request, settings, user_id) or updated
+    updated = await _update_openai_compatible_max_tokens_field(request, settings, user_id) or updated
+    updated = await _update_openai_compatible_reasoning_format(request, settings, user_id) or updated
 
     return updated
 
@@ -423,7 +434,7 @@ async def set_default_provider(
                 detail=f"Provider {request.provider} has no API key configured",
             )
 
-    await _set_preference("llm.default_provider", request.provider)
+    await _set_preference("llm.default_provider", request.provider, user_id)
     settings.llm.default_provider = request.provider
     return DefaultProviderResponse(provider=request.provider, status="ok")
 
@@ -431,7 +442,7 @@ async def set_default_provider(
 @router.patch("", response_model=SettingsUpdateResponse)
 async def update_settings(
     request: SettingsUpdateRequest,
-    user_id: str = Depends(get_current_user_id),  # noqa: ARG001
+    user_id: str = Depends(get_current_user_id),
 ):
     """Update runtime settings. Changes persist to DB across restarts."""
     settings = get_settings()
@@ -442,6 +453,7 @@ async def update_settings(
         await _set_preference(
             "llm.monthly_budget_usd",
             str(request.monthly_budget_usd),
+            user_id,
         )
         settings.llm.monthly_budget_usd = request.monthly_budget_usd
 
@@ -449,10 +461,11 @@ async def update_settings(
         await _set_preference(
             "llm.fallback_enabled",
             str(request.fallback_enabled).lower(),
+            user_id,
         )
         settings.llm.fallback_enabled = request.fallback_enabled
 
-    if await _update_openai_compatible_settings(request, settings):
+    if await _update_openai_compatible_settings(request, settings, user_id):
         _refresh_openai_compatible_enabled(settings)
 
     if request.default_provider is not None:
@@ -462,7 +475,7 @@ async def update_settings(
                 status_code=400,
                 detail=(f"Unknown provider: {request.default_provider}"),
             )
-        await _set_preference("llm.default_provider", request.default_provider)
+        await _set_preference("llm.default_provider", request.default_provider, user_id)
         settings.llm.default_provider = request.default_provider
 
     return SettingsUpdateResponse(status="ok")
@@ -651,6 +664,6 @@ async def complete_onboarding(
     user_id: str = Depends(get_current_user_id),
 ):
     """Mark onboarding as complete for the current user."""
-    await _set_preference(_onboarding_key("onboarding.completed", user_id), "true")
-    await _set_preference(_onboarding_key("onboarding.step", user_id), "5")
+    await _set_preference(_onboarding_key("onboarding.completed", user_id), "true", user_id)
+    await _set_preference(_onboarding_key("onboarding.step", user_id), "5", user_id)
     return OnboardingStatusResponse(completed=True, step=5)

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -230,7 +230,9 @@ async def _set_preference(key: str, value: str, user_id: str) -> None:
 
 
 async def _update_openai_compatible_base_url(
-    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+    request: SettingsUpdateRequest,
+    settings: Settings,
+    user_id: str,
 ) -> bool:
     """Persist the configured OpenAI-compatible base URL if present."""
     if request.openai_compatible_base_url is None:
@@ -246,7 +248,9 @@ async def _update_openai_compatible_base_url(
 
 
 async def _update_openai_compatible_model(
-    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+    request: SettingsUpdateRequest,
+    settings: Settings,
+    user_id: str,
 ) -> bool:
     """Persist the configured OpenAI-compatible model if present."""
     if request.openai_compatible_model is None:
@@ -262,7 +266,9 @@ async def _update_openai_compatible_model(
 
 
 async def _update_openai_compatible_bools(
-    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+    request: SettingsUpdateRequest,
+    settings: Settings,
+    user_id: str,
 ) -> bool:
     """Persist OpenAI-compatible boolean capability flags."""
     updated = False
@@ -282,7 +288,9 @@ async def _update_openai_compatible_bools(
 
 
 async def _update_openai_compatible_max_tokens_field(
-    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+    request: SettingsUpdateRequest,
+    settings: Settings,
+    user_id: str,
 ) -> bool:
     """Persist the max-tokens field selection if present."""
     if request.openai_compatible_max_tokens_field is None:
@@ -327,7 +335,9 @@ async def _update_openai_compatible_reasoning_format(
 
 
 async def _update_openai_compatible_settings(
-    request: SettingsUpdateRequest, settings: Settings, user_id: str,
+    request: SettingsUpdateRequest,
+    settings: Settings,
+    user_id: str,
 ) -> bool:
     """Persist runtime OpenAI-compatible settings and update the singleton."""
     updated = False

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -280,6 +280,7 @@ async def recompile_article(
         job_type=JobType.RECOMPILE_ARTICLE,
         status=JobStatus.QUEUED,
         source_id=article_id,
+        user_id=user_id,
     )
     session.add(job)
     await session.commit()

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -411,13 +411,16 @@ async def _backfill_conversation_for_legacy_queries(engine) -> None:
 
         def _select_legacy(sync_conn):
             return sync_conn.execute(
-                sa_text("SELECT id, question, created_at, filed_article_id FROM query WHERE conversation_id IS NULL")
+                sa_text(
+                    "SELECT id, question, created_at, filed_article_id, user_id"
+                    " FROM query WHERE conversation_id IS NULL"
+                )
             ).fetchall()
 
         legacy_rows = await conn.run_sync(_select_legacy)
 
         for row in legacy_rows:
-            query_id, question, created_at_raw, filed_article_id = row
+            query_id, question, created_at_raw, filed_article_id, user_id = row
             conv_id = str(uuid.uuid4())
             title = (question or "")[:title_max]
             # SQLite stores datetimes as strings via SQLModel; reuse the raw value if present
@@ -425,11 +428,12 @@ async def _backfill_conversation_for_legacy_queries(engine) -> None:
 
             await conn.execute(
                 sa_text(
-                    "INSERT INTO conversation (id, title, created_at, updated_at, filed_article_id) "
-                    "VALUES (:id, :title, :created_at, :updated_at, :filed_article_id)"
+                    "INSERT INTO conversation (id, user_id, title, created_at, updated_at, filed_article_id) "
+                    "VALUES (:id, :user_id, :title, :created_at, :updated_at, :filed_article_id)"
                 ),
                 {
                     "id": conv_id,
+                    "user_id": user_id or "anonymous",
                     "title": title,
                     "created_at": created_at,
                     "updated_at": created_at,

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -66,7 +66,7 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
 def _extract_claims(article: Article) -> list[str]:
     """Extract key claims from an article's markdown file."""
     try:
-        wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)  # type: ignore[arg-type]  # #393
+        wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
         content = wiki_path.read_text(encoding="utf-8")
     except (OSError, FileNotFoundError):
         return []

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -332,7 +332,7 @@ def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     if not source.file_path:
         msg = f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument"
         raise ValueError(msg)
-    raw_path = resolve_raw_path(source.file_path, user_id=source.user_id)  # type: ignore[arg-type]  # #393
+    raw_path = resolve_raw_path(source.file_path, user_id=source.user_id)
     clean_text = raw_path.read_text(encoding="utf-8")
     return NormalizedDocument(
         raw_source_id=source.id,

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -60,7 +60,7 @@ async def _sweep_single_article(
         return False
 
     uid = article.user_id
-    file_path = resolve_wiki_path(article.file_path, user_id=uid)  # type: ignore[arg-type]  # #393
+    file_path = resolve_wiki_path(article.file_path, user_id=uid)
     if not file_path.exists():
         log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
         return False
@@ -78,7 +78,7 @@ async def _sweep_single_article(
     resolved, _unresolved = await resolve_backlink_candidates(
         unique_candidates,
         session,
-        user_id=uid,  # type: ignore[arg-type]  # #393
+        user_id=uid,
         exclude_article_id=article.id,
     )
 

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -81,7 +81,7 @@ def _build_normalized_doc(source: Source) -> NormalizedDocument:
         msg = "No cleaned text file path for source"
         raise ValueError(msg)
 
-    text_path = resolve_raw_path(source.file_path, user_id=source.user_id)  # type: ignore[arg-type]  # #393
+    text_path = resolve_raw_path(source.file_path, user_id=source.user_id)
     content = text_path.read_text(encoding="utf-8")
 
     return NormalizedDocument(
@@ -110,13 +110,13 @@ def _try_embed_article(article: Article) -> None:
         embedding_service = get_embedding_service()
         if embedding_service is not None:
             uid = article.user_id
-            wiki_path = resolve_wiki_path(article.file_path, user_id=uid)  # type: ignore[arg-type]  # #393
+            wiki_path = resolve_wiki_path(article.file_path, user_id=uid)
             content = wiki_path.read_text(encoding="utf-8")
             embedding_service.embed_article(
                 article.id,
                 article.title,
                 content,
-                user_id=uid,  # type: ignore[arg-type]  # #393
+                user_id=uid,
             )
             log.info("Article embedded", article_id=article.id)
     except (RuntimeError, ValueError, OSError) as embed_err:
@@ -422,35 +422,25 @@ async def recompile_article(_ctx, article_id: str, mode: str, _job_id: str, user
 
 
 async def lint_all_users(ctx) -> None:
-    """Weekly lint — runs for each user with data, plus legacy unowned data."""
+    """Weekly lint — runs for each user with data."""
     async with get_session_factory()() as session:
         result = await session.execute(
-            select(distinct(Article.user_id)).where(  # type: ignore[arg-type]
-                Article.user_id.isnot(None)  # type: ignore[union-attr]
-            )
+            select(distinct(Article.user_id))  # type: ignore[arg-type]
         )
         user_ids = [row[0] for row in result]
     for uid in user_ids:
         await lint_wiki(ctx, user_id=uid)
-    # Also lint data with no user_id (legacy single-user).
-    # Remove once #393 makes user_id NOT NULL on all models.
-    await lint_wiki(ctx, user_id="anonymous")
 
 
 async def sweep_all_users(ctx) -> None:
-    """Daily sweep — runs for each user with data, plus legacy unowned data."""
+    """Daily sweep — runs for each user with data."""
     async with get_session_factory()() as session:
         result = await session.execute(
-            select(distinct(Article.user_id)).where(  # type: ignore[arg-type]
-                Article.user_id.isnot(None)  # type: ignore[union-attr]
-            )
+            select(distinct(Article.user_id))  # type: ignore[arg-type]
         )
         user_ids = [row[0] for row in result]
     for uid in user_ids:
         await sweep_wikilinks(ctx, user_id=uid)
-    # Also sweep data with no user_id (legacy single-user).
-    # Remove once #393 makes user_id NOT NULL on all models.
-    await sweep_wikilinks(ctx, user_id="anonymous")
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -4,7 +4,6 @@ Runs as a local daemon on localhost:7842. Initializes the database,
 registers all routers, and configures CORS for Electron and web dev servers.
 """
 
-import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -31,7 +30,7 @@ from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
 from wikimind.middleware.request_logging import RequestLoggingMiddleware
 from wikimind.middleware.security_headers import SecurityHeadersMiddleware
-from wikimind.models import Article, IngestStatus, Source
+from wikimind.models import IngestStatus, Source
 
 log = structlog.get_logger()
 
@@ -129,28 +128,6 @@ async def lifespan(_app: FastAPI):
         if stuck:
             await session.commit()
             log.info("Reset stuck processing sources", count=len(stuck))
-
-    # Backfill article.user_id from linked source for articles created
-    # before user_id propagation was fixed. One-time migration that
-    # becomes a no-op once all articles have a user_id set.
-    async with get_session_factory()() as session:
-        result = await session.execute(
-            select(Article).where(Article.user_id.is_(None))  # type: ignore[union-attr]
-        )
-        orphan_articles = list(result.scalars().all())
-        backfilled = 0
-        for article in orphan_articles:
-            source_ids = json.loads(article.source_ids) if article.source_ids else []
-            if not source_ids:
-                continue
-            source = await session.get(Source, source_ids[0])
-            if source and source.user_id:
-                article.user_id = source.user_id
-                session.add(article)
-                backfilled += 1
-        if backfilled:
-            await session.commit()
-            log.info("Backfilled article user_id from source", count=backfilled)
 
     # Start Redis Pub/Sub subscriber for cross-replica WebSocket broadcasts.
     # Idempotent — no-op when Redis is not configured (single-replica dev mode).

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -151,7 +151,7 @@ class Source(SQLModel, table=True):
     """Raw ingested source — before compilation."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     source_type: SourceType
     source_url: str | None = None
     title: str | None = None
@@ -176,7 +176,7 @@ class Source(SQLModel, table=True):
             return False
         from wikimind.storage import find_original_sibling, resolve_raw_path  # noqa: PLC0415
 
-        txt_path = resolve_raw_path(self.file_path, user_id=self.user_id)  # type: ignore[arg-type]  # #393
+        txt_path = resolve_raw_path(self.file_path, user_id=self.user_id)
         return find_original_sibling(txt_path) is not None
 
 
@@ -186,7 +186,7 @@ class Article(SQLModel, table=True):
     __table_args__ = (UniqueConstraint("user_id", "slug", name="uq_article_user_slug"),)
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     slug: str = Field(index=True)
     title: str
     file_path: str  # Path to .md file in wiki/
@@ -255,7 +255,7 @@ class Concept(SQLModel, table=True):
     __table_args__ = (UniqueConstraint("user_id", "name", name="uq_concept_user_name"),)
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     name: str = Field(index=True)
     parent_id: str | None = Field(default=None, foreign_key="concept.id")
     article_count: int = 0
@@ -269,7 +269,7 @@ class Backlink(SQLModel, table=True):
 
     source_article_id: str = Field(foreign_key="article.id", primary_key=True)
     target_article_id: str = Field(foreign_key="article.id", primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     context: str | None = None  # Sentence where link appears
     relation_type: str = Field(default=RelationType.REFERENCES)
     resolution: str | None = None
@@ -292,7 +292,7 @@ class Conversation(SQLModel, table=True):
     """
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     title: str
     created_at: datetime = Field(default_factory=utcnow_naive)
     updated_at: datetime = Field(default_factory=utcnow_naive)
@@ -305,7 +305,7 @@ class Query(SQLModel, table=True):
     """Q&A history entry."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     question: str
     answer: str
     confidence: str | None = None
@@ -326,7 +326,7 @@ class Job(SQLModel, table=True):
     """Async job record."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     job_type: JobType
     status: JobStatus = JobStatus.QUEUED
     source_id: str | None = None
@@ -343,7 +343,7 @@ class CostLog(SQLModel, table=True):
     """LLM API cost tracking."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     provider: Provider
     model: str
     task_type: TaskType
@@ -359,7 +359,7 @@ class SyncLog(SQLModel, table=True):
     """Cloud sync history."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     direction: str  # push | pull
     articles_pushed: int = 0
     articles_pulled: int = 0
@@ -395,7 +395,7 @@ class UserPreference(SQLModel, table=True):
     """
 
     key: str = Field(primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     value: str
     updated_at: datetime = Field(default_factory=utcnow_naive)
 
@@ -623,7 +623,7 @@ class LintReport(SQLModel, table=True):
     """One run of the linter. All findings from a run FK back to this row via report_id."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     generated_at: datetime = Field(default_factory=utcnow_naive, index=True)
     completed_at: datetime | None = None
     status: LintReportStatus = LintReportStatus.IN_PROGRESS
@@ -645,7 +645,7 @@ class _LintFindingBase(SQLModel):
     """Fields shared across every per-kind finding table. NOT a table itself."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    user_id: str | None = Field(default=None, foreign_key="user.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
     report_id: str = Field(foreign_key="lintreport.id", index=True)
     severity: LintSeverity = LintSeverity.WARN
     description: str

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -134,7 +134,7 @@ class IngestService:
             append_log_entry(
                 "ingest",
                 source.title or "untitled",
-                user_id=source.user_id,  # type: ignore[arg-type]  # #393
+                user_id=source.user_id,
                 extra={"source_type": source.source_type, "source_url": source.source_url},
             )
         except OSError:
@@ -169,7 +169,7 @@ class IngestService:
             )
             return
         compiler = get_background_compiler()
-        await compiler.schedule_compile(source.id, user_id=source.user_id, doc=doc)  # type: ignore[arg-type]  # #393
+        await compiler.schedule_compile(source.id, user_id=source.user_id, doc=doc)
         log.info("compilation scheduled", source_id=source.id)
 
     async def list_sources(
@@ -274,12 +274,12 @@ class IngestService:
         files are silently ignored — this method is best-effort cleanup.
         """
         if source.file_path:
-            resolved = resolve_raw_path(source.file_path, user_id=source.user_id)  # type: ignore[arg-type]  # #393
+            resolved = resolve_raw_path(source.file_path, user_id=source.user_id)
             with suppress(OSError):
                 resolved.unlink(missing_ok=True)
 
         # Resolve the user-scoped raw directory to find sibling files
-        raw_dir = resolve_raw_path(f"{source.id}.txt", user_id=source.user_id)  # type: ignore[arg-type]  # #393.parent
+        raw_dir = resolve_raw_path(f"{source.id}.txt", user_id=source.user_id).parent
         if not raw_dir.is_dir():
             return
         for sibling in raw_dir.glob(f"{source.id}.*"):

--- a/tests/unit/test_backlink_enforcer.py
+++ b/tests/unit/test_backlink_enforcer.py
@@ -211,7 +211,7 @@ async def test_contradiction_detection_creates_typed_backlink(db_session, _isola
         }
     )
     settings = get_settings()
-    report = LintReport(id="r1")
+    report = LintReport(id="r1", user_id=TEST_USER_ID)
     db_session.add(report)
     await db_session.flush()
     findings = await detect_contradictions(db_session, mock_router, settings, report, user_id=TEST_USER_ID)

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -297,6 +297,7 @@ async def test_lint_wiki_with_articles(db_session, tmp_path) -> None:
         status=LintReportStatus.COMPLETE,
         contradictions_count=1,
         orphans_count=0,
+        user_id=TEST_USER_ID,
     )
     with (
         _patch_session_factory(db_session),

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -122,7 +122,7 @@ async def test_detect_contradictions_single_concept(db_session, _isolated_data_d
     )
 
     settings = get_settings()
-    report = LintReport(id="r1")
+    report = LintReport(id="r1", user_id=TEST_USER_ID)
     db_session.add(report)
     await db_session.flush()
     findings = await detect_contradictions(db_session, mock_router, settings, report, user_id=TEST_USER_ID)
@@ -170,7 +170,7 @@ async def test_detect_contradictions_no_contradictions(db_session, _isolated_dat
     mock_router.parse_json_response = MagicMock(return_value={"contradictions": []})
 
     settings = get_settings()
-    report = LintReport(id="r1")
+    report = LintReport(id="r1", user_id=TEST_USER_ID)
     db_session.add(report)
     await db_session.flush()
     findings = await detect_contradictions(db_session, mock_router, settings, report, user_id=TEST_USER_ID)
@@ -209,7 +209,7 @@ async def test_detect_contradictions_respects_pair_cap(db_session, _isolated_dat
     # Disable batching so each pair = one LLM call
     settings.linter.contradiction_batch_enabled = False
 
-    report = LintReport(id="r1")
+    report = LintReport(id="r1", user_id=TEST_USER_ID)
     db_session.add(report)
     await db_session.flush()
     await detect_contradictions(db_session, mock_router, settings, report, user_id=TEST_USER_ID)
@@ -246,7 +246,7 @@ async def test_detect_contradictions_batch_single_dict_response(db_session, _iso
     settings.linter.contradiction_batch_enabled = True
     settings.linter.enable_pair_cache = False
 
-    report = LintReport(id="r1")
+    report = LintReport(id="r1", user_id=TEST_USER_ID)
     db_session.add(report)
     await db_session.flush()
     findings = await detect_contradictions(db_session, mock_router, settings, report, user_id=TEST_USER_ID)
@@ -406,6 +406,7 @@ async def test_dismiss_finding_persists_and_suppresses_on_next_run(db_session, _
         id="r1",
         status=LintReportStatus.COMPLETE,
         article_count=2,
+        user_id=TEST_USER_ID,
     )
     db_session.add(report)
 
@@ -425,6 +426,7 @@ async def test_dismiss_finding_persists_and_suppresses_on_next_run(db_session, _
         article_a_claim="claim a",
         article_b_claim="claim b",
         llm_confidence="high",
+        user_id=TEST_USER_ID,
     )
     db_session.add(finding)
     await db_session.commit()
@@ -492,6 +494,7 @@ async def test_linter_service_get_report_filters_dismissed(db_session, _isolated
         article_b_claim="c2",
         llm_confidence="high",
         dismissed=False,
+        user_id=TEST_USER_ID,
     )
     f2 = ContradictionFinding(
         id="f2",
@@ -505,6 +508,7 @@ async def test_linter_service_get_report_filters_dismissed(db_session, _isolated
         llm_confidence="low",
         dismissed=True,
         dismissed_at=utcnow_naive(),
+        user_id=TEST_USER_ID,
     )
     db_session.add(f1)
     db_session.add(f2)

--- a/tests/unit/test_linter_user_scoping.py
+++ b/tests/unit/test_linter_user_scoping.py
@@ -38,13 +38,11 @@ def _make_article(
     article_id: str = "a1",
     slug: str = "test-article",
     title: str = "Test Article",
-    user_id: str | None = None,
+    user_id: str = "test-user",
     claims: list[str] | None = None,
 ) -> Article:
     """Create an Article with a real .md file containing claims."""
-    wiki_dir = tmp_path / "wikimind" / "wiki"
-    if user_id:
-        wiki_dir = wiki_dir / user_id
+    wiki_dir = tmp_path / "wikimind" / "wiki" / user_id
     wiki_dir.mkdir(parents=True, exist_ok=True)
     file_path = wiki_dir / f"{slug}.md"
     body_lines = [f"# {title}", ""]

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -233,7 +233,9 @@ async def test_answer_appends_to_existing_conversation(db_session, tmp_path) -> 
 
 async def test_load_prior_turns_returns_in_order_capped_at_max(db_session, tmp_path) -> None:
     """_load_prior_turns returns at most qa.max_prior_turns_in_context, ordered by turn_index."""
-    conv = Conversation(id="conv-x", title="t", created_at=utcnow_naive(), updated_at=utcnow_naive())
+    conv = Conversation(
+        id="conv-x", title="t", created_at=utcnow_naive(), updated_at=utcnow_naive(), user_id=TEST_USER_ID
+    )
     db_session.add(conv)
 
     for i in range(7):

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -330,6 +330,7 @@ async def test_query_service_ask_returns_ask_response_with_conversation(db_sessi
         related_article_ids=json.dumps([]),
         conversation_id="conv-loop",
         turn_index=0,
+        user_id=TEST_USER_ID,
     )
     db_session.add(fake_conv)
     db_session.add(fake_query)

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -415,4 +415,3 @@ class TestEmbeddingServiceUserScoping:
 
             call_kwargs = mock_collection.query.call_args.kwargs
             assert call_kwargs["where"] == {"user_id": "alice"}
-

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -379,37 +379,6 @@ class TestEmbeddingServiceUserScoping:
         not _SEARCH_AVAILABLE,
         reason="search extras not installed",
     )
-    def test_embed_article_omits_user_id_when_none(self) -> None:
-        from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
-
-        with (
-            patch.object(EmbeddingService, "__init__", lambda self: None),
-            patch.object(
-                EmbeddingService,
-                "_encode",
-                return_value=[[0.1, 0.2]],
-            ),
-        ):
-            svc = EmbeddingService.__new__(EmbeddingService)
-            svc._chunk_size = 500
-            svc._chunk_overlap = 50
-            mock_collection = MagicMock()
-            mock_collection.count.return_value = 0
-            svc._collection = mock_collection
-
-            svc.embed_article("art-1", "Test", "Content here.", user_id=TEST_USER_ID)
-
-            call_args = mock_collection.add.call_args
-            metadatas = call_args.kwargs.get(
-                "metadatas",
-                call_args[1].get("metadatas"),
-            )
-            assert "user_id" not in metadatas[0]
-
-    @pytest.mark.skipif(
-        not _SEARCH_AVAILABLE,
-        reason="search extras not installed",
-    )
     def test_search_passes_user_id_filter(self) -> None:
         from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
 
@@ -447,34 +416,3 @@ class TestEmbeddingServiceUserScoping:
             call_kwargs = mock_collection.query.call_args.kwargs
             assert call_kwargs["where"] == {"user_id": "alice"}
 
-    @pytest.mark.skipif(
-        not _SEARCH_AVAILABLE,
-        reason="search extras not installed",
-    )
-    def test_search_no_where_without_user_id(self) -> None:
-        from wikimind.services.embedding import EmbeddingService  # noqa: PLC0415
-
-        with (
-            patch.object(EmbeddingService, "__init__", lambda self: None),
-            patch.object(
-                EmbeddingService,
-                "_encode",
-                return_value=[[0.1, 0.2]],
-            ),
-        ):
-            svc = EmbeddingService.__new__(EmbeddingService)
-            mock_collection = MagicMock()
-            mock_collection.count.return_value = 5
-            mock_collection.query.return_value = {
-                "ids": [[]],
-                "distances": [[]],
-                "metadatas": [[]],
-                "documents": [[]],
-            }
-            svc._collection = mock_collection
-            svc._min_score = 0.65
-
-            svc.search("query text", limit=5, user_id=TEST_USER_ID)
-
-            call_kwargs = mock_collection.query.call_args.kwargs
-            assert "where" not in call_kwargs

--- a/tests/unit/test_wikilink_user_scoping.py
+++ b/tests/unit/test_wikilink_user_scoping.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 async def _make_article(
     session: AsyncSession,
     title: str,
-    user_id: str | None = None,
+    user_id: str = "test-user",
     slug: str | None = None,
 ) -> Article:
     article = Article(
@@ -153,37 +153,3 @@ async def test_ensure_bidirectional_propagates_user_id(
     inverse = result.scalars().first()
     assert inverse is not None
     assert inverse.user_id == user
-
-
-@pytest.mark.asyncio
-async def test_ensure_bidirectional_null_user_id(
-    db_session: AsyncSession,
-) -> None:
-    """Inverse backlink with null user_id is preserved (legacy compat)."""
-    art_a = await _make_article(db_session, "Art A", slug="art-a-legacy")
-    art_b = await _make_article(db_session, "Art B", slug="art-b-legacy")
-
-    bl = Backlink(
-        source_article_id=art_a.id,
-        target_article_id=art_b.id,
-        relation_type=RelationType.RELATED_TO,
-        context="related",
-        user_id=None,
-    )
-    db_session.add(bl)
-    await db_session.commit()
-
-    created = await ensure_bidirectional(bl, db_session)
-    await db_session.commit()
-
-    assert created is True
-
-    result = await db_session.execute(
-        select(Backlink).where(
-            Backlink.source_article_id == art_b.id,
-            Backlink.target_article_id == art_a.id,
-        )
-    )
-    inverse = result.scalars().first()
-    assert inverse is not None
-    assert inverse.user_id is None


### PR DESCRIPTION
## Summary

Rows could silently get `NULL` user_id because the database models still declared `user_id: str | None = Field(default=None, ...)` even though all service/engine methods already required `user_id: str` after #388. This closes that gap at the schema level.

- Changed all 14 SQLModel table classes (`Source`, `Article`, `Concept`, `Backlink`, `Conversation`, `Query`, `Job`, `CostLog`, `SyncLog`, `UserPreference`, `LintReport`, `ContradictionFinding`, `OrphanFinding`, `StructuralFinding`) from nullable to required `user_id`
- Added Alembic migration 0005 that backfills existing NULL rows with `'anonymous'` then sets `NOT NULL` (with SQLite batch mode support)
- Removed all 12 `# type: ignore[arg-type]  # #393` markers across the codebase
- Cleaned up obsolete runtime backfill code and NULL-guard logic that is no longer needed
- Fixed a few spots where model instances were created without `user_id` (recompile Job, conversation backfill migration, UserPreference creation)

## Test plan

- [x] All 959 unit/integration tests pass
- [x] mypy passes with zero errors
- [x] ruff lint + format pass
- [ ] Verify Alembic migration runs on Fly.io Postgres (`alembic upgrade head`)
- [ ] Verify existing data is backfilled correctly (NULL → 'anonymous')

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)