### PR TITLE
feat: auto-file high-quality Q&A answers as wiki pages (#414)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,11 @@
 # WIKIMIND_QA__PRIOR_ANSWER_TRUNCATE_CHARS=500
 # WIKIMIND_QA__CONVERSATION_TITLE_MAX_CHARS=120
 # WIKIMIND_QA__MAX_TOKENS=2048
+# Auto file-back: when enabled, high-quality Q&A answers are automatically
+# saved back to the wiki as ANSWER pages without needing file_back=true.
+# WIKIMIND_QA__AUTO_FILE_BACK_ENABLED=false
+# WIKIMIND_QA__AUTO_FILE_BACK_MIN_WORDS=200
+# WIKIMIND_QA__AUTO_FILE_BACK_MIN_SOURCES=3
 
 # ----------------------------------------------------------------------------
 # Force-Enable a Provider (only needed if you want a key-less provider active)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".env.example",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 231
+        "line_number": 236
       }
     ],
     "Makefile": [
@@ -206,14 +206,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 424
+        "line_number": 427
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 449
+        "line_number": 452
       }
     ],
     "src/wikimind/engine/providers/openai.py": [
@@ -312,5 +312,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-06T18:41:15Z"
+  "generated_at": "2026-05-07T14:04:18Z"
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3107,6 +3107,10 @@ components:
           type: array
           title: Citations
           default: []
+        wiki_worthiness:
+          anyOf:
+          - $ref: '#/components/schemas/WikiWorthinessScore'
+          - type: 'null'
       type: object
       required:
       - id
@@ -3563,6 +3567,44 @@ components:
       - msg
       - type
       title: ValidationError
+    WikiWorthinessScore:
+      properties:
+        word_count:
+          type: integer
+          title: Word Count
+        source_count:
+          type: integer
+          title: Source Count
+        synthesizes:
+          type: boolean
+          title: Synthesizes
+        dedup_collision:
+          type: boolean
+          title: Dedup Collision
+        passed:
+          type: boolean
+          title: Passed
+        auto_filed:
+          type: boolean
+          title: Auto Filed
+          default: false
+      type: object
+      required:
+      - word_count
+      - source_count
+      - synthesizes
+      - dedup_collision
+      - passed
+      title: WikiWorthinessScore
+      description: 'Score describing whether a Q&A answer is worth filing back as
+        a wiki page.
+
+
+        Produced by the Q&A agent''s auto file-back scorer. ``passed`` is the
+
+        overall verdict; ``auto_filed`` records whether a wiki article was
+
+        actually created as a result of this score.'
 tags:
 - name: Wiki
   description: Browse wiki articles, knowledge graph, and search

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -154,6 +154,9 @@ class QAConfig(BaseModel):
     prior_answer_truncate_chars: int = 500
     conversation_title_max_chars: int = 120
     max_tokens: int = 2048
+    auto_file_back_enabled: bool = False
+    auto_file_back_min_words: int = 200
+    auto_file_back_min_sources: int = 3
 
 
 class TaxonomyConfig(BaseModel):

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
+from slugify import slugify
 from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
@@ -30,6 +31,7 @@ from wikimind.models import (
     QueryRequest,
     QueryResult,
     TaskType,
+    WikiWorthinessScore,
 )
 from wikimind.services.activity_log import append_log_entry
 from wikimind.storage import get_wiki_storage
@@ -77,6 +79,82 @@ class _PreparedContext:
     wiki_context: list[dict]
     completion_request: CompletionRequest | None  # None when wiki_context is empty
     no_context_result: QueryResult | None  # non-None when wiki_context is empty
+
+
+def _derive_auto_file_back_title(result: QueryResult) -> str:
+    """Pick a title for an auto-filed Q&A answer.
+
+    Uses ``result.new_article_suggested`` when the LLM proposed one, else
+    falls back to the first 8 words of the answer.
+
+    Args:
+        result: The Q&A result returned by the LLM.
+
+    Returns:
+        A non-empty title string.
+    """
+    if result.new_article_suggested:
+        return result.new_article_suggested.strip()
+    words = result.answer.split()
+    if not words:
+        return "Untitled answer"
+    return " ".join(words[:8])
+
+
+async def _score_wiki_worthiness(
+    result: QueryResult,
+    answer_text: str,
+    db_session: AsyncSession,
+    *,
+    min_words: int,
+    min_sources: int,
+    user_id: str,
+) -> WikiWorthinessScore:
+    """Score whether a Q&A answer should be auto-filed back as a wiki page.
+
+    Pure-ish helper — runs a single SELECT against ``Article`` to detect
+    slug collisions. Does not write.
+
+    Args:
+        result: Parsed Q&A result from the LLM.
+        answer_text: The answer string used for word counting (caller
+            may pass ``result.answer`` or, in the streaming path, the
+            assembled streamed text).
+        db_session: Async session used to detect slug collisions.
+        min_words: Threshold for ``word_count``.
+        min_sources: Threshold for ``source_count``.
+        user_id: User scope for the dedup lookup.
+
+    Returns:
+        :class:`WikiWorthinessScore` describing the verdict. ``passed``
+        is True when all thresholds are met regardless of dedup; the
+        caller decides whether to skip on collision.
+    """
+    word_count = len(answer_text.split())
+    source_count = len(result.sources)
+    synthesizes = source_count >= 2 and result.confidence != "low"
+
+    derived_title = _derive_auto_file_back_title(result)
+    candidate_slug = slugify(derived_title)
+
+    dedup_collision = False
+    if candidate_slug:
+        stmt = select(Article).where(Article.slug == candidate_slug)
+        if user_id:
+            stmt = stmt.where(Article.user_id == user_id)
+        existing = await db_session.execute(stmt)
+        dedup_collision = existing.scalar_one_or_none() is not None
+
+    passed = word_count >= min_words and source_count >= min_sources and synthesizes
+
+    return WikiWorthinessScore(
+        word_count=word_count,
+        source_count=source_count,
+        synthesizes=synthesizes,
+        dedup_collision=dedup_collision,
+        passed=passed,
+        auto_filed=False,
+    )
 
 
 class QAAgent:
@@ -317,7 +395,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         ctx: _PreparedContext,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Query, Conversation]:
+    ) -> tuple[Query, Conversation, WikiWorthinessScore | None]:
         """Persist the Query row and handle file-back.
 
         Shared by ``answer()`` and the ``answer_stream()`` completion path.
@@ -330,7 +408,9 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (the new Query row, the parent Conversation).
+            Tuple of (the new Query row, the parent Conversation, optional
+            wiki-worthiness score). The score is non-None only when the
+            ``auto_file_back_enabled`` config flag is set.
         """
         query_record = Query(
             question=request.question,
@@ -356,6 +436,41 @@ conversation context contradicts the wiki, prefer the wiki."""
             filed_article = article
             session.add(query_record)
 
+        # Auto file-back: independent of request.file_back. Runs only when the
+        # config flag is on, the score passes thresholds, there's no dedup
+        # collision, and we haven't already filed-back via the manual path.
+        score: WikiWorthinessScore | None = None
+        if self.settings.qa.auto_file_back_enabled:
+            score = await _score_wiki_worthiness(
+                result,
+                result.answer,
+                session,
+                min_words=self.settings.qa.auto_file_back_min_words,
+                min_sources=self.settings.qa.auto_file_back_min_sources,
+                user_id=user_id,
+            )
+            already_filed = filed_article is not None
+            if score.passed and not score.dedup_collision and not already_filed:
+                try:
+                    derived_title = _derive_auto_file_back_title(result)
+                    # Update the Conversation title so _file_back_thread uses it
+                    # for the new Article row (it reads conversation.title).
+                    ctx.conversation.title = derived_title
+                    session.add(ctx.conversation)
+                    await session.flush()
+                    article, _ = await self._file_back_thread(ctx.conversation.id, session, user_id=user_id)
+                    query_record.filed_back = True
+                    query_record.filed_article_id = article.id
+                    filed_article = article
+                    session.add(query_record)
+                    score.auto_filed = True
+                except Exception:
+                    # Must never fail the user-facing answer.
+                    log.exception(
+                        "Auto file-back failed; user-facing answer is unaffected",
+                        conversation_id=ctx.conversation.id,
+                    )
+
         await session.commit()
 
         try:
@@ -373,14 +488,14 @@ conversation context contradicts the wiki, prefer the wiki."""
         await session.refresh(query_record)
         await session.refresh(ctx.conversation)
 
-        return query_record, ctx.conversation
+        return query_record, ctx.conversation, score
 
     async def answer(
         self,
         request: QueryRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Query, Conversation]:
+    ) -> tuple[Query, Conversation, WikiWorthinessScore | None]:
         """Answer a question against the wiki.
 
         Conversation-aware: if request.conversation_id is None a new
@@ -394,7 +509,9 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (the new Query row, the parent Conversation).
+            Tuple of (the new Query row, the parent Conversation, optional
+            wiki-worthiness score). The score is non-None only when the
+            ``auto_file_back_enabled`` config flag is set.
         """
         ctx = await self._prepare_context(request, session, user_id=user_id)
 
