### PR TITLE
refactor: replace dict/tuple returns with typed models (#394)

### DIFF
--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -15,7 +15,7 @@ import hashlib
 import itertools
 import json
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import structlog
 from sqlalchemy import delete
@@ -201,12 +201,19 @@ async def _create_contradiction_backlink(
 # ---------------------------------------------------------------------------
 
 
+class BatchPrompt(NamedTuple):
+    """System and user prompts for a batch LLM call."""
+
+    system: str
+    user: str
+
+
 def _build_batch_prompt(
     pairs_with_claims: list[tuple[Article, Article, list[str], list[str]]],
-) -> tuple[str, str]:
+) -> BatchPrompt:
     """Build batch system + user prompt for multiple article pairs.
 
-    Returns (system_str, user_str).
+    Returns BatchPrompt with system and user strings.
     """
     sections: list[str] = []
     for idx, (art_a, art_b, claims_a, claims_b) in enumerate(pairs_with_claims):
@@ -225,7 +232,7 @@ def _build_batch_prompt(
         pair_count=len(pairs_with_claims),
         pair_sections="\n\n".join(sections),
     )
-    return CONTRADICTION_BATCH_SYSTEM, user_msg
+    return BatchPrompt(CONTRADICTION_BATCH_SYSTEM, user_msg)
 
 
 def _parse_batch_response(response_data: list[dict], expected_count: int) -> dict[int, list[dict]]:
@@ -439,6 +446,13 @@ def _cache_data_from_findings(new_findings: list[ContradictionFinding]) -> list[
     ]
 
 
+class PairProcessResult(NamedTuple):
+    """Result of processing uncached article pairs."""
+
+    findings: list[ContradictionFinding]
+    checked_count: int
+
+
 async def _process_uncached_pairs(
     uncached_pairs: list[tuple[Article, Article, list[str], list[str]]],
     concept_id: str | None,
@@ -448,10 +462,10 @@ async def _process_uncached_pairs(
     session: AsyncSession,
     checked: int,
     user_id: str,
-) -> tuple[list[ContradictionFinding], int]:
+) -> PairProcessResult:
     """Process uncached pairs via batch or per-pair LLM calls.
 
-    Returns (findings, updated_checked_count).
+    Returns PairProcessResult with findings and updated checked count.
     """
     cfg = settings.linter
     findings: list[ContradictionFinding] = []
@@ -500,7 +514,7 @@ async def _process_uncached_pairs(
             session.add(report)
             await session.flush()
 
-    return findings, checked
+    return PairProcessResult(findings, checked)
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -549,7 +549,7 @@ class LLMRouter:
         msg = f"All LLM providers failed. Last error: {last_error}"
         raise UpstreamError(msg)
 
-    def parse_json_response(self, response: CompletionResponse) -> dict:
+    def parse_json_response(self, response: CompletionResponse) -> Any:
         """Parse JSON from LLM response, handling common formatting issues.
 
         Handles markdown fences, leading/trailing text around JSON, and

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -992,6 +992,33 @@ class AdminActionResult(BaseModel):
     job_id: str | None = None
 
 
+class FileBackArticleRef(BaseModel):
+    """Minimal article reference returned by file-back operations."""
+
+    id: str
+    slug: str
+    title: str
+
+
+class FileBackResult(BaseModel):
+    """Result of filing a conversation or selection back to the wiki."""
+
+    article: FileBackArticleRef
+    was_update: bool = False
+
+
+class DeleteConfirmation(BaseModel):
+    """Confirmation of a resource deletion."""
+
+    deleted: str
+
+
+class EmbeddingStats(BaseModel):
+    """Basic statistics about the vector store."""
+
+    total_chunks: int
+
+
 class CitationArticleRef(BaseModel):
     """Minimal reference to an article used inside a :class:`CitationResponse`."""
 

--- a/src/wikimind/services/admin.py
+++ b/src/wikimind/services/admin.py
@@ -7,7 +7,17 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.config import get_settings
 from wikimind.jobs.background import get_background_compiler
-from wikimind.models import Article, Backlink, Concept, Conversation, Source
+from wikimind.models import (
+    AdminActionResult,
+    Article,
+    Backlink,
+    Concept,
+    Conversation,
+    EligibleConcept,
+    OrphanArticle,
+    Source,
+    SystemStats,
+)
 from wikimind.storage import resolve_wiki_path
 
 log = structlog.get_logger()
@@ -20,7 +30,7 @@ class AdminService:
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> dict:
+    ) -> SystemStats:
         """Compute aggregate counts across all tables.
 
         Args:
@@ -28,7 +38,7 @@ class AdminService:
             user_id: Optional user ID filter.
 
         Returns:
-            Dict with aggregate counts and breakdowns.
+            SystemStats with aggregate counts and breakdowns.
         """
         counts: dict[str, int] = {}
         for model, key in [
@@ -63,17 +73,17 @@ class AdminService:
                 if not wiki_path.exists():
                     orphan_count += 1
 
-        return {
+        return SystemStats(
             **counts,
-            "orphan_count": orphan_count,
-            "articles_by_type": articles_by_type,
-        }
+            orphan_count=orphan_count,
+            articles_by_type=articles_by_type,
+        )
 
     async def get_orphan_articles(
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> list[dict]:
+    ) -> list[OrphanArticle]:
         """Find articles whose wiki file is missing from disk.
 
         Args:
@@ -81,26 +91,26 @@ class AdminService:
             user_id: Optional user ID filter.
 
         Returns:
-            List of dicts with orphan article info.
+            List of OrphanArticle with orphan article info.
         """
         stmt = select(Article)
         if user_id:
             stmt = stmt.where(Article.user_id == user_id)
         result = await session.execute(stmt)
 
-        orphans = []
+        orphans: list[OrphanArticle] = []
         for article in result.scalars().all():
             if not article.file_path:
                 continue
             wiki_path = resolve_wiki_path(article.file_path, user_id=article.user_id)
             if not wiki_path.exists():
                 orphans.append(
-                    {
-                        "id": article.id,
-                        "slug": article.slug,
-                        "title": article.title,
-                        "file_path": article.file_path,
-                    }
+                    OrphanArticle(
+                        id=article.id,
+                        slug=article.slug,
+                        title=article.title,
+                        file_path=article.file_path,
+                    )
                 )
         return orphans
 
@@ -108,7 +118,7 @@ class AdminService:
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> list[dict]:
+    ) -> list[EligibleConcept]:
         """Find concepts eligible for concept-page generation.
 
         A concept is eligible when its article_count meets the threshold
@@ -119,7 +129,7 @@ class AdminService:
             user_id: Optional user ID filter.
 
         Returns:
-            List of dicts with eligible concept info.
+            List of EligibleConcept with eligible concept info.
         """
         settings = get_settings()
         threshold = settings.taxonomy.concept_page_min_sources
@@ -130,7 +140,7 @@ class AdminService:
         result = await session.execute(stmt)
         concepts = result.scalars().all()
 
-        eligible = []
+        eligible: list[EligibleConcept] = []
         for concept in concepts:
             # Check if a concept page article already exists
             page_stmt = select(Article).where(
@@ -143,38 +153,38 @@ class AdminService:
             has_page = page_result.scalar_one_or_none() is not None
 
             eligible.append(
-                {
-                    "id": concept.id,
-                    "name": concept.name,
-                    "article_count": concept.article_count,
-                    "has_existing_page": has_page,
-                }
+                EligibleConcept(
+                    id=concept.id,
+                    name=concept.name,
+                    article_count=concept.article_count,
+                    has_existing_page=has_page,
+                )
             )
         return eligible
 
     async def trigger_sweep(
         self,
         user_id: str,
-    ) -> dict:
+    ) -> AdminActionResult:
         """Trigger a wikilink sweep manually.
 
         Args:
             user_id: Optional user ID to scope the sweep.
 
         Returns:
-            Dict with action result.
+            AdminActionResult with action result.
         """
         bg = get_background_compiler()
         await bg.schedule_lint(user_id=user_id)
-        return {"action": "sweep", "status": "scheduled"}
+        return AdminActionResult(action="sweep", status="scheduled")
 
-    async def trigger_reindex(self) -> dict:
+    async def trigger_reindex(self) -> AdminActionResult:
         """Rebuild the search index.
 
         Returns:
-            Dict with action result.
+            AdminActionResult with action result.
         """
-        return {"action": "reindex", "status": "scheduled"}
+        return AdminActionResult(action="reindex", status="scheduled")
 
 
 _admin_service: AdminService | None = None

--- a/src/wikimind/services/api_keys.py
+++ b/src/wikimind/services/api_keys.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import base64
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import structlog
 from cryptography.fernet import Fernet
@@ -50,20 +50,27 @@ def _derive_fernet_key(salt: bytes) -> bytes:
     return base64.urlsafe_b64encode(kdf.derive(secret.encode()))
 
 
-def encrypt_api_key(plaintext: str) -> tuple[str, str]:
+class EncryptedApiKey(NamedTuple):
+    """Result of encrypting an API key."""
+
+    encrypted_key: str
+    salt_hex: str
+
+
+def encrypt_api_key(plaintext: str) -> EncryptedApiKey:
     """Encrypt an API key, returning (encrypted_key, salt_hex).
 
     Args:
         plaintext: The raw API key to encrypt.
 
     Returns:
-        Tuple of (Fernet-encrypted key as base64 string, salt as hex string).
+        EncryptedApiKey with Fernet-encrypted key and salt hex string.
     """
     salt = os.urandom(16)
     fernet_key = _derive_fernet_key(salt)
     f = Fernet(fernet_key)
     encrypted = f.encrypt(plaintext.encode())
-    return encrypted.decode(), salt.hex()
+    return EncryptedApiKey(encrypted.decode(), salt.hex())
 
 
 def decrypt_api_key(encrypted_key: str, salt_hex: str) -> str:

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -17,6 +17,7 @@ from typing import Any
 import structlog
 
 from wikimind.config import get_settings
+from wikimind.models import EmbeddingStats
 
 log = structlog.get_logger()
 
@@ -298,15 +299,15 @@ class EmbeddingService:
             # Collection may be empty or article may not exist -- both are fine
             log.debug("delete_article no-op", article_id=article_id)
 
-    def get_stats(self) -> dict:
+    def get_stats(self) -> EmbeddingStats:
         """Return basic statistics about the vector store.
 
         Returns:
-            Dict with ``total_chunks`` count.
+            EmbeddingStats with ``total_chunks`` count.
         """
-        return {
-            "total_chunks": self._collection.count(),
-        }
+        return EmbeddingStats(
+            total_chunks=self._collection.count(),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -19,7 +19,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind.errors import IngestError, NotFoundError
 from wikimind.ingest.service import IngestService as IngestAdapter
 from wikimind.jobs.background import get_background_compiler
-from wikimind.models import NormalizedDocument, Source
+from wikimind.models import DeleteConfirmation, NormalizedDocument, Source
 from wikimind.services.activity_log import append_log_entry
 from wikimind.storage import resolve_raw_path
 
@@ -234,7 +234,7 @@ class IngestService:
         source_id: str,
         session: AsyncSession,
         user_id: str,
-    ) -> dict[str, str]:
+    ) -> DeleteConfirmation:
         """Delete a source by ID and remove its raw and cleaned files from disk.
 
         Adapters write a cleaned ``{id}.txt`` and may also write a sibling raw
@@ -249,7 +249,7 @@ class IngestService:
             user_id: When provided, verify the source belongs to this user.
 
         Returns:
-            Confirmation dict with the deleted ID.
+            DeleteConfirmation with the deleted ID.
 
         Raises:
             NotFoundError: If the source is not found or doesn't belong to the user.
@@ -265,7 +265,7 @@ class IngestService:
 
         await session.delete(source)
         await session.commit()
-        return {"deleted": source_id}
+        return DeleteConfirmation(deleted=source_id)
 
     @staticmethod
     def _remove_source_files(source: Source) -> None:

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -39,6 +39,8 @@ from wikimind.models import (
     ConversationDetail,
     ConversationResponse,
     ConversationSummary,
+    FileBackArticleRef,
+    FileBackResult,
     FileBackSelectionRequest,
     ForkRequest,
     PageType,
@@ -453,7 +455,7 @@ class QueryService:
         conversation_id: str,
         session: AsyncSession,
         user_id: str,
-    ) -> dict[str, object]:
+    ) -> FileBackResult:
         """File a whole conversation back to the wiki.
 
         Delegates to QAAgent._file_back_thread which handles create-vs-update
@@ -467,7 +469,7 @@ class QueryService:
             user_id: User ID for data isolation.
 
         Returns:
-            Dict with article metadata (id, slug, title) and a was_update flag.
+            FileBackResult with article metadata and a was_update flag.
         """
         # Ownership check before delegating to QAAgent
         conversation = await session.get(Conversation, conversation_id)
@@ -478,10 +480,10 @@ class QueryService:
             raise NotFoundError(msg)
 
         article, was_update = await self._qa_agent._file_back_thread(conversation_id, session, user_id=user_id)
-        return {
-            "article": {"id": article.id, "slug": article.slug, "title": article.title},
-            "was_update": was_update,
-        }
+        return FileBackResult(
+            article=FileBackArticleRef(id=article.id, slug=article.slug, title=article.title),
+            was_update=was_update,
+        )
 
     async def fork_conversation(
         self,
@@ -552,7 +554,7 @@ class QueryService:
         request: FileBackSelectionRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> dict[str, object]:
+    ) -> FileBackResult:
         """File selected turns from one or more conversations back to the wiki.
 
         Validates that all referenced conversations and turns exist, builds
@@ -565,7 +567,7 @@ class QueryService:
             user_id: User ID for data isolation.
 
         Returns:
-            Dict with article metadata (id, slug, title).
+            FileBackResult with article metadata.
 
         Raises:
             QueryError: If selections are empty or invalid.
@@ -647,9 +649,9 @@ class QueryService:
         await session.commit()
         await session.refresh(article)
 
-        return {
-            "article": {"id": article.id, "slug": article.slug, "title": article.title},
-        }
+        return FileBackResult(
+            article=FileBackArticleRef(id=article.id, slug=article.slug, title=article.title),
+        )
 
     async def export_conversation(
         self,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -32,6 +32,7 @@ from wikimind.models import (
     Backlink,
     BacklinkEntry,
     Concept,
+    ConceptDetailResponse,
     GraphEdge,
     GraphNode,
     GraphResponse,
@@ -583,7 +584,7 @@ class WikiService:
         name: str,
         session: AsyncSession,
         user_id: str,
-    ) -> dict:
+    ) -> ConceptDetailResponse:
         """Retrieve a concept by name with its linked articles.
 
         Args:
@@ -592,7 +593,7 @@ class WikiService:
             user_id: Optional user ID filter.
 
         Returns:
-            Dict with concept fields and linked articles list.
+            ConceptDetailResponse with concept fields and linked articles list.
 
         Raises:
             NotFoundError: If concept not found.
@@ -607,16 +608,16 @@ class WikiService:
             raise NotFoundError(msg)
 
         articles = await self.list_articles(session=session, concept=name, user_id=user_id)
-        return {
-            "id": concept.id,
-            "name": concept.name,
-            "description": concept.description,
-            "article_count": concept.article_count,
-            "parent_id": concept.parent_id,
-            "concept_kind": concept.concept_kind,
-            "created_at": concept.created_at,
-            "articles": articles,
-        }
+        return ConceptDetailResponse(
+            id=concept.id,
+            name=concept.name,
+            description=concept.description,
+            article_count=concept.article_count,
+            parent_id=concept.parent_id,
+            concept_kind=concept.concept_kind,
+            created_at=concept.created_at,
+            articles=articles,
+        )
 
     async def get_concept_articles(
         self,

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -12,7 +12,7 @@ import contextlib
 import json
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import structlog
 from sqlmodel import select
@@ -71,10 +71,17 @@ def _article_entry(article: Article) -> str:
     return f"- [[{article.slug}]]{type_badge}{summary_part}\n"
 
 
+class GroupedArticles(NamedTuple):
+    """Articles grouped by concept with uncategorized remainder."""
+
+    by_concept: dict[str, list[Article]]
+    uncategorized: list[Article]
+
+
 async def _group_articles_by_concept(
     articles: list[Article],
     session: AsyncSession,
-) -> tuple[dict[str, list[Article]], list[Article]]:
+) -> GroupedArticles:
     """Group articles by concept name and identify uncategorized articles.
 
     Reads from the ArticleConcept join table with a fallback to the legacy
@@ -85,7 +92,7 @@ async def _group_articles_by_concept(
         session: Async database session.
 
     Returns:
-        A tuple of (concept_name -> article list, uncategorized articles).
+        GroupedArticles with by_concept mapping and uncategorized list.
     """
     concepts_result = await session.execute(select(Concept))
     concept_map: dict[str, str] = {c.id: c.name for c in concepts_result.scalars().all()}
@@ -115,7 +122,7 @@ async def _group_articles_by_concept(
             name = concept_map.get(raw_id, raw_id)
             concept_articles[name].append(article)
 
-    return concept_articles, uncategorized
+    return GroupedArticles(concept_articles, uncategorized)
 
 
 def _build_index_lines(
@@ -212,10 +219,17 @@ async def regenerate_index_md(
     return "index.md"
 
 
+class HealthData(NamedTuple):
+    """Articles and backlinks fetched for the health page."""
+
+    articles: list[Article]
+    backlinks: list[Backlink]
+
+
 async def _fetch_health_data(
     session: AsyncSession,
     user_id: str,
-) -> tuple[list[Article], list[Backlink]]:
+) -> HealthData:
     """Fetch articles and backlinks for the health page, scoped by user_id."""
     article_stmt = select(Article)
     if user_id:
@@ -234,7 +248,7 @@ async def _fetch_health_data(
     backlinks_result = await session.execute(backlink_stmt)
     backlinks: list[Backlink] = list(backlinks_result.scalars().all())
 
-    return articles, backlinks
+    return HealthData(articles, backlinks)
 
 
 async def generate_meta_health_page(

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -441,12 +441,12 @@ class TestFileBackSelection:
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
 
-        assert "article" in result
-        article_data = result["article"]
-        assert article_data["title"] == "First Thread"  # defaults to first conv title
+        assert result.article is not None
+        article_data = result.article
+        assert article_data.title == "First Thread"  # defaults to first conv title
 
         # Verify the article was created on disk
-        article = await db_session.get(Article, article_data["id"])
+        article = await db_session.get(Article, article_data.id)
         assert article is not None
         resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
         content = resolved.read_text(encoding="utf-8")
@@ -469,10 +469,10 @@ class TestFileBackSelection:
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
 
-        article_data = result["article"]
-        assert article_data["title"] == "Merged Research"
+        article_data = result.article
+        assert article_data.title == "Merged Research"
 
-        article = await db_session.get(Article, article_data["id"])
+        article = await db_session.get(Article, article_data.id)
         resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
         content = resolved.read_text(encoding="utf-8")
         assert "# Merged Research" in content
@@ -491,7 +491,7 @@ class TestFileBackSelection:
             ],
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
-        article_id = result["article"]["id"]
+        article_id = result.article.id
 
         # Refresh the selected queries
         res = await db_session.execute(select(Query).where(Query.conversation_id == "conv-sel-1"))
@@ -554,8 +554,8 @@ class TestFileBackSelection:
         )
         result = await service.file_back_selection(request, db_session, user_id=TEST_USER_ID)
 
-        assert result["article"]["title"] == "My Custom Title"
-        article = await db_session.get(Article, result["article"]["id"])
+        assert result.article.title == "My Custom Title"
+        article = await db_session.get(Article, result.article.id)
         resolved = resolve_wiki_path(article.file_path, user_id=TEST_USER_ID)
         content = resolved.read_text(encoding="utf-8")
         assert "# My Custom Title" in content

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -227,7 +227,7 @@ async def test_ingest_service_delete_source(db_session, tmp_path, monkeypatch) -
     db_session.add(s)
     await db_session.commit()
     result = await svc.delete_source(s.id, db_session, user_id=TEST_USER_ID)
-    assert result["deleted"] == s.id
+    assert result.deleted == s.id
 
 
 async def test_ingest_service_delete_missing(db_session) -> None:
@@ -474,9 +474,9 @@ async def test_query_service_file_back_conversation(db_session, tmp_path, monkey
 
     result = await svc.file_back_conversation("conv-fb", db_session, user_id=TEST_USER_ID)
 
-    assert result["was_update"] is False
-    assert result["article"]["id"] == "art-1"
-    assert result["article"]["slug"] == "conv-fb"
+    assert result.was_update is False
+    assert result.article.id == "art-1"
+    assert result.article.slug == "conv-fb"
     svc._qa_agent._file_back_thread.assert_awaited_once_with("conv-fb", db_session, user_id=TEST_USER_ID)
 
 

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -321,10 +321,10 @@ class TestFileBackSelectionPathScoping:
             db_session,
             user_id="alice",
         )
-        article_info = result["article"]
+        article_info = result.article
 
         # Verify the article stores a relative path and resolves under wiki/alice/
-        art_result = await db_session.execute(select(Article).where(Article.id == article_info["id"]))
+        art_result = await db_session.execute(select(Article).where(Article.id == article_info.id))
         article = art_result.scalar_one()
         assert article.file_path.startswith("qa-answers/")
         resolved = resolve_wiki_path(article.file_path, user_id="alice")


### PR DESCRIPTION
## Summary

- Replace untyped `dict` and `tuple` return types in service and engine layers with Pydantic models (`SystemStats`, `OrphanArticle`, `EligibleConcept`, `AdminActionResult`, `ConceptDetailResponse`, `FileBackResult`, `DeleteConfirmation`, `EmbeddingStats`) and NamedTuples (`EncryptedApiKey`, `BatchPrompt`, `PairProcessResult`, `GroupedArticles`, `HealthData`)
- Change `LLMRouter.parse_json_response` return type from `dict` to `Any` (more honest since `json.loads` returns `Any`)
- Leave OAuth pass-through dicts and YAML parse results as `dict` (they're truly unstructured external data)

## Changes

**New types in `models.py`:** `FileBackArticleRef`, `FileBackResult`, `DeleteConfirmation`, `EmbeddingStats`

**Services updated:**
- `AdminService`: `get_stats` → `SystemStats`, `get_orphan_articles` → `list[OrphanArticle]`, `get_eligible_concepts` → `list[EligibleConcept]`, `trigger_sweep`/`trigger_reindex` → `AdminActionResult`
- `WikiService.get_concept` → `ConceptDetailResponse`
- `QueryService.file_back_conversation`/`file_back_selection` → `FileBackResult`
- `IngestService.delete_source` → `DeleteConfirmation`
- `EmbeddingService.get_stats` → `EmbeddingStats`

**Engine updated:**
- `encrypt_api_key` → `EncryptedApiKey` (NamedTuple)
- `_build_batch_prompt` → `BatchPrompt` (NamedTuple)
- `_process_uncached_pairs` → `PairProcessResult` (NamedTuple)
- `_group_articles_by_concept` → `GroupedArticles` (NamedTuple)
- `_fetch_health_data` → `HealthData` (NamedTuple)
- `LLMRouter.parse_json_response` → `Any`

## Test plan

- [x] `make lint` — all checks passed
- [x] `make format` — all files formatted
- [x] `make typecheck` — 0 errors (improved from 5 pre-existing)
- [x] All 1018 tests pass, 1027 collected
- [x] No test files deleted, no test count decrease

🤖 Generated with [Claude Code](https://claude.com/claude-code)