### PR TITLE
refactor: eliminate resolve_wiki_path/resolve_raw_path bypass

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3316,8 +3316,15 @@ components:
         has_original:
           type: boolean
           title: Has Original
-          description: Whether the original document (PDF, HTML) exists alongside
+          description: 'Whether the original document (PDF, HTML) exists alongside
             the .txt.
+
+
+            Uses get_raw_storage().root for synchronous filesystem access — this is
+
+            a @property on a Pydantic model and cannot be async. The raw path is
+
+            needed for find_original_sibling which scans the directory.'
           readOnly: true
       type: object
       required:

--- a/src/wikimind/api/routes/export.py
+++ b/src/wikimind/api/routes/export.py
@@ -10,17 +10,18 @@ from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
 from wikimind.models import Article, ExportFormat, ExportResponse
 from wikimind.services.export import ExportService, get_export_service
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 log = structlog.get_logger()
 
 router = APIRouter()
 
 
-def _read_article_content(file_path: str, user_id: str) -> str:
-    """Read article markdown content from disk."""
+async def _read_article_content(file_path: str, user_id: str) -> str:
+    """Read article markdown content from disk via storage abstraction."""
     try:
-        return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
+        storage = get_wiki_storage(user_id)
+        return await storage.read(file_path)
     except OSError:
         return ""
 
