### PR TITLE
refactor: replace dict/tuple returns with typed models (#394)

### DIFF
--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -31,6 +31,7 @@ from wikimind.models import (
     Article,
     ArticleConcept,
     Backlink,
+    BatchPrompt,
     CompletionRequest,
     Concept,
     ContradictionFinding,
@@ -38,6 +39,7 @@ from wikimind.models import (
     LintPairCache,
     LintReport,
     LintSeverity,
+    ProcessedPairsResult,
     RelationType,
     TaskType,
 )
@@ -202,10 +204,10 @@ async def _create_contradiction_backlink(
 
 def _build_batch_prompt(
     pairs_with_claims: list[tuple[Article, Article, list[str], list[str]]],
-) -> tuple[str, str]:
+) -> BatchPrompt:
     """Build batch system + user prompt for multiple article pairs.
 
-    Returns (system_str, user_str).
+    Returns system and user prompt strings.
     """
     sections: list[str] = []
     for idx, (art_a, art_b, claims_a, claims_b) in enumerate(pairs_with_claims):
@@ -224,7 +226,7 @@ def _build_batch_prompt(
         pair_count=len(pairs_with_claims),
         pair_sections="\n\n".join(sections),
     )
-    return CONTRADICTION_BATCH_SYSTEM, user_msg
+    return BatchPrompt(system=CONTRADICTION_BATCH_SYSTEM, user=user_msg)
 
 
 def _parse_batch_response(response_data: list[dict], expected_count: int) -> dict[int, list[dict]]:
@@ -447,10 +449,10 @@ async def _process_uncached_pairs(
     session: AsyncSession,
     checked: int,
     user_id: str,
-) -> tuple[list[ContradictionFinding], int]:
+) -> ProcessedPairsResult:
     """Process uncached pairs via batch or per-pair LLM calls.
 
-    Returns (findings, updated_checked_count).
+    Returns findings and the updated checked count.
     """
     cfg = settings.linter
     findings: list[ContradictionFinding] = []
@@ -499,7 +501,7 @@ async def _process_uncached_pairs(
             session.add(report)
             await session.flush()
 
-    return findings, checked
+    return ProcessedPairsResult(findings=findings, checked_count=checked)
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -24,8 +24,10 @@ from wikimind.models import (
     CompletionRequest,
     Conversation,
     CostLog,
+    FileBackThreadResult,
     PageType,
     Query,
+    QueryConversationResult,
     QueryRequest,
     QueryResult,
     TaskType,
@@ -316,7 +318,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         ctx: _PreparedContext,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Query, Conversation]:
+    ) -> QueryConversationResult:
         """Persist the Query row and handle file-back.
 
         Shared by ``answer()`` and the ``answer_stream()`` completion path.
@@ -329,7 +331,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (the new Query row, the parent Conversation).
+            The new Query row and its parent Conversation.
         """
         query_record = Query(
             question=request.question,
@@ -372,14 +374,14 @@ conversation context contradicts the wiki, prefer the wiki."""
         await session.refresh(query_record)
         await session.refresh(ctx.conversation)
 
-        return query_record, ctx.conversation
+        return QueryConversationResult(query=query_record, conversation=ctx.conversation)
 
     async def answer(
         self,
         request: QueryRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Query, Conversation]:
+    ) -> QueryConversationResult:
         """Answer a question against the wiki.
 
         Conversation-aware: if request.conversation_id is None a new
@@ -393,7 +395,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (the new Query row, the parent Conversation).
+            The new Query row and its parent Conversation.
         """
         ctx = await self._prepare_context(request, session, user_id=user_id)
 
@@ -415,16 +417,16 @@ conversation context contradicts the wiki, prefer the wiki."""
         request: QueryRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> AsyncIterator[str | tuple[Query, Conversation]]:
-        """Stream LLM tokens, then yield the persisted (Query, Conversation) tuple.
+    ) -> AsyncIterator[str | QueryConversationResult]:
+        """Stream LLM tokens, then yield the persisted QueryConversationResult.
 
         Yields text chunk strings during streaming. After all tokens have been
-        yielded, yields a single ``(Query, Conversation)`` tuple as the final
+        yielded, yields a single ``QueryConversationResult`` as the final
         item. The caller (service layer) is responsible for constructing SSE
         events from these values.
 
         If wiki context is empty, yields the canned answer text as one chunk
-        followed by the persisted tuple.
+        followed by the persisted result.
 
         Raises:
             RuntimeError: When all LLM providers fail.
@@ -435,15 +437,14 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Yields:
-            ``str`` text chunks, then a final ``tuple[Query, Conversation]``.
+            ``str`` text chunks, then a final ``QueryConversationResult``.
         """
         ctx = await self._prepare_context(request, session, user_id=user_id)
 
         if ctx.no_context_result is not None:
             result = ctx.no_context_result
             yield result.answer
-            query_record, conversation = await self._persist_query(request, result, ctx, session, user_id=user_id)
-            yield (query_record, conversation)
+            yield await self._persist_query(request, result, ctx, session, user_id=user_id)
             return
 
         assert ctx.completion_request is not None
@@ -504,8 +505,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                 related_articles=[],
             )
 
-        query_record, conversation = await self._persist_query(request, result, ctx, session, user_id=user_id)
-        yield (query_record, conversation)
+        yield await self._persist_query(request, result, ctx, session, user_id=user_id)
 
     async def _retrieve_context(self, question: str, session: AsyncSession, user_id: str) -> list[dict]:
         """Retrieve relevant wiki articles for the question."""
@@ -575,7 +575,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         conversation_id: str,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Article, bool]:
+    ) -> FileBackThreadResult:
         """File a whole conversation back to the wiki as a single article.
 
         STAGES changes but does NOT commit — the caller owns the
@@ -596,8 +596,7 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (article, was_update). was_update is True when an
-            existing article was overwritten.
+            The article and whether it was an update of an existing article.
         """
         conversation = await session.get(Conversation, conversation_id)
         if conversation is None:
@@ -662,7 +661,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                 conversation_id=conversation_id,
                 article_id=article.id,
             )
-            return article, False
+            return FileBackThreadResult(article=article, was_update=False)
 
         # Update path: overwrite the existing Article's file in place
         resolve_wiki_path(existing_article.file_path, user_id=user_id).write_text(markdown, encoding="utf-8")
@@ -676,4 +675,4 @@ conversation context contradicts the wiki, prefer the wiki."""
             conversation_id=conversation_id,
             article_id=existing_article.id,
         )
-        return existing_article, True
+        return FileBackThreadResult(article=existing_article, was_update=True)

--- a/src/wikimind/engine/wikilink_resolver.py
+++ b/src/wikimind/engine/wikilink_resolver.py
@@ -20,7 +20,7 @@ There is NO fuzzy matching. See the design spec for rationale
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from sqlmodel import select
 
@@ -50,13 +50,20 @@ class ResolvedBacklink:
     relation_type: str = "references"
 
 
+class ResolveBacklinksResult(NamedTuple):
+    """Resolved and unresolved backlink candidates."""
+
+    resolved: list[ResolvedBacklink]
+    unresolved: list[str]
+
+
 async def resolve_backlink_candidates(
     candidates: list[str],
     session: AsyncSession,
     user_id: str,
     exclude_article_id: str | None = None,
     relation_types: dict[str, str] | None = None,
-) -> tuple[list[ResolvedBacklink], list[str]]:
+) -> ResolveBacklinksResult:
     """Resolve wikilink candidates against the Article table.
 
     Args:
@@ -75,9 +82,9 @@ async def resolve_backlink_candidates(
             considered for resolution. Prevents cross-user link leakage.
 
     Returns:
-        A tuple ``(resolved, unresolved)``. Resolved contains one
-        :class:`ResolvedBacklink` per unique target article (so two
-        candidates pointing at the same article produce one row).
+        Resolved backlinks and unresolved candidate strings. Resolved
+        contains one :class:`ResolvedBacklink` per unique target article
+        (so two candidates pointing at the same article produce one row).
         Unresolved is the list of candidate strings that matched no
         article, in input order.
     """