@@ -416,13 +533,13 @@ conversation context contradicts the wiki, prefer the wiki."""
         request: QueryRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> AsyncIterator[str | tuple[Query, Conversation]]:
-        """Stream LLM tokens, then yield the persisted (Query, Conversation) tuple.
+    ) -> AsyncIterator[str | tuple[Query, Conversation, WikiWorthinessScore | None]]:
+        """Stream LLM tokens, then yield the persisted result tuple.
 
         Yields text chunk strings during streaming. After all tokens have been
-        yielded, yields a single ``(Query, Conversation)`` tuple as the final
-        item. The caller (service layer) is responsible for constructing SSE
-        events from these values.
+        yielded, yields a single ``(Query, Conversation, WikiWorthinessScore | None)``
+        tuple as the final item. The caller (service layer) is responsible for
+        constructing SSE events from these values.
 
         If wiki context is empty, yields the canned answer text as one chunk
         followed by the persisted tuple.
@@ -436,15 +553,18 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Yields:
-            ``str`` text chunks, then a final ``tuple[Query, Conversation]``.
+            ``str`` text chunks, then a final
+            ``tuple[Query, Conversation, WikiWorthinessScore | None]``.
         """
         ctx = await self._prepare_context(request, session, user_id=user_id)
 
         if ctx.no_context_result is not None:
             result = ctx.no_context_result
             yield result.answer
