### PR TITLE
refactor: unify async file readers, eliminate storage.root bypass (#441)

### DIFF
--- a/src/wikimind/api/routes/export.py
+++ b/src/wikimind/api/routes/export.py
@@ -10,20 +10,11 @@ from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
 from wikimind.models import Article, ExportFormat, ExportResponse
 from wikimind.services.export import ExportService, get_export_service
-from wikimind.storage import get_wiki_storage
+from wikimind.storage import read_article_content
 
 log = structlog.get_logger()
 
 router = APIRouter()
-
-
-async def _read_article_content(file_path: str, user_id: str) -> str:
-    """Read article markdown content from disk."""
-    try:
-        storage = get_wiki_storage(user_id)
-        return await storage.read(file_path)
-    except OSError:
-        return ""
 
 
 async def _resolve_article(
@@ -77,7 +68,7 @@ async def export_article(
     - **slides**: Returns a Marp-compatible markdown slide deck (JSON with content field).
     """
     article = await _resolve_article(id_or_slug, session, user_id)
-    content = await _read_article_content(article.file_path, user_id=user_id)
+    content = await read_article_content(article.file_path, user_id=user_id)
 
     if not content:
         raise HTTPException(status_code=404, detail="Article content not found on disk")

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -129,7 +129,7 @@ async def get_source_original(
         raise HTTPException(status_code=404, detail="No original document available")
 
     raw_storage = get_raw_storage(user_id)
-    txt_path = raw_storage.root / source.file_path
+    txt_path = raw_storage.resolve_path(source.file_path)
     original = find_original_sibling(txt_path)
     if original is None:
         raise HTTPException(status_code=404, detail="No original document available")

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -632,7 +632,7 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
             "startup: removed orphaned concept page (file missing)",
             article_id=article.id,
             slug=article.slug,
-            path=str(wiki_storage.root / article.file_path),
+            path=str(wiki_storage.resolve_path(article.file_path)),
         )
 
     if cleaned:

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -373,7 +373,8 @@ Compile this into a wiki article following the JSON schema exactly."""
         if existing is not None:
             slug = existing.slug
             # Strip any legacy absolute prefix to get a relative path for comparison.
-            old_relative = existing.file_path.removeprefix(str(wiki_storage.root) + "/")
+            root_prefix = str(wiki_storage.resolve_path("")) + "/"
+            old_relative = existing.file_path.removeprefix(root_prefix)
         else:
             slug = await self._generate_unique_slug(result.title, session)
 

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -6,10 +6,8 @@ Every answer can be filed back to make the wiki smarter.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -35,7 +33,7 @@ from wikimind.models import (
 )
 from wikimind.services.activity_log import append_log_entry
 from wikimind.services.search import index_article as fts_index_article
-from wikimind.storage import get_wiki_storage
+from wikimind.storage import get_wiki_storage, read_article_content
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -642,7 +640,7 @@ conversation context contradicts the wiki, prefer the wiki."""
 
         relevant = []
         for article in all_articles:
-            content = await self._read_article_content(article.file_path, user_id=user_id)
+            content = await read_article_content(article.file_path, user_id=user_id)
             if not content:
                 continue
 
@@ -660,13 +658,6 @@ conversation context contradicts the wiki, prefer the wiki."""
         # Sort by relevance, take top 5
         relevant.sort(key=lambda x: x["score"], reverse=True)
         return relevant[:5]
-
-    async def _read_article_content(self, file_path: str, user_id: str) -> str | None:
-        try:
-            storage = get_wiki_storage(user_id)
-            return await storage.read(file_path)
-        except OSError:
-            return None
 
     async def _query_llm(
         self,
@@ -749,19 +740,11 @@ conversation context contradicts the wiki, prefer the wiki."""
                 conversation.filed_article_id = None
 
         if existing_article is None:
-            # Create path
-            wiki_dir = Path(self.settings.data_dir) / "wiki"
-            if user_id:
-                wiki_dir = wiki_dir / user_id
-            wiki_dir = wiki_dir / "qa-answers"
-            await asyncio.to_thread(wiki_dir.mkdir, parents=True, exist_ok=True)
+            wiki_storage = get_wiki_storage(user_id)
 
             slug = conversation.id  # UUID — guaranteed unique, no collision possible
-            file_path = wiki_dir / f"{slug}.md"
-            await asyncio.to_thread(file_path.write_text, markdown, encoding="utf-8")
-
-            # Store wiki-relative path in the DB
             relative_path = f"qa-answers/{slug}.md"
+            await wiki_storage.write(relative_path, markdown)
             article = Article(
                 slug=slug,
                 title=conversation.title,

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -193,7 +193,7 @@ class PDFAdapter:
         raw_storage = get_raw_storage(user_id)
         await raw_storage.write_bytes(f"{source.id}.pdf", file_bytes)
         # Docling and fitz need a filesystem Path to open the PDF.
-        raw_pdf_path = raw_storage.root / f"{source.id}.pdf"
+        raw_pdf_path = raw_storage.resolve_path(f"{source.id}.pdf")
 
         # Extract text — prefer docling-serve for structured output (markdown
         # with heading hierarchy, table-aware), fall back to fitz plain text

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -66,7 +66,7 @@ async def _sweep_single_article(
         log.warning(
             "sweep: file not found, skipping",
             article_id=article.id,
-            path=str(wiki_storage.root / article.file_path),
+            path=str(wiki_storage.resolve_path(article.file_path)),
         )
         return False
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -178,7 +178,7 @@ class Source(SQLModel, table=True):
         from wikimind.storage import find_original_sibling, get_raw_storage  # noqa: PLC0415
 
         raw_storage = get_raw_storage(self.user_id)
-        txt_path = raw_storage.root / self.file_path
+        txt_path = raw_storage.resolve_path(self.file_path)
         return find_original_sibling(txt_path) is not None
 
 

--- a/src/wikimind/services/crystallization.py
+++ b/src/wikimind/services/crystallization.py
@@ -5,10 +5,8 @@ to synthesize the key findings, and persists the result as a new Article
 with ``page_type: synthesis``.
 """
 
-import asyncio
 import json
 from datetime import datetime
-from pathlib import Path
 
 import structlog
 from slugify import slugify
@@ -28,6 +26,7 @@ from wikimind.models import (
     Query,
     TaskType,
 )
+from wikimind.storage import get_wiki_storage
 
 log = structlog.get_logger()
 
@@ -272,16 +271,9 @@ Distill this conversation into a structured wiki article following the JSON sche
     )
 
     # Write to disk
-    settings = get_settings()
-    wiki_dir = Path(settings.data_dir) / "wiki"
-    if user_id:
-        wiki_dir = wiki_dir / user_id
-    synthesis_dir = wiki_dir / "synthesis"
-    await asyncio.to_thread(synthesis_dir.mkdir, parents=True, exist_ok=True)
-
+    wiki_storage = get_wiki_storage(user_id)
     relative_path = f"synthesis/{slug}.md"
-    file_path = wiki_dir / relative_path
-    await asyncio.to_thread(file_path.write_text, content, encoding="utf-8")
+    await wiki_storage.write(relative_path, content)
 
     # Create Article row
     article = Article(

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -258,8 +258,8 @@ class IngestService:
         raw_storage = get_raw_storage(user_id)
 
         # Defense-in-depth: ensure the resolved path stays under the storage root.
-        resolved = (raw_storage.root / source.file_path).resolve()
-        if not resolved.is_relative_to(raw_storage.root.resolve()):
+        resolved = raw_storage.resolve_path(source.file_path).resolve()
+        if not resolved.is_relative_to(raw_storage.resolve_path("").resolve()):
             msg = "Source content file not found"
             raise NotFoundError(msg)
 
@@ -332,12 +332,12 @@ class IngestService:
         """
         raw_storage = get_raw_storage(source.user_id)
         if source.file_path:
-            resolved = raw_storage.root / source.file_path
+            resolved = raw_storage.resolve_path(source.file_path)
             with suppress(OSError):
                 resolved.unlink(missing_ok=True)
 
         # Use the storage root to find sibling files
-        raw_dir = raw_storage.root
+        raw_dir = raw_storage.resolve_path("")
         if not raw_dir.is_dir():
             return
         for sibling in raw_dir.glob(f"{source.id}.*"):

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -7,13 +7,11 @@ chains so callers can trace every answer back to the raw source it came
 from.
 """
 
-import asyncio
 import functools
 import json
 import re
 import uuid
 from collections.abc import AsyncIterator
-from pathlib import Path
 
 import structlog
 from fastapi.responses import Response
@@ -21,7 +19,6 @@ from sqlmodel import func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
-from wikimind.config import get_settings
 from wikimind.engine.confidence import apply_decay
 from wikimind.engine.conversation_serializer import (
     SelectedTurn,
@@ -53,6 +50,7 @@ from wikimind.models import (
     WikiWorthinessScore,
 )
 from wikimind.services.search import index_article as fts_index_article
+from wikimind.storage import get_wiki_storage
 
 log = structlog.get_logger()
 
@@ -628,24 +626,19 @@ class QueryService:
 
         markdown = serialize_selected_turns_to_markdown(selected_turns, title=request.title)
 
-        settings = get_settings()
-        wiki_dir = Path(settings.data_dir) / "wiki"
-        if user_id:
-            wiki_dir = wiki_dir / user_id
-        wiki_dir = wiki_dir / "qa-answers"
-        await asyncio.to_thread(wiki_dir.mkdir, parents=True, exist_ok=True)
+        wiki_storage = get_wiki_storage(user_id)
 
         now = utcnow_naive()
         effective_title = request.title or selected_turns[0].conversation.title
 
         slug = str(uuid.uuid4())
-        file_path = wiki_dir / f"{slug}.md"
-        await asyncio.to_thread(file_path.write_text, markdown, encoding="utf-8")
+        relative_path = f"qa-answers/{slug}.md"
+        await wiki_storage.write(relative_path, markdown)
 
         article = Article(
             slug=slug,
             title=effective_title,
-            file_path=f"qa-answers/{slug}.md",
+            file_path=relative_path,
             summary=(selected_turns[0].query.answer[:200] if selected_turns else None),
             confidence=None,
             page_type=PageType.ANSWER,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -11,10 +11,8 @@ vector similarity and results are merged via configurable hybrid
 scoring. Otherwise the service falls back to keyword-only search.
 """
 
-import asyncio
 import functools
 import json
-from pathlib import Path
 
 import structlog
 from sqlalchemy import func
@@ -48,7 +46,7 @@ from wikimind.models import (
     SourceResponse,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
-from wikimind.storage import get_wiki_storage
+from wikimind.storage import get_wiki_storage, read_article_content
 
 log = structlog.get_logger()
 
@@ -95,23 +93,6 @@ def _first_concept(concept_ids_json: str | None) -> str | None:
     """
     items = _parse_source_ids(concept_ids_json)
     return items[0] if items else None
-
-
-async def _read_article_content(file_path: str, user_id: str) -> str:
-    """Read article markdown content from disk.
-
-    Args:
-        file_path: Relative path to the article markdown file.
-        user_id: User ID for storage namespacing.
-
-    Returns:
-        The file content, or an empty string if the file cannot be read.
-    """
-    try:
-        storage = get_wiki_storage(user_id)
-        return await storage.read(file_path)
-    except OSError:
-        return ""
 
 
 def _parse_source_ids(raw: str | None) -> list[str]:
@@ -442,7 +423,7 @@ class WikiService:
             concepts=concepts,
             backlinks_in=backlinks_in,
             backlinks_out=backlinks_out,
-            content=await _read_article_content(article.file_path, user_id=article.user_id),
+            content=await read_article_content(article.file_path, user_id=article.user_id),
             sources=[_to_source_response(s) for s in sources],
             created_at=article.created_at,
             updated_at=article.updated_at,
@@ -882,7 +863,7 @@ class WikiService:
         q_lower = q.lower()
         raw_scores: dict[str, int] = {}
         for article in all_articles:
-            content = await _read_article_content(article.file_path, user_id=article.user_id)
+            content = await read_article_content(article.file_path, user_id=article.user_id)
             if q_lower in article.title.lower() or q_lower in content.lower():
                 score = 10 if q_lower in article.title.lower() else 0
                 score += content.lower().count(q_lower)
@@ -1006,14 +987,11 @@ class WikiService:
         Returns:
             Health report dict.
         """
-        settings = get_settings()
-        health_dir = Path(settings.data_dir) / "wiki"
-        if user_id:
-            health_dir = health_dir / user_id
-        health_path = health_dir / "_meta" / "health.json"
+        storage = get_wiki_storage(user_id)
+        health_relative = "_meta/health.json"
 
-        if await asyncio.to_thread(health_path.exists):
-            content = await asyncio.to_thread(health_path.read_text)
+        if await storage.exists(health_relative):
+            content = await storage.read(health_relative)
             return json.loads(content)
 
         article_stmt = select(Article)

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -7,19 +7,17 @@ file is rewritten in place on every call (NOT append-only).
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import json
 from collections import Counter, defaultdict
-from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 import structlog
 from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
-from wikimind.config import get_settings
 from wikimind.models import Article, ArticleConcept, Backlink, Concept, PageType
+from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -198,12 +196,7 @@ async def regenerate_index_md(
     Returns:
         The wiki-relative path string of the written file.
     """
-    settings = get_settings()
-    wiki_dir = Path(settings.data_dir) / "wiki"
-    if user_id:
-        wiki_dir = wiki_dir / user_id
-    await asyncio.to_thread(wiki_dir.mkdir, parents=True, exist_ok=True)
-    index_path = wiki_dir / "index.md"
+    wiki_storage = get_wiki_storage(user_id)
 
     article_stmt = select(Article)
     if user_id:
@@ -214,7 +207,7 @@ async def regenerate_index_md(
     concept_articles, uncategorized = await _group_articles_by_concept(articles, session)
     lines = _build_index_lines(articles, concept_articles, uncategorized)
 
-    await asyncio.to_thread(index_path.write_text, "".join(lines), encoding="utf-8")
+    await wiki_storage.write("index.md", "".join(lines))
     log.info("index.md regenerated", article_count=len(articles))
     return "index.md"
 
@@ -268,13 +261,7 @@ async def generate_meta_health_page(
     Returns:
         The wiki-relative path string of the written meta page file.
     """
-    settings = get_settings()
-    meta_dir = Path(settings.data_dir) / "wiki"
-    if user_id:
-        meta_dir = meta_dir / user_id
-    meta_dir = meta_dir / "meta"
-    await asyncio.to_thread(meta_dir.mkdir, parents=True, exist_ok=True)
-    health_path = meta_dir / "wiki-health.md"
+    wiki_storage = get_wiki_storage(user_id)
 
     articles, backlinks = await _fetch_health_data(session, user_id=user_id)
 
@@ -327,6 +314,6 @@ async def generate_meta_health_page(
     lines.append("## Orphan Articles\n\n")
     lines.append(f"**{orphan_count}** articles with no inbound or outbound links.\n")
 
-    await asyncio.to_thread(health_path.write_text, "".join(lines), encoding="utf-8")
+    await wiki_storage.write("meta/wiki-health.md", "".join(lines))
     log.info("wiki-health.md generated", article_count=total, orphan_count=orphan_count)
     return "meta/wiki-health.md"

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -50,6 +50,15 @@ class FileStorage(Protocol):
         """List all files under the given prefix (or root if empty)."""
         ...
 
+    def resolve_path(self, relative_path: str) -> Path:
+        """Resolve a relative path to an absolute filesystem path.
+
+        Needed by callers that must hand a real path to external tools
+        (e.g. PDF extractors, log messages). Prefer ``read`` / ``write``
+        for normal I/O.
+        """
+        ...
+
 
 class LocalFileStorage:
     """Local filesystem implementation of FileStorage."""
@@ -59,6 +68,15 @@ class LocalFileStorage:
 
     def _resolve(self, relative_path: str) -> Path:
         return self.root / relative_path
+
+    def resolve_path(self, relative_path: str) -> Path:
+        """Resolve a relative path to an absolute filesystem path.
+
+        Needed by callers that must hand a real path to external tools
+        (e.g. PDF extractors, log messages). Prefer ``read`` / ``write``
+        for normal I/O.
+        """
+        return self._resolve(relative_path)
 
     async def read(self, relative_path: str) -> str:
         """Read text content from a file."""
@@ -132,6 +150,28 @@ def get_raw_storage(user_id: str) -> LocalFileStorage:
     if user_id:
         root = root / user_id
     return LocalFileStorage(root=root)
+
+
+async def read_article_content(file_path: str, user_id: str) -> str:
+    """Read article markdown content from disk.
+
+    Canonical helper used by wiki service, Q&A agent, and export routes.
+    Returns an empty string when the file cannot be read (missing, permission
+    error, etc.) so callers never need their own OSError handling.
+
+    Args:
+        file_path: Relative path to the article markdown file within the
+            user's wiki storage directory.
+        user_id: User ID for storage namespacing.
+
+    Returns:
+        The file content, or an empty string if the file cannot be read.
+    """
+    try:
+        storage = get_wiki_storage(user_id)
+        return await storage.read(file_path)
+    except OSError:
+        return ""
 
 
 def find_original_sibling(txt_path: Path) -> Path | None:

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -25,7 +25,7 @@ from wikimind.models import (
     QueryRequest,
     QueryResult,
 )
-from wikimind.storage import get_wiki_storage
+from wikimind.storage import get_wiki_storage, read_article_content
 
 
 def _agent(tmp_path) -> QAAgent:
@@ -52,26 +52,27 @@ def _agent(tmp_path) -> QAAgent:
 
 
 async def test_read_article_content_missing(tmp_path) -> None:
-    a = _agent(tmp_path)
-    assert await a._read_article_content("/no/such/file.md", user_id=TEST_USER_ID) is None
+    with patch("wikimind.storage.get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))):
+        assert await read_article_content("/no/such/file.md", user_id=TEST_USER_ID) == ""
 
 
 async def test_read_article_content_ok(tmp_path) -> None:
-    a = _agent(tmp_path)
-    f = tmp_path / "wikimind" / "wiki" / TEST_USER_ID / "x.md"
-    f.parent.mkdir(parents=True, exist_ok=True)
-    f.write_text("hello", encoding="utf-8")
-    assert await a._read_article_content("x.md", user_id=TEST_USER_ID) == "hello"
+    wiki_dir = tmp_path / "wiki" / TEST_USER_ID
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / "x.md").write_text("hello", encoding="utf-8")
+    with patch("wikimind.storage.get_settings", return_value=SimpleNamespace(data_dir=str(tmp_path))):
+        assert await read_article_content("x.md", user_id=TEST_USER_ID) == "hello"
 
 
 async def test_retrieve_context_scores(db_session, tmp_path) -> None:
     a = _agent(tmp_path)
-    f1 = tmp_path / "a.md"
-    f1.write_text("apple banana cherry", encoding="utf-8")
-    f2 = tmp_path / "b.md"
-    f2.write_text("nothing here", encoding="utf-8")
-    art1 = Article(slug="a", title="A", file_path=str(f1), user_id=TEST_USER_ID)
-    art2 = Article(slug="b", title="B", file_path=str(f2), user_id=TEST_USER_ID)
+    # Place files in the wiki storage directory used by read_article_content
+    wiki_dir = tmp_path / "wikimind" / "wiki" / TEST_USER_ID
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / "a.md").write_text("apple banana cherry", encoding="utf-8")
+    (wiki_dir / "b.md").write_text("nothing here", encoding="utf-8")
+    art1 = Article(slug="a", title="A", file_path="a.md", user_id=TEST_USER_ID)
+    art2 = Article(slug="b", title="B", file_path="b.md", user_id=TEST_USER_ID)
     db_session.add_all([art1, art2])
     await db_session.commit()
     ctx = await a._retrieve_context("apple banana", db_session, user_id=TEST_USER_ID)
@@ -81,7 +82,7 @@ async def test_retrieve_context_scores(db_session, tmp_path) -> None:
 
 async def test_retrieve_context_skips_unreadable(db_session, tmp_path) -> None:
     a = _agent(tmp_path)
-    art = Article(slug="x", title="X", file_path="/no/such/file", user_id=TEST_USER_ID)
+    art = Article(slug="x", title="X", file_path="no/such/file", user_id=TEST_USER_ID)
     db_session.add(art)
     await db_session.commit()
     assert await a._retrieve_context("anything", db_session, user_id=TEST_USER_ID) == []

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -14,6 +14,7 @@ from wikimind.storage import (
     find_original_sibling,
     get_raw_storage,
     get_wiki_storage,
+    read_article_content,
 )
 
 
@@ -153,40 +154,63 @@ def test_get_raw_storage_with_user_id(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_wiki_storage_root_relative(tmp_path, monkeypatch):
+def test_wiki_storage_resolve_path(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
     storage = get_wiki_storage(TEST_USER_ID)
-    result = storage.root / "concept/article.md"
+    result = storage.resolve_path("concept/article.md")
     assert result == tmp_path / "wiki" / TEST_USER_ID / "concept" / "article.md"
     get_settings.cache_clear()
 
 
-def test_wiki_storage_root_with_user_id(tmp_path, monkeypatch):
+def test_wiki_storage_resolve_path_with_user_id(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
     storage = get_wiki_storage("user-abc")
-    result = storage.root / "concept/article.md"
+    result = storage.resolve_path("concept/article.md")
     assert result == tmp_path / "wiki" / "user-abc" / "concept" / "article.md"
     get_settings.cache_clear()
 
 
-def test_raw_storage_root_relative(tmp_path, monkeypatch):
+def test_raw_storage_resolve_path(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
     storage = get_raw_storage(TEST_USER_ID)
-    result = storage.root / "source-id.txt"
+    result = storage.resolve_path("source-id.txt")
     assert result == tmp_path / "raw" / TEST_USER_ID / "source-id.txt"
     get_settings.cache_clear()
 
 
-def test_raw_storage_root_with_user_id(tmp_path, monkeypatch):
+def test_raw_storage_resolve_path_with_user_id(tmp_path, monkeypatch):
     monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
     get_settings.cache_clear()
     storage = get_raw_storage("user-xyz")
-    result = storage.root / "source-id.txt"
+    result = storage.resolve_path("source-id.txt")
     assert result == tmp_path / "raw" / "user-xyz" / "source-id.txt"
     get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# read_article_content tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_article_content_ok(tmp_path):
+    """read_article_content returns file contents via wiki storage."""
+    # _isolated_data_dir fixture sets WIKIMIND_DATA_DIR to tmp_path / "wikimind"
+    wiki_dir = tmp_path / "wikimind" / "wiki" / TEST_USER_ID
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "test.md").write_text("hello world", encoding="utf-8")
+    result = await read_article_content("test.md", user_id=TEST_USER_ID)
+    assert result == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_read_article_content_missing_returns_empty(tmp_path):
+    """read_article_content returns empty string for missing files."""
+    result = await read_article_content("nonexistent.md", user_id=TEST_USER_ID)
+    assert result == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After PR #440 introduced the FileStorage abstraction, 9+ callers still bypassed it via `storage.root` + sync `read_text()`, and 3 identical copies of `_read_article_content` existed across the codebase. This PR finishes the migration.

- **Canonical `read_article_content()`** added to `storage.py` -- replaces 3 duplicate functions in wiki.py, qa_agent.py, and export.py
- **`resolve_path()` method** added to `FileStorage` protocol and `LocalFileStorage` -- replaces all 9 direct `storage.root` accesses for callers that need real filesystem paths (PDF extraction, log messages, path traversal guards)
- **11 `asyncio.to_thread` file operations** converted to use `FileStorage.write()`/`read()`/`exists()` in qa_agent.py, query.py, crystallization.py, wiki_index.py, and wiki.py
- **Unused imports cleaned up** -- removed `asyncio`, `Path`, `get_settings` from 5 files that no longer need them

## Changes

| Metric | Value |
|--------|-------|
| Files changed | 16 (14 source + 2 test) |
| Lines added / removed | +125 / -135 (net -10) |
| Duplicate functions removed | 3 |
| `storage.root` bypasses eliminated | 9 |
| `asyncio.to_thread` bypasses eliminated | 11 |
| Tests passing | 1189/1189 |

## Test plan

- [x] `make format` -- 174 files unchanged
- [x] `make typecheck` -- no issues in 89 source files
- [x] `make test` -- 1189 passed, 9 skipped
- [x] `make verify` -- all doc checks pass (single pre-existing PLR0915 lint warning in linter/runner.py unrelated to this change)
- [x] New tests for `read_article_content` and `resolve_path` added to test_storage.py
- [x] Existing qa_agent tests updated to use canonical function

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)