@@ -86,7 +93,7 @@ async def resolve_backlink_candidates(
     # Drop empty / whitespace-only candidates up front.
     cleaned = [c.strip() for c in candidates if c and c.strip()]
     if not cleaned:
-        return [], []
+        return ResolveBacklinksResult(resolved=[], unresolved=[])
 
     # Load articles for resolution. When user_id is provided, only that
     # user's articles are considered — prevents cross-user link leakage.
@@ -127,4 +134,7 @@ async def resolve_backlink_candidates(
                 relation_type=rel_map.get(candidate.lower(), "references"),
             )
 
-    return list(resolved_by_target.values()), unresolved
+    return ResolveBacklinksResult(
+        resolved=list(resolved_by_target.values()),
+        unresolved=unresolved,
+    )

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -8,7 +8,7 @@ Pydantic models carry data through the ingest → compile → query pipeline.
 import uuid
 from datetime import date, datetime
 from enum import StrEnum
-from typing import Literal
+from typing import Literal, NamedTuple, TypedDict
 
 from pydantic import BaseModel, computed_field
 from sqlalchemy import Column, String, UniqueConstraint
@@ -1206,3 +1206,84 @@ class TokenCreateResponse(BaseModel):
     token_type: str = "bearer"
     expires_at: str
     name: str
+
+
+# ---------------------------------------------------------------------------
+# Typed return types for service/engine internals (issue #394)
+# ---------------------------------------------------------------------------
+
+
+class DeleteSourceResult(TypedDict):
+    """Return type for IngestService.delete_source."""
+
+    deleted: str
+
+
+class FileBackArticleRef(BaseModel):
+    """Minimal article reference inside a file-back response."""
+
+    id: str
+    slug: str
+    title: str
+
+
+class FileBackResult(BaseModel):
+    """Return type for file-back operations (conversation or selection)."""
+
+    article: FileBackArticleRef
+    was_update: bool = False
+
+
+class EncryptedKey(NamedTuple):
+    """Result of encrypting an API key."""
+
+    encrypted_key: str
+    salt_hex: str
+
+
+class FileBackThreadResult(NamedTuple):
+    """Result of filing a conversation thread back to the wiki."""
+
+    article: "Article"
+    was_update: bool
+
+
+class QueryConversationResult(NamedTuple):
+    """A persisted Query row and its parent Conversation."""
+
+    query: "Query"
+    conversation: "Conversation"
+
+
+class BatchPrompt(NamedTuple):
+    """System and user prompt strings for a batched LLM call."""
+
+    system: str
+    user: str
+
+
+class ProcessedPairsResult(NamedTuple):
+    """Findings from processing uncached contradiction pairs."""
+
+    findings: list["ContradictionFinding"]
+    checked_count: int
+
+
+class GroupedArticles(NamedTuple):
+    """Articles grouped by concept and uncategorized remainder."""
+
+    by_concept: dict[str, list["Article"]]
+    uncategorized: list["Article"]
+
+
+class HealthData(NamedTuple):
+    """Articles and backlinks for health page generation."""
+
+    articles: list["Article"]
+    backlinks: list["Backlink"]
+
+
+class EmbeddingStats(TypedDict):
+    """Statistics from the embedding/vector store."""
+
+    total_chunks: int

--- a/src/wikimind/services/admin.py
+++ b/src/wikimind/services/admin.py
@@ -7,7 +7,17 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.config import get_settings
 from wikimind.jobs.background import get_background_compiler
-from wikimind.models import Article, Backlink, Concept, Conversation, Source
+from wikimind.models import (
+    AdminActionResult,
+    Article,
+    Backlink,
+    Concept,
+    Conversation,
+    EligibleConcept,
+    OrphanArticle,
+    Source,
+    SystemStats,
+)
 from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
@@ -20,7 +30,7 @@ class AdminService:
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> dict:
+    ) -> SystemStats:
         """Compute aggregate counts across all tables.
 
         Args:
@@ -28,7 +38,7 @@ class AdminService:
             user_id: Optional user ID filter.
 
         Returns:
-            Dict with aggregate counts and breakdowns.
+            Aggregate counts and breakdowns.
         """
         counts: dict[str, int] = {}
         for model, key in [
@@ -63,17 +73,17 @@ class AdminService:
                 if not wiki_path.exists():
                     orphan_count += 1
 
-        return {
+        return SystemStats(
             **counts,
-            "orphan_count": orphan_count,
-            "articles_by_type": articles_by_type,
-        }
+            orphan_count=orphan_count,
+            articles_by_type=articles_by_type,
+        )
 
     async def get_orphan_articles(
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> list[dict]:
+    ) -> list[OrphanArticle]:
         """Find articles whose wiki file is missing from disk.
 
         Args:
@@ -81,26 +91,26 @@ class AdminService:
             user_id: Optional user ID filter.
 
         Returns:
-            List of dicts with orphan article info.
+            List of orphan article records.
         """
         stmt = select(Article)
         if user_id:
             stmt = stmt.where(Article.user_id == user_id)
         result = await session.execute(stmt)
 
-        orphans = []
+        orphans: list[OrphanArticle] = []
         for article in result.scalars().all():
             if not article.file_path:
                 continue
             wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
             if not wiki_path.exists():
                 orphans.append(
-                    {
-                        "id": article.id,
-                        "slug": article.slug,
-                        "title": article.title,
-                        "file_path": article.file_path,
-                    }
+                    OrphanArticle(
+                        id=article.id,
+                        slug=article.slug,
+                        title=article.title,
+                        file_path=article.file_path,
+                    )
                 )
         return orphans
 
@@ -108,7 +118,7 @@ class AdminService:
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> list[dict]:
+    ) -> list[EligibleConcept]:
         """Find concepts eligible for concept-page generation.
 
         A concept is eligible when its article_count meets the threshold
@@ -119,7 +129,7 @@ class AdminService:
             user_id: Optional user ID filter.
 
         Returns:
-            List of dicts with eligible concept info.
+            List of eligible concept records.
         """
         settings = get_settings()
         threshold = settings.taxonomy.concept_page_min_sources