-            query_record, conversation = await self._persist_query(request, result, ctx, session, user_id=user_id)
-            yield (query_record, conversation)
+            query_record, conversation, score = await self._persist_query(
+                request, result, ctx, session, user_id=user_id
+            )
+            yield (query_record, conversation, score)
             return
 
         assert ctx.completion_request is not None
@@ -505,8 +625,8 @@ conversation context contradicts the wiki, prefer the wiki."""
                 related_articles=[],
             )
 
-        query_record, conversation = await self._persist_query(request, result, ctx, session, user_id=user_id)
-        yield (query_record, conversation)
+        query_record, conversation, score = await self._persist_query(request, result, ctx, session, user_id=user_id)
+        yield (query_record, conversation, score)
 
     async def _retrieve_context(self, question: str, session: AsyncSession, user_id: str) -> list[dict]:
         """Retrieve relevant wiki articles for the question."""

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -569,6 +569,22 @@ class QueryResult(BaseModel):
     follow_up_questions: list[str] = []
 
 
+class WikiWorthinessScore(BaseModel):
+    """Score describing whether a Q&A answer is worth filing back as a wiki page.
+
+    Produced by the Q&A agent's auto file-back scorer. ``passed`` is the
+    overall verdict; ``auto_filed`` records whether a wiki article was
+    actually created as a result of this score.
+    """
+
+    word_count: int
+    source_count: int
+    synthesizes: bool
+    dedup_collision: bool
+    passed: bool
+    auto_filed: bool = False
+
+
 class LinterContradiction(BaseModel):
     """A contradiction found by the linter."""
 
@@ -1054,6 +1070,7 @@ class QueryResponse(BaseModel):
     conversation_id: str | None = None
     turn_index: int = 0
     citations: list[CitationResponse] = []
+    wiki_worthiness: WikiWorthinessScore | None = None
 
 
 class ConversationResponse(BaseModel):

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -49,6 +49,7 @@ from wikimind.models import (
     QueryResponse,
     Source,
     SourceResponse,
+    WikiWorthinessScore,
 )
 
 log = structlog.get_logger()
@@ -168,7 +169,11 @@ async def _build_citations(query: Query, session: AsyncSession, user_id: str) ->
     return citations
 
 
-def _to_query_response(query: Query, citations: list[CitationResponse]) -> QueryResponse:
+def _to_query_response(
+    query: Query,
+    citations: list[CitationResponse],
+    wiki_worthiness: WikiWorthinessScore | None = None,
+) -> QueryResponse:
     """Project a persisted :class:`Query` plus citations into a :class:`QueryResponse`."""
     return QueryResponse(
         id=query.id,
@@ -183,6 +188,7 @@ def _to_query_response(query: Query, citations: list[CitationResponse]) -> Query
         conversation_id=query.conversation_id,
         turn_index=query.turn_index,
         citations=citations,
+        wiki_worthiness=wiki_worthiness,
     )
 
 
@@ -268,10 +274,10 @@ class QueryService:
         Returns:
             :class:`AskResponse` with the new query and its parent conversation.
         """
-        query, conversation = await self._qa_agent.answer(request, session, user_id=user_id)
+        query, conversation, wiki_worthiness = await self._qa_agent.answer(request, session, user_id=user_id)
         citations = await _build_citations(query, session, user_id=user_id)
         return AskResponse(
-            query=_to_query_response(query, citations),
+            query=_to_query_response(query, citations, wiki_worthiness=wiki_worthiness),
             conversation=_to_conversation_response(conversation),
         )
 
@@ -304,11 +310,11 @@ class QueryService:
                 if isinstance(item, str):
                     yield (f"event: chunk\ndata: {json.dumps({'text': item})}\n\n")
                 else:
-                    # Final tuple: (Query, Conversation)
-                    query_record, conversation = item
+                    # Final tuple: (Query, Conversation, WikiWorthinessScore | None)
+                    query_record, conversation, wiki_worthiness = item
                     citations = await _build_citations(query_record, session, user_id=user_id)
                     done_payload = AskResponse(
-                        query=_to_query_response(query_record, citations),
+                        query=_to_query_response(query_record, citations, wiki_worthiness=wiki_worthiness),
                         conversation=_to_conversation_response(conversation),
                     )
                     yield (f"event: done\ndata: {done_payload.model_dump_json()}\n\n")
@@ -541,11 +547,11 @@ class QueryService:
             question=fork_request.new_question,
             conversation_id=fork_conv.id,
         )
-        query, conversation = await self._qa_agent.answer(ask_request, session, user_id=user_id)
+        query, conversation, wiki_worthiness = await self._qa_agent.answer(ask_request, session, user_id=user_id)
         citations = await _build_citations(query, session, user_id=user_id)
         fork_count = await _count_forks(fork_conv.id, session)
         return AskResponse(
-            query=_to_query_response(query, citations),
+            query=_to_query_response(query, citations, wiki_worthiness=wiki_worthiness),
             conversation=_to_conversation_response(conversation, fork_count),
         )
 

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -27,6 +27,7 @@ from wikimind.engine.qa_agent import QAAgent
 from wikimind.models import (
     Article,
     CompletionResponse,
+    PageType,
     Provider,
     Query,
     QueryRequest,
@@ -43,6 +44,9 @@ _FAKE_QA_SETTINGS = SimpleNamespace(
         prior_answer_truncate_chars=500,
         conversation_title_max_chars=120,
         max_tokens=2048,
+        auto_file_back_enabled=False,
+        auto_file_back_min_words=200,
+        auto_file_back_min_sources=3,
     ),
 )
 
@@ -89,6 +93,9 @@ async def test_ask_with_file_back_creates_article_end_to_end(
                     prior_answer_truncate_chars=500,
                     conversation_title_max_chars=120,
                     max_tokens=2048,
+                    auto_file_back_enabled=False,
+                    auto_file_back_min_words=200,
+                    auto_file_back_min_sources=3,
                 ),
             ),
         ),