@@ -76,7 +77,7 @@ async def export_article(
     - **slides**: Returns a Marp-compatible markdown slide deck (JSON with content field).
     """
     article = await _resolve_article(id_or_slug, session, user_id)
-    content = _read_article_content(article.file_path, user_id=user_id)
+    content = await _read_article_content(article.file_path, user_id=user_id)
 
     if not content:
         raise HTTPException(status_code=404, detail="Article content not found on disk")

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -10,7 +10,7 @@ from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
 from wikimind.models import IngestTextRequest, IngestURLRequest, Source
 from wikimind.services.ingest import IngestService, get_ingest_service
-from wikimind.storage import find_original_sibling, resolve_raw_path
+from wikimind.storage import find_original_sibling, get_raw_storage
 
 router = APIRouter()
 
@@ -113,7 +113,11 @@ async def get_source_original(
     if not source.file_path:
         raise HTTPException(status_code=404, detail="No original document available")
 
-    txt_path = resolve_raw_path(source.file_path, user_id=user_id)
+    # Requires raw filesystem path for find_original_sibling (directory scan)
+    # and StreamingResponse (chunked binary read). This is a legitimate use of
+    # storage.root — the streaming response cannot use the async abstraction.
+    storage = get_raw_storage(user_id)
+    txt_path = storage.root / source.file_path
     original = find_original_sibling(txt_path)
     if original is None:
         raise HTTPException(status_code=404, detail="No original document available")

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -721,15 +721,15 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
     from sqlalchemy import or_ as sa_or  # noqa: PLC0415
 
     from wikimind.models import Article, Backlink, PageType  # noqa: PLC0415
-    from wikimind.storage import resolve_wiki_path  # noqa: PLC0415
+    from wikimind.storage import get_wiki_storage  # noqa: PLC0415
 
     result = await session.execute(select(Article).where(Article.page_type == PageType.CONCEPT))
     concept_articles = list(result.scalars().all())
 
     cleaned = 0
     for article in concept_articles:
-        file_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
-        if file_path.exists():
+        storage = get_wiki_storage(article.user_id)
+        if await storage.exists(article.file_path):
             continue
 
         # Remove backlinks referencing the orphaned article first.
@@ -747,7 +747,7 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
             "startup: removed orphaned concept page (file missing)",
             article_id=article.id,
             slug=article.slug,
-            path=str(file_path),
+            path=article.file_path,
         )
 
     if cleaned:

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -7,7 +7,6 @@ This is the core value-creation step.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -50,7 +49,7 @@ from wikimind.services.taxonomy import (
     upsert_concepts,
 )
 from wikimind.services.wiki_index import regenerate_index_md
-from wikimind.storage import LocalFileStorage, resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -424,7 +423,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         """Replace an existing same-source same-provider article in place."""
         old_concept_ids = existing.concept_ids
 
-        old_path = resolve_wiki_path(existing.file_path, user_id=self.user_id)
+        old_relative = existing.file_path
 
         resolved, unresolved = await resolve_backlink_candidates(
             result.backlink_suggestions,
@@ -438,8 +437,9 @@ Compile this into a wiki article following the JSON schema exactly."""
 
         # Delete old file only after new file is written successfully to
         # avoid data loss if the write fails (issue #183).
-        if old_path != resolve_wiki_path(relative_path, user_id=self.user_id):
-            old_path.unlink(missing_ok=True)
+        if old_relative != relative_path:
+            storage = get_wiki_storage(self.user_id)
+            await storage.delete(old_relative)
 
         existing.title = result.title
         existing.summary = result.summary
@@ -649,10 +649,7 @@ provider: {provider_str}
 - {source.title or source.source_url or "Uploaded document"} (ingested {source.ingested_at.strftime("%Y-%m-%d")})
 """
 
-        wiki_root = Path(self.settings.data_dir) / "wiki"
-        if source.user_id:
-            wiki_root = wiki_root / source.user_id
-        storage = LocalFileStorage(root=wiki_root)
+        storage = get_wiki_storage(source.user_id)
         await storage.write(relative_path, content)
 
         # Post-write frontmatter validation (best-effort, log warnings)

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -28,7 +27,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
-from wikimind.storage import LocalFileStorage, resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -113,15 +112,16 @@ async def _collect_source_articles(concept_name: str, session: AsyncSession) -> 
     return list(result.scalars().all())
 
 
-def _build_source_material(articles: list[Article], user_id: str) -> str:
+async def _build_source_material(articles: list[Article], user_id: str) -> str:
     max_chars = get_settings().compiler.concept_source_max_chars
+    storage = get_wiki_storage(user_id)
     parts: list[str] = []
     for i, article in enumerate(articles, 1):
         section = f"### Source {i}: {article.title}\n"
         if article.summary:
             section += f"Summary: {article.summary}\n"
         try:
-            fc = resolve_wiki_path(article.file_path, user_id=user_id).read_text(encoding="utf-8")
+            fc = await storage.read(article.file_path)
             if len(fc) > max_chars:
                 fc = fc[:max_chars] + "\n[...truncated...]"
             section += f"\nContent:\n{fc}\n"
@@ -182,7 +182,7 @@ class ConceptCompiler:
         min_sources = self.settings.taxonomy.concept_page_min_sources
         if len(source_articles) < min_sources:
             return None
-        source_material = _build_source_material(source_articles, user_id=self.user_id)
+        source_material = await _build_source_material(source_articles, user_id=self.user_id)
         source_ids = [a.id for a in source_articles]
         ct = await _collect_contradictions(source_ids, session)
         contradiction_section = ct or "No known contradictions."
@@ -364,10 +364,7 @@ provider: {self._last_provider_used or "unknown"}
 
 {compilation.sources_summary}
 """
-        wiki_root = Path(self.settings.data_dir) / "wiki"
-        if concept.user_id:
-            wiki_root = wiki_root / concept.user_id
-        storage = LocalFileStorage(root=wiki_root)
+        storage = get_wiki_storage(concept.user_id)
         await storage.write(relative_path, content)
         return relative_path
 

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -41,7 +41,7 @@ from wikimind.models import (
     RelationType,
     TaskType,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -63,11 +63,11 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-def _extract_claims(article: Article) -> list[str]:
+async def _extract_claims(article: Article) -> list[str]:
     """Extract key claims from an article's markdown file."""
     try:
-        wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
-        content = wiki_path.read_text(encoding="utf-8")
+        storage = get_wiki_storage(article.user_id)
+        content = await storage.read(article.file_path)
     except (OSError, FileNotFoundError):
         return []
 
@@ -578,8 +578,8 @@ async def detect_contradictions(
                     continue
 
             # Collect claims for uncached pair
-            claims_a = _extract_claims(article_a)
-            claims_b = _extract_claims(article_b)
+            claims_a = await _extract_claims(article_a)
+            claims_b = await _extract_claims(article_b)
             if claims_a and claims_b:
                 uncached_pairs.append((article_a, article_b, claims_a, claims_b))
             else:
@@ -621,8 +621,8 @@ async def _compare_article_pair(
 ) -> list[ContradictionFinding]:
     """Compare a single article pair via LLM and return any findings."""
     cfg = settings.linter
-    claims_a = _extract_claims(article_a)
-    claims_b = _extract_claims(article_b)
+    claims_a = await _extract_claims(article_a)
+    claims_b = await _extract_claims(article_b)
 
     if not claims_a or not claims_b:
         return []

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -31,7 +31,7 @@ from wikimind.models import (
     TaskType,
 )
 from wikimind.services.activity_log import append_log_entry
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -520,7 +520,7 @@ conversation context contradicts the wiki, prefer the wiki."""
 
         relevant = []
         for article in all_articles:
-            content = self._read_article_content(article.file_path, user_id=user_id)
+            content = await self._read_article_content(article.file_path, user_id=user_id)
             if not content:
                 continue
 
@@ -539,9 +539,10 @@ conversation context contradicts the wiki, prefer the wiki."""
         relevant.sort(key=lambda x: x["score"], reverse=True)
         return relevant[:5]
 
-    def _read_article_content(self, file_path: str, user_id: str) -> str | None:
+    async def _read_article_content(self, file_path: str, user_id: str) -> str | None:
         try:
-            return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
+            storage = get_wiki_storage(user_id)
+            return await storage.read(file_path)
         except OSError:
             return None
 
@@ -665,7 +666,8 @@ conversation context contradicts the wiki, prefer the wiki."""
             return article, False
 
         # Update path: overwrite the existing Article's file in place
-        resolve_wiki_path(existing_article.file_path, user_id=user_id).write_text(markdown, encoding="utf-8")
+        storage = get_wiki_storage(user_id)
+        await storage.write(existing_article.file_path, markdown)
         existing_article.updated_at = now
         conversation.updated_at = now
         session.add(existing_article)

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -31,7 +31,7 @@ from wikimind.ingest.utils import (
     estimate_tokens,
 )
 from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType, TaskType
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -190,9 +190,11 @@ class PDFAdapter:
         # worker only ever reads the .txt file (see issue #59), so file_path
         # always points at the cleaned text. The raw .pdf is kept for lineage
         # and future re-extraction (e.g. Docling — see issue #57).
-        raw_pdf_path = resolve_raw_path(f"{source.id}.pdf", user_id=user_id)
-        raw_pdf_path.parent.mkdir(parents=True, exist_ok=True)
-        raw_pdf_path.write_bytes(file_bytes)
+        storage = get_raw_storage(user_id)
+        await storage.write_bytes(f"{source.id}.pdf", file_bytes)
+        # The filesystem path is needed by docling-serve (HTTP upload) and
+        # fitz (PDF library) which require direct file access.
+        raw_pdf_path = storage.root / f"{source.id}.pdf"
 
         # Extract text — prefer docling-serve for structured output (markdown
         # with heading hierarchy, table-aware), fall back to fitz plain text
@@ -219,8 +221,7 @@ class PDFAdapter:
         except _LLM_PROVIDER_ERRORS:
             log.warning("Vision enhancement failed — using extracted text as-is", source_id=source.id)
 
-        text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.write_text(clean_text, encoding="utf-8")
+        await storage.write(f"{source.id}.txt", clean_text)
         source.file_path = f"{source.id}.txt"
 
         token_count = estimate_tokens(clean_text)

--- a/src/wikimind/ingest/adapters/text.py
+++ b/src/wikimind/ingest/adapters/text.py
@@ -17,7 +17,7 @@ from wikimind.ingest.utils import (
     estimate_tokens,
 )
 from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -61,9 +61,8 @@ class TextAdapter:
         # Pasted text is already plain text, so the raw and cleaned files are
         # the same .txt file. file_path always points at the .txt the worker
         # reads (see issue #59).
-        text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.parent.mkdir(parents=True, exist_ok=True)
-        text_path.write_text(content, encoding="utf-8")
+        storage = get_raw_storage(user_id)
+        await storage.write(f"{source.id}.txt", content)
         source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -21,7 +21,7 @@ from wikimind.ingest.utils import (
     estimate_tokens,
 )
 from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -91,11 +91,9 @@ class URLAdapter:
 
         # Save clean extracted text (used by the compiler worker) and
         # keep the raw HTML alongside it for reference/reprocessing.
-        html_path = resolve_raw_path(f"{source.id}.html", user_id=user_id)
-        html_path.parent.mkdir(parents=True, exist_ok=True)
-        html_path.write_text(html, encoding="utf-8")
-        text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.write_text(downloaded, encoding="utf-8")
+        storage = get_raw_storage(user_id)
+        await storage.write(f"{source.id}.html", html)
+        await storage.write(f"{source.id}.txt", downloaded)
         source.file_path = f"{source.id}.txt"
 
         # Normalize

--- a/src/wikimind/ingest/adapters/youtube.py
+++ b/src/wikimind/ingest/adapters/youtube.py
@@ -20,7 +20,7 @@ from wikimind.ingest.utils import (
     estimate_tokens,
 )
 from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -78,9 +78,8 @@ class YouTubeAdapter:
 
         # YouTube transcripts are already plain text, so the raw and cleaned
         # files are the same .txt. There is no separate raw video payload.
-        text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.parent.mkdir(parents=True, exist_ok=True)
-        text_path.write_text(transcript_text, encoding="utf-8")
+        storage = get_raw_storage(user_id)
+        await storage.write(f"{source.id}.txt", transcript_text)
         source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -14,7 +14,7 @@ import structlog
 from sqlmodel import select
 
 from wikimind.models import DocumentChunk, NormalizedDocument, Source
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -305,14 +305,14 @@ async def _check_source_dedup(
                 source_id=existing.id,
                 hash=content_hash[:16],
             )
-            return existing, reconstruct_normalized_doc(existing)
+            return existing, await reconstruct_normalized_doc(existing)
         log.warning("Deleting zombie source (no file_path)", source_id=existing.id)
         await session.delete(existing)
         await session.commit()
     return None
 
 
-def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
+async def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     """Rebuild a :class:`NormalizedDocument` from a previously-ingested source.
 
     Used by the dedup hit path so the adapter's return contract
@@ -332,8 +332,8 @@ def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     if not source.file_path:
         msg = f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument"
         raise ValueError(msg)
-    raw_path = resolve_raw_path(source.file_path, user_id=source.user_id)
-    clean_text = raw_path.read_text(encoding="utf-8")
+    storage = get_raw_storage(source.user_id)
+    clean_text = await storage.read(source.file_path)
     return NormalizedDocument(
         raw_source_id=source.id,
         clean_text=clean_text,

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -24,7 +24,7 @@ from wikimind._datetime import utcnow_naive
 from wikimind.database import get_session_factory
 from wikimind.engine.wikilink_resolver import resolve_backlink_candidates
 from wikimind.models import Article, Backlink, Job, JobStatus, JobType, PageType
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -60,12 +60,12 @@ async def _sweep_single_article(
         return False
 
     uid = article.user_id
-    file_path = resolve_wiki_path(article.file_path, user_id=uid)
-    if not file_path.exists():
-        log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
+    storage = get_wiki_storage(uid)
+    if not await storage.exists(article.file_path):
+        log.warning("sweep: file not found, skipping", article_id=article.id, path=article.file_path)
         return False
 
-    content = file_path.read_text(encoding="utf-8")
+    content = await storage.read(article.file_path)
 
     # Collect all unique bracket texts
     matches = _WIKILINK_RE.findall(content)
@@ -105,7 +105,7 @@ async def _sweep_single_article(
         return False  # pragma: no cover — defensive; resolved non-empty implies change
 
     # Write the updated file
-    file_path.write_text(new_content, encoding="utf-8")
+    await storage.write(article.file_path, new_content)
 
     # Persist Backlink rows — use get-or-create to handle duplicates
     # gracefully. We check each backlink by composite PK and only insert
@@ -154,9 +154,9 @@ async def _cleanup_orphaned_concept_pages(
     concept_articles = list(result.scalars().all())
 
     cleaned = 0
+    storage = get_wiki_storage(user_id)
     for article in concept_articles:
-        file_path = resolve_wiki_path(article.file_path, user_id=user_id)
-        if file_path.exists():
+        if await storage.exists(article.file_path):
             continue
 
         # Bulk-delete backlinks referencing the orphaned article to avoid
@@ -177,7 +177,7 @@ async def _cleanup_orphaned_concept_pages(
             "sweep: removed orphaned concept page (file missing)",
             article_id=article.id,
             slug=article.slug,
-            path=str(file_path),
+            path=article.file_path,
         )
 
     if cleaned:

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -51,7 +51,7 @@ from wikimind.models import (
     Source,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
-from wikimind.storage import resolve_raw_path, resolve_wiki_path
+from wikimind.storage import get_raw_storage, get_wiki_storage
 
 log = structlog.get_logger()
 
@@ -61,7 +61,7 @@ log = structlog.get_logger()
 # ---------------------------------------------------------------------------
 
 
-def _build_normalized_doc(source: Source) -> NormalizedDocument:
+async def _build_normalized_doc(source: Source) -> NormalizedDocument:
     """Read a source's cleaned text file and build a NormalizedDocument.
 
     Used as fallback when no pre-built document is passed (ARQ path or
@@ -81,8 +81,8 @@ def _build_normalized_doc(source: Source) -> NormalizedDocument:
         msg = "No cleaned text file path for source"
         raise ValueError(msg)
 
-    text_path = resolve_raw_path(source.file_path, user_id=source.user_id)
-    content = text_path.read_text(encoding="utf-8")
+    storage = get_raw_storage(source.user_id)
+    content = await storage.read(source.file_path)
 
     return NormalizedDocument(
         raw_source_id=source.id,
@@ -95,7 +95,7 @@ def _build_normalized_doc(source: Source) -> NormalizedDocument:
     )
 
 
-def _try_embed_article(article: Article) -> None:
+async def _try_embed_article(article: Article) -> None:
     """Embed article chunks for semantic search (non-blocking, best-effort).
 
     Silently logs and returns on failure so compilation is never blocked
@@ -110,8 +110,8 @@ def _try_embed_article(article: Article) -> None:
         embedding_service = get_embedding_service()
         if embedding_service is not None:
             uid = article.user_id
-            wiki_path = resolve_wiki_path(article.file_path, user_id=uid)
-            content = wiki_path.read_text(encoding="utf-8")
+            storage = get_wiki_storage(uid)
+            content = await storage.read(article.file_path)
             embedding_service.embed_article(
                 article.id,
                 article.title,
@@ -174,7 +174,7 @@ async def compile_source(
         try:
             if doc is None:
                 await emit_source_progress(source_id, "Normalizing content...", user_id=user_id)
-                doc = _build_normalized_doc(source)
+                doc = await _build_normalized_doc(source)
 
             await emit_source_progress(source_id, "Compiling with LLM...", user_id=user_id)
 
@@ -202,7 +202,7 @@ async def compile_source(
             await emit_compilation_complete(article.slug, article.title, user_id=user_id)
             log.info("compile_source complete", source_id=source_id, slug=article.slug)
 
-            _try_embed_article(article)
+            await _try_embed_article(article)
 
             # Sweep existing articles — a newly compiled article may resolve
             # brackets that were previously unresolvable. Fast (no LLM),
@@ -307,7 +307,7 @@ async def _recompile_from_source(article: Article, session, user_id: str) -> Non
         msg = "Source or source file_path not found"
         raise ValueError(msg)
 
-    doc = _build_normalized_doc(source)
+    doc = await _build_normalized_doc(source)
 
     compiler = Compiler(user_id=user_id)
     result = await compiler.compile(doc, session)

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -171,12 +171,18 @@ class Source(SQLModel, table=True):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def has_original(self) -> bool:
-        """Whether the original document (PDF, HTML) exists alongside the .txt."""
+        """Whether the original document (PDF, HTML) exists alongside the .txt.
+
+        Uses get_raw_storage().root for synchronous filesystem access — this is
+        a @property on a Pydantic model and cannot be async. The raw path is
+        needed for find_original_sibling which scans the directory.
+        """
         if not self.file_path:
             return False
-        from wikimind.storage import find_original_sibling, resolve_raw_path  # noqa: PLC0415
+        from wikimind.storage import find_original_sibling, get_raw_storage  # noqa: PLC0415
 
-        txt_path = resolve_raw_path(self.file_path, user_id=self.user_id)
+        storage = get_raw_storage(self.user_id)
+        txt_path = storage.root / self.file_path
         return find_original_sibling(txt_path) is not None
 
 

--- a/src/wikimind/services/admin.py
+++ b/src/wikimind/services/admin.py
@@ -8,7 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind.config import get_settings
 from wikimind.jobs.background import get_background_compiler
 from wikimind.models import Article, Backlink, Concept, Conversation, Source
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 log = structlog.get_logger()
 
@@ -59,8 +59,8 @@ class AdminService:
         orphan_count = 0
         for article in art_result.scalars().all():
             if article.file_path:
-                wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
-                if not wiki_path.exists():
+                storage = get_wiki_storage(article.user_id)
+                if not await storage.exists(article.file_path):
                     orphan_count += 1
 
         return {
@@ -92,8 +92,8 @@ class AdminService:
         for article in result.scalars().all():
             if not article.file_path:
                 continue
-            wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
-            if not wiki_path.exists():
+            storage = get_wiki_storage(article.user_id)
+            if not await storage.exists(article.file_path):
                 orphans.append(
                     {
                         "id": article.id,

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -9,6 +9,7 @@ and cleaned files written by adapters under ``~/.wikimind/raw/`` (see issue
 
 import functools
 from contextlib import suppress
+from pathlib import PurePosixPath
 
 import httpx
 import structlog
@@ -20,7 +21,7 @@ from wikimind.ingest.service import IngestService as IngestAdapter
 from wikimind.jobs.background import get_background_compiler
 from wikimind.models import NormalizedDocument, Source
 from wikimind.services.activity_log import append_log_entry
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 log = structlog.get_logger()
 
@@ -260,34 +261,33 @@ class IngestService:
         if user_id and source.user_id != user_id:
             raise NotFoundError(msg)
 
-        self._remove_source_files(source)
+        await self._remove_source_files(source)
 
         await session.delete(source)
         await session.commit()
         return {"deleted": source_id}
 
     @staticmethod
-    def _remove_source_files(source: Source) -> None:
+    async def _remove_source_files(source: Source) -> None:
         """Remove the cleaned ``.txt`` file and any sibling raw file for a source.
 
-        The cleaned file path is resolved via ``resolve_raw_path()`` which
-        scopes to the user's directory when ``user_id`` is set. The raw
-        sibling is discovered by scanning the same directory for files sharing
-        the ``{source_id}`` stem (e.g. ``{id}.pdf``, ``{id}.html``). Missing
-        files are silently ignored — this method is best-effort cleanup.
+        Uses the raw storage abstraction to delete the cleaned text and any
+        sibling files sharing the ``{source_id}`` stem (e.g. ``{id}.pdf``,
+        ``{id}.html``). Missing files are silently ignored — this method is
+        best-effort cleanup.
         """
+        storage = get_raw_storage(source.user_id)
         if source.file_path:
-            resolved = resolve_raw_path(source.file_path, user_id=source.user_id)
             with suppress(OSError):
-                resolved.unlink(missing_ok=True)
+                await storage.delete(source.file_path)
 
-        # Resolve the user-scoped raw directory to find sibling files
-        raw_dir = resolve_raw_path(f"{source.id}.txt", user_id=source.user_id).parent
-        if not raw_dir.is_dir():
-            return
-        for sibling in raw_dir.glob(f"{source.id}.*"):
-            with suppress(OSError):
-                sibling.unlink(missing_ok=True)
+        # Delete all sibling files with the same source ID stem
+        all_files = await storage.list()
+        stem = source.id
+        for f in all_files:
+            if PurePosixPath(f).stem == stem:
+                with suppress(OSError):
+                    await storage.delete(f)
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -40,7 +40,7 @@ from wikimind.models import (
     SourceResponse,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 log = structlog.get_logger()
 
@@ -64,18 +64,19 @@ def _first_concept(concept_ids_json: str | None) -> str | None:
     return items[0] if items else None
 
 
-def _read_article_content(file_path: str, user_id: str) -> str:
-    """Read article markdown content from disk.
+async def _read_article_content(file_path: str, user_id: str) -> str:
+    """Read article markdown content from disk via storage abstraction.
 
     Args:
-        file_path: Absolute path to the article markdown file.
+        file_path: Relative path to the article markdown file.
         user_id: Optional user ID for storage namespacing.
 
     Returns:
         The file content, or an empty string if the file cannot be read.
     """
     try:
-        return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
+        storage = get_wiki_storage(user_id)
+        return await storage.read(file_path)
     except OSError:
         return ""
 
@@ -380,7 +381,7 @@ class WikiService:
             concepts=concepts,
             backlinks_in=backlinks_in,
             backlinks_out=backlinks_out,
-            content=_read_article_content(article.file_path, user_id=article.user_id),
+            content=await _read_article_content(article.file_path, user_id=article.user_id),
             sources=[_to_source_response(s) for s in sources],
             created_at=article.created_at,
             updated_at=article.updated_at,
@@ -525,7 +526,7 @@ class WikiService:
         q_lower = q.lower()
         raw_scores: dict[str, int] = {}
         for article in all_articles:
-            content = _read_article_content(article.file_path, user_id=article.user_id)
+            content = await _read_article_content(article.file_path, user_id=article.user_id)
             if q_lower in article.title.lower() or q_lower in content.lower():
                 score = 10 if q_lower in article.title.lower() else 0
                 score += content.lower().count(q_lower)

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -116,8 +116,13 @@ class LocalFileStorage:
         return await asyncio.to_thread(_list)
 
 
-def get_wiki_storage(user_id: str) -> FileStorage:
-    """Return wiki file storage, optionally scoped to a user."""
+def get_wiki_storage(user_id: str) -> LocalFileStorage:
+    """Return wiki file storage, optionally scoped to a user.
+
+    Returns LocalFileStorage so callers that legitimately need the
+    filesystem root (e.g., streaming binary responses) can access
+    ``storage.root``.
+    """
     settings = get_settings()
     root = Path(settings.data_dir) / "wiki"
     if user_id:
@@ -125,45 +130,18 @@ def get_wiki_storage(user_id: str) -> FileStorage:
     return LocalFileStorage(root=root)
 
 
-def get_raw_storage(user_id: str) -> FileStorage:
-    """Return raw source file storage, optionally scoped to a user."""
+def get_raw_storage(user_id: str) -> LocalFileStorage:
+    """Return raw source file storage, optionally scoped to a user.
+
+    Returns LocalFileStorage so callers that legitimately need the
+    filesystem root (e.g., streaming binary responses, PDF extraction
+    via external tools) can access ``storage.root``.
+    """
     settings = get_settings()
     root = Path(settings.data_dir) / "raw"
     if user_id:
         root = root / user_id
     return LocalFileStorage(root=root)
-
-
-def resolve_wiki_path(relative_path: str, user_id: str) -> Path:
-    """Resolve a wiki-relative path to an absolute filesystem path.
-
-    Handles backward compatibility: if the path is already absolute,
-    returns it as-is.
-    """
-    path = Path(relative_path)
-    if path.is_absolute():
-        return path
-    settings = get_settings()
-    root = Path(settings.data_dir) / "wiki"
-    if user_id:
-        root = root / user_id
-    return root / relative_path
-
-
-def resolve_raw_path(relative_path: str, user_id: str) -> Path:
-    """Resolve a raw-relative path to an absolute filesystem path.
-
-    Handles backward compatibility: if the path is already absolute,
-    returns it as-is.
-    """
-    path = Path(relative_path)
-    if path.is_absolute():
-        return path
-    settings = get_settings()
-    root = Path(settings.data_dir) / "raw"
-    if user_id:
-        root = root / user_id
-    return root / relative_path
 
 
 def find_original_sibling(txt_path: Path) -> Path | None:

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -238,7 +238,7 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
     production conditional that gates file-back on confidence.
     """
     # Build the agent with patched router and settings, with data_dir matching
-    # the autouse _isolated_data_dir fixture so resolve_wiki_path is consistent.
+    # the autouse _isolated_data_dir fixture so get_wiki_storage is consistent.
     data_dir = tmp_path / "wikimind"
     with (
         patch.object(qa_mod, "get_llm_router"),

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -31,7 +31,7 @@ from wikimind.models import (
     Source,
     SourceType,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -92,7 +92,8 @@ async def test_wikilink_resolution_end_to_end(
     assert backlinks[0].target_article_id == target.id
 
     # 4. Markdown has the resolved link by ID and the unresolved bracket
-    content = resolve_wiki_path(article.file_path, user_id=article.user_id).read_text()
+    storage = get_wiki_storage(article.user_id)
+    content = (storage.root / article.file_path).read_text()
     assert f"[Existing Target](/wiki/{target.id})" in content
     assert "[[Nonexistent Topic]]" in content
 

--- a/tests/unit/test_concept_compiler.py
+++ b/tests/unit/test_concept_compiler.py
@@ -62,14 +62,16 @@ async def _seed_kind(s, name="topic"):
 
 
 async def _mk_art(s, tp, slug, title, concepts, summary="Sum."):
-    d = tp / "wiki" / "test"
-    d.mkdir(parents=True, exist_ok=True)
-    fp = d / f"{slug}.md"
+    # Write under the storage root set by the autouse _isolated_data_dir fixture
+    wiki_dir = tp / "wikimind" / "wiki" / TEST_USER_ID / "test"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    fp = wiki_dir / f"{slug}.md"
     fp.write_text(f"# {title}\n{summary}", encoding="utf-8")
+    relative_path = f"test/{slug}.md"
     a = Article(
         slug=slug,
         title=title,
-        file_path=str(fp),
+        file_path=relative_path,
         summary=summary,
         concept_ids=json.dumps(concepts),
         page_type=PageType.SOURCE,
@@ -108,14 +110,14 @@ class TestCollectSourceArticles:
 
     async def test_excludes_concept(self, db_session, tmp_path):
         await _mk_art(db_session, tmp_path, "s1", "S1", ["ml"])
-        d = tmp_path / "wiki" / "ml"
+        d = tmp_path / "wikimind" / "wiki" / TEST_USER_ID / "ml"
         d.mkdir(parents=True, exist_ok=True)
         fp = d / "c.md"
         fp.write_text("# C", encoding="utf-8")
         ca = Article(
             slug="concept-ml",
             title="ML",
-            file_path=str(fp),
+            file_path="ml/c.md",
             concept_ids=json.dumps(["ml"]),
             page_type=PageType.CONCEPT,
             user_id=TEST_USER_ID,
@@ -202,7 +204,7 @@ class TestConceptPageOutput:
             patch(
                 "wikimind.engine.concept_compiler.get_settings",
                 return_value=SimpleNamespace(
-                    data_dir=str(tmp_path),
+                    data_dir=str(tmp_path / "wikimind"),
                     taxonomy=SimpleNamespace(concept_page_min_sources=2),
                     compiler=SimpleNamespace(
                         max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000
@@ -212,7 +214,7 @@ class TestConceptPageOutput:
         ):
             art = await ConceptCompiler(user_id=TEST_USER_ID).compile_concept_page(c, db_session)
         assert art is not None
-        content = (Path(tmp_path) / "wiki" / TEST_USER_ID / art.file_path).read_text(encoding="utf-8")
+        content = (Path(tmp_path) / "wikimind" / "wiki" / TEST_USER_ID / art.file_path).read_text(encoding="utf-8")
         assert "page_type: concept" in content
         for s in [
             "## Overview",

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -39,7 +39,7 @@ from wikimind.models import (
 )
 from wikimind.services import ingest as svc_ingest
 from wikimind.services.ingest import IngestService
-from wikimind.storage import resolve_raw_path
+from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -177,7 +177,8 @@ class TestTextAdapterDedup:
         body = "Stable text content."
 
         first, _ = await adapter.ingest(body, "first", db_session, user_id=TEST_USER_ID)
-        text_path = resolve_raw_path(first.file_path, user_id=TEST_USER_ID)
+        storage = get_raw_storage(TEST_USER_ID)
+        text_path = storage.root / first.file_path
         first_mtime = text_path.stat().st_mtime_ns
 
         second, _ = await adapter.ingest(body, "second", db_session, user_id=TEST_USER_ID)
@@ -261,17 +262,17 @@ class TestReconstructNormalizedDoc:
         body = "Cached body content."
         source, _ = await adapter.ingest(body, "title", db_session, user_id=TEST_USER_ID)
 
-        doc = reconstruct_normalized_doc(source)
+        doc = await reconstruct_normalized_doc(source)
 
         assert doc.raw_source_id == source.id
         assert doc.clean_text == body
         assert doc.title == "title"
         assert doc.chunks  # at least one chunk
 
-    def test_raises_when_file_path_missing(self) -> None:
+    async def test_raises_when_file_path_missing(self) -> None:
         source = Source(source_type=SourceType.TEXT, title="x", file_path=None, user_id=TEST_USER_ID)
         with pytest.raises(ValueError, match="no file_path"):
-            reconstruct_normalized_doc(source)
+            await reconstruct_normalized_doc(source)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -239,15 +239,13 @@ async def test_generate_unique_slug_skips_multiple_collisions(db_session) -> Non
 
 
 async def test_write_article_file(tmp_path) -> None:
-    with (
-        patch.object(compiler_mod, "get_llm_router"),
-        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
-    ):
+    with patch.object(compiler_mod, "get_llm_router"):
         c = Compiler(user_id=TEST_USER_ID)
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X", user_id=TEST_USER_ID)
     rel_path = await c._write_article_file(_result(), src, "test-slug", [], [])
     assert isinstance(rel_path, str)
-    full_path = Path(tmp_path) / "wiki" / TEST_USER_ID / rel_path
+    # The autouse _isolated_data_dir fixture sets data_dir to tmp_path / "wikimind"
+    full_path = Path(tmp_path) / "wikimind" / "wiki" / TEST_USER_ID / rel_path
     assert full_path.exists()
     text = full_path.read_text()
     assert "Test Article" in text
@@ -255,10 +253,7 @@ async def test_write_article_file(tmp_path) -> None:
 
 
 async def test_write_article_file_no_concepts(tmp_path) -> None:
-    with (
-        patch.object(compiler_mod, "get_llm_router"),
-        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
-    ):
+    with patch.object(compiler_mod, "get_llm_router"):
         c = Compiler(user_id=TEST_USER_ID)
     r = CompilationResult(
         title="t",
@@ -272,16 +267,13 @@ async def test_write_article_file_no_concepts(tmp_path) -> None:
     src = Source(source_type=SourceType.TEXT, title=None, user_id=TEST_USER_ID)
     rel_path = await c._write_article_file(r, src, "no-concept", [], [])
     assert isinstance(rel_path, str)
-    full_path = Path(tmp_path) / "wiki" / TEST_USER_ID / rel_path
+    full_path = Path(tmp_path) / "wikimind" / "wiki" / TEST_USER_ID / rel_path
     assert full_path.exists()
     assert "general" in rel_path
 
 
 async def test_save_article(db_session, tmp_path) -> None:
-    with (
-        patch.object(compiler_mod, "get_llm_router"),
-        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
-    ):
+    with patch.object(compiler_mod, "get_llm_router"):
         c = Compiler(user_id=TEST_USER_ID)
     src = Source(
         source_type=SourceType.URL,
@@ -296,7 +288,7 @@ async def test_save_article(db_session, tmp_path) -> None:
     article = await c.save_article(_result(), src, db_session)
     assert article.slug
     assert not Path(article.file_path).is_absolute()  # relative path
-    assert (Path(tmp_path) / "wiki" / TEST_USER_ID / article.file_path).exists()
+    assert (Path(tmp_path) / "wikimind" / "wiki" / TEST_USER_ID / article.file_path).exists()
     assert src.status == IngestStatus.COMPILED
 
 
@@ -373,10 +365,7 @@ async def _make_source(session) -> Source:
 
 
 def _compiler_for(tmp_path: Path) -> Compiler:
-    with (
-        patch.object(compiler_mod, "get_llm_router"),
-        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
-    ):
+    with patch.object(compiler_mod, "get_llm_router"):
         return Compiler(user_id=TEST_USER_ID)
 
 
@@ -428,7 +417,7 @@ async def test_save_markdown_has_resolved_link_and_unresolved_bracket(db_session
     )
     article = await compiler.save_article(result, source, db_session)
 
-    content = (Path(tmp_path) / "wiki" / TEST_USER_ID / article.file_path).read_text()
+    content = (Path(tmp_path) / "wikimind" / "wiki" / TEST_USER_ID / article.file_path).read_text()
     assert f"[Existing Article](/wiki/{target.id})" in content
     assert "[[Nonexistent Topic]]" in content
     assert "- [[Existing Article]]" not in content

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -47,7 +47,7 @@ def _make_article(
     claims: list[str] | None = None,
 ) -> Article:
     """Create an Article with a real .md file containing claims."""
-    # Write into the wiki directory so resolve_wiki_path can find it.
+    # Write into the wiki directory so get_wiki_storage can find it.
     wiki_dir = tmp_path / "wikimind" / "wiki" / TEST_USER_ID
     wiki_dir.mkdir(parents=True, exist_ok=True)
     file_path = wiki_dir / f"{slug}.md"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,11 +1,11 @@
 """Tests for core data models — enums, SQLModel tables, Pydantic schemas."""
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
 from tests.conftest import TEST_USER_ID
+from wikimind.config import get_settings
 from wikimind.models import (
     Article,
     ConfidenceLevel,
@@ -81,19 +81,27 @@ class TestJobModel:
 
 def test_source_has_original_true_when_pdf_sibling_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """has_original is True when a non-.txt sibling exists in raw/."""
-    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p, **kw: tmp_path / p)
-    (tmp_path / "src-1.txt").write_text("text")
-    (tmp_path / "src-1.pdf").write_bytes(b"%PDF")
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    raw_dir = tmp_path / "raw" / TEST_USER_ID
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "src-1.txt").write_text("text")
+    (raw_dir / "src-1.pdf").write_bytes(b"%PDF")
     source = Source(id="src-1", source_type=SourceType.PDF, file_path="src-1.txt", user_id=TEST_USER_ID)
     assert source.has_original is True
+    get_settings.cache_clear()
 
 
 def test_source_has_original_false_for_text_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """has_original is False when only the .txt exists."""
-    monkeypatch.setattr("wikimind.storage.resolve_raw_path", lambda p, **kw: tmp_path / p)
-    (tmp_path / "src-2.txt").write_text("text")
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    raw_dir = tmp_path / "raw" / TEST_USER_ID
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "src-2.txt").write_text("text")
     source = Source(id="src-2", source_type=SourceType.TEXT, file_path="src-2.txt", user_id=TEST_USER_ID)
     assert source.has_original is False
+    get_settings.cache_clear()
 
 
 def test_source_has_original_false_when_no_file_path() -> None:
@@ -102,13 +110,15 @@ def test_source_has_original_false_when_no_file_path() -> None:
     assert source.has_original is False
 
 
-def test_source_has_original_passes_user_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """has_original passes user_id to resolve_raw_path for correct directory scoping."""
-    mock_resolve = MagicMock(return_value=tmp_path / "src-4.txt")
-    monkeypatch.setattr("wikimind.storage.resolve_raw_path", mock_resolve)
-    (tmp_path / "src-4.txt").write_text("text")
+def test_source_has_original_scopes_by_user_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """has_original uses the correct user-scoped raw directory."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    raw_dir = tmp_path / "raw" / "user-abc"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "src-4.txt").write_text("text")
+    (raw_dir / "src-4.pdf").write_bytes(b"%PDF")
 
     source = Source(id="src-4", source_type=SourceType.PDF, file_path="src-4.txt", user_id="user-abc")
-    _ = source.has_original
-
-    mock_resolve.assert_called_once_with("src-4.txt", user_id="user-abc")
+    assert source.has_original is True
+    get_settings.cache_clear()

--- a/tests/unit/test_phase2_compiler.py
+++ b/tests/unit/test_phase2_compiler.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from sqlmodel import select
@@ -55,10 +54,7 @@ def _doc(tokens=100):
 
 
 def _compiler_for(tmp_path):
-    with (
-        patch.object(compiler_mod, "get_llm_router"),
-        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
-    ):
+    with patch.object(compiler_mod, "get_llm_router"):
         return Compiler(user_id=TEST_USER_ID)
 
 
@@ -282,14 +278,12 @@ def test_parse_frontmatter_extracts_yaml():
 
 
 async def test_write_article_file_includes_page_type(tmp_path):
-    with (
-        patch.object(compiler_mod, "get_llm_router"),
-        patch.object(compiler_mod, "get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))),
-    ):
+    with patch.object(compiler_mod, "get_llm_router"):
         c = Compiler(user_id=TEST_USER_ID)
     src = Source(source_type=SourceType.URL, source_url="http://x", title="X", user_id=TEST_USER_ID)
     rel_path = await c._write_article_file(_result(), src, "test-slug", [], [])
-    full_path = Path(tmp_path) / "wiki" / TEST_USER_ID / rel_path
+    # The autouse _isolated_data_dir fixture sets data_dir to tmp_path / "wikimind"
+    full_path = Path(tmp_path) / "wikimind" / "wiki" / TEST_USER_ID / rel_path
     assert full_path.exists()
     text = full_path.read_text()
     assert "page_type: source" in text

--- a/tests/unit/test_phase5.py
+++ b/tests/unit/test_phase5.py
@@ -24,7 +24,7 @@ from wikimind.services.wiki_index import (
     generate_meta_health_page,
     regenerate_index_md,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -82,7 +82,7 @@ class TestRegenerateIndexMdPageType:
     async def test_frontmatter_includes_page_type(self, db_session: AsyncSession) -> None:
         """The index should have page_type: index in its frontmatter."""
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "page_type: index" in content
         assert "scope: global" in content
@@ -96,7 +96,7 @@ class TestRegenerateIndexMdPageType:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "2 articles" in content
         assert "1 source" in content
@@ -116,7 +116,7 @@ class TestRegenerateIndexMdPageType:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "## Concept Pages" in content
         assert "[[llm-reasoning]]" in content
@@ -131,7 +131,7 @@ class TestRegenerateIndexMdPageType:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "`[Answer]`" in content
 
@@ -146,7 +146,7 @@ class TestGenerateMetaHealthPage:
     async def test_empty_database_produces_health_page(self, db_session: AsyncSession) -> None:
         """An empty DB should produce a valid health page."""
         rel = await generate_meta_health_page(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         assert path.exists()
         content = path.read_text(encoding="utf-8")
         assert "page_type: meta" in content
@@ -164,7 +164,7 @@ class TestGenerateMetaHealthPage:
         await db_session.commit()
 
         rel = await generate_meta_health_page(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "| Source | 2 |" in content
         assert "| Answer | 1 |" in content
@@ -183,7 +183,7 @@ class TestGenerateMetaHealthPage:
         await db_session.commit()
 
         rel = await generate_meta_health_page(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "**1** articles with no inbound or outbound links" in content
 
@@ -211,7 +211,7 @@ class TestGenerateMetaHealthPage:
         await db_session.commit()
 
         rel = await generate_meta_health_page(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
         assert "| contradicts | 1 |" in content
         assert "| references | 1 |" in content

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -24,7 +24,7 @@ from wikimind.models import (
     QueryRequest,
     QueryResult,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 
 def _agent(tmp_path) -> QAAgent:
@@ -47,16 +47,18 @@ def _agent(tmp_path) -> QAAgent:
         return QAAgent()
 
 
-def test_read_article_content_missing(tmp_path) -> None:
+async def test_read_article_content_missing(tmp_path) -> None:
     a = _agent(tmp_path)
-    assert a._read_article_content("/no/such/file.md", user_id=TEST_USER_ID) is None
+    assert await a._read_article_content("no/such/file.md", user_id=TEST_USER_ID) is None
 
 
-def test_read_article_content_ok(tmp_path) -> None:
+async def test_read_article_content_ok(tmp_path) -> None:
     a = _agent(tmp_path)
-    f = tmp_path / "x.md"
-    f.write_text("hello", encoding="utf-8")
-    assert a._read_article_content(str(f), user_id=TEST_USER_ID) == "hello"
+    # The autouse _isolated_data_dir sets data_dir to tmp_path / "wikimind"
+    wiki_dir = tmp_path / "wikimind" / "wiki" / TEST_USER_ID
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / "x.md").write_text("hello", encoding="utf-8")
+    assert await a._read_article_content("x.md", user_id=TEST_USER_ID) == "hello"
 
 
 async def test_retrieve_context_scores(db_session, tmp_path) -> None:
@@ -76,7 +78,7 @@ async def test_retrieve_context_scores(db_session, tmp_path) -> None:
 
 async def test_retrieve_context_skips_unreadable(db_session, tmp_path) -> None:
     a = _agent(tmp_path)
-    art = Article(slug="x", title="X", file_path="/no/such/file", user_id=TEST_USER_ID)
+    art = Article(slug="x", title="X", file_path="no/such/file.md", user_id=TEST_USER_ID)
     db_session.add(art)
     await db_session.commit()
     assert await a._retrieve_context("anything", db_session, user_id=TEST_USER_ID) == []
@@ -315,7 +317,8 @@ async def test_file_back_thread_creates_article_when_first_save(db_session, tmp_
     assert refreshed.filed_article_id == article.id
 
     # The .md file exists on disk
-    assert resolve_wiki_path(article.file_path, user_id=TEST_USER_ID).exists()
+    storage = get_wiki_storage(TEST_USER_ID)
+    assert (storage.root / article.file_path).exists()
 
 
 async def test_file_back_thread_updates_in_place_on_second_save(db_session, tmp_path, monkeypatch) -> None:
@@ -372,7 +375,8 @@ async def test_file_back_thread_updates_in_place_on_second_save(db_session, tmp_
     assert second_article.file_path == first_path  # same file path
 
     # The file content now reflects both turns
-    content = resolve_wiki_path(first_path, user_id=TEST_USER_ID).read_text()
+    storage = get_wiki_storage(TEST_USER_ID)
+    content = (storage.root / first_path).read_text()
     assert "Q1: What is Y?" in content
     assert "Q2: follow-up" in content
 
@@ -443,11 +447,12 @@ async def test_file_back_thread_uses_uuid_slug_so_identical_titles_coexist(db_se
     assert article_a.file_path != article_b.file_path
 
     # Both files exist on disk
-    assert resolve_wiki_path(article_a.file_path, user_id=TEST_USER_ID).exists()
-    assert resolve_wiki_path(article_b.file_path, user_id=TEST_USER_ID).exists()
+    storage = get_wiki_storage(TEST_USER_ID)
+    assert (storage.root / article_a.file_path).exists()
+    assert (storage.root / article_b.file_path).exists()
 
     # The first article's content mentions the first answer
-    content_a = resolve_wiki_path(article_a.file_path, user_id=TEST_USER_ID).read_text()
+    content_a = (storage.root / article_a.file_path).read_text()
     assert "First answer" in content_a
 
 

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -23,7 +23,7 @@ from wikimind.models import (
     TurnSelection,
 )
 from wikimind.services.query import QueryService, _build_citations, _sanitize_filename
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 
 async def _seed(db_session, tmp_path: Path) -> tuple[Query, Article, Source]:
@@ -448,7 +448,7 @@ class TestFileBackSelection:
         # Verify the article was created on disk
         article = await db_session.get(Article, article_data["id"])
         assert article is not None
-        resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
+        resolved = get_wiki_storage(TEST_USER_ID).root / article.file_path
         content = resolved.read_text(encoding="utf-8")
         assert "## Q1: Q1 from thread 1" in content
         assert "## Q2: Q3 from thread 1" in content
@@ -473,7 +473,7 @@ class TestFileBackSelection:
         assert article_data["title"] == "Merged Research"
 
         article = await db_session.get(Article, article_data["id"])
-        resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
+        resolved = get_wiki_storage(TEST_USER_ID).root / article.file_path
         content = resolved.read_text(encoding="utf-8")
         assert "# Merged Research" in content
         assert "## Q1: Q1 from thread 1" in content
@@ -556,7 +556,7 @@ class TestFileBackSelection:
 
         assert result["article"]["title"] == "My Custom Title"
         article = await db_session.get(Article, result["article"]["id"])
-        resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
+        resolved = get_wiki_storage(TEST_USER_ID).root / article.file_path
         content = resolved.read_text(encoding="utf-8")
         assert "# My Custom Title" in content
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -14,8 +14,6 @@ from wikimind.storage import (
     find_original_sibling,
     get_raw_storage,
     get_wiki_storage,
-    resolve_raw_path,
-    resolve_wiki_path,
 )
 
 
@@ -147,48 +145,6 @@ def test_get_raw_storage_with_user_id(tmp_path, monkeypatch):
     storage = get_raw_storage(user_id="user-456")
     assert isinstance(storage, LocalFileStorage)
     assert storage.root == tmp_path / "raw" / "user-456"
-    get_settings.cache_clear()
-
-
-# ---------------------------------------------------------------------------
-# resolve_wiki_path / resolve_raw_path tests
-# ---------------------------------------------------------------------------
-
-
-def test_resolve_wiki_path_relative(tmp_path, monkeypatch):
-    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    get_settings.cache_clear()
-    result = resolve_wiki_path("concept/article.md", user_id=TEST_USER_ID)
-    assert result == tmp_path / "wiki" / TEST_USER_ID / "concept" / "article.md"
-    get_settings.cache_clear()
-
-
-def test_resolve_wiki_path_absolute():
-    result = resolve_wiki_path("/absolute/path/article.md", user_id=TEST_USER_ID)
-    assert result == Path("/absolute/path/article.md")
-
-
-def test_resolve_wiki_path_with_user_id(tmp_path, monkeypatch):
-    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    get_settings.cache_clear()
-    result = resolve_wiki_path("concept/article.md", user_id="user-abc")
-    assert result == tmp_path / "wiki" / "user-abc" / "concept" / "article.md"
-    get_settings.cache_clear()
-
-
-def test_resolve_raw_path_relative(tmp_path, monkeypatch):
-    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    get_settings.cache_clear()
-    result = resolve_raw_path("source-id.txt", user_id=TEST_USER_ID)
-    assert result == tmp_path / "raw" / TEST_USER_ID / "source-id.txt"
-    get_settings.cache_clear()
-
-
-def test_resolve_raw_path_with_user_id(tmp_path, monkeypatch):
-    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    get_settings.cache_clear()
-    result = resolve_raw_path("source-id.txt", user_id="user-xyz")
-    assert result == tmp_path / "raw" / "user-xyz" / "source-id.txt"
     get_settings.cache_clear()
 
 

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -34,7 +34,7 @@ from wikimind.services.wiki_index import (
     generate_meta_health_page,
     regenerate_index_md,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -327,7 +327,8 @@ class TestFileBackSelectionPathScoping:
         art_result = await db_session.execute(select(Article).where(Article.id == article_info["id"]))
         article = art_result.scalar_one()
         assert article.file_path.startswith("qa-answers/")
-        resolved = resolve_wiki_path(article.file_path, user_id="alice")
+        storage = get_wiki_storage("alice")
+        resolved = storage.root / article.file_path
         assert "/alice/" in str(resolved)
 
 

--- a/tests/unit/test_view_original.py
+++ b/tests/unit/test_view_original.py
@@ -13,6 +13,7 @@ from wikimind.database import get_session
 from wikimind.main import app
 from wikimind.models import Source, SourceType
 from wikimind.services.ingest import get_ingest_service
+from wikimind.storage import LocalFileStorage
 
 
 @pytest.fixture
@@ -38,12 +39,12 @@ def source_text_only():
 
 
 async def _fake_session() -> AsyncGenerator:
-    """Minimal session override that satisfies FastAPI DI without a real DB."""
     yield AsyncMock()
 
 
-async def test_original_endpoint_streams_pdf(tmp_path: Path, source_with_pdf: Source) -> None:
-    """Endpoint returns PDF bytes with correct Content-Type."""
+@pytest.mark.asyncio
+async def test_original_endpoint_returns_pdf(tmp_path: Path, source_with_pdf: Source) -> None:
+    """Endpoint streams the original PDF binary when a sibling exists."""
     pdf_bytes = b"%PDF-1.4 fake pdf content"
     (tmp_path / "src-pdf.txt").write_text("extracted text")
     (tmp_path / "src-pdf.pdf").write_bytes(pdf_bytes)
@@ -56,8 +57,8 @@ async def test_original_endpoint_streams_pdf(tmp_path: Path, source_with_pdf: So
 
     try:
         with patch(
-            "wikimind.api.routes.ingest.resolve_raw_path",
-            return_value=tmp_path / "src-pdf.txt",
+            "wikimind.api.routes.ingest.get_raw_storage",
+            return_value=LocalFileStorage(root=tmp_path),
         ):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -83,8 +84,8 @@ async def test_original_endpoint_404_for_text_source(tmp_path: Path, source_text
 
     try:
         with patch(
-            "wikimind.api.routes.ingest.resolve_raw_path",
-            return_value=tmp_path / "src-text.txt",
+            "wikimind.api.routes.ingest.get_raw_storage",
+            return_value=LocalFileStorage(root=tmp_path),
         ):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -111,8 +112,8 @@ async def test_original_endpoint_passes_user_id(tmp_path: Path, source_with_pdf:
 
     try:
         with patch(
-            "wikimind.api.routes.ingest.resolve_raw_path",
-            return_value=tmp_path / "src-pdf.txt",
+            "wikimind.api.routes.ingest.get_raw_storage",
+            return_value=LocalFileStorage(root=tmp_path),
         ):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/unit/test_wiki_index.py
+++ b/tests/unit/test_wiki_index.py
@@ -14,7 +14,7 @@ from wikimind.services.wiki_index import (
     _first_sentence,
     regenerate_index_md,
 )
-from wikimind.storage import resolve_wiki_path
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -52,7 +52,7 @@ class TestRegenerateIndexMd:
     async def test_empty_database_produces_header_only(self, db_session: AsyncSession) -> None:
         """An empty DB should produce a file with frontmatter and the header."""
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         assert path.exists()
         content = path.read_text(encoding="utf-8")
         assert "page_type: index" in content
@@ -88,7 +88,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         # Both concept headings should appear
@@ -117,7 +117,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         assert "## Uncategorized" in content
@@ -138,7 +138,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         assert "## Machine Learning" in content
@@ -164,7 +164,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         expected = "- [[unit-testing-guide]] \u2014 How to write effective unit tests."
@@ -190,7 +190,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         # The entry line should contain a truncated summary
@@ -219,7 +219,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         first_content = path.read_text(encoding="utf-8")
         assert "[[first-article]]" in first_content
 
@@ -236,7 +236,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         second_content = path.read_text(encoding="utf-8")
 
         # Both should be present
@@ -261,7 +261,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         assert "- [[no-summary]]\n" in content
@@ -287,7 +287,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         # Should appear under both headings
@@ -324,7 +324,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         assert content.index("[[alpha]]") < content.index("[[zebra]]")
@@ -344,7 +344,7 @@ class TestRegenerateIndexMd:
         await db_session.commit()
 
         rel = await regenerate_index_md(db_session, user_id=TEST_USER_ID)
-        path = resolve_wiki_path(rel, user_id=TEST_USER_ID)
+        path = get_wiki_storage(TEST_USER_ID).root / rel
         content = path.read_text(encoding="utf-8")
 
         assert "## Uncategorized" in content


### PR DESCRIPTION
## Summary

- Remove `resolve_wiki_path()` and `resolve_raw_path()` functions that allowed callers to bypass the `FileStorage` abstraction with direct synchronous filesystem access
- Refactor all callers (19 source files, 15 test files) to use `get_wiki_storage()`/`get_raw_storage()` async methods instead
- Three cases retain raw path access via `storage.root` with documented justification: sync `Source.has_original` property, PDF adapter docling-serve extraction, and chunked binary streaming response

Closes #315

## Test plan

- [x] `make lint` passes
- [x] `make format` passes (no changes)
- [x] `make typecheck` (mypy) passes
- [x] All 988 tests pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)