### PR TITLE
ci: add nightly scheduled CI run (#410)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@
 #   - uploads the HTML coverage report as a build artifact
 #   - uploads coverage to Codecov on pushes and PRs so patch coverage is reported
 #   - executes on every push / PR to `main` when backend test inputs change
+#   - runs nightly at 6 AM UTC (schedule) to catch dependency drift
+#   - supports manual trigger via workflow_dispatch
 # ---------------------------------------------------------------
 
 name: Tests & Coverage
@@ -34,6 +36,9 @@ on:
       - "Makefile"
       - "codecov.yml"
       - ".github/workflows/test.yml"
+  schedule:
+    - cron: "0 6 * * *" # 6 AM UTC daily — catches dependency drift
+  workflow_dispatch: # allow manual trigger
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Unpinned dependencies can release breaking changes that only surface when someone pushes code. Without a scheduled CI run, these regressions go unnoticed until the next push or PR -- potentially days or weeks later.

This adds a `schedule` trigger (daily at 6 AM UTC) and a `workflow_dispatch` trigger to the existing test workflow so dependency drift is caught proactively.

## Changes

- Added `schedule` trigger with cron `0 6 * * *` (6 AM UTC daily) to `.github/workflows/test.yml`
- Added `workflow_dispatch` trigger for on-demand manual runs
- Updated the file header comment to document the new triggers
- Existing `paths` filters on `push`/`pull_request` are scoped to those events only and do not affect scheduled or manual runs
- The job-level `if` condition already passes for non-PR event types, so no adjustment was needed

## Test plan

- [ ] Verify YAML parses correctly (validated locally via `python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Trigger a manual run via the "Run workflow" button in GitHub Actions to confirm `workflow_dispatch` works
- [ ] Confirm the nightly run appears in the Actions tab after the next 6 AM UTC window

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)