@@ -124,7 +131,7 @@ async def test_ask_with_file_back_creates_article_end_to_end(
     # Real call — must not raise. Pre-fix this raised ValueError because
     # ConfidenceLevel("high") is not a member of the enum.
     # answer(user_id="anonymous") now returns a tuple of (Query, Conversation).
-    query, _ = await agent.answer(request, db_session, user_id=ANONYMOUS_USER_ID)
+    query, _, _ = await agent.answer(request, db_session, user_id=ANONYMOUS_USER_ID)
 
     # Query row was persisted with the agent-confidence string preserved.
     assert query.id is not None
@@ -192,10 +199,10 @@ async def test_multi_turn_conversation_includes_prior_context_in_prompt(
     agent._retrieve_context = AsyncMock(return_value=[{"title": "Seed Article", "content": "seed content", "score": 1}])
 
     # Q1 — starts a new conversation
-    _q1, conv = await agent.answer(QueryRequest(question="What is X?"), db_session, user_id=ANONYMOUS_USER_ID)
+    _q1, conv, _ = await agent.answer(QueryRequest(question="What is X?"), db_session, user_id=ANONYMOUS_USER_ID)
 
     # Q2 — continues the same conversation
-    _q2, _ = await agent.answer(
+    _q2, _, _ = await agent.answer(
         QueryRequest(question="How does it work?", conversation_id=conv.id),
         db_session,
         user_id=ANONYMOUS_USER_ID,
@@ -252,6 +259,9 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
                     prior_answer_truncate_chars=500,
                     conversation_title_max_chars=120,
                     max_tokens=2048,
+                    auto_file_back_enabled=False,
+                    auto_file_back_min_words=200,
+                    auto_file_back_min_sources=3,
                 ),
             ),
         ),
@@ -301,7 +311,7 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
     # Phase 1: Conversation A asks with file_back=True, exercising the production
     # conditional: if request.file_back and result.confidence in ("high", "medium").
     # answer(user_id="anonymous") commits internally — no manual commit needed.
-    q_a, _conv_a = await agent.answer(
+    q_a, _conv_a, _score_a = await agent.answer(
         QueryRequest(question="How does the Karpathy loop work?", file_back=True),
         db_session,
         user_id=ANONYMOUS_USER_ID,
@@ -327,3 +337,89 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
         f"LOOP CLOSURE FAILED: filed-back article was not found by a related "
         f"future question. Retrieved: {retrieved_titles}"
     )
+
+
+async def test_auto_file_back_creates_answer_article_when_flag_on(
+    db_session: AsyncSession,
+    tmp_path,
+) -> None:
+    """With ``auto_file_back_enabled=True`` and a qualifying answer, an ANSWER Article is created.
+
+    Exercises the new wire-up: scoring runs after ``_query_llm`` returns,
+    passes thresholds, and ``_file_back_thread`` is invoked even though
+    ``request.file_back`` is False.
+    """
+    data_dir = tmp_path / "wikimind"
+    with (
+        patch.object(qa_mod, "get_llm_router"),
+        patch.object(
+            qa_mod,
+            "get_settings",
+            return_value=SimpleNamespace(
+                data_dir=str(data_dir),
+                qa=SimpleNamespace(
+                    max_prior_turns_in_context=5,
+                    prior_answer_truncate_chars=500,
+                    conversation_title_max_chars=120,
+                    max_tokens=2048,
+                    auto_file_back_enabled=True,
+                    auto_file_back_min_words=200,
+                    auto_file_back_min_sources=3,
+                ),
+            ),
+        ),
+    ):
+        agent = QAAgent()
+
+    seed_md = tmp_path / "seed.md"
+    seed_md.write_text("seed content used by retrieval", encoding="utf-8")
+    seed = Article(
+        slug="seed-article",
+        title="Seed Article",
+        file_path=str(seed_md),
+        summary="seed",
+        user_id=ANONYMOUS_USER_ID,
+    )
+    db_session.add(seed)
+    await db_session.commit()
+
+    long_answer = " ".join(["wikimind"] * 220)
+    fake_response = CompletionResponse(
+        content="{}",
+        provider_used=Provider.ANTHROPIC,
+        model_used="test-model",
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=0.0,
+        latency_ms=0,
+    )
+    agent.router.complete = AsyncMock(return_value=fake_response)
+    agent.router.parse_json_response = lambda _resp: {
+        "answer": long_answer,
+        "confidence": "high",
+        "sources": ["A1", "A2", "A3"],
+        "related_articles": [],
+        "new_article_suggested": "How wikimind compiles knowledge",
+        "follow_up_questions": [],
+    }
+    agent._retrieve_context = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{"title": "Seed Article", "content": "seed content", "score": 1}]
+    )
+
+    # file_back=False — proves the auto path fires independently.
+    query, _conv, score = await agent.answer(
+        QueryRequest(question="How does wikimind work?", file_back=False),
+        db_session,
+        user_id=ANONYMOUS_USER_ID,
+    )
+
+    assert score is not None
+    assert score.passed is True
+    assert score.auto_filed is True
+    assert query.filed_back is True
+    assert query.filed_article_id is not None
+
+    filed = await db_session.get(Article, query.filed_article_id)
+    assert filed is not None
+    assert filed.page_type == PageType.ANSWER
+    assert filed.title == "How wikimind compiles knowledge"

--- a/tests/unit/test_conversation_fork.py
+++ b/tests/unit/test_conversation_fork.py
@@ -97,7 +97,7 @@ class TestForkConversation:
                 await session.commit()
                 await session.refresh(q)
                 await session.refresh(fork_conv)
-                return q, fork_conv
+                return q, fork_conv, None
 
             mock_answer.side_effect = _fake_answer
 

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -13,12 +13,13 @@ from wikimind._datetime import utcnow_naive
 from wikimind.config import QAConfig, get_settings
 from wikimind.engine import qa_agent as qa_mod
 from wikimind.engine.provider_base import StreamSession
-from wikimind.engine.qa_agent import QAAgent
+from wikimind.engine.qa_agent import QAAgent, _score_wiki_worthiness
 from wikimind.errors import NotFoundError
 from wikimind.models import (
     Article,
     CompletionResponse,
     Conversation,
+    PageType,
     Provider,
     Query,
     QueryRequest,
@@ -40,6 +41,9 @@ def _agent(tmp_path) -> QAAgent:
                     prior_answer_truncate_chars=500,
                     conversation_title_max_chars=120,
                     max_tokens=2048,
+                    auto_file_back_enabled=False,
+                    auto_file_back_min_words=200,
+                    auto_file_back_min_sources=3,
                 ),
             ),
         ),
@@ -127,7 +131,7 @@ async def test_query_llm_parse_error_returns_fallback(db_session, tmp_path) -> N
 async def test_answer_no_context(db_session, tmp_path) -> None:
     a = _agent(tmp_path)
     with patch.object(a, "_retrieve_context", AsyncMock(return_value=[])):
-        q, _conversation = await a.answer(QueryRequest(question="hello"), db_session, user_id=TEST_USER_ID)
+        q, _conversation, _score = await a.answer(QueryRequest(question="hello"), db_session, user_id=TEST_USER_ID)
     assert q.confidence == "low"
 
 
@@ -143,7 +147,9 @@ async def test_answer_with_context_and_file_back(db_session, tmp_path) -> None:
         ),
         patch.object(a, "_file_back_thread", AsyncMock(return_value=(fake_article, False))),
     ):
