### PR TITLE
chore: set auth public_url in fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,6 +18,7 @@ primary_region = "ord"
   WIKIMIND_SERVER__HOST = "0.0.0.0"
   WIKIMIND_SERVER__PORT = "7842"
   WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
+  WIKIMIND_AUTH__PUBLIC_URL = "https://wikimind.fly.dev"
   # Gunicorn workers — 4 ensures at least one worker can respond to health
   # checks while others are still initializing (DB init, migrations).
   # Fewer workers caused deploy timeouts (health check fails within 5 min).


### PR DESCRIPTION
## Summary

Sets `WIKIMIND_AUTH__PUBLIC_URL=https://wikimind.fly.dev` as an env var in `fly.toml` so OAuth callback URLs use a deterministic base URL instead of trusting the Host header. Required for the token generation page added in #459.

Not a secret — just the public-facing URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)