### PR TITLE
dx: make dev starts Redis, worker, and API server via honcho

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,7 +142,7 @@
         "filename": "Makefile",
         "hashed_secret": "a2af834e65ad267df89a30dd525c7aac8451b394",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 126
       }
     ],
     "design-system/ui_kits/app/index.html": [
@@ -312,5 +312,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-07T15:54:50Z"
+  "generated_at": "2026-05-07T16:20:38Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ WikiMind is a personal LLM-powered knowledge OS. The backend is a local FastAPI 
 
 ```bash
 make install-dev   # Install all dependencies
-make dev           # Start gateway (port 7842)
+make dev           # Start full local stack (API + worker + Redis)
+make dev-api       # Start only the API server (port 7842)
 make lint          # Run ruff linter
 make format        # Run ruff formatter
 make typecheck     # Run mypy

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,11 @@ check-env: check-venv ## Verify Python version, venv hygiene, and required tools
 ##@ ▶️  SERVE
 
 .PHONY: dev
-dev: check-venv ## Run fast-reload dev server on :7842 (uvicorn)
+dev: check-venv ## Start full local stack: API server + ARQ worker + Redis (via honcho)
+	$(BIN)/honcho start -f Procfile.dev
+
+.PHONY: dev-api
+dev-api: check-venv ## Run only the fast-reload API server on :7842 (uvicorn)
 	@if lsof -i :7842 -sTCP:LISTEN >/dev/null 2>&1; then \
 		echo ""; \
 		echo "ERROR: port 7842 is already in use."; \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ setup-git-mergedrivers: ## Configure custom git merge drivers (secrets baseline)
 
 # Path to the editable install marker file inside the venv. We use this to
 # detect when an agent worktree has hijacked the root venv (issue #66).
-EDITABLE_PTH := $(VENV)/lib/python3.12/site-packages/__editable__.wikimind-0.1.0.pth
+EDITABLE_PTH := $(firstword $(wildcard $(VENV)/lib/python3.*/site-packages/__editable__.wikimind-0.1.0.pth))
 EXPECTED_SRC := $(abspath src)
 
 .PHONY: check-venv

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 api: .venv/bin/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
 worker: .venv/bin/python -m arq wikimind.jobs.worker.WorkerSettings
-redis: docker run --rm -p 6379:6379 --name wikimind-redis redis:7-alpine
+redis: sh -c 'docker start -a wikimind-redis 2>/dev/null || docker run --rm -p 6379:6379 --name wikimind-redis redis:7-alpine'

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+api: .venv/bin/uvicorn wikimind.main:app --host 127.0.0.1 --port 7842 --reload --reload-exclude "scripts/*" --reload-exclude "tests/*" --reload-exclude "docs/*"
+worker: .venv/bin/python -m arq wikimind.jobs.worker.WorkerSettings
+redis: docker run --rm -p 6379:6379 --name wikimind-redis redis:7-alpine

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ cp .env.example .env
 # For OpenRouter/other OpenAI-compatible gateways, see .env.example.
 # Providers auto-enable when their key is detected.
 
-# 3. Start the local gateway (FastAPI on :7842)
+# 3. Start the full local stack (API server + ARQ worker + Redis)
 make dev
+# (Requires Docker for Redis. Use `make dev-api` for just the API server.)
 
 # 4. (optional) Start the React UI in another terminal
 cd apps/web
@@ -281,7 +282,8 @@ WIKIMIND_LLM__DEFAULT_PROVIDER=openai_compatible
 
 | Target | Description |
 |--------|-------------|
-| `make dev` | Run fast-reload dev server on :7842 (uvicorn) |
+| `make dev` | Start full local stack: API server + ARQ worker + Redis (via honcho) |
+| `make dev-api` | Run only the fast-reload API server on :7842 (uvicorn) |
 | `make dev-token` | Generate a JWT API token for dev/testing (uses .env secret) |
 | `make serve` | Run production server on :7842 (gunicorn) |
 | `make pg-up` | Start local Postgres (docker-compose.dev.yml, port 5433) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ transcribe = [
 ]
 dev = [
     "wikimind[test,lint]",
+    "honcho>=2.0.0",
 ]
 test = [
     "pytest>=8.3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1280,6 +1280,18 @@ wheels = [
 ]
 
 [[package]]
+name = "honcho"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/c8/d860888358bf5c8a6e7d78d1b508b59b0e255afd5655f243b8f65166dafd/honcho-2.0.0.tar.gz", hash = "sha256:af3815c03c634bf67d50f114253ea9fef72ecff26e4fd06b29234789ac5b8b2e", size = 45618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/1c/25631fc359955569e63f5446dbb7022c320edf9846cbe892ee5113433a7e/honcho-2.0.0-py3-none-any.whl", hash = "sha256:56dcd04fc72d362a4befb9303b1a1a812cba5da283526fbc6509be122918ddf3", size = 22093 },
+]
+
+[[package]]
 name = "htmldate"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4747,6 +4759,7 @@ dev = [
     { name = "bandit" },
     { name = "deptry" },
     { name = "greenlet" },
+    { name = "honcho" },
     { name = "httpx" },
     { name = "interrogate" },
     { name = "mypy" },
@@ -4813,6 +4826,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "greenlet", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "gunicorn", specifier = ">=22.0.0" },
+    { name = "honcho", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.2" },
     { name = "interrogate", marker = "extra == 'lint'", specifier = ">=1.7.0" },


### PR DESCRIPTION
## Summary

`make dev` only started the API server, requiring users to separately start Redis and the ARQ worker for background jobs to process. This caused silent failures when ingesting, compiling, or embedding content.

- **`make dev`** now starts the full local stack (API server + ARQ worker + Redis) via `honcho`, a lightweight process manager
- The previous API-only behavior is preserved as **`make dev-api`** for when only the server is needed
- Added `honcho` as a dev dependency and created `Procfile.dev` defining the three processes

Closes #470

## Test plan

- [x] Run `make dev` and verify all three processes start (api, worker, redis)
- [x] Submit an ingest job and confirm the ARQ worker picks it up
- [x] Run `make dev-api` and verify only the API server starts
- [x] `Ctrl+C` on `make dev` cleanly shuts down all three processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)