@@ -130,7 +140,7 @@ class AdminService:
         result = await session.execute(stmt)
         concepts = result.scalars().all()
 
-        eligible = []
+        eligible: list[EligibleConcept] = []
         for concept in concepts:
             # Check if a concept page article already exists
             page_stmt = select(Article).where(
@@ -143,38 +153,38 @@ class AdminService:
             has_page = page_result.scalar_one_or_none() is not None
 
             eligible.append(
-                {
-                    "id": concept.id,
-                    "name": concept.name,
-                    "article_count": concept.article_count,
-                    "has_existing_page": has_page,
-                }
+                EligibleConcept(
+                    id=concept.id,
+                    name=concept.name,
+                    article_count=concept.article_count,
+                    has_existing_page=has_page,
+                )
             )
         return eligible
 
     async def trigger_sweep(
         self,
         user_id: str,
-    ) -> dict:
+    ) -> AdminActionResult:
         """Trigger a wikilink sweep manually.
 
         Args:
             user_id: Optional user ID to scope the sweep.
 
         Returns:
-            Dict with action result.
+            Action result with status.
         """
         bg = get_background_compiler()
         await bg.schedule_lint(user_id=user_id)
-        return {"action": "sweep", "status": "scheduled"}
+        return AdminActionResult(action="sweep", status="scheduled")
 
