### PR TITLE
refactor: adopt structlog contextvars for automatic log context propagation

### DIFF
--- a/src/wikimind/middleware/correlation.py
+++ b/src/wikimind/middleware/correlation.py
@@ -6,10 +6,18 @@ Generates a UUID-v4 correlation ID for each request and attaches it to
 micro-service), that value is reused so the same trace ID propagates
 across the entire call chain.  The chosen ID is always echoed back in
 the ``X-Request-ID`` response header.
+
+The middleware also binds the ``request_id`` to structlog's contextvars
+so every log entry emitted during the request automatically includes it.
+After the ``AuthMiddleware`` runs and sets ``request.state.user_id``,
+the logging middleware further binds ``user_id`` — but the correlation
+middleware handles the initial ``request_id`` binding and the final
+cleanup via ``clear_contextvars``.
 """
 
 import uuid
 
+import structlog
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -24,10 +32,19 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        """Generate or propagate a request ID, then forward the request."""
+        """Generate or propagate a request ID, bind it to structlog contextvars."""
         request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
         request.state.request_id = request_id
 
+        # Bind request_id to structlog contextvars so all downstream log
+        # entries include it automatically — no manual passing needed.
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
+
+        # Clear contextvars after the request to prevent leaking between
+        # requests in async frameworks where tasks may share contextvars.
+        structlog.contextvars.clear_contextvars()
         return response

--- a/src/wikimind/middleware/error_handling.py
+++ b/src/wikimind/middleware/error_handling.py
@@ -29,7 +29,6 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
                 "domain_error",
                 code=exc.code,
                 message=exc.message,
-                request_id=request_id,
                 path=request.url.path,
             )
             return _error_response(exc.status_code, exc.code, exc.message, request_id)
@@ -38,7 +37,6 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
             log.exception(
                 "unhandled_error",
                 error=str(exc),
-                request_id=request_id,
                 path=request.url.path,
             )
             return _error_response(500, "internal_error", "An unexpected error occurred", request_id)

--- a/src/wikimind/middleware/request_logging.py
+++ b/src/wikimind/middleware/request_logging.py
@@ -1,9 +1,10 @@
 """Middleware that emits a structured log line for every HTTP request.
 
 Captures method, path, status code, response time, and the correlation
-ID assigned by ``CorrelationIdMiddleware``.  Noisy endpoints such as
-``/health`` and ``/docs`` are silently skipped to keep logs focused on
-meaningful application traffic.
+ID assigned by ``CorrelationIdMiddleware``.  Also binds ``user_id`` to
+structlog contextvars so all downstream log entries automatically
+include it. Noisy endpoints such as ``/health`` and ``/docs`` are
+silently skipped to keep logs focused on meaningful application traffic.
 """
 
 import time
@@ -31,7 +32,13 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         if request.url.path in _SKIP_PATHS:
             return await call_next(request)
 
-        request_id: str = getattr(request.state, "request_id", "unknown")
+        # Bind user_id to structlog contextvars so all downstream log
+        # entries include it automatically.  At this point in the middleware
+        # stack, AuthMiddleware has already set request.state.user_id.
+        user_id: str | None = getattr(request.state, "user_id", None)
+        if user_id:
+            structlog.contextvars.bind_contextvars(user_id=user_id)
+
         start = time.perf_counter()
 
         response = await call_next(request)
@@ -43,6 +50,5 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             path=request.url.path,
             status_code=response.status_code,
             duration_ms=duration_ms,
-            request_id=request_id,
         )
         return response

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -7,6 +7,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import structlog
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -30,6 +31,7 @@ from wikimind.config import get_settings
 from wikimind.database import close_db, get_db_path, get_session_factory, init_db
 from wikimind.errors import WikiMindError
 from wikimind.middleware import logging_config
+from wikimind.middleware.correlation import CorrelationIdMiddleware
 from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import _sanitize_event_dict
 from wikimind.models import CompletionResponse, Conversation, Provider, Query
@@ -172,6 +174,62 @@ async def test_error_handling_wikimind_error() -> None:
         r = c.get("/crash")
         assert r.status_code == 500
         assert r.json()["error"]["code"] == "internal_error"
+
+
+# ----- middleware correlation (structlog contextvars) -----
+
+
+def test_correlation_middleware_binds_request_id_to_contextvars() -> None:
+    """Correlation middleware binds request_id to structlog contextvars."""
+    captured_ctx: dict = {}
+
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.get("/check")
+    async def check():
+        captured_ctx.update(structlog.contextvars.get_contextvars())
+        return {"ok": True}
+
+    with TestClient(app) as c:
+        r = c.get("/check")
+    assert r.status_code == 200
+    assert "request_id" in captured_ctx
+
+
+def test_correlation_middleware_uses_provided_request_id() -> None:
+    """Correlation middleware re-uses the X-Request-ID header value."""
+    captured_ctx: dict = {}
+
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.get("/check")
+    async def check():
+        captured_ctx.update(structlog.contextvars.get_contextvars())
+        return {"ok": True}
+
+    custom_id = "my-trace-42"
+    with TestClient(app) as c:
+        r = c.get("/check", headers={"X-Request-ID": custom_id})
+    assert r.status_code == 200
+    assert captured_ctx.get("request_id") == custom_id
+    assert r.headers["x-request-id"] == custom_id
+
+
+def test_correlation_middleware_clears_contextvars_after_request() -> None:
+    """Contextvars are cleared after the request to prevent leaking."""
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.get("/check")
+    async def check():
+        return {"ok": True}
+
+    with TestClient(app) as c:
+        c.get("/check")
+    # After the request completes, contextvars should be empty.
+    assert structlog.contextvars.get_contextvars() == {}
 
 
 # ----- middleware logging_config -----


### PR DESCRIPTION
## Summary

- **Problem**: Although the codebase already uses structlog with JSON/console rendering, `request_id` and `user_id` had to be manually passed as kwargs to every log call. Most log sites omitted them, making log aggregation and correlation difficult in production (Fly.io).
- **Solution**: Wire up structlog's contextvars so `request_id` and `user_id` are automatically included in every log entry during a request lifecycle — no manual passing needed.
- **Changes**: `CorrelationIdMiddleware` now binds `request_id` to structlog contextvars at request start and clears them after completion. `RequestLoggingMiddleware` binds `user_id` after auth runs. Redundant manual `request_id=` kwargs removed from error handling and request logging middleware.

Closes #357

## Test plan

- [x] 3 new tests verify contextvars binding, custom X-Request-ID propagation, and post-request cleanup
- [x] `make verify` passes (lint, format, mypy, 1090 tests)
- [ ] Deploy to staging and verify JSON logs include `request_id` on all log lines
- [ ] Verify `user_id` appears in logs for authenticated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)