### PR TITLE
fix: handle unreachable backend gracefully in Chrome extension

### DIFF
--- a/apps/web-extension/manifest.json
+++ b/apps/web-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "WikiMind",
   "version": "0.1.0",
-  "description": "Clip pages and query your personal knowledge base",
+  "description": "Save web pages to your WikiMind knowledge base. Requires a running WikiMind instance — configure the server URL in extension settings.",
   "browser_specific_settings": {
     "gecko": {
       "id": "wikimind@wikimind.io",

--- a/apps/web-extension/src/lib/__tests__/api.test.ts
+++ b/apps/web-extension/src/lib/__tests__/api.test.ts
@@ -28,7 +28,7 @@ describe("clipUrl", () => {
     expect(result).toEqual(source);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:7842/ingest/url",
+      "https://wikimind.fly.dev/ingest/url",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
@@ -74,7 +74,7 @@ describe("getSource", () => {
     const result = await getSource("abc");
     expect(result).toEqual(source);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:7842/ingest/sources/abc",
+      "https://wikimind.fly.dev/ingest/sources/abc",
       expect.anything()
     );
   });
@@ -86,7 +86,7 @@ describe("listRecentSources", () => {
 
     await listRecentSources(3);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:7842/ingest/sources?limit=3",
+      "https://wikimind.fly.dev/ingest/sources?limit=3",
       expect.anything()
     );
   });
@@ -99,7 +99,7 @@ describe("checkConnection", () => {
     const result = await checkConnection();
     expect(result).toEqual({ ok: true, message: "Connected" });
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:7842/health",
+      "https://wikimind.fly.dev/health",
       expect.objectContaining({ method: "GET" })
     );
   });
@@ -118,6 +118,6 @@ describe("checkConnection", () => {
     const result = await checkConnection();
     expect(result.ok).toBe(false);
     expect(result.message).toContain("Cannot reach WikiMind server");
-    expect(result.message).toContain("localhost:7842");
+    expect(result.message).toContain("wikimind.fly.dev");
   });
 });

--- a/apps/web-extension/src/lib/__tests__/api.test.ts
+++ b/apps/web-extension/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { clipUrl, getSource, listRecentSources } from "../api";
+import { clipUrl, getSource, listRecentSources, checkConnection } from "../api";
 import { resetStorage } from "../../test-setup";
 
 const fetchMock = vi.fn();
@@ -89,5 +89,35 @@ describe("listRecentSources", () => {
       "http://localhost:7842/ingest/sources?limit=3",
       expect.anything()
     );
+  });
+});
+
+describe("checkConnection", () => {
+  it("returns ok:true when server responds 200", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: "ok" }));
+
+    const result = await checkConnection();
+    expect(result).toEqual({ ok: true, message: "Connected" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:7842/health",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("returns ok:false with message when server returns non-200", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+    const result = await checkConnection();
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("503");
+  });
+
+  it("returns ok:false with helpful message on network error", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const result = await checkConnection();
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("Cannot reach WikiMind server");
+    expect(result.message).toContain("localhost:7842");
   });
 });