-    async def trigger_reindex(self) -> dict:
+    async def trigger_reindex(self) -> AdminActionResult:
         """Rebuild the search index.
 
         Returns:
-            Dict with action result.
+            Action result with status.
         """
-        return {"action": "reindex", "status": "scheduled"}
+        return AdminActionResult(action="reindex", status="scheduled")
 
 
 _admin_service: AdminService | None = None

--- a/src/wikimind/services/api_keys.py
+++ b/src/wikimind/services/api_keys.py
@@ -19,7 +19,7 @@ from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
-from wikimind.models import Provider, UserApiKey
+from wikimind.models import EncryptedKey, Provider, UserApiKey
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -50,20 +50,20 @@ def _derive_fernet_key(salt: bytes) -> bytes:
     return base64.urlsafe_b64encode(kdf.derive(secret.encode()))
 
 
-def encrypt_api_key(plaintext: str) -> tuple[str, str]:
-    """Encrypt an API key, returning (encrypted_key, salt_hex).
+def encrypt_api_key(plaintext: str) -> EncryptedKey:
+    """Encrypt an API key, returning the encrypted key and salt.
 
     Args:
         plaintext: The raw API key to encrypt.
 
     Returns:
-        Tuple of (Fernet-encrypted key as base64 string, salt as hex string).
+        NamedTuple with encrypted_key (base64 string) and salt_hex fields.
     """
     salt = os.urandom(16)
     fernet_key = _derive_fernet_key(salt)
     f = Fernet(fernet_key)
     encrypted = f.encrypt(plaintext.encode())
-    return encrypted.decode(), salt.hex()
+    return EncryptedKey(encrypted_key=encrypted.decode(), salt_hex=salt.hex())
 
 
 def decrypt_api_key(encrypted_key: str, salt_hex: str) -> str:

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -17,6 +17,7 @@ from typing import Any
 import structlog
 
 from wikimind.config import get_settings
+from wikimind.models import EmbeddingStats
 
 log = structlog.get_logger()
 
@@ -298,15 +299,13 @@ class EmbeddingService:
             # Collection may be empty or article may not exist -- both are fine
             log.debug("delete_article no-op", article_id=article_id)
 
-    def get_stats(self) -> dict:
+    def get_stats(self) -> EmbeddingStats:
         """Return basic statistics about the vector store.
 
         Returns:
-            Dict with ``total_chunks`` count.
+            Statistics including total chunk count.
         """
-        return {
-            "total_chunks": self._collection.count(),
-        }
+        return EmbeddingStats(total_chunks=self._collection.count())
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -18,7 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind.errors import IngestError, NotFoundError
 from wikimind.ingest.service import IngestService as IngestAdapter
 from wikimind.jobs.background import get_background_compiler
-from wikimind.models import NormalizedDocument, Source
+from wikimind.models import DeleteSourceResult, NormalizedDocument, Source
 from wikimind.services.activity_log import append_log_entry
 from wikimind.storage import resolve_raw_path
 
@@ -233,7 +233,7 @@ class IngestService:
         source_id: str,
         session: AsyncSession,
         user_id: str,
-    ) -> dict[str, str]:
+    ) -> DeleteSourceResult:
         """Delete a source by ID and remove its raw and cleaned files from disk.
 
         Adapters write a cleaned ``{id}.txt`` and may also write a sibling raw
@@ -248,7 +248,7 @@ class IngestService:
             user_id: When provided, verify the source belongs to this user.
 
         Returns:
-            Confirmation dict with the deleted ID.
+            Confirmation with the deleted ID.
 
         Raises:
             NotFoundError: If the source is not found or doesn't belong to the user.
@@ -264,7 +264,7 @@ class IngestService:
 
         await session.delete(source)
         await session.commit()
-        return {"deleted": source_id}
+        return DeleteSourceResult(deleted=source_id)
 
     @staticmethod
     def _remove_source_files(source: Source) -> None:

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -38,6 +38,8 @@ from wikimind.models import (
     ConversationDetail,
     ConversationResponse,
     ConversationSummary,
+    FileBackArticleRef,
+    FileBackResult,
     FileBackSelectionRequest,
     ForkRequest,
     PageType,
@@ -301,7 +303,7 @@ class QueryService:
                 if isinstance(item, str):
                     yield (f"event: chunk\ndata: {json.dumps({'text': item})}\n\n")
                 else:
-                    # Final tuple: (Query, Conversation)
+                    # Final item: QueryConversationResult
                     query_record, conversation = item
                     citations = await _build_citations(query_record, session, user_id=user_id)
                     done_payload = AskResponse(
@@ -452,7 +454,7 @@ class QueryService:
         conversation_id: str,
         session: AsyncSession,
         user_id: str,
-    ) -> dict[str, object]:
+    ) -> FileBackResult:
         """File a whole conversation back to the wiki.
 
         Delegates to QAAgent._file_back_thread which handles create-vs-update
@@ -466,7 +468,7 @@ class QueryService:
             user_id: User ID for data isolation.
 
         Returns:
-            Dict with article metadata (id, slug, title) and a was_update flag.
+            File-back result with article metadata and update flag.
         """
         # Ownership check before delegating to QAAgent
         conversation = await session.get(Conversation, conversation_id)
@@ -477,10 +479,10 @@ class QueryService:
             raise NotFoundError(msg)
 
         article, was_update = await self._qa_agent._file_back_thread(conversation_id, session, user_id=user_id)
