### PR TITLE
fix: recompile updates article in place instead of creating orphan

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -304,6 +304,20 @@ Compile this into a wiki article following the JSON schema exactly."""
             return await self._replace_article_in_place(existing, result, source, session)
         return await self._create_article(result, source, session, provider)
 
+    async def save_article_in_place(
+        self,
+        existing: Article,
+        result: CompilationResult,
+        source: Source,
+        session: AsyncSession,
+    ) -> Article:
+        """Replace an existing article in place, bypassing provider lookup.
+
+        Use this when the caller already holds the article row that should be
+        updated (e.g. the force-recompile path).
+        """
+        return await self._replace_article_in_place(existing, result, source, session)
+
     async def _find_article_for_source_and_provider(
         self,
         session: AsyncSession,

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -315,7 +315,7 @@ async def _recompile_from_source(article: Article, session, user_id: str) -> Non
         msg = "Compiler returned no result"
         raise ValueError(msg)
 
-    await compiler.save_article(result, source, session)
+    await compiler.save_article_in_place(article, result, source, session)
 
 
 async def _recompile_from_concept(article: Article, session, user_id: str) -> None:

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -524,3 +524,48 @@ async def test_replace_article_upserts_new_concepts(db_session, tmp_path) -> Non
     assert "alpha" in names
     assert "beta" in names
     assert "gamma" in names
+
+
+# ---------------------------------------------------------------------------
+# save_article_in_place — bypasses provider lookup (issue #492)
+# ---------------------------------------------------------------------------
+
+
+async def test_save_article_in_place_updates_existing_row(db_session, tmp_path) -> None:
+    """save_article_in_place must update the same article row (same ID, same slug)."""
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+
+    # Create an initial article via normal save.
+    compiler._last_provider_used = Provider.ANTHROPIC
+    result1 = _result(concepts=["alpha"])
+    original = await compiler.save_article(result1, source, db_session)
+    original_id = original.id
+    original_slug = original.slug
+
+    # Simulate a recompile where provider may differ: use save_article_in_place.
+    compiler2 = _compiler_for(tmp_path)
+    # _last_provider_used is None — this is the scenario that caused the orphan.
+    result2 = _result(concepts=["beta", "gamma"])
+    replaced = await compiler2.save_article_in_place(original, result2, source, db_session)
+
+    assert replaced.id == original_id
+    assert replaced.slug == original_slug
+
+    # Confirm only one article exists in the DB.
+    all_articles = (await db_session.execute(select(Article))).scalars().all()
+    assert len(all_articles) == 1
+
+
+async def test_save_article_in_place_preserves_user_id(db_session, tmp_path) -> None:
+    """user_id must not change after an in-place recompile."""
+    compiler = _compiler_for(tmp_path)
+    source = await _make_source(db_session)
+
+    compiler._last_provider_used = Provider.ANTHROPIC
+    original = await compiler.save_article(_result(), source, db_session)
+    assert original.user_id == TEST_USER_ID
+
+    compiler2 = _compiler_for(tmp_path)
+    replaced = await compiler2.save_article_in_place(original, _result(), source, db_session)
+    assert replaced.user_id == TEST_USER_ID

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.conftest import TEST_USER_ID
 from wikimind.jobs import background as bg_mod
 from wikimind.jobs import worker as worker_mod
 from wikimind.jobs.background import BackgroundCompiler, get_background_compiler
-from wikimind.jobs.worker import compile_source, get_redis_settings, lint_wiki
-from wikimind.models import IngestStatus, LintReport, LintReportStatus, Source, SourceType
+from wikimind.jobs.worker import _recompile_from_source, compile_source, get_redis_settings, lint_wiki
+from wikimind.models import Article, IngestStatus, LintReport, LintReportStatus, PageType, Source, SourceType
 
 
 async def test_background_compiler_dev_mode_compile() -> None:
@@ -313,3 +314,53 @@ async def test_lint_wiki_failure(db_session, tmp_path) -> None:
         patch("wikimind.jobs.worker.run_lint", AsyncMock(side_effect=RuntimeError("boom"))),
     ):
         await lint_wiki({}, user_id=TEST_USER_ID)
+
+
+# ---------------------------------------------------------------------------
+# _recompile_from_source — must update in place, not create orphan (#492)
+# ---------------------------------------------------------------------------
+
+
+async def test_recompile_from_source_calls_save_article_in_place(db_session, tmp_path) -> None:
+    """_recompile_from_source must call save_article_in_place with the existing article."""
+    text_file = tmp_path / "src.txt"
+    text_file.write_text("hello world", encoding="utf-8")
+    src = Source(
+        source_type=SourceType.TEXT,
+        title="t",
+        file_path=str(text_file),
+        status=IngestStatus.COMPILED,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    await db_session.refresh(src)
+
+    article = Article(
+        slug="test-article",
+        title="Test",
+        file_path="test-article/test-article.md",
+        page_type=PageType.SOURCE,
+        source_ids=json.dumps([src.id]),
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(article)
+    await db_session.commit()
+    await db_session.refresh(article)
+
+    fake_result = MagicMock()
+    fake_compiler = MagicMock()
+    fake_compiler.compile = AsyncMock(return_value=fake_result)
+    fake_compiler.save_article_in_place = AsyncMock(return_value=article)
+
+    with patch.object(worker_mod, "Compiler", return_value=fake_compiler):
+        await _recompile_from_source(article, db_session, TEST_USER_ID)
+
+    # Must call save_article_in_place, not save_article.
+    fake_compiler.save_article_in_place.assert_awaited_once_with(
+        article,
+        fake_result,
+        src,
+        db_session,
+    )
+    fake_compiler.save_article.assert_not_called()


### PR DESCRIPTION
## Summary

- **Problem:** `_recompile_from_source()` called `save_article()` which looks up the existing article by source_id + provider. When the fresh `Compiler` instance has `_last_provider_used = None`, the lookup falls through to `_create_article()`, creating an orphan row instead of updating the existing article.
- **Fix:** Added `Compiler.save_article_in_place()` — a public method that bypasses the provider lookup and directly delegates to `_replace_article_in_place()`. The recompile path in `worker.py` now calls this method, passing the article it already holds.
- `_recompile_from_concept()` does NOT have this bug — `ConceptCompiler` uses its own `_find_existing_concept_article()` lookup which matches by concept name, not provider.

## Test plan

- [x] Unit test: `save_article_in_place` updates existing row (same ID, same slug), no new row created
- [x] Unit test: `user_id` preserved after in-place recompile
- [x] Unit test: `_recompile_from_source` calls `save_article_in_place` (not `save_article`)
- [x] Lint, format, typecheck pass
- [x] Full test suite: 1117 passed, 0 failed

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)