### PR TITLE
fix: CLI token generator uses user UUID from DB instead of email

### DIFF
--- a/src/wikimind/cli/create_token.py
+++ b/src/wikimind/cli/create_token.py
@@ -20,11 +20,50 @@ Security note:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 import uuid
 from datetime import UTC, datetime, timedelta
 
 import jwt
+
+
+async def _lookup_user_by_email(email: str) -> tuple[str, str | None]:
+    """Look up a user by email and return (user_id, user_name).
+
+    Raises SystemExit if the user is not found.
+    """
+    from sqlmodel import select
+
+    from wikimind.database import get_async_engine, get_session_factory
+    from wikimind.models import User
+
+    engine = get_async_engine()
+
+    # Ensure tables exist (engine may point at a fresh DB)
+    async with engine.begin() as conn:
+        from sqlmodel import SQLModel
+
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(select(User).where(User.email == email))
+        user = result.scalar_one_or_none()
+
+    if user is None:
+        print(f"ERROR: No user found with email '{email}'.", file=sys.stderr)
+        print(
+            "  The user must log in via OAuth or magic link first to create an account.",
+            file=sys.stderr,
+        )
+        print(
+            "  Then re-run this command to generate a token with the correct user ID.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return user.id, user.name
 
 
 def main() -> None:  # noqa: D103
@@ -38,8 +77,8 @@ def main() -> None:  # noqa: D103
     )
     parser.add_argument(
         "--name",
-        default="cli-token",
-        help="Token name (default: cli-token).",
+        default=None,
+        help="Token name (default: user's name from DB, or 'cli-token').",
     )
     parser.add_argument(
         "--exp-days",
@@ -78,11 +117,12 @@ def main() -> None:  # noqa: D103
         print("  or pass --secret <key>.", file=sys.stderr)
         sys.exit(1)
 
+    # Look up the user by email to get their actual UUID
+    user_id, user_name = asyncio.run(_lookup_user_by_email(args.email))
+    token_name = args.name or user_name or "cli-token"
+
     now = datetime.now(UTC)
     expire = now + timedelta(days=args.exp_days)
-
-    # Use email as a stable user ID (matches get_or_create_by_email behavior)
-    user_id = args.email
 
     payload = {
         "sub": user_id,
@@ -95,7 +135,7 @@ def main() -> None:  # noqa: D103
         "user": {
             "id": user_id,
             "email": args.email,
-            "name": args.name,
+            "name": token_name,
         },
     }
 
@@ -103,8 +143,9 @@ def main() -> None:  # noqa: D103
 
     print(token)
     print(f"\n# Expires: {expire.isoformat()}", file=sys.stderr)
+    print(f"# User ID: {user_id}", file=sys.stderr)
     print(f"# Email: {args.email}", file=sys.stderr)
-    print(f"# Name: {args.name}", file=sys.stderr)
+    print(f"# Name: {token_name}", file=sys.stderr)
     print("#", file=sys.stderr)
     print("# Usage:", file=sys.stderr)
     print(f'#   export TOKEN="{token}"', file=sys.stderr)

--- a/tests/unit/test_cli_create_token.py
+++ b/tests/unit/test_cli_create_token.py
@@ -1,0 +1,161 @@
+"""Tests for the CLI token generator — verifies it uses user UUID from DB."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+
+from wikimind.cli.create_token import _lookup_user_by_email, main
+from wikimind.models import User
+
+
+class _FakeSessionCtx:
+    """Async context manager that yields a test db_session."""
+
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _mock_engine_begin():
+    """Return a mock engine whose begin() skips create_all."""
+    mock_engine = AsyncMock()
+    mock_conn = AsyncMock()
+    mock_begin = AsyncMock()
+    mock_begin.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_begin.__aexit__ = AsyncMock(return_value=False)
+    mock_engine.begin = lambda: mock_begin
+    return mock_engine
+
+
+@pytest.mark.asyncio
+async def test_lookup_user_by_email_returns_uuid(db_session):
+    """_lookup_user_by_email should return the user's UUID, not the email."""
+    user = User(
+        id="uuid-abc-123",
+        email="alice@example.com",
+        name="Alice",
+        auth_provider="google",
+        auth_provider_id="g-1",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    with (
+        patch(
+            "wikimind.database.get_async_engine",
+            return_value=_mock_engine_begin(),
+        ),
+        patch(
+            "wikimind.database.get_session_factory",
+            return_value=lambda: _FakeSessionCtx(db_session),
+        ),
+    ):
+        user_id, user_name = await _lookup_user_by_email("alice@example.com")
+
+    assert user_id == "uuid-abc-123"
+    assert user_name == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_lookup_user_by_email_exits_when_not_found(db_session):
+    """_lookup_user_by_email should sys.exit(1) when no user matches."""
+    with (
+        patch(
+            "wikimind.database.get_async_engine",
+            return_value=_mock_engine_begin(),
+        ),
+        patch(
+            "wikimind.database.get_session_factory",
+            return_value=lambda: _FakeSessionCtx(db_session),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        await _lookup_user_by_email("nobody@example.com")
+
+    assert exc_info.value.code == 1
+
+
+def test_main_generates_token_with_user_uuid(monkeypatch):
+    """main() should produce a JWT whose sub claim is the user's UUID, not the email."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["create_token", "--email", "alice@example.com", "--secret", "test-secret"],
+    )
+
+    # Patch _lookup_user_by_email to return a known UUID
+    async def _fake_lookup(email):
+        return ("uuid-abc-123", "Alice")
+
+    monkeypatch.setattr("wikimind.cli.create_token._lookup_user_by_email", _fake_lookup)
+
+    # Capture the printed token (stdout only, not stderr)
+    captured = {}
+    original_print = print
+
+    def _capture_print(text, **kwargs):
+        file = kwargs.get("file")
+        if file is None:
+            captured["token"] = text
+        else:
+            original_print(text, **kwargs)
+
+    monkeypatch.setattr("builtins.print", _capture_print)
+
+    main()
+
+    token = captured["token"]
+    decoded = jwt.decode(token, "test-secret", algorithms=["HS256"], options={"verify_aud": False})
+
+    # The critical fix: sub must be the UUID, not the email
+    assert decoded["sub"] == "uuid-abc-123"
+    assert decoded["user"]["id"] == "uuid-abc-123"
+    assert decoded["user"]["email"] == "alice@example.com"
+    assert decoded["user"]["name"] == "Alice"
+    assert decoded["iss"] == "wikimind"
+    assert decoded["aud"] == "wikimind-api"
+    assert decoded["token_use"] == "api"
+
+
+def test_main_uses_custom_token_name(monkeypatch):
+    """When --name is provided, the token should use it instead of the DB name."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "create_token",
+            "--email",
+            "alice@example.com",
+            "--secret",
+            "test-secret",
+            "--name",
+            "my-custom-name",
+        ],
+    )
+
+    async def _fake_lookup(email):
+        return ("uuid-abc-123", "Alice")
+
+    monkeypatch.setattr("wikimind.cli.create_token._lookup_user_by_email", _fake_lookup)
+
+    captured = {}
+    original_print = print
+
+    def _capture_print(text, **kwargs):
+        if kwargs.get("file") is None:
+            captured["token"] = text
+        else:
+            original_print(text, **kwargs)
+
+    monkeypatch.setattr("builtins.print", _capture_print)
+
+    main()
+
+    decoded = jwt.decode(captured["token"], "test-secret", algorithms=["HS256"], options={"verify_aud": False})
+    assert decoded["user"]["name"] == "my-custom-name"


### PR DESCRIPTION
Closes #468 - CLI now looks up user by email in DB and uses their UUID as sub claim