--- a/apps/web-extension/src/lib/__tests__/storage.test.ts
+++ b/apps/web-extension/src/lib/__tests__/storage.test.ts
@@ -27,7 +27,7 @@ function makeClip(overrides: Partial<ClipRecord> = {}): ClipRecord {
 describe("getSettings", () => {
   it("returns default gateway URL when empty", async () => {
     const settings = await getSettings();
-    expect(settings.gatewayUrl).toBe("http://localhost:7842");
+    expect(settings.gatewayUrl).toBe("https://wikimind.fly.dev");
   });
 
   it("returns stored gateway URL", async () => {

--- a/apps/web-extension/src/lib/api.ts
+++ b/apps/web-extension/src/lib/api.ts
@@ -36,6 +36,26 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return (await response.json()) as T;
 }
 
+export async function checkConnection(): Promise<{ ok: boolean; message: string }> {
+  const base = await getBaseUrl();
+  try {
+    const response = await fetch(`${base}/health`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (response.ok) {
+      return { ok: true, message: "Connected" };
+    }
+    return { ok: false, message: `Server returned ${response.status}` };
+  } catch {
+    return {
+      ok: false,
+      message: `Cannot reach WikiMind server at ${base}. Make sure your WikiMind instance is running and the URL is correct in Settings.`,
+    };
+  }
+}
+
 export function clipUrl(url: string, autoCompile = true): Promise<Source> {
   const body: IngestURLRequest = { url, auto_compile: autoCompile };
   return withRetry(() =>

--- a/apps/web-extension/src/lib/storage.ts
+++ b/apps/web-extension/src/lib/storage.ts
@@ -1,6 +1,6 @@
 import type { ClipRecord, ExtensionSettings, IngestStatus } from "../types";
 
-const DEFAULT_GATEWAY_URL = "http://localhost:7842";
+const DEFAULT_GATEWAY_URL = "https://wikimind.fly.dev";
 const MAX_RECENT_CLIPS = 20;
 
 export async function getSettings(): Promise<ExtensionSettings> {

--- a/apps/web-extension/src/popup/components/ClipTab.tsx
+++ b/apps/web-extension/src/popup/components/ClipTab.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "preact/hooks";
 import type { Source, ClipRecord } from "../../types";
 import { clipUrl, checkConnection } from "../../lib/api";
-import { addRecentClip, getRecentClips } from "../../lib/storage";
+import { ApiError } from "../../lib/retry";
+import { addRecentClip, getRecentClips, getSettings } from "../../lib/storage";
 import { ClipButton } from "./ClipButton";
 import { StatusBadge } from "./StatusBadge";
 import { RecentClips } from "./RecentClips";
@@ -59,7 +60,10 @@ export function ClipTab() {
     } catch (err) {
       setClipState("error");
       let msg: string;
-      if (err instanceof TypeError) {
+      if (err instanceof ApiError && err.status === 401) {
+        const { gatewayUrl } = await getSettings();
+        msg = `Sign in required. Please log in to your WikiMind instance at ${gatewayUrl}`;
+      } else if (err instanceof TypeError) {
         msg =
           "Could not reach the WikiMind server. Ensure your instance is running and the URL in Settings is correct.";
       } else {

--- a/apps/web-extension/src/popup/components/ClipTab.tsx
+++ b/apps/web-extension/src/popup/components/ClipTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "preact/hooks";
 import type { Source, ClipRecord } from "../../types";
-import { clipUrl } from "../../lib/api";
+import { clipUrl, checkConnection } from "../../lib/api";
 import { addRecentClip, getRecentClips } from "../../lib/storage";
 import { ClipButton } from "./ClipButton";
 import { StatusBadge } from "./StatusBadge";
@@ -20,12 +20,18 @@ export function ClipTab() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [currentUrl, setCurrentUrl] = useState("");
   const [recentClips, setRecentClips] = useState<ClipRecord[]>([]);
+  const [connected, setConnected] = useState<boolean | null>(null);
+  const [connectionMsg, setConnectionMsg] = useState<string>("");
 
   useEffect(() => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs[0]?.url) setCurrentUrl(tabs[0].url);
     });
     getRecentClips().then((clips) => setRecentClips(clips.slice(0, 5)));
+    checkConnection().then(({ ok, message }) => {
+      setConnected(ok);
+      setConnectionMsg(message);
+    });
   }, []);
 
   async function handleClip() {
@@ -52,17 +58,69 @@ export function ClipTab() {
       chrome.runtime.sendMessage({ type: "clip:success" });
     } catch (err) {
       setClipState("error");
-      const msg = err instanceof Error ? err.message : "Unknown error";
+      let msg: string;
+      if (err instanceof TypeError) {
+        msg =
+          "Could not reach the WikiMind server. Ensure your instance is running and the URL in Settings is correct.";
+      } else {
+        msg = err instanceof Error ? err.message : "Unknown error";
+      }
       setErrorMsg(msg);
       chrome.runtime.sendMessage({ type: "clip:error" });
     }
   }
 
-  const canClip = currentUrl !== "" && isClippableUrl(currentUrl);
+  const canClip = currentUrl !== "" && isClippableUrl(currentUrl) && connected === true;
+
+  if (connected === false) {
+    return (
+      <div>
+        <div
+          style={{
+            padding: "16px",
+            borderRadius: "8px",
+            backgroundColor: "#fef2f2",
+            border: "1px solid #fecaca",
+            textAlign: "center",
+          }}
+        >
+          <div style={{ fontSize: "24px", marginBottom: "8px" }}>&#9888;</div>
+          <p
+            style={{
+              fontSize: "13px",
+              fontWeight: 600,
+              color: "#dc2626",
+              margin: "0 0 8px",
+            }}
+          >
+            WikiMind server not reachable
+          </p>
+          <p style={{ fontSize: "12px", color: "#64748b", margin: 0 }}>
+            {connectionMsg}
+          </p>
+        </div>
+        <p
+          style={{
+            fontSize: "11px",
+            color: "#94a3b8",
+            marginTop: "12px",
+            textAlign: "center",
+          }}
+        >
+          Open Settings &#9881; to configure your server URL.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div>
       <div style={{ marginBottom: "12px" }}>
+        {connected === null && (
+          <p style={{ fontSize: "12px", color: "#94a3b8", margin: "0 0 4px" }}>
+            Checking connection...
+          </p>
+        )}
         {currentUrl && isClippableUrl(currentUrl) ? (
           <p
             style={{

--- a/apps/web-extension/src/popup/components/Settings.tsx
+++ b/apps/web-extension/src/popup/components/Settings.tsx
@@ -108,7 +108,7 @@ export function Settings({ onBack }: Props) {
           boxSizing: "border-box",
           outline: "none",
         }}
-        placeholder="http://localhost:7842"
+        placeholder="https://wikimind.fly.dev"
       />
 
       {error && (


### PR DESCRIPTION
## Summary

- **Problem**: Chrome Web Store rejected the extension because "clipping" appeared non-functional. The reviewer had no WikiMind backend and got a cryptic "Failed to fetch" error.

- **Solution**: 
  - Changed default gateway URL from `localhost:7842` to `https://wikimind.fly.dev` (production instance)
  - Added connection check on popup open — shows server status clearly
  - When clipping returns 401 (auth required), shows "Sign in required" with a link to the server
  - When server is unreachable, shows clear "WikiMind server not reachable" message with instructions
  - Updated manifest description to state backend requirement

- **Changes**:
  - `src/lib/storage.ts` — default URL now `https://wikimind.fly.dev`
  - `src/lib/api.ts` — added `checkConnection()` function
  - `src/popup/components/ClipTab.tsx` — connection check on load, 401 handling with "Sign in required" message
  - `src/popup/components/Settings.tsx` — updated placeholder URL
  - `manifest.json` — updated description
  - Tests updated for new default URL

## Test plan
- [ ] Load unpacked extension with default settings — popup shows "Connected" (health check against wikimind.fly.dev passes)
- [ ] Click "Clip this page" without being signed in — shows "Sign in required. Please log in to your WikiMind instance at https://wikimind.fly.dev"
- [ ] Configure a non-existent URL in Settings — popup shows "WikiMind server not reachable" with the configured URL
- [ ] Configure `http://localhost:7842` with local backend running — clip works end-to-end
- [ ] Verify `npx vitest run` passes all 22 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)