### PR TITLE
fix: make docker-down clean up orphan containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,8 @@ docker-logs: ## Tail logs from all dev stack services
 
 .PHONY: docker-down
 docker-down: ## Stop and remove the dev stack
-	docker compose down
+	docker compose down --remove-orphans
+	docker compose rm -f 2>/dev/null || true
 
 ##@ 🚀 DEPLOY
 


### PR DESCRIPTION
## Summary
- `docker compose down` alone doesn't remove stale container storage in Podman, causing "name already in use" errors on subsequent `docker compose up -d`
- Adds `--remove-orphans` flag and `docker compose rm -f` fallback

## Test plan
- [x] `make docker-down && make docker-up` no longer fails with name conflicts on Podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)