-        q, _conversation = await a.answer(QueryRequest(question="hi", file_back=True), db_session, user_id=TEST_USER_ID)
+        q, _conversation, _score = await a.answer(
+            QueryRequest(question="hi", file_back=True), db_session, user_id=TEST_USER_ID
+        )
     assert q.filed_back is True
     assert q.filed_article_id == "art-1"
 
@@ -155,7 +161,9 @@ async def test_answer_with_context_no_file_back(db_session, tmp_path) -> None:
         patch.object(a, "_retrieve_context", AsyncMock(return_value=[{"title": "T", "content": "C"}])),
         patch.object(a, "_query_llm", AsyncMock(return_value=qr)),
     ):
-        q, _conversation = await a.answer(QueryRequest(question="hi", file_back=True), db_session, user_id=TEST_USER_ID)
+        q, _conversation, _score = await a.answer(
+            QueryRequest(question="hi", file_back=True), db_session, user_id=TEST_USER_ID
+        )
     assert q.filed_back is False
 
 
@@ -178,7 +186,7 @@ async def test_answer_creates_new_conversation_when_id_missing(db_session, tmp_p
         patch.object(agent, "_retrieve_context", AsyncMock(return_value=[])),
     ):
         req = QueryRequest(question="What is the meaning of life?")
-        query, conversation = await agent.answer(req, db_session, user_id=TEST_USER_ID)
+        query, conversation, _score = await agent.answer(req, db_session, user_id=TEST_USER_ID)
 
     assert isinstance(conversation, Conversation)
     assert conversation.title == "What is the meaning of life?"
@@ -225,7 +233,7 @@ async def test_answer_appends_to_existing_conversation(db_session, tmp_path) -> 
         patch.object(agent, "_retrieve_context", AsyncMock(return_value=[])),
     ):
         req = QueryRequest(question="follow-up question", conversation_id="conv-existing")
-        query, conversation = await agent.answer(req, db_session, user_id=TEST_USER_ID)
+        query, conversation, _score = await agent.answer(req, db_session, user_id=TEST_USER_ID)
 
     assert conversation.id == "conv-existing"
     assert query.conversation_id == "conv-existing"
