### PR TITLE
chore: add .editorconfig for cross-editor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,23 +1,25 @@
 root = true
 
 [*]
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-charset = utf-8
-
-[*.py]
 indent_style = space
 indent_size = 4
-max_line_length = 100
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+max_line_length = 120
+
+[*.{ts,tsx,js,jsx,json,css,html}]
+indent_size = 2
 
 [*.{yml,yaml}]
-indent_style = space
 indent_size = 2
 
-[*.{js,ts,tsx,json}]
-indent_style = space
-indent_size = 2
+[*.md]
+trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Summary
- Enhances existing `.editorconfig` with project-wide defaults (`indent_style = space`, `indent_size = 4`) so all file types get consistent settings out of the box
- Fixes `max_line_length` for Python from 100 to 120 to match the actual ruff config in `pyproject.toml`
- Adds `jsx`, `css`, `html` to the frontend file glob for 2-space indent
- Adds `[*.md]` section with `trim_trailing_whitespace = false` (Markdown uses trailing spaces for line breaks)

Closes #408

## Test plan
- [x] Verify `make lint` and `make format` still pass (no formatting conflicts)
- [x] Open `.editorconfig` in VS Code / IntelliJ and confirm editor picks up the correct indent settings per file type

🤖 Generated with [Claude Code](https://claude.com/claude-code)