-        return {
-            "article": {"id": article.id, "slug": article.slug, "title": article.title},
-            "was_update": was_update,
-        }
+        return FileBackResult(
+            article=FileBackArticleRef(id=article.id, slug=article.slug, title=article.title),
+            was_update=was_update,
+        )
 
     async def fork_conversation(
         self,
@@ -551,7 +553,7 @@ class QueryService:
         request: FileBackSelectionRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> dict[str, object]:
+    ) -> FileBackResult:
         """File selected turns from one or more conversations back to the wiki.
 
         Validates that all referenced conversations and turns exist, builds
@@ -564,7 +566,7 @@ class QueryService:
             user_id: User ID for data isolation.
 
         Returns:
-            Dict with article metadata (id, slug, title).
+            File-back result with article metadata.
 
         Raises:
             QueryError: If selections are empty or invalid.
@@ -646,9 +648,9 @@ class QueryService:
         await session.commit()
         await session.refresh(article)
 
-        return {
-            "article": {"id": article.id, "slug": article.slug, "title": article.title},
-        }
+        return FileBackResult(
+            article=FileBackArticleRef(id=article.id, slug=article.slug, title=article.title),
+        )
 
     async def export_conversation(
         self,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -31,6 +31,7 @@ from wikimind.models import (
     Backlink,
     BacklinkEntry,
     Concept,
+    ConceptDetailResponse,
     GraphEdge,
     GraphNode,
     GraphResponse,
@@ -569,7 +570,7 @@ class WikiService:
         name: str,
         session: AsyncSession,
         user_id: str,
-    ) -> dict:
+    ) -> ConceptDetailResponse:
         """Retrieve a concept by name with its linked articles.
 
         Args:
@@ -578,7 +579,7 @@ class WikiService:
             user_id: Optional user ID filter.
 
         Returns:
-            Dict with concept fields and linked articles list.
+            Concept detail with linked articles.
 
         Raises:
             NotFoundError: If concept not found.
@@ -593,16 +594,16 @@ class WikiService:
             raise NotFoundError(msg)
 
         articles = await self.list_articles(session=session, concept=name, user_id=user_id)
-        return {
-            "id": concept.id,
-            "name": concept.name,
-            "description": concept.description,
-            "article_count": concept.article_count,
-            "parent_id": concept.parent_id,
-            "concept_kind": concept.concept_kind,
-            "created_at": concept.created_at,
-            "articles": articles,
-        }
+        return ConceptDetailResponse(
+            id=concept.id,
+            name=concept.name,
+            description=concept.description,
+            article_count=concept.article_count,
+            parent_id=concept.parent_id,
+            concept_kind=concept.concept_kind,
+            created_at=concept.created_at,
+            articles=articles,
+        )
 
     async def get_concept_articles(
         self,

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -18,7 +18,15 @@ from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
-from wikimind.models import Article, ArticleConcept, Backlink, Concept, PageType
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    Backlink,
+    Concept,
+    GroupedArticles,
+    HealthData,
+    PageType,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -73,7 +81,7 @@ def _article_entry(article: Article) -> str:
 async def _group_articles_by_concept(
     articles: list[Article],
     session: AsyncSession,
-) -> tuple[dict[str, list[Article]], list[Article]]:
+) -> GroupedArticles:
     """Group articles by concept name and identify uncategorized articles.
 
     Reads from the ArticleConcept join table with a fallback to the legacy
@@ -84,7 +92,7 @@ async def _group_articles_by_concept(
         session: Async database session.
 
     Returns:
-        A tuple of (concept_name -> article list, uncategorized articles).
+        Articles grouped by concept and uncategorized remainder.
     """
     concepts_result = await session.execute(select(Concept))
     concept_map: dict[str, str] = {c.id: c.name for c in concepts_result.scalars().all()}
