### PR TITLE
chore: configure python-semantic-release for automated versioning (#413)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# ===============================================================
+#  Automated Release via python-semantic-release
+# ===============================================================
+#
+#   - triggers on push to main
+#   - determines version bump from conventional commits (feat/fix)
+#   - updates version in pyproject.toml, creates git tag + GitHub release
+#   - skips if no releasable commits since last tag
+# ---------------------------------------------------------------
+
+name: Release
+
+on:
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write   # create tags, push commits, create GitHub releases
+      id-token: write   # trusted publishing (future PyPI)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
+
+      - name: Semantic Release — version + publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          semantic-release version
+          semantic-release publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ transcribe = [
 dev = [
     "wikimind[test,lint]",
     "honcho>=2.0.0",
+    "python-semantic-release>=9.0.0",
 ]
 test = [
     "pytest>=8.3.3",
@@ -311,6 +312,7 @@ DEP002 = [
     "feedparser",         # RSS/Atom feed ingestion adapter
     "boto3",              # S3 sync feature
     "gunicorn",           # production WSGI server (CLI tool)
+    "python-semantic-release",  # release automation CLI tool (not imported in app code)
     "python-dateutil",    # date parsing utility (used transitively)
     "toml",               # config file parsing utility
     "openai-whisper",     # Whisper CLI transcription tool (optional extra)
@@ -329,3 +331,19 @@ DEP003 = [
 # "unsafe-best-match" considers *all* indexes and picks the highest compatible
 # version, which mirrors pip's --extra-index-url semantics.
 index-strategy = "unsafe-best-match"
+
+# ---------- Semantic Release ----------
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+commit_message = "chore(release): v{version}"
+tag_format = "v{version}"
+
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
+
+[tool.semantic_release.remote]
+type = "github"


### PR DESCRIPTION
## Problem

Version bumping, changelog generation, and release creation are entirely manual. The project already uses conventional commits (`feat:`, `fix:`, etc.), so this process can and should be automated.

## Solution

Configure `python-semantic-release` to automatically determine version bumps from commit history, generate changelogs, and create GitHub releases on every push to `main`.

## Changes

- **pyproject.toml**: Add `python-semantic-release>=9.0.0` to `[project.optional-dependencies.dev]` and configure `[tool.semantic_release]` with version source, commit message format, branch rules, changelog output, and GitHub remote type
- **pyproject.toml**: Add `python-semantic-release` to deptry `DEP002` ignore list (CLI tool, not imported in app code)
- **.github/workflows/release.yml**: New workflow that triggers on push to `main`, installs `python-semantic-release`, and runs `semantic-release version` + `semantic-release publish` to create tags, update `pyproject.toml` version, generate changelog, and publish GitHub releases

The next release (once merged) will be **v1.0.0** based on the existing `feat:` commit history.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)