@@ -499,9 +507,9 @@ async def test_answer_stream_no_context_yields_text_and_tuple(db_session, tmp_pa
     assert isinstance(items[0], str)
     assert "No relevant articles" in items[0]
 
-    # Second item: the (Query, Conversation) tuple
+    # Second item: the (Query, Conversation, WikiWorthinessScore | None) tuple
     assert isinstance(items[1], tuple)
-    query_record, conversation = items[1]
+    query_record, conversation, _score = items[1]
     assert isinstance(query_record, Query)
     assert isinstance(conversation, Conversation)
     assert query_record.confidence == "low"
@@ -530,8 +538,8 @@ async def test_answer_stream_with_context_yields_chunks_and_tuple(db_session, tm
     # Concatenated text should equal the mock JSON
     assert "".join(text_chunks) == _MOCK_QA_JSON
 
-    # The final tuple contains persisted Query and Conversation
-    query_record, _conversation = tuples[0]
+    # The final tuple contains persisted Query, Conversation, and optional score
+    query_record, _conversation, _score = tuples[0]
     assert query_record.answer == "Streamed answer."
     assert query_record.confidence == "high"
 
@@ -555,7 +563,7 @@ async def test_answer_stream_persists_query_after_completion(db_session, tmp_pat
 
     # Extract the final tuple
     final = next(i for i in items if isinstance(i, tuple))
-    query_record, _conversation = final
+    query_record, _conversation, _score = final
 
     # The query was persisted with the streamed answer
     assert query_record.answer == "Streamed answer."
@@ -576,3 +584,217 @@ async def test_answer_stream_raises_on_stream_failure(db_session, tmp_path) -> N
         with pytest.raises(RuntimeError, match="all providers dead"):
             async for _ in a.answer_stream(QueryRequest(question="will fail"), db_session, user_id=TEST_USER_ID):
                 pass
+
+
+def _long_answer(words: int = 220) -> str:
+    return " ".join(["word"] * words)
+
+
+@pytest.mark.parametrize(
+    ("answer_words", "sources", "confidence", "expected_passed", "expected_synth"),
+    [
+        # Passes everything: long enough, enough sources, synthesizes.
+        (220, ["A", "B", "C"], "high", True, True),
+        # Fails word-count threshold.
+        (50, ["A", "B", "C"], "high", False, True),
+        # Fails source-count threshold.
+        (220, ["A"], "high", False, False),
+        # Low confidence breaks synthesizes and therefore passed.
+        (220, ["A", "B", "C"], "low", False, False),
+    ],
+)
+async def test_score_wiki_worthiness_table(
+    db_session,
+    answer_words,
+    sources,
+    confidence,
+    expected_passed,
+    expected_synth,
+) -> None:
+    result = QueryResult(
+        answer=_long_answer(answer_words),
+        confidence=confidence,
+        sources=sources,
+        related_articles=[],
+        new_article_suggested="A wholly novel topic",
+    )
+    score = await _score_wiki_worthiness(
+        result,
+        result.answer,
+        db_session,
+        min_words=200,
+        min_sources=3,
+        user_id=TEST_USER_ID,
+    )
+    assert score.word_count == answer_words
+    assert score.source_count == len(sources)
+    assert score.synthesizes is expected_synth
+    assert score.dedup_collision is False
+    assert score.passed is expected_passed
+    assert score.auto_filed is False
+
+
+async def test_score_wiki_worthiness_dedup_collision(db_session) -> None:
+    """When an Article already exists with the same slug, dedup_collision is True."""
+    existing = Article(
+        slug="a-wholly-novel-topic",
+        title="A wholly novel topic",
+        file_path="/dev/null",
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    result = QueryResult(
+        answer=_long_answer(220),
+        confidence="high",
+        sources=["A", "B", "C"],
+        related_articles=[],
+        new_article_suggested="A wholly novel topic",
+    )
+    score = await _score_wiki_worthiness(
+        result,
+        result.answer,
+        db_session,
+        min_words=200,
+        min_sources=3,
+        user_id=TEST_USER_ID,
+    )
+    assert score.dedup_collision is True
+    # Score still passes thresholds — caller decides to skip on collision.
+    assert score.passed is True
+
+
+async def test_score_falls_back_to_first_8_words_for_dedup_when_no_suggested(db_session) -> None:
+    """When new_article_suggested is None, slug derives from the first 8 words of the answer."""
+    answer = "Auto filed answer about wikimind topic xyz tail words " + " ".join(["w"] * 200)
+    # First 8 words → "Auto filed answer about wikimind topic xyz tail" → slug "auto-filed-answer-about-wikimind-topic-xyz-tail"
+    existing = Article(
+        slug="auto-filed-answer-about-wikimind-topic-xyz-tail",
+        title="seed",
+        file_path="/dev/null",
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    result = QueryResult(
+        answer=answer,
+        confidence="high",
+        sources=["A", "B"],
+        related_articles=[],
+        new_article_suggested=None,
+    )
+    score = await _score_wiki_worthiness(
+        result,
+        result.answer,
+        db_session,
+        min_words=200,
+        min_sources=2,
+        user_id=TEST_USER_ID,
+    )
+    assert score.dedup_collision is True
+
+
+async def test_auto_file_back_disabled_by_default_returns_no_score(db_session, tmp_path) -> None:
+    """With auto_file_back_enabled=False, persist returns score=None and no auto-file occurs."""
+    a = _agent(tmp_path)
+    qr = QueryResult(
+        answer=_long_answer(220),
+        confidence="high",
+        sources=["A", "B", "C"],
+        related_articles=[],
+        new_article_suggested="A wholly novel topic",
+    )
+    with (
+        patch.object(a, "_retrieve_context", AsyncMock(return_value=[{"title": "T", "content": "C"}])),
+        patch.object(a, "_query_llm", AsyncMock(return_value=qr)),
+        patch.object(a, "_file_back_thread") as fb_mock,
+    ):
+        fb_mock.side_effect = AssertionError("auto file-back must not run when flag is off")
+        q, _conversation, score = await a.answer(QueryRequest(question="hi"), db_session, user_id=TEST_USER_ID)
+    assert score is None
+    assert q.filed_back is False
+
+
+def _agent_with_auto_on(tmp_path) -> QAAgent:
+    with (
+        patch.object(qa_mod, "get_llm_router"),
+        patch.object(
+            qa_mod,
+            "get_settings",
+            return_value=SimpleNamespace(
+                data_dir=str(tmp_path),
+                qa=SimpleNamespace(
+                    max_prior_turns_in_context=5,
+                    prior_answer_truncate_chars=500,
+                    conversation_title_max_chars=120,
+                    max_tokens=2048,
+                    auto_file_back_enabled=True,
+                    auto_file_back_min_words=200,
+                    auto_file_back_min_sources=3,
+                ),
+            ),
+        ),
+    ):
+        return QAAgent()
+
+
+async def test_auto_file_back_skipped_on_dedup_collision(db_session, tmp_path) -> None:
+    """auto_file_back_enabled with a dedup collision: passes score but does not file."""
+    a = _agent_with_auto_on(tmp_path)
+    existing = Article(
+        slug="a-wholly-novel-topic",
+        title="A wholly novel topic",
+        file_path="/dev/null",
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    qr = QueryResult(
+        answer=_long_answer(220),
+        confidence="high",
+        sources=["A", "B", "C"],
+        related_articles=[],
+        new_article_suggested="A wholly novel topic",
+    )
+    with (
+        patch.object(a, "_retrieve_context", AsyncMock(return_value=[{"title": "T", "content": "C"}])),
+        patch.object(a, "_query_llm", AsyncMock(return_value=qr)),
+        patch.object(a, "_file_back_thread") as fb_mock,
+    ):
+        fb_mock.side_effect = AssertionError("must not file on dedup collision")
+        q, _conversation, score = await a.answer(QueryRequest(question="hi"), db_session, user_id=TEST_USER_ID)
+    assert score is not None
+    assert score.passed is True
+    assert score.dedup_collision is True
+    assert score.auto_filed is False
+    assert q.filed_back is False
+
+
+async def test_auto_file_back_passes_and_creates_article(db_session, tmp_path) -> None:
+    """Integration-ish: with auto on and a qualifying answer, an ANSWER Article is created."""
+    a = _agent_with_auto_on(tmp_path)
+    qr = QueryResult(
+        answer=_long_answer(220),
+        confidence="high",
+        sources=["A", "B", "C"],
+        related_articles=[],
+        new_article_suggested="A wholly novel topic",
+    )
+    with (
+        patch.object(a, "_retrieve_context", AsyncMock(return_value=[{"title": "T", "content": "C"}])),
+        patch.object(a, "_query_llm", AsyncMock(return_value=qr)),
+    ):
+        q, _conversation, score = await a.answer(QueryRequest(question="hi"), db_session, user_id=TEST_USER_ID)
+    assert score is not None
+    assert score.passed is True
+    assert score.auto_filed is True
+    assert q.filed_back is True
+    assert q.filed_article_id is not None
+
+    filed = await db_session.get(Article, q.filed_article_id)
+    assert filed is not None
+    assert filed.page_type == PageType.ANSWER
+    assert filed.title == "A wholly novel topic"

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -298,7 +298,7 @@ class TestAskStream:
         async def _fake_stream(request, session, user_id=None):
             yield "hello "
             yield "world"
-            yield (q, conv)
+            yield (q, conv, None)
 
         with patch.object(service._qa_agent, "answer_stream", side_effect=_fake_stream):
             events = [

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -337,7 +337,7 @@ async def test_query_service_ask_returns_ask_response_with_conversation(db_sessi
     await db_session.commit()
 
     svc._qa_agent = MagicMock()
-    svc._qa_agent.answer = AsyncMock(return_value=(fake_query, fake_conv))
+    svc._qa_agent.answer = AsyncMock(return_value=(fake_query, fake_conv, None))
 
     request = QueryRequest(question="What is the loop?")
     response = await svc.ask(request, db_session, user_id=TEST_USER_ID)


### PR DESCRIPTION
## Summary

Adds an opt-in auto file-back path that promotes high-quality Q&A answers to wiki ANSWER pages immediately after they are generated, without requiring callers to set `file_back=true` on the request. Reuses the existing `_file_back_thread()` machinery — only scoring and auto-invocation are new.

- New `QAConfig` fields (off by default): `auto_file_back_enabled`, `auto_file_back_min_words`, `auto_file_back_min_sources`. Mirrored in `.env.example`.
- New `WikiWorthinessScore` Pydantic model surfaced on `QueryResponse`.
- `_score_wiki_worthiness` checks word count, source count, "synthesizes" (>= 2 sources and confidence != low), and slug-equality dedup against existing Articles.
- `_persist_query` auto-invokes `_file_back_thread` when the score passes and there is no dedup collision; failures are logged and never break the user-facing answer.

## In scope

- Config flag + thresholds
- Pure-ish scorer with table-driven unit tests
- Wire-up inside `_persist_query` so both `answer()` and `answer_stream()` benefit
- `WikiWorthinessScore` exposed on the API response
- OpenAPI spec regenerated

## Out of scope (deliberately not implemented)

- Semantic dedup (slug-equality only)
- Per-claim scoring
- Recompile triggers
- Frontend changes

## Test plan

- [x] `make lint` clean
- [x] `make format-check` clean
- [x] `make typecheck` clean
- [x] `make docstyle` clean
- [x] `make coverage-check` passes (80.39% total, threshold is 80%)
- [x] `make check-docs` clean (OpenAPI regenerated)
- [x] `make check-doc-sync` clean
- [x] New unit tests cover: passes all thresholds, fails word count, fails source count, low confidence, dedup collision, flag-off path, fallback title from first 8 words
- [x] New integration test: with the flag on and a qualifying answer, an Article with `page_type=ANSWER` is created (no `file_back=true` required)

Closes #414

https://claude.ai/code/session_01PBdm4PNU7hD6kkqqZF74j1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBdm4PNU7hD6kkqqZF74j1)_