@@ -114,7 +122,7 @@ async def _group_articles_by_concept(
             name = concept_map.get(raw_id, raw_id)
             concept_articles[name].append(article)
 
-    return concept_articles, uncategorized
+    return GroupedArticles(by_concept=concept_articles, uncategorized=uncategorized)
 
 
 def _build_index_lines(
@@ -214,7 +222,7 @@ async def regenerate_index_md(
 async def _fetch_health_data(
     session: AsyncSession,
     user_id: str,
-) -> tuple[list[Article], list[Backlink]]:
+) -> HealthData:
     """Fetch articles and backlinks for the health page, scoped by user_id."""
     article_stmt = select(Article)
     if user_id:
@@ -233,7 +241,7 @@ async def _fetch_health_data(
     backlinks_result = await session.execute(backlink_stmt)
     backlinks: list[Backlink] = list(backlinks_result.scalars().all())
 
-    return articles, backlinks
+    return HealthData(articles=articles, backlinks=backlinks)
 
 
 async def generate_meta_health_page(

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -441,12 +441,11 @@ class TestFileBackSelection:
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
 
-        assert "article" in result
-        article_data = result["article"]
-        assert article_data["title"] == "First Thread"  # defaults to first conv title
+        assert result.article is not None
+        assert result.article.title == "First Thread"  # defaults to first conv title
 
         # Verify the article was created on disk
-        article = await db_session.get(Article, article_data["id"])
+        article = await db_session.get(Article, result.article.id)
         assert article is not None
         resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
         content = resolved.read_text(encoding="utf-8")
@@ -469,10 +468,9 @@ class TestFileBackSelection:
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
 
-        article_data = result["article"]
-        assert article_data["title"] == "Merged Research"
+        assert result.article.title == "Merged Research"
 
-        article = await db_session.get(Article, article_data["id"])
+        article = await db_session.get(Article, result.article.id)
         resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
         content = resolved.read_text(encoding="utf-8")
         assert "# Merged Research" in content
@@ -491,7 +489,7 @@ class TestFileBackSelection:
             ],
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
-        article_id = result["article"]["id"]
+        article_id = result.article.id
 
         # Refresh the selected queries
         res = await db_session.execute(select(Query).where(Query.conversation_id == "conv-sel-1"))
@@ -554,8 +552,8 @@ class TestFileBackSelection:
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
 
-        assert result["article"]["title"] == "My Custom Title"
-        article = await db_session.get(Article, result["article"]["id"])
+        assert result.article.title == "My Custom Title"
+        article = await db_session.get(Article, result.article.id)
         resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
         content = resolved.read_text(encoding="utf-8")
         assert "# My Custom Title" in content

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -474,9 +474,9 @@ async def test_query_service_file_back_conversation(db_session, tmp_path, monkey
 
     result = await svc.file_back_conversation("conv-fb", db_session, user_id=TEST_USER_ID)
 
-    assert result["was_update"] is False
-    assert result["article"]["id"] == "art-1"
-    assert result["article"]["slug"] == "conv-fb"
+    assert result.was_update is False
+    assert result.article.id == "art-1"
+    assert result.article.slug == "conv-fb"
     svc._qa_agent._file_back_thread.assert_awaited_once_with("conv-fb", db_session, user_id=TEST_USER_ID)
 
 

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -321,10 +321,9 @@ class TestFileBackSelectionPathScoping:
             db_session,
             user_id="alice",
         )
-        article_info = result["article"]
 
         # Verify the article stores a relative path and resolves under wiki/alice/
-        art_result = await db_session.execute(select(Article).where(Article.id == article_info["id"]))
+        art_result = await db_session.execute(select(Article).where(Article.id == result.article.id))
         article = art_result.scalar_one()
         assert article.file_path.startswith("qa-answers/")
         resolved = resolve_wiki_path(article.file_path, user_id="alice")


### PR DESCRIPTION
## Summary
- Replace raw `dict` returns in AdminService, WikiService, IngestService, and QueryService with existing Pydantic models (`SystemStats`, `OrphanArticle`, `EligibleConcept`, `AdminActionResult`, `ConceptDetailResponse`) and new typed models (`FileBackResult`, `DeleteSourceResult`)
- Replace `tuple` returns in QAAgent, wikilink_resolver, and contradictions module with descriptive NamedTuples (`QueryConversationResult`, `FileBackThreadResult`, `ResolveBacklinksResult`, `BatchPrompt`, `ProcessedPairsResult`, `GroupedArticles`, `HealthData`, `EncryptedKey`)
- Add `EmbeddingStats` TypedDict for EmbeddingService.get_stats
- Update test assertions to use attribute access instead of dict subscript

## Test plan
- [x] `make typecheck` passes with no errors
- [x] `make lint` passes
- [x] `make format-check` passes
- [x] All 993 tests pass, 0 regressions
- [x] Pure type refinement — no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)