### PR TITLE
enhancement: adopt consistent structured logging (#357)

### DIFF
--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -390,7 +390,7 @@ def _reconcile_providers(settings: Settings) -> None:
                 hint="set WIKIMIND_LLM__OPENAI_COMPATIBLE__BASE_URL",
             )
         elif not has_key and cfg.enabled:
-            log.warning("provider enabled but no API key", provider=name, hint=f"set {raw_env}")
+            log.warning("provider enabled but no API key", provider=name, env_var=raw_env)
         elif name == "openai_compatible" and cfg.enabled and not cfg.base_url:
             log.warning(
                 "provider enabled but required base URL is missing",


### PR DESCRIPTION
## Summary

- Replaced the only f-string interpolation in log calls (`hint=f"set {raw_env}"`) with a proper structured key-value pair (`env_var=raw_env`) in `src/wikimind/config.py`
- Audited all ~100+ log calls across the codebase using AST analysis and confirmed this was the sole inconsistency — all other log calls already follow structured `log.level("message", key=value)` patterns

## Context

The codebase already uses `structlog` with keyword arguments throughout. The one exception was a log warning in `_reconcile_providers()` that embedded a variable via f-string in a keyword argument value rather than passing it as a separate structured field.

## Test plan

- [x] `make verify` passes (973 tests pass, lint, format, mypy, pyright all clean)
- [x] AST-based scan confirms zero f-strings remain in any log call

🤖 Generated with [Claude Code](https://claude.com/claude-code)