### PR TITLE
fix: wrap sync file I/O in asyncio.to_thread to unblock event loop

### DIFF
--- a/src/wikimind/api/routes/export.py
+++ b/src/wikimind/api/routes/export.py
@@ -1,5 +1,7 @@
 """Export wiki articles as PDF HTML, LinkedIn drafts, or Marp slide decks."""
 
+import asyncio
+
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
@@ -76,7 +78,7 @@ async def export_article(
     - **slides**: Returns a Marp-compatible markdown slide deck (JSON with content field).
     """
     article = await _resolve_article(id_or_slug, session, user_id)
-    content = _read_article_content(article.file_path, user_id=user_id)
+    content = await asyncio.to_thread(_read_article_content, article.file_path, user_id=user_id)
 
     if not content:
         raise HTTPException(status_code=404, detail="Article content not found on disk")

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -6,6 +6,7 @@ This is the core value-creation step.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -373,7 +374,7 @@ Compile this into a wiki article following the JSON schema exactly."""
             # Delete old file only after new file is written successfully to
             # avoid data loss if the write fails (issue #183).
             if old_path is not None and old_path != resolve_wiki_path(relative_path, user_id=self.user_id):
-                old_path.unlink(missing_ok=True)
+                await asyncio.to_thread(lambda: old_path.unlink(missing_ok=True))
 
             existing.title = result.title
             existing.summary = result.summary

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -182,7 +183,7 @@ class ConceptCompiler:
         min_sources = self.settings.taxonomy.concept_page_min_sources
         if len(source_articles) < min_sources:
             return None
-        source_material = _build_source_material(source_articles, user_id=self.user_id)
+        source_material = await asyncio.to_thread(_build_source_material, source_articles, user_id=self.user_id)
         source_ids = [a.id for a in source_articles]
         ct = await _collect_contradictions(source_ids, session)
         contradiction_section = ct or "No known contradictions."

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -10,6 +10,7 @@ contradictions are modelled as first-class edges in the knowledge graph.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import itertools
 import json
@@ -578,8 +579,8 @@ async def detect_contradictions(
                     continue
 
             # Collect claims for uncached pair
-            claims_a = _extract_claims(article_a)
-            claims_b = _extract_claims(article_b)
+            claims_a = await asyncio.to_thread(_extract_claims, article_a)
+            claims_b = await asyncio.to_thread(_extract_claims, article_b)
             if claims_a and claims_b:
                 uncached_pairs.append((article_a, article_b, claims_a, claims_b))
             else:
@@ -621,8 +622,8 @@ async def _compare_article_pair(
 ) -> list[ContradictionFinding]:
     """Compare a single article pair via LLM and return any findings."""
     cfg = settings.linter
-    claims_a = _extract_claims(article_a)
-    claims_b = _extract_claims(article_b)
+    claims_a = await asyncio.to_thread(_extract_claims, article_a)
+    claims_b = await asyncio.to_thread(_extract_claims, article_b)
 
     if not claims_a or not claims_b:
         return []

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -6,6 +6,7 @@ Every answer can be filed back to make the wiki smarter.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -520,7 +521,7 @@ conversation context contradicts the wiki, prefer the wiki."""
 
         relevant = []
         for article in all_articles:
-            content = self._read_article_content(article.file_path, user_id=user_id)
+            content = await asyncio.to_thread(self._read_article_content, article.file_path, user_id=user_id)
             if not content:
                 continue
 
@@ -631,11 +632,11 @@ conversation context contradicts the wiki, prefer the wiki."""
             if user_id:
                 wiki_dir = wiki_dir / user_id
             wiki_dir = wiki_dir / "qa-answers"
-            wiki_dir.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(wiki_dir.mkdir, parents=True, exist_ok=True)
 
             slug = conversation.id  # UUID — guaranteed unique, no collision possible
             file_path = wiki_dir / f"{slug}.md"
-            file_path.write_text(markdown, encoding="utf-8")
+            await asyncio.to_thread(file_path.write_text, markdown, encoding="utf-8")
 
             # Store wiki-relative path in the DB
             relative_path = f"qa-answers/{slug}.md"
@@ -665,7 +666,8 @@ conversation context contradicts the wiki, prefer the wiki."""
             return article, False
 
         # Update path: overwrite the existing Article's file in place
-        resolve_wiki_path(existing_article.file_path, user_id=user_id).write_text(markdown, encoding="utf-8")
+        update_path = resolve_wiki_path(existing_article.file_path, user_id=user_id)
+        await asyncio.to_thread(update_path.write_text, markdown, encoding="utf-8")
         existing_article.updated_at = now
         conversation.updated_at = now
         session.add(existing_article)

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -12,6 +12,7 @@ pointing at the latter.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import re
 from datetime import date
@@ -191,8 +192,8 @@ class PDFAdapter:
         # always points at the cleaned text. The raw .pdf is kept for lineage
         # and future re-extraction (e.g. Docling — see issue #57).
         raw_pdf_path = resolve_raw_path(f"{source.id}.pdf", user_id=user_id)
-        raw_pdf_path.parent.mkdir(parents=True, exist_ok=True)
-        raw_pdf_path.write_bytes(file_bytes)
+        await asyncio.to_thread(raw_pdf_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(raw_pdf_path.write_bytes, file_bytes)
 
         # Extract text — prefer docling-serve for structured output (markdown
         # with heading hierarchy, table-aware), fall back to fitz plain text
@@ -220,7 +221,7 @@ class PDFAdapter:
             log.warning("Vision enhancement failed — using extracted text as-is", source_id=source.id)
 
         text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.write_text(clean_text, encoding="utf-8")
+        await asyncio.to_thread(text_path.write_text, clean_text, encoding="utf-8")
         source.file_path = f"{source.id}.txt"
 
         token_count = estimate_tokens(clean_text)

--- a/src/wikimind/ingest/adapters/text.py
+++ b/src/wikimind/ingest/adapters/text.py
@@ -6,6 +6,7 @@ are the same ``.txt`` file.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import structlog
@@ -62,8 +63,8 @@ class TextAdapter:
         # the same .txt file. file_path always points at the .txt the worker
         # reads (see issue #59).
         text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.parent.mkdir(parents=True, exist_ok=True)
-        text_path.write_text(content, encoding="utf-8")
+        await asyncio.to_thread(text_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(text_path.write_text, content, encoding="utf-8")
         source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -6,6 +6,7 @@ and returns a NormalizedDocument for downstream compilation.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -92,10 +93,10 @@ class URLAdapter:
         # Save clean extracted text (used by the compiler worker) and
         # keep the raw HTML alongside it for reference/reprocessing.
         html_path = resolve_raw_path(f"{source.id}.html", user_id=user_id)
-        html_path.parent.mkdir(parents=True, exist_ok=True)
-        html_path.write_text(html, encoding="utf-8")
+        await asyncio.to_thread(html_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(html_path.write_text, html, encoding="utf-8")
         text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.write_text(downloaded, encoding="utf-8")
+        await asyncio.to_thread(text_path.write_text, downloaded, encoding="utf-8")
         source.file_path = f"{source.id}.txt"
 
         # Normalize

--- a/src/wikimind/ingest/adapters/youtube.py
+++ b/src/wikimind/ingest/adapters/youtube.py
@@ -79,8 +79,8 @@ class YouTubeAdapter:
         # YouTube transcripts are already plain text, so the raw and cleaned
         # files are the same .txt. There is no separate raw video payload.
         text_path = resolve_raw_path(f"{source.id}.txt", user_id=user_id)
-        text_path.parent.mkdir(parents=True, exist_ok=True)
-        text_path.write_text(transcript_text, encoding="utf-8")
+        await asyncio.to_thread(text_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(text_path.write_text, transcript_text, encoding="utf-8")
         source.file_path = f"{source.id}.txt"
         session.add(source)
         await session.commit()

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -6,6 +6,7 @@ functions used by all adapters and the orchestrating IngestService.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import re
 from typing import TYPE_CHECKING
@@ -305,7 +306,8 @@ async def _check_source_dedup(
                 source_id=existing.id,
                 hash=content_hash[:16],
             )
-            return existing, reconstruct_normalized_doc(existing)
+            doc = await asyncio.to_thread(reconstruct_normalized_doc, existing)
+            return existing, doc
         log.warning("Deleting zombie source (no file_path)", source_id=existing.id)
         await session.delete(existing)
         await session.commit()

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -12,6 +12,7 @@ promote is a no-op.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import TYPE_CHECKING
 
@@ -61,11 +62,11 @@ async def _sweep_single_article(
 
     uid = article.user_id
     file_path = resolve_wiki_path(article.file_path, user_id=uid)
-    if not file_path.exists():
+    if not await asyncio.to_thread(file_path.exists):
         log.warning("sweep: file not found, skipping", article_id=article.id, path=str(file_path))
         return False
 
-    content = file_path.read_text(encoding="utf-8")
+    content = await asyncio.to_thread(file_path.read_text, encoding="utf-8")
 
     # Collect all unique bracket texts
     matches = _WIKILINK_RE.findall(content)
@@ -105,7 +106,7 @@ async def _sweep_single_article(
         return False  # pragma: no cover — defensive; resolved non-empty implies change
 
     # Write the updated file
-    file_path.write_text(new_content, encoding="utf-8")
+    await asyncio.to_thread(file_path.write_text, new_content, encoding="utf-8")
 
     # Persist Backlink rows — use get-or-create to handle duplicates
     # gracefully. We check each backlink by composite PK and only insert

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -7,6 +7,7 @@ and cleaned files written by adapters under ``~/.wikimind/raw/`` (see issue
 #59) and removes them on delete.
 """
 
+import asyncio
 import functools
 from contextlib import suppress
 
@@ -260,7 +261,7 @@ class IngestService:
         if user_id and source.user_id != user_id:
             raise NotFoundError(msg)
 
-        self._remove_source_files(source)
+        await asyncio.to_thread(self._remove_source_files, source)
 
         await session.delete(source)
         await session.commit()

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -7,6 +7,7 @@ chains so callers can trace every answer back to the raw source it came
 from.
 """
 
+import asyncio
 import functools
 import json
 import re
@@ -615,14 +616,14 @@ class QueryService:
         if user_id:
             wiki_dir = wiki_dir / user_id
         wiki_dir = wiki_dir / "qa-answers"
-        wiki_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(wiki_dir.mkdir, parents=True, exist_ok=True)
 
         now = utcnow_naive()
         effective_title = request.title or selected_turns[0].conversation.title
 
         slug = str(uuid.uuid4())
         file_path = wiki_dir / f"{slug}.md"
-        file_path.write_text(markdown, encoding="utf-8")
+        await asyncio.to_thread(file_path.write_text, markdown, encoding="utf-8")
 
         article = Article(
             slug=slug,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -11,6 +11,7 @@ vector similarity and results are merged via configurable hybrid
 scoring. Otherwise the service falls back to keyword-only search.
 """
 
+import asyncio
 import functools
 import json
 from pathlib import Path
@@ -78,6 +79,19 @@ def _read_article_content(file_path: str, user_id: str) -> str:
         return resolve_wiki_path(file_path, user_id=user_id).read_text(encoding="utf-8")
     except OSError:
         return ""
+
+
+async def _read_article_content_async(file_path: str, user_id: str) -> str:
+    """Read article markdown content from disk without blocking the event loop.
+
+    Args:
+        file_path: Absolute path to the article markdown file.
+        user_id: Optional user ID for storage namespacing.
+
+    Returns:
+        The file content, or an empty string if the file cannot be read.
+    """
+    return await asyncio.to_thread(_read_article_content, file_path, user_id)
 
 
 def _parse_source_ids(raw: str | None) -> list[str]:
@@ -380,7 +394,7 @@ class WikiService:
             concepts=concepts,
             backlinks_in=backlinks_in,
             backlinks_out=backlinks_out,
-            content=_read_article_content(article.file_path, user_id=article.user_id),
+            content=await _read_article_content_async(article.file_path, user_id=article.user_id),
             sources=[_to_source_response(s) for s in sources],
             created_at=article.created_at,
             updated_at=article.updated_at,
@@ -525,7 +539,7 @@ class WikiService:
         q_lower = q.lower()
         raw_scores: dict[str, int] = {}
         for article in all_articles:
-            content = _read_article_content(article.file_path, user_id=article.user_id)
+            content = await _read_article_content_async(article.file_path, user_id=article.user_id)
             if q_lower in article.title.lower() or q_lower in content.lower():
                 score = 10 if q_lower in article.title.lower() else 0
                 score += content.lower().count(q_lower)
@@ -655,8 +669,9 @@ class WikiService:
             health_dir = health_dir / user_id
         health_path = health_dir / "_meta" / "health.json"
 
-        if health_path.exists():
-            return json.loads(health_path.read_text())
+        if await asyncio.to_thread(health_path.exists):
+            content = await asyncio.to_thread(health_path.read_text)
+            return json.loads(content)
 
         article_stmt = select(Article)
         if user_id:

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -7,6 +7,7 @@ file is rewritten in place on every call (NOT append-only).
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 from collections import Counter, defaultdict
@@ -206,7 +207,7 @@ async def regenerate_index_md(
     concept_articles, uncategorized = await _group_articles_by_concept(articles, session)
     lines = _build_index_lines(articles, concept_articles, uncategorized)
 
-    index_path.write_text("".join(lines), encoding="utf-8")
+    await asyncio.to_thread(index_path.write_text, "".join(lines), encoding="utf-8")
     log.info("index.md regenerated", article_count=len(articles))
     return "index.md"
 
@@ -312,6 +313,6 @@ async def generate_meta_health_page(
     lines.append("## Orphan Articles\n\n")
     lines.append(f"**{orphan_count}** articles with no inbound or outbound links.\n")
 
-    health_path.write_text("".join(lines), encoding="utf-8")
+    await asyncio.to_thread(health_path.write_text, "".join(lines), encoding="utf-8")
     log.info("wiki-health.md generated", article_count=total, orphan_count=orphan_count)
     return "meta/wiki-health.md"

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -195,7 +195,7 @@ async def regenerate_index_md(
     wiki_dir = Path(settings.data_dir) / "wiki"
     if user_id:
         wiki_dir = wiki_dir / user_id
-    wiki_dir.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(wiki_dir.mkdir, parents=True, exist_ok=True)
     index_path = wiki_dir / "index.md"
 
     article_stmt = select(Article)
@@ -259,7 +259,7 @@ async def generate_meta_health_page(
     if user_id:
         meta_dir = meta_dir / user_id
     meta_dir = meta_dir / "meta"
-    meta_dir.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(meta_dir.mkdir, parents=True, exist_ok=True)
     health_path = meta_dir / "wiki-health.md"
 
     articles, backlinks = await _fetch_health_data(session, user_id=user_id)


### PR DESCRIPTION
## Summary

- Wraps all synchronous file I/O operations (`Path.write_text`, `Path.write_bytes`, `Path.read_text`, `Path.unlink`, `Path.exists`, `Path.mkdir`) in `asyncio.to_thread()` when called from async functions in the compiler, ingest adapters, and service layers
- Prevents event-loop blocking during disk I/O in the PDF, text, URL, and YouTube ingest adapters, the compiler's article file management, the wiki index generator, and the wiki service's article content reads

## Test plan

- [x] `make lint` passes
- [x] `make format` passes (no changes)
- [x] `make typecheck` passes
- [x] All 993 tests pass (`make test`)

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)