### PR TITLE
fix: add port-in-use check to make dev (#435)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,7 +142,7 @@
         "filename": "Makefile",
         "hashed_secret": "a2af834e65ad267df89a30dd525c7aac8451b394",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 118
       }
     ],
     "design-system/ui_kits/app/index.html": [
@@ -312,5 +312,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-03T15:57:14Z"
+  "generated_at": "2026-05-04T19:31:13Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,14 @@ check-env: check-venv ## Verify Python version, venv hygiene, and required tools
 
 .PHONY: dev
 dev: check-venv ## Run fast-reload dev server on :7842 (uvicorn)
+	@if lsof -i :7842 -sTCP:LISTEN >/dev/null 2>&1; then \
+		echo ""; \
+		echo "ERROR: port 7842 is already in use."; \
+		echo "  A Docker container or another process may be listening."; \
+		echo "  Run: make docker-down  (or: lsof -i :7842 to inspect)"; \
+		echo ""; \
+		exit 1; \
+	fi
 	$(BIN)/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
 
 .PHONY: serve


### PR DESCRIPTION
## Summary

- `make dev` now checks whether port 7842 is already occupied before launching uvicorn
- If the port is in use (e.g., a Docker container from `docker compose up`), the command fails immediately with a clear error message and remediation steps
- Prevents confusing "address already in use" crashes from uvicorn

Closes #435

## Test plan

- [ ] Run `make dev` with nothing on :7842 -- starts normally
- [ ] Start something on :7842 (e.g., `docker compose up -d`), then run `make dev` -- should print the error and exit 1
- [ ] Verify `make -n dev` shows the lsof check before the uvicorn line

🤖 Generated with [Claude Code](https://claude.com/claude-code)