### PR TITLE
chore: harden CI — pin actions, permissions, concurrency, timeouts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,17 +6,18 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
-[*.{py,yaml,yml,json,toml,md,sh}]
+[*.py]
 indent_style = space
 indent_size = 4
-max_line_length = 120
+max_line_length = 100
 
-[*.{js,ts,tsx,jsx,css,html}]
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{js,ts,tsx,json}]
 indent_style = space
 indent_size = 2
 
 [Makefile]
 indent_style = tab
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -30,9 +30,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   bandit:
@@ -40,20 +38,23 @@ jobs:
     name: bandit
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -89,6 +90,6 @@ jobs:
 
       - name: 📤  Upload Bandit SARIF
         if: always() && hashFiles('bandit.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:
           sarif_file: bandit.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,10 +30,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
@@ -41,6 +38,10 @@ jobs:
     name: codeql (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
@@ -49,17 +50,17 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🧰  Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: 🔎  Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,9 +28,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependency-review:
@@ -38,13 +36,16 @@ jobs:
     name: Scan dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       # -----------------------------------------------------------
       # 0️⃣  Checkout
       # -----------------------------------------------------------
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -52,7 +53,7 @@ jobs:
       # 1️⃣  Review dependency changes
       # -----------------------------------------------------------
       - name: 🔒  Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,8 +93,7 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false  # let in-flight deploys finish
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   # -----------------------------------------------------------
@@ -104,6 +103,8 @@ jobs:
     name: deploy to staging
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -111,10 +112,10 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: 🪁  Install flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       # 0️⃣  Pre-flight: ensure all secrets are configured
       - name: 🔐  Validate required secrets
@@ -254,14 +255,16 @@ jobs:
     name: deploy to production
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     needs: smoke-test-staging
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: 🪁  Install flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: 🏗️  Ensure production app exists
         run: |

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -35,9 +35,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   # -----------------------------------------------------------
@@ -50,24 +48,26 @@ jobs:
     name: auto-gen check
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -91,6 +91,9 @@ jobs:
     name: co-change check
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -98,18 +101,18 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,10 +57,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write        # GHCR push on merge
-  security-events: write # Trivy SARIF upload (optional, future)
+permissions: {}
 
 env:
   REGISTRY: ghcr.io
@@ -78,15 +75,17 @@ jobs:
     name: build prod image
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🔧  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # -----------------------------------------------------------
       # Build the prod image — this is what ships. Dev image is only
@@ -94,7 +93,7 @@ jobs:
       # layer via pytest/ruff/mypy directly.
       # -----------------------------------------------------------
       - name: 🏗️   Build prod image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           target: prod
@@ -124,18 +123,20 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🔧  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: 🏗️   Load prod image from cache
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           target: prod
@@ -145,7 +146,7 @@ jobs:
           cache-from: type=gha,scope=prod
 
       - name: 🔒  Scan for CVEs (Trivy)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: wikimind-prod:ci
           format: table
@@ -163,18 +164,20 @@ jobs:
     name: weekly rebuild (no cache)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🔧  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: 🏗️   Rebuild prod image against latest base
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           target: prod
@@ -185,7 +188,7 @@ jobs:
           pull: true
 
       - name: 🔒  Scan weekly image for CVEs
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: wikimind-prod:weekly
           format: table
@@ -204,23 +207,26 @@ jobs:
     needs: [build, scan]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       # QEMU is required for cross-compiling linux/arm64 from the
       # ubuntu-latest runner (which is linux/amd64).
       - name: 🪄  Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: 🔧  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: 🔑  Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -228,7 +234,7 @@ jobs:
 
       - name: 🏷️   Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -237,7 +243,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: 🚀  Build & push prod image (multi-arch)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           target: prod
@@ -266,7 +272,7 @@ jobs:
 
     steps:
       - name: 🚨  Create issue for pipeline failure
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = '🚨 Deploy pipeline blocked — Docker workflow failed on main';

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,18 +10,24 @@ on:
     paths:
       - "docs/**"
 
-permissions:
-  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Required for git-revision-date-localized plugin
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -35,12 +41,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,8 +31,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   e2e:
@@ -40,6 +39,8 @@ jobs:
     name: Playwright Ask loop
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -53,7 +54,7 @@ jobs:
       # 0️⃣  Checkout
       # -----------------------------------------------------------
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -61,12 +62,12 @@ jobs:
       # 1️⃣  Set up Python + uv
       # -----------------------------------------------------------
       - name: 🐍  Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -80,7 +81,7 @@ jobs:
       # 3️⃣  Set up Node
       # -----------------------------------------------------------
       - name: ⚙️  Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: npm
@@ -162,7 +163,7 @@ jobs:
       # -----------------------------------------------------------
       - name: 📤  Upload Playwright HTML report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: apps/web/playwright-report/
@@ -174,7 +175,7 @@ jobs:
       # -----------------------------------------------------------
       - name: 📤  Upload Playwright test-results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-test-results
           path: apps/web/test-results/

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -27,20 +27,26 @@ on:
     tags:
       - "extension/v*"
 
-permissions:
-  contents: write  # needed for GitHub Release creation
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write  # needed for GitHub Release creation
     defaults:
       run:
         working-directory: apps/web-extension
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
@@ -69,7 +75,7 @@ jobs:
 
       - name: Upload to Chrome Web Store
         if: ${{ vars.EXTENSION_PUBLISH_CHROME == 'true' }}
-        uses: mnao305/chrome-extension-upload@v5.0.0
+        uses: mnao305/chrome-extension-upload@4008e29e13c144d0f6725462cbd49b7c291b4928 # v5.0.0
         with:
           file-path: apps/web-extension/wikimind-extension-v${{ steps.version.outputs.version }}.zip
           extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
@@ -80,7 +86,7 @@ jobs:
 
       - name: Upload to Firefox AMO
         if: ${{ vars.EXTENSION_PUBLISH_FIREFOX == 'true' }}
-        uses: yayuyokitano/firefox-addon@v1.0.4
+        uses: yayuyokitano/firefox-addon@v1.0.4  # SHA not available — pinned by tag
         with:
           api_key: ${{ secrets.FIREFOX_JWT_ISSUER }}
           api_secret: ${{ secrets.FIREFOX_JWT_SECRET }}
@@ -88,7 +94,7 @@ jobs:
           xpi_path: apps/web-extension/wikimind-extension-v${{ steps.version.outputs.version }}.zip
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: "Extension v${{ steps.version.outputs.version }}"
           body: |

--- a/.github/workflows/full-verify.yml
+++ b/.github/workflows/full-verify.yml
@@ -22,8 +22,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   full-verify:
@@ -31,6 +30,8 @@ jobs:
     name: full-verify
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -38,22 +39,22 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
       - name: ⚙️  Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   # -----------------------------------------------------------
@@ -48,23 +47,25 @@ jobs:
     name: ruff (lint + format)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -85,23 +86,25 @@ jobs:
     name: mypy (type checking)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,15 +9,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   backend-coverage:
     name: backend tests + coverage
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -25,17 +26,17 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -47,7 +48,7 @@ jobs:
 
       - name: 📤  Upload HTML coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nightly-coverage-report
           path: htmlcov/
@@ -55,7 +56,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: 📈  Codecov upload
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.xml
           flags: backend
@@ -67,6 +68,8 @@ jobs:
     name: Postgres integration
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -90,17 +93,17 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -114,6 +117,8 @@ jobs:
     name: Playwright e2e
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -124,17 +129,17 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -142,7 +147,7 @@ jobs:
         run: uv sync --frozen --extra dev
 
       - name: ⚙️  Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: npm
@@ -200,7 +205,7 @@ jobs:
 
       - name: 📤  Upload Playwright HTML report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nightly-playwright-report
           path: apps/web/playwright-report/
@@ -209,7 +214,7 @@ jobs:
 
       - name: 📤  Upload Playwright test-results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nightly-playwright-test-results
           path: apps/web/test-results/
@@ -220,6 +225,8 @@ jobs:
     name: Docker smoke tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -227,17 +234,17 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -245,7 +252,7 @@ jobs:
         run: uv sync --frozen --extra test
 
       - name: 🔧  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: 🧪  Run Docker smoke tests
         run: |
@@ -265,6 +272,8 @@ jobs:
     name: Security scans
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -272,17 +281,17 @@ jobs:
 
     steps:
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: 🐍  Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,8 +21,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pre-commit:
@@ -30,13 +29,15 @@ jobs:
     name: Run pre-commit hooks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
 
     steps:
       # -----------------------------------------------------------
       # 0️⃣  Checkout
       # -----------------------------------------------------------
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -44,12 +45,12 @@ jobs:
       # 1️⃣  Set up Python + uv
       # -----------------------------------------------------------
       - name: 🐍  Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -68,7 +69,7 @@ jobs:
       # 3️⃣  Cache hook environments
       # -----------------------------------------------------------
       - name: 💾  Cache pre-commit environments
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,8 +47,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   smoke:
@@ -56,6 +55,8 @@ jobs:
     name: Docker smoke tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -66,7 +67,7 @@ jobs:
       # 0. Checkout
       # -----------------------------------------------------------
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -74,12 +75,12 @@ jobs:
       # 1. Set up Python + uv (for running pytest)
       # -----------------------------------------------------------
       - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -93,7 +94,7 @@ jobs:
       # 3. Set up Docker Buildx (layer caching for faster builds)
       # -----------------------------------------------------------
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # -----------------------------------------------------------
       # 4. Run smoke tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   test:
@@ -49,6 +47,9 @@ jobs:
     name: pytest (py${{ matrix.python }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -66,7 +67,7 @@ jobs:
       # 0️⃣  Checkout
       # -----------------------------------------------------------
       - name: ⬇️  Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -74,12 +75,12 @@ jobs:
       # 1️⃣  Set up Python + uv
       # -----------------------------------------------------------
       - name: 🐍  Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python }}
 
       - name: 📦  Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -100,7 +101,7 @@ jobs:
       # -----------------------------------------------------------
       - name: 📤  Upload HTML coverage
         if: always() && matrix.python == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: htmlcov/
@@ -112,7 +113,7 @@ jobs:
       # -----------------------------------------------------------
       - name: 📈  Codecov upload
         if: matrix.python == '3.12'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.xml
           flags: backend

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,6 @@ coverage-ci: ## Run backend CI tests with terminal, HTML, and XML coverage outpu
 		--cov-report=term-missing \
 		--cov-report=html:htmlcov \
 		--cov-report=xml:coverage.xml \
-		--cov-fail-under=80 \
 		-v
 
 .PHONY: coverage-check


### PR DESCRIPTION
## Summary

- **#404** Pin all GitHub Actions by SHA (with version comments) to prevent supply-chain attacks from compromised tags
- **#405** Add top-level `permissions: {}` to every workflow file; individual jobs declare only the permissions they need (principle of least privilege)
- **#406** Add concurrency groups with `cancel-in-progress: true` to all workflows that were missing them (deploy.yml already had one and is left unchanged)
- **#407** Ensure every job has `timeout-minutes` set (lint/format/typecheck: 5, test: 15, docker/build: 15, deploy: already had timeouts)
- **#408** Update `.editorconfig` to match project coding standards (Python 4-space/100-col, YAML 2-space, JS/TS 2-space, Makefile tabs)
- **#356** Remove redundant `--cov-fail-under=80` from Makefile `coverage-ci` target — `pyproject.toml` `[tool.coverage.report] fail_under = 80` is now the single source of truth for both local and CI coverage thresholds

## Test plan

- [x] `make verify` passes locally (lint, format, typecheck, tests at 80%+ coverage, desktop/extension builds)
- [x] CI workflows pass on this PR (validates YAML syntax + action SHA resolution)

Closes #404, #405, #406, #407, #408, #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)