### PR TITLE
refactor: add /api prefix to all API routes (#359)

### DIFF
--- a/apps/web/src/api/lint.ts
+++ b/apps/web/src/api/lint.ts
@@ -78,22 +78,22 @@ export interface LintReportDetail {
 // --- API functions ---
 
 export function runLint(): Promise<{ status: string }> {
-  return apiFetch<{ status: string }>("/lint/run", { method: "POST" });
+  return apiFetch<{ status: string }>("/api/lint/run", { method: "POST" });
 }
 
 export function listReports(limit = 20): Promise<LintReport[]> {
-  return apiFetch<LintReport[]>("/lint/reports", { query: { limit } });
+  return apiFetch<LintReport[]>("/api/lint/reports", { query: { limit } });
 }
 
 export function getLatestReport(): Promise<LintReportDetail> {
-  return apiFetch<LintReportDetail>("/lint/reports/latest");
+  return apiFetch<LintReportDetail>("/api/lint/reports/latest");
 }
 
 export function getReport(
   id: string,
   includeDismissed = false,
 ): Promise<LintReportDetail> {
-  return apiFetch<LintReportDetail>(`/lint/reports/${encodeURIComponent(id)}`, {
+  return apiFetch<LintReportDetail>(`/api/lint/reports/${encodeURIComponent(id)}`, {
     query: { include_dismissed: includeDismissed },
   });
 }
@@ -102,7 +102,7 @@ export function dismissFinding(
   kind: LintFindingKind,
   id: string,
 ): Promise<{ dismissed: boolean; kind: string; finding_id: string }> {
-  return apiFetch(`/lint/findings/${kind}/${encodeURIComponent(id)}/dismiss`, {
+  return apiFetch(`/api/lint/findings/${kind}/${encodeURIComponent(id)}/dismiss`, {
     method: "POST",
   });
 }
@@ -112,7 +112,7 @@ export async function recompileArticle(
   mode?: "source" | "concept",
 ): Promise<{ status: string; job_id: string }> {
   const params = mode ? `?mode=${mode}` : "";
-  return apiFetch(`/wiki/articles/${articleId}/recompile${params}`, {
+  return apiFetch(`/api/wiki/articles/${articleId}/recompile${params}`, {
     method: "POST",
   });
 }
@@ -123,7 +123,7 @@ export interface ResolutionOption {
 }
 
 export function getResolutionOptions(): Promise<ResolutionOption[]> {
-  return apiFetch<ResolutionOption[]>("/wiki/contradiction-resolutions");
+  return apiFetch<ResolutionOption[]>("/api/wiki/contradiction-resolutions");
 }
 
 export async function resolveContradiction(
@@ -132,7 +132,7 @@ export async function resolveContradiction(
   _note?: string,
 ): Promise<{ status: string; resolution: string | null }> {
   return apiFetch(
-    `/wiki/contradictions/${encodeURIComponent(contradictionId)}`,
+    `/api/wiki/contradictions/${encodeURIComponent(contradictionId)}`,
     {
       method: "PATCH",
       body: { status: "resolved", resolution },

--- a/apps/web/src/api/query.ts
+++ b/apps/web/src/api/query.ts
@@ -90,40 +90,40 @@ export interface FileBackSelectionResponse {
 // ----- Functions -----
 
 export function askQuestion(req: AskRequest): Promise<AskResponse> {
-  return apiFetch<AskResponse>("/query", { method: "POST", body: req });
+  return apiFetch<AskResponse>("/api/query", { method: "POST", body: req });
 }
 
 export function queryHistory(limit = 50): Promise<QueryRecord[]> {
-  return apiFetch<QueryRecord[]>("/query/history", { query: { limit } });
+  return apiFetch<QueryRecord[]>("/api/query/history", { query: { limit } });
 }
 
 export function listConversations(limit = 50): Promise<ConversationSummary[]> {
-  return apiFetch<ConversationSummary[]>("/query/conversations", { query: { limit } });
+  return apiFetch<ConversationSummary[]>("/api/query/conversations", { query: { limit } });
 }
 
 export function getConversation(id: string): Promise<ConversationDetail> {
-  return apiFetch<ConversationDetail>(`/query/conversations/${id}`);
+  return apiFetch<ConversationDetail>(`/api/query/conversations/${id}`);
 }
 
 export function fileBackConversation(id: string): Promise<FileBackResponse> {
-  return apiFetch<FileBackResponse>(`/query/conversations/${id}/file-back`, { method: "POST" });
+  return apiFetch<FileBackResponse>(`/api/query/conversations/${id}/file-back`, { method: "POST" });
 }
 
 export function fileBackSelection(req: FileBackSelectionRequest): Promise<FileBackSelectionResponse> {
-  return apiFetch<FileBackSelectionResponse>("/query/conversations/file-back", {
+  return apiFetch<FileBackSelectionResponse>("/api/query/conversations/file-back", {
     method: "POST",
     body: req,
   });
 }
 
 export async function exportConversation(id: string): Promise<string> {
-  const res = await fetch(`${getBaseUrl()}/query/conversations/${id}/export`);
+  const res = await fetch(`${getBaseUrl()}/api/query/conversations/${id}/export`);
   if (!res.ok) throw new Error("Export failed");
   return res.text();
 }
 
 export function forkConversation(id: string, req: ForkRequest): Promise<AskResponse> {
-  return apiFetch<AskResponse>(`/query/conversations/${id}/fork`, {
+  return apiFetch<AskResponse>(`/api/query/conversations/${id}/fork`, {
     method: "POST",
     body: req,
   });
@@ -146,7 +146,7 @@ export async function* askQuestionStream(
   req: AskRequest,
   signal?: AbortSignal,
 ): AsyncGenerator<StreamEvent> {
-  const res = await fetch(`${getBaseUrl()}/query/stream`, {
+  const res = await fetch(`${getBaseUrl()}/api/query/stream`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/apps/web/src/api/settings.ts
+++ b/apps/web/src/api/settings.ts
@@ -45,29 +45,29 @@ export interface TestResult {
 }
 
 export function getSettings(): Promise<SettingsResponse> {
-  return apiFetch<SettingsResponse>("/settings");
+  return apiFetch<SettingsResponse>("/api/settings");
 }
 
 export function getCostBreakdown(): Promise<CostBreakdown> {
-  return apiFetch<CostBreakdown>("/settings/llm/cost/breakdown");
+  return apiFetch<CostBreakdown>("/api/settings/llm/cost/breakdown");
 }
 
 export function setApiKey(provider: string, apiKey: string): Promise<void> {
-  return apiFetch<void>(`/api/settings/api-keys/${provider}`, {
+  return apiFetch<void>(`/api/settings/api-keys/${encodeURIComponent(provider)}`, {
     method: "PUT",
     body: { api_key: apiKey },
   });
 }
 
 export function testProvider(provider: string): Promise<TestResult> {
-  return apiFetch<TestResult>("/settings/llm/test", {
+  return apiFetch<TestResult>("/api/settings/llm/test", {
     method: "POST",
     query: { provider },
   });
 }
 
 export function setDefaultProvider(provider: string): Promise<{ provider: string; status: string }> {
-  return apiFetch("/settings/llm/default-provider", {
+  return apiFetch("/api/settings/llm/default-provider", {
     method: "POST",
     body: { provider },
   });
@@ -84,7 +84,7 @@ export function updateSettings(updates: {
   openai_compatible_max_tokens_field?: "max_tokens" | "max_completion_tokens";
   openai_compatible_reasoning_format?: "none" | "openai" | "openrouter";
 }): Promise<{ status: string }> {
-  return apiFetch("/settings", {
+  return apiFetch("/api/settings", {
     method: "PATCH",
     body: updates,
   });
@@ -96,11 +96,11 @@ export interface OnboardingStatus {
 }
 
 export function getOnboardingStatus(): Promise<OnboardingStatus> {
-  return apiFetch<OnboardingStatus>("/settings/onboarding-status");
+  return apiFetch<OnboardingStatus>("/api/settings/onboarding-status");
 }
 
 export function completeOnboarding(): Promise<OnboardingStatus> {
-  return apiFetch<OnboardingStatus>("/settings/onboarding-status", {
+  return apiFetch<OnboardingStatus>("/api/settings/onboarding-status", {
     method: "POST",
   });
 }

--- a/apps/web/src/api/sources.ts
+++ b/apps/web/src/api/sources.ts
@@ -10,15 +10,15 @@ export interface ListSourcesParams {
 }
 
 export function listSources(params: ListSourcesParams = {}): Promise<Source[]> {
-  return apiFetch<Source[]>("/ingest/sources", { query: { ...params } });
+  return apiFetch<Source[]>("/api/ingest/sources", { query: { ...params } });
 }
 
 export function getSource(sourceId: string): Promise<Source> {
-  return apiFetch<Source>(`/ingest/sources/${encodeURIComponent(sourceId)}`);
+  return apiFetch<Source>(`/api/ingest/sources/${encodeURIComponent(sourceId)}`);
 }
 
 export function ingestUrl(url: string, autoCompile = true): Promise<Source> {
-  return apiFetch<Source>("/ingest/url", {
+  return apiFetch<Source>("/api/ingest/url", {
     method: "POST",
     body: { url, auto_compile: autoCompile },
   });
@@ -27,18 +27,18 @@ export function ingestUrl(url: string, autoCompile = true): Promise<Source> {
 export function ingestPdf(file: File): Promise<Source> {
   const form = new FormData();
   form.append("file", file);
-  return apiFetch<Source>("/ingest/pdf", { method: "POST", body: form });
+  return apiFetch<Source>("/api/ingest/pdf", { method: "POST", body: form });
 }
 
 export function deleteSource(sourceId: string): Promise<{ deleted: string }> {
-  return apiFetch(`/ingest/sources/${encodeURIComponent(sourceId)}`, {
+  return apiFetch(`/api/ingest/sources/${encodeURIComponent(sourceId)}`, {
     method: "DELETE",
   });
 }
 
 export function retryCompile(sourceId: string): Promise<TriggerCompileResponse> {
   return apiFetch<TriggerCompileResponse>(
-    `/jobs/compile/${encodeURIComponent(sourceId)}`,
+    `/api/jobs/compile/${encodeURIComponent(sourceId)}`,
     { method: "POST" },
   );
 }
@@ -50,5 +50,5 @@ export function getSourceContent(sourceId: string): Promise<SourceContentRespons
 }
 
 export function getOriginalUrl(sourceId: string): string {
-  return `${getBaseUrl()}/ingest/sources/${encodeURIComponent(sourceId)}/original`;
+  return `${getBaseUrl()}/api/ingest/sources/${encodeURIComponent(sourceId)}/original`;
 }

--- a/apps/web/src/api/wiki.ts
+++ b/apps/web/src/api/wiki.ts
@@ -20,23 +20,23 @@ export interface ListArticlesParams {
 export function listArticles(
   params: ListArticlesParams = {},
 ): Promise<Article[]> {
-  return apiFetch<Article[]>("/wiki/articles", { query: { ...params } });
+  return apiFetch<Article[]>("/api/wiki/articles", { query: { ...params } });
 }
 
 export function getArticle(slug: string): Promise<ArticleResponse> {
-  return apiFetch<ArticleResponse>(`/wiki/articles/${encodeURIComponent(slug)}`);
+  return apiFetch<ArticleResponse>(`/api/wiki/articles/${encodeURIComponent(slug)}`);
 }
 
 export function listConcepts(): Promise<Concept[]> {
-  return apiFetch<Concept[]>("/wiki/concepts");
+  return apiFetch<Concept[]>("/api/wiki/concepts");
 }
 
 export function searchWiki(q: string, limit = 20): Promise<Article[]> {
-  return apiFetch<Article[]>("/wiki/search", { query: { q, limit } });
+  return apiFetch<Article[]>("/api/wiki/search", { query: { q, limit } });
 }
 
 export function getRandomArticle(): Promise<Article> {
-  return apiFetch<Article>("/wiki/articles/random");
+  return apiFetch<Article>("/api/wiki/articles/random");
 }
 
 export interface ArticleEditRequest {
@@ -49,11 +49,11 @@ export function editArticle(
   body: ArticleEditRequest,
 ): Promise<ArticleResponse> {
   return apiFetch<ArticleResponse>(
-    `/wiki/articles/${encodeURIComponent(slug)}`,
+    `/api/wiki/articles/${encodeURIComponent(slug)}`,
     { method: "PATCH", body },
   );
 }
 
 export function getGraph(): Promise<GraphResponse> {
-  return apiFetch<GraphResponse>("/wiki/graph");
+  return apiFetch<GraphResponse>("/api/wiki/graph");
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,13 +4,13 @@ info:
   description: Local LLM Knowledge OS — Personal API
   version: 0.1.0
 paths:
-  /ingest/url:
+  /api/ingest/url:
     post:
       tags:
       - Ingest
       summary: Ingest Url
       description: Ingest a web URL or YouTube video.
-      operationId: ingest_url_ingest_url_post
+      operationId: ingest_url_api_ingest_url_post
       requestBody:
         content:
           application/json:
@@ -30,7 +30,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ingest/pdf:
+  /api/ingest/pdf:
     post:
       tags:
       - Ingest
@@ -41,7 +41,7 @@ paths:
         The ``auto_compile`` query parameter (default ``True``) controls whether the
 
         source is enqueued for background compilation immediately after upload.'
-      operationId: ingest_pdf_ingest_pdf_post
+      operationId: ingest_pdf_api_ingest_pdf_post
       parameters:
       - name: auto_compile
         in: query
@@ -55,7 +55,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Body_ingest_pdf_ingest_pdf_post'
+              $ref: '#/components/schemas/Body_ingest_pdf_api_ingest_pdf_post'
       responses:
         '200':
           description: Successful Response
@@ -69,13 +69,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ingest/text:
+  /api/ingest/text:
     post:
       tags:
       - Ingest
       summary: Ingest Text
       description: Ingest raw text or a note.
-      operationId: ingest_text_ingest_text_post
+      operationId: ingest_text_api_ingest_text_post
       requestBody:
         content:
           application/json:
@@ -95,13 +95,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ingest/sources:
+  /api/ingest/sources:
     get:
       tags:
       - Ingest
       summary: List Sources
       description: List all ingested sources.
-      operationId: list_sources_ingest_sources_get
+      operationId: list_sources_api_ingest_sources_get
       parameters:
       - name: status
         in: query
@@ -137,13 +137,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ingest/sources/{source_id}:
+  /api/ingest/sources/{source_id}:
     get:
       tags:
       - Ingest
       summary: Get Source
       description: Get source by ID.
-      operationId: get_source_ingest_sources__source_id__get
+      operationId: get_source_api_ingest_sources__source_id__get
       parameters:
       - name: source_id
         in: path
@@ -169,7 +169,7 @@ paths:
       - Ingest
       summary: Delete Source
       description: Delete a source by ID.
-      operationId: delete_source_ingest_sources__source_id__delete
+      operationId: delete_source_api_ingest_sources__source_id__delete
       parameters:
       - name: source_id
         in: path
@@ -189,13 +189,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ingest/sources/{source_id}/content:
+  /api/ingest/sources/{source_id}/content:
     get:
       tags:
       - Ingest
       summary: Get Source Content
       description: Return the raw text content of a source for side-by-side reading.
-      operationId: get_source_content_ingest_sources__source_id__content_get
+      operationId: get_source_content_api_ingest_sources__source_id__content_get
       parameters:
       - name: source_id
         in: path
@@ -218,7 +218,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ingest/sources/{source_id}/original:
+  /api/ingest/sources/{source_id}/original:
     get:
       tags:
       - Ingest
@@ -229,7 +229,7 @@ paths:
         Returns the raw binary stored during ingest — not the extracted text.
 
         Sources that have no original (text, YouTube) return 404.'
-      operationId: get_source_original_ingest_sources__source_id__original_get
+      operationId: get_source_original_api_ingest_sources__source_id__original_get
       parameters:
       - name: source_id
         in: path
@@ -249,13 +249,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/contradiction-resolutions:
+  /api/wiki/contradiction-resolutions:
     get:
       tags:
       - Wiki
       summary: List Contradiction Resolutions
       description: Return the valid contradiction resolution options.
-      operationId: list_contradiction_resolutions_wiki_contradiction_resolutions_get
+      operationId: list_contradiction_resolutions_api_wiki_contradiction_resolutions_get
       responses:
         '200':
           description: Successful Response
@@ -265,15 +265,15 @@ paths:
                 items:
                   $ref: '#/components/schemas/ContradictionResolutionOption'
                 type: array
-                title: Response List Contradiction Resolutions Wiki Contradiction
+                title: Response List Contradiction Resolutions Api Wiki Contradiction
                   Resolutions Get
-  /wiki/contradictions:
+  /api/wiki/contradictions:
     get:
       tags:
       - Wiki
       summary: List Contradictions
       description: List all contradictions for the user, optionally filtered by status.
-      operationId: list_contradictions_wiki_contradictions_get
+      operationId: list_contradictions_api_wiki_contradictions_get
       parameters:
       - name: status
         in: query
@@ -308,20 +308,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ContradictionResponse'
-                title: Response List Contradictions Wiki Contradictions Get
+                title: Response List Contradictions Api Wiki Contradictions Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/contradictions/{contradiction_id}:
+  /api/wiki/contradictions/{contradiction_id}:
     get:
       tags:
       - Wiki
       summary: Get Contradiction
       description: Get a single contradiction with article details.
-      operationId: get_contradiction_wiki_contradictions__contradiction_id__get
+      operationId: get_contradiction_api_wiki_contradictions__contradiction_id__get
       parameters:
       - name: contradiction_id
         in: path
@@ -349,7 +349,7 @@ paths:
       - Wiki
       summary: Resolve Persisted Contradiction
       description: Resolve or dismiss a contradiction.
-      operationId: resolve_persisted_contradiction_wiki_contradictions__contradiction_id__patch
+      operationId: resolve_persisted_contradiction_api_wiki_contradictions__contradiction_id__patch
       parameters:
       - name: contradiction_id
         in: path
@@ -378,13 +378,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles:
+  /api/wiki/articles:
     get:
       tags:
       - Wiki
       summary: List Articles
       description: List wiki articles with optional filtering and source provenance.
-      operationId: list_articles_wiki_articles_get
+      operationId: list_articles_api_wiki_articles_get
       parameters:
       - name: concept
         in: query
@@ -433,20 +433,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ArticleSummaryResponse'
-                title: Response List Articles Wiki Articles Get
+                title: Response List Articles Api Wiki Articles Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/random:
+  /api/wiki/articles/random:
     get:
       tags:
       - Wiki
       summary: Get Random Article
       description: Return a random article belonging to the current user.
-      operationId: get_random_article_wiki_articles_random_get
+      operationId: get_random_article_api_wiki_articles_random_get
       responses:
         '200':
           description: Successful Response
@@ -456,14 +456,14 @@ paths:
                 $ref: '#/components/schemas/ArticleSummaryResponse'
         '404':
           description: No articles found
-  /wiki/articles/{id_or_slug}:
+  /api/wiki/articles/{id_or_slug}:
     get:
       tags:
       - Wiki
       summary: Get Article
       description: Get full article by ID or slug, with content, backlinks, and source
         provenance.
-      operationId: get_article_wiki_articles__id_or_slug__get
+      operationId: get_article_api_wiki_articles__id_or_slug__get
       parameters:
       - name: id_or_slug
         in: path
@@ -496,7 +496,7 @@ paths:
         Sets ``manually_edited=True`` so that recompilation respects user edits.
 
         Only the article owner can edit.'
-      operationId: edit_article_wiki_articles__id_or_slug__patch
+      operationId: edit_article_api_wiki_articles__id_or_slug__patch
       parameters:
       - name: id_or_slug
         in: path
@@ -525,7 +525,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/graph:
+  /api/wiki/graph:
     get:
       tags:
       - Wiki
@@ -544,7 +544,7 @@ paths:
 
 
         Filters compose with AND. Filtering is pushed down into SQL.'
-      operationId: get_graph_wiki_graph_get
+      operationId: get_graph_api_wiki_graph_get
       parameters:
       - name: relation_type
         in: query
@@ -583,14 +583,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/{id_or_slug}/relationships:
+  /api/wiki/articles/{id_or_slug}/relationships:
     get:
       tags:
       - Wiki
       summary: Get Article Relationships
       description: Return typed relationships for an article, grouped by direction
         and type.
-      operationId: get_article_relationships_wiki_articles__id_or_slug__relationships_get
+      operationId: get_article_relationships_api_wiki_articles__id_or_slug__relationships_get
       parameters:
       - name: id_or_slug
         in: path
@@ -613,13 +613,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/search:
+  /api/wiki/search:
     get:
       tags:
       - Wiki
       summary: Search
       description: Full-text search across wiki articles using BM25 ranking.
-      operationId: search_wiki_search_get
+      operationId: search_api_wiki_search_get
       parameters:
       - name: q
         in: query
@@ -658,13 +658,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/concepts:
+  /api/wiki/concepts:
     get:
       tags:
       - Wiki
       summary: Get Concepts
       description: Concept taxonomy tree.
-      operationId: get_concepts_wiki_concepts_get
+      operationId: get_concepts_api_wiki_concepts_get
       parameters:
       - name: include_empty
         in: query
@@ -685,13 +685,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/concepts/rebuild:
+  /api/wiki/concepts/rebuild:
     post:
       tags:
       - Wiki
       summary: Rebuild Concepts
       description: Trigger LLM-powered taxonomy hierarchy rebuild.
-      operationId: rebuild_concepts_wiki_concepts_rebuild_post
+      operationId: rebuild_concepts_api_wiki_concepts_rebuild_post
       responses:
         '200':
           description: Successful Response
@@ -699,13 +699,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RebuildConceptsResponse'
-  /wiki/concepts/{name}:
+  /api/wiki/concepts/{name}:
     get:
       tags:
       - Wiki
       summary: Get Concept
       description: Concept detail with linked articles.
-      operationId: get_concept_wiki_concepts__name__get
+      operationId: get_concept_api_wiki_concepts__name__get
       parameters:
       - name: name
         in: path
@@ -727,13 +727,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/concepts/{name}/articles:
+  /api/wiki/concepts/{name}/articles:
     get:
       tags:
       - Wiki
       summary: Get Concept Articles
       description: Articles tagged with this concept.
-      operationId: get_concept_articles_wiki_concepts__name__articles_get
+      operationId: get_concept_articles_api_wiki_concepts__name__articles_get
       parameters:
       - name: name
         in: path
@@ -764,7 +764,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ArticleSummaryResponse'
-                title: Response Get Concept Articles Wiki Concepts  Name  Articles
+                title: Response Get Concept Articles Api Wiki Concepts  Name  Articles
                   Get
         '422':
           description: Validation Error
@@ -772,7 +772,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/health:
+  /api/wiki/health:
     get:
       tags:
       - Wiki
@@ -783,7 +783,7 @@ paths:
         DEPRECATED: Use GET /lint/reports/latest instead. This endpoint
 
         delegates to the new LinterService for backward compatibility.'
-      operationId: get_health_wiki_health_get
+      operationId: get_health_api_wiki_health_get
       responses:
         '200':
           description: Successful Response
@@ -791,7 +791,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthSummaryResponse'
-  /wiki/backlinks/{source_id}/{target_id}/resolve:
+  /api/wiki/backlinks/{source_id}/{target_id}/resolve:
     post:
       tags:
       - Wiki
@@ -804,7 +804,7 @@ paths:
         updates the Backlink for backward compatibility AND forwards the resolution
 
         to the Contradiction table (single source of truth).'
-      operationId: resolve_contradiction_wiki_backlinks__source_id___target_id__resolve_post
+      operationId: resolve_contradiction_api_wiki_backlinks__source_id___target_id__resolve_post
       deprecated: true
       parameters:
       - name: source_id
@@ -838,7 +838,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/{id_or_slug}/refresh:
+  /api/wiki/articles/{id_or_slug}/refresh:
     post:
       tags:
       - Wiki
@@ -851,7 +851,7 @@ paths:
         staleness score. Use this when you have reviewed an article and
 
         confirmed its content is still accurate.'
-      operationId: refresh_article_wiki_articles__id_or_slug__refresh_post
+      operationId: refresh_article_api_wiki_articles__id_or_slug__refresh_post
       parameters:
       - name: id_or_slug
         in: path
@@ -874,7 +874,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /wiki/articles/{article_id}/recompile:
+  /api/wiki/articles/{article_id}/recompile:
     post:
       tags:
       - Wiki
@@ -887,7 +887,7 @@ paths:
         returns 409 Conflict unless ``force=true`` is passed. When forced,
 
         the manual edits flag is cleared before recompilation.'
-      operationId: recompile_article_wiki_articles__article_id__recompile_post
+      operationId: recompile_article_api_wiki_articles__article_id__recompile_post
       parameters:
       - name: article_id
         in: path
@@ -925,7 +925,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query:
+  /api/query:
     post:
       tags:
       - Query
@@ -938,7 +938,7 @@ paths:
         Otherwise the question is appended as a new turn in the existing
 
         conversation.'
-      operationId: ask_query_post
+      operationId: ask_api_query_post
       requestBody:
         content:
           application/json:
@@ -958,7 +958,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/stream:
+  /api/query/stream:
     post:
       tags:
       - Query
@@ -971,7 +971,7 @@ paths:
         or ``error``. The Query row is persisted only after the stream completes
 
         successfully. Client disconnect aborts without persisting.'
-      operationId: ask_stream_query_stream_post
+      operationId: ask_stream_api_query_stream_post
       requestBody:
         content:
           application/json:
@@ -990,13 +990,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/history:
+  /api/query/history:
     get:
       tags:
       - Query
       summary: Query History
       description: List past queries (legacy endpoint — UI uses /conversations instead).
-      operationId: query_history_query_history_get
+      operationId: query_history_api_query_history_get
       parameters:
       - name: limit
         in: query
@@ -1017,13 +1017,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations:
+  /api/query/conversations:
     get:
       tags:
       - Query
       summary: List Conversations
       description: List conversations ordered by most recently updated first.
-      operationId: list_conversations_query_conversations_get
+      operationId: list_conversations_api_query_conversations_get
       parameters:
       - name: limit
         in: query
@@ -1041,20 +1041,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ConversationSummary'
-                title: Response List Conversations Query Conversations Get
+                title: Response List Conversations Api Query Conversations Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations/{conversation_id}:
+  /api/query/conversations/{conversation_id}:
     get:
       tags:
       - Query
       summary: Get Conversation
       description: Return a single conversation with all its turns.
-      operationId: get_conversation_query_conversations__conversation_id__get
+      operationId: get_conversation_api_query_conversations__conversation_id__get
       parameters:
       - name: conversation_id
         in: path
@@ -1075,14 +1075,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations/{conversation_id}/export:
+  /api/query/conversations/{conversation_id}/export:
     get:
       tags:
       - Query
       summary: Export Conversation
       description: Export a conversation as standalone markdown. Pure read, no DB
         writes.
-      operationId: export_conversation_query_conversations__conversation_id__export_get
+      operationId: export_conversation_api_query_conversations__conversation_id__export_get
       parameters:
       - name: conversation_id
         in: path
@@ -1103,14 +1103,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations/file-back:
+  /api/query/conversations/file-back:
     post:
       tags:
       - Query
       summary: File Back Selection
       description: File selected turns from one or more conversations back to the
         wiki as a single article.
-      operationId: file_back_selection_query_conversations_file_back_post
+      operationId: file_back_selection_api_query_conversations_file_back_post
       requestBody:
         content:
           application/json:
@@ -1129,13 +1129,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations/{conversation_id}/file-back:
+  /api/query/conversations/{conversation_id}/file-back:
     post:
       tags:
       - Query
       summary: File Back Conversation
       description: File the entire conversation back to the wiki as a single article.
-      operationId: file_back_conversation_query_conversations__conversation_id__file_back_post
+      operationId: file_back_conversation_api_query_conversations__conversation_id__file_back_post
       parameters:
       - name: conversation_id
         in: path
@@ -1155,13 +1155,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations/{conversation_id}/crystallize:
+  /api/query/conversations/{conversation_id}/crystallize:
     post:
       tags:
       - Query
       summary: Crystallize
       description: Distill a conversation into a new wiki article with page_type synthesis.
-      operationId: crystallize_query_conversations__conversation_id__crystallize_post
+      operationId: crystallize_api_query_conversations__conversation_id__crystallize_post
       parameters:
       - name: conversation_id
         in: path
@@ -1182,7 +1182,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /query/conversations/{conversation_id}/fork:
+  /api/query/conversations/{conversation_id}/fork:
     post:
       tags:
       - Query
@@ -1193,7 +1193,7 @@ paths:
         Creates a new conversation that shares turns 0..turn_index-1 with the
 
         parent by reference. The original branch is preserved immutably.'
-      operationId: fork_conversation_query_conversations__conversation_id__fork_post
+      operationId: fork_conversation_api_query_conversations__conversation_id__fork_post
       parameters:
       - name: conversation_id
         in: path
@@ -1220,13 +1220,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /jobs:
+  /api/jobs:
     get:
       tags:
       - Jobs
       summary: List Jobs
       description: List jobs with optional status filter.
-      operationId: list_jobs_jobs_get
+      operationId: list_jobs_api_jobs_get
       parameters:
       - name: status
         in: query
@@ -1252,20 +1252,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Job'
-                title: Response List Jobs Jobs Get
+                title: Response List Jobs Api Jobs Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /jobs/{job_id}:
+  /api/jobs/{job_id}:
     get:
       tags:
       - Jobs
       summary: Get Job
       description: Get job by ID.
-      operationId: get_job_jobs__job_id__get
+      operationId: get_job_api_jobs__job_id__get
       parameters:
       - name: job_id
         in: path
@@ -1282,20 +1282,20 @@ paths:
                 anyOf:
                 - $ref: '#/components/schemas/Job'
                 - type: 'null'
-                title: Response Get Job Jobs  Job Id  Get
+                title: Response Get Job Api Jobs  Job Id  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /jobs/compile/{source_id}:
+  /api/jobs/compile/{source_id}:
     post:
       tags:
       - Jobs
       summary: Trigger Compile
       description: Trigger compilation for a source.
-      operationId: trigger_compile_jobs_compile__source_id__post
+      operationId: trigger_compile_api_jobs_compile__source_id__post
       parameters:
       - name: source_id
         in: path
@@ -1316,7 +1316,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /jobs/lint:
+  /api/jobs/lint:
     post:
       tags:
       - Jobs
@@ -1327,7 +1327,7 @@ paths:
         DEPRECATED: Use POST /lint/run instead. This endpoint delegates
 
         to the new LinterService for backward compatibility.'
-      operationId: trigger_lint_jobs_lint_post
+      operationId: trigger_lint_api_jobs_lint_post
       responses:
         '200':
           description: Successful Response
@@ -1335,13 +1335,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JobTriggerResponse'
-  /jobs/reindex:
+  /api/jobs/reindex:
     post:
       tags:
       - Jobs
       summary: Trigger Reindex
       description: Trigger wiki reindexing.
-      operationId: trigger_reindex_jobs_reindex_post
+      operationId: trigger_reindex_api_jobs_reindex_post
       responses:
         '200':
           description: Successful Response
@@ -1349,13 +1349,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JobTriggerResponse'
-  /lint/run:
+  /api/lint/run:
     post:
       tags:
       - Lint
       summary: Run Lint
       description: Trigger a new lint run. Returns immediately with status.
-      operationId: run_lint_lint_run_post
+      operationId: run_lint_api_lint_run_post
       responses:
         '200':
           description: Successful Response
@@ -1363,13 +1363,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LintRunResponse'
-  /lint/reports:
+  /api/lint/reports:
     get:
       tags:
       - Lint
       summary: List Reports
       description: List lint reports ordered by most recent first.
-      operationId: list_reports_lint_reports_get
+      operationId: list_reports_api_lint_reports_get
       parameters:
       - name: limit
         in: query
@@ -1389,20 +1389,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LintReport'
-                title: Response List Reports Lint Reports Get
+                title: Response List Reports Api Lint Reports Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /lint/reports/latest:
+  /api/lint/reports/latest:
     get:
       tags:
       - Lint
       summary: Get Latest Report
       description: Get the most recent lint report with all non-dismissed findings.
-      operationId: get_latest_report_lint_reports_latest_get
+      operationId: get_latest_report_api_lint_reports_latest_get
       responses:
         '200':
           description: Successful Response
@@ -1410,13 +1410,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LintReportDetail'
-  /lint/reports/{report_id}:
+  /api/lint/reports/{report_id}:
     get:
       tags:
       - Lint
       summary: Get Report
       description: Get a specific lint report with findings.
-      operationId: get_report_lint_reports__report_id__get
+      operationId: get_report_api_lint_reports__report_id__get
       parameters:
       - name: report_id
         in: path
@@ -1444,14 +1444,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /lint/findings/{kind}/{finding_id}/dismiss:
+  /api/lint/findings/{kind}/{finding_id}/dismiss:
     post:
       tags:
       - Lint
       summary: Dismiss Finding
       description: Dismiss a finding. Persists across future lint runs via content
         hash.
-      operationId: dismiss_finding_lint_findings__kind___finding_id__dismiss_post
+      operationId: dismiss_finding_api_lint_findings__kind___finding_id__dismiss_post
       parameters:
       - name: kind
         in: path
@@ -1477,13 +1477,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /settings:
+  /api/settings:
     get:
       tags:
       - Settings
       summary: Get All Settings
       description: Return all application settings, with DB overrides applied.
-      operationId: get_all_settings_settings_get
+      operationId: get_all_settings_api_settings_get
       responses:
         '200':
           description: Successful Response
@@ -1496,7 +1496,7 @@ paths:
       - Settings
       summary: Update Settings
       description: Update runtime settings. Changes persist to DB across restarts.
-      operationId: update_settings_settings_patch
+      operationId: update_settings_api_settings_patch
       requestBody:
         content:
           application/json:
@@ -1516,13 +1516,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /settings/llm/default-provider:
+  /api/settings/llm/default-provider:
     post:
       tags:
       - Settings
       summary: Set Default Provider
       description: Set the default LLM provider. Persists to DB, survives restarts.
-      operationId: set_default_provider_settings_llm_default_provider_post
+      operationId: set_default_provider_api_settings_llm_default_provider_post
       requestBody:
         content:
           application/json:
@@ -1542,13 +1542,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /settings/llm/test:
+  /api/settings/llm/test:
     post:
       tags:
       - Settings
       summary: Test Llm Connection
       description: Test if a provider is configured and reachable.
-      operationId: test_llm_connection_settings_llm_test_post
+      operationId: test_llm_connection_api_settings_llm_test_post
       parameters:
       - name: provider
         in: query
@@ -1569,13 +1569,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /settings/llm/cost/breakdown:
+  /api/settings/llm/cost/breakdown:
     get:
       tags:
       - Settings
       summary: Get Llm Cost Breakdown
       description: Cost breakdown by provider and task type for current month.
-      operationId: get_llm_cost_breakdown_settings_llm_cost_breakdown_get
+      operationId: get_llm_cost_breakdown_api_settings_llm_cost_breakdown_get
       responses:
         '200':
           description: Successful Response
@@ -1583,13 +1583,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBreakdownResponse'
-  /settings/llm/cost:
+  /api/settings/llm/cost:
     get:
       tags:
       - Settings
       summary: Get Llm Cost
       description: Cost summary for current month.
-      operationId: get_llm_cost_settings_llm_cost_get
+      operationId: get_llm_cost_api_settings_llm_cost_get
       responses:
         '200':
           description: Successful Response
@@ -1597,7 +1597,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostSummaryResponse'
-  /settings/onboarding-status:
+  /api/settings/onboarding-status:
     get:
       tags:
       - Settings
@@ -1610,7 +1610,7 @@ paths:
         articles in the wiki, treat onboarding as implicitly complete — they
 
         are clearly past the first-run stage.'
-      operationId: get_onboarding_status_settings_onboarding_status_get
+      operationId: get_onboarding_status_api_settings_onboarding_status_get
       responses:
         '200':
           description: Successful Response
@@ -1623,7 +1623,7 @@ paths:
       - Settings
       summary: Complete Onboarding
       description: Mark onboarding as complete for the current user.
-      operationId: complete_onboarding_settings_onboarding_status_post
+      operationId: complete_onboarding_api_settings_onboarding_status_post
       responses:
         '200':
           description: Successful Response
@@ -1704,6 +1704,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiKeyListResponse'
+  /api/admin/stats:
+    get:
+      tags:
+      - Admin
+      summary: Get Stats
+      description: Aggregate system statistics.
+      operationId: get_stats_api_admin_stats_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/admin/orphans:
+    get:
+      tags:
+      - Admin
+      summary: Get Orphans
+      description: Articles with missing wiki files.
+      operationId: get_orphans_api_admin_orphans_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/admin/concepts/eligible:
+    get:
+      tags:
+      - Admin
+      summary: Get Eligible Concepts
+      description: Concepts eligible for page generation.
+      operationId: get_eligible_concepts_api_admin_concepts_eligible_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/admin/sweep:
+    post:
+      tags:
+      - Admin
+      summary: Trigger Sweep
+      description: Trigger wikilink sweep manually.
+      operationId: trigger_sweep_api_admin_sweep_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/admin/reindex:
+    post:
+      tags:
+      - Admin
+      summary: Trigger Reindex
+      description: Rebuild search index.
+      operationId: trigger_reindex_api_admin_reindex_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/wiki/articles/{id_or_slug}/export:
+    post:
+      tags:
+      - Export
+      summary: Export Article
+      description: 'Export a wiki article in the requested format.
+
+
+        - **pdf**: Returns styled HTML (text/html) suitable for browser print-to-PDF.
+
+        - **linkedin**: Returns a LinkedIn post draft (JSON with content field).
+
+        - **slides**: Returns a Marp-compatible markdown slide deck (JSON with content
+        field).'
+      operationId: export_article_api_wiki_articles__id_or_slug__export_post
+      parameters:
+      - name: id_or_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Id Or Slug
+      - name: format
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/ExportFormat'
+          description: 'Export format: pdf, linkedin, or slides'
+        description: 'Export format: pdf, linkedin, or slides'
+      responses:
+        '200':
+          description: Export result (JSON for linkedin/slides, HTML for pdf)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportResponse'
+            text/html: {}
+        '404':
+          description: Article not found
+        '422':
+          description: Invalid export format
   /auth/login/{provider}:
     get:
       tags:
@@ -1933,112 +2039,6 @@ paths:
                 additionalProperties: true
                 type: object
                 title: Response Delete Account Auth Account Delete
-  /admin/stats:
-    get:
-      tags:
-      - Admin
-      summary: Get Stats
-      description: Aggregate system statistics.
-      operationId: get_stats_admin_stats_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-  /admin/orphans:
-    get:
-      tags:
-      - Admin
-      summary: Get Orphans
-      description: Articles with missing wiki files.
-      operationId: get_orphans_admin_orphans_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-  /admin/concepts/eligible:
-    get:
-      tags:
-      - Admin
-      summary: Get Eligible Concepts
-      description: Concepts eligible for page generation.
-      operationId: get_eligible_concepts_admin_concepts_eligible_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-  /admin/sweep:
-    post:
-      tags:
-      - Admin
-      summary: Trigger Sweep
-      description: Trigger wikilink sweep manually.
-      operationId: trigger_sweep_admin_sweep_post
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-  /admin/reindex:
-    post:
-      tags:
-      - Admin
-      summary: Trigger Reindex
-      description: Rebuild search index.
-      operationId: trigger_reindex_admin_reindex_post
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-  /wiki/articles/{id_or_slug}/export:
-    post:
-      tags:
-      - Export
-      summary: Export Article
-      description: 'Export a wiki article in the requested format.
-
-
-        - **pdf**: Returns styled HTML (text/html) suitable for browser print-to-PDF.
-
-        - **linkedin**: Returns a LinkedIn post draft (JSON with content field).
-
-        - **slides**: Returns a Marp-compatible markdown slide deck (JSON with content
-        field).'
-      operationId: export_article_wiki_articles__id_or_slug__export_post
-      parameters:
-      - name: id_or_slug
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Id Or Slug
-      - name: format
-        in: query
-        required: true
-        schema:
-          $ref: '#/components/schemas/ExportFormat'
-          description: 'Export format: pdf, linkedin, or slides'
-        description: 'Export format: pdf, linkedin, or slides'
-      responses:
-        '200':
-          description: Export result (JSON for linkedin/slides, HTML for pdf)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExportResponse'
-            text/html: {}
-        '404':
-          description: Article not found
-        '422':
-          description: Invalid export format
   /health:
     get:
       summary: Health
@@ -2454,7 +2454,7 @@ components:
       - slug
       title: BacklinkEntry
       description: A backlink entry with human-readable metadata for the frontend.
-    Body_ingest_pdf_ingest_pdf_post:
+    Body_ingest_pdf_api_ingest_pdf_post:
       properties:
         file:
           type: string
@@ -2463,7 +2463,7 @@ components:
       type: object
       required:
       - file
-      title: Body_ingest_pdf_ingest_pdf_post
+      title: Body_ingest_pdf_api_ingest_pdf_post
     CitationArticleRef:
       properties:
         slug:

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import structlog
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -202,18 +202,24 @@ _images_dir = Path(get_settings().data_dir) / "images"
 _images_dir.mkdir(parents=True, exist_ok=True)
 app.mount("/images", StaticFiles(directory=str(_images_dir)), name="images")
 
-# Mount routers
-app.include_router(ingest.router, prefix="/ingest", tags=["Ingest"])
-app.include_router(wiki.router, prefix="/wiki", tags=["Wiki"])
-app.include_router(query.router, prefix="/query", tags=["Query"])
-app.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
-app.include_router(lint.router, prefix="/lint", tags=["Lint"])
-app.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
-app.include_router(api_keys.router, prefix="/api/settings/api-keys", tags=["Settings"])
+# Mount routers — all API routes live under /api for clean SPA separation.
+# Health, docs, and auth remain at root level.
+api_router = APIRouter(prefix="/api")
+api_router.include_router(ingest.router, prefix="/ingest", tags=["Ingest"])
+api_router.include_router(wiki.router, prefix="/wiki", tags=["Wiki"])
+api_router.include_router(query.router, prefix="/query", tags=["Query"])
+api_router.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
+api_router.include_router(lint.router, prefix="/lint", tags=["Lint"])
+api_router.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
+api_router.include_router(api_keys.router, prefix="/settings/api-keys", tags=["Settings"])
+api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])
+api_router.include_router(export.router, prefix="/wiki", tags=["Export"])
+app.include_router(api_router)
+
+# Auth and WebSocket remain at root — auth redirects require stable paths,
+# and WebSocket connections are not prefixed.
 app.include_router(ws.router, tags=["WebSocket"])
 app.include_router(auth.router, prefix="/auth", tags=["Auth"])
-app.include_router(admin.router, prefix="/admin", tags=["Admin"])
-app.include_router(export.router, prefix="/wiki", tags=["Export"])
 
 # ---------------------------------------------------------------------------
 # Exception handlers — catch domain errors raised inside route handlers

--- a/tests/integration/test_typed_graph_filtering.py
+++ b/tests/integration/test_typed_graph_filtering.py
@@ -69,12 +69,12 @@ async def test_graph_relation_type_contradicts_returns_only_contradictions(clien
         await session.commit()
 
     # Without filter: both edges visible.
-    full = await client.get("/wiki/graph")
+    full = await client.get("/api/wiki/graph")
     assert full.status_code == 200
     assert len(full.json()["edges"]) == 2
 
     # With contradicts filter: only X→Y survives.
-    filtered = await client.get("/wiki/graph", params={"relation_type": "contradicts"})
+    filtered = await client.get("/api/wiki/graph", params={"relation_type": "contradicts"})
     assert filtered.status_code == 200
     edges = filtered.json()["edges"]
     assert len(edges) == 1

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -97,7 +97,7 @@ async def test_wikilink_resolution_end_to_end(
     assert "[[Nonexistent Topic]]" in content
 
     # 5. ID-first lookup via the HTTP route
-    response = await client.get(f"/wiki/articles/{article.id}")
+    response = await client.get(f"/api/wiki/articles/{article.id}")
     assert response.status_code == 200
     payload = response.json()
     assert payload["id"] == article.id
@@ -105,6 +105,6 @@ async def test_wikilink_resolution_end_to_end(
     assert f"[Existing Target](/wiki/{target.id})" in payload["content"]
 
     # Slug-based lookup still works (backward compat)
-    response_by_slug = await client.get(f"/wiki/articles/{article.slug}")
+    response_by_slug = await client.get(f"/api/wiki/articles/{article.slug}")
     assert response_by_slug.status_code == 200
     assert response_by_slug.json()["id"] == article.id

--- a/tests/smoke/test_docker_smoke.py
+++ b/tests/smoke/test_docker_smoke.py
@@ -272,7 +272,7 @@ class TestIngestEndpoint:
 
     def test_ingest_text_accepts_request(self, container_url: str):
         resp = httpx.post(
-            f"{container_url}/ingest/text",
+            f"{container_url}/api/ingest/text",
             json={
                 "content": "Smoke test content for WikiMind.",
                 "title": "Smoke Test",
@@ -288,7 +288,7 @@ class TestIngestEndpoint:
     def test_ingest_url_validates_input(self, container_url: str):
         """POST with missing required fields should return 422."""
         resp = httpx.post(
-            f"{container_url}/ingest/url",
+            f"{container_url}/api/ingest/url",
             json={},
             timeout=10,
         )
@@ -305,7 +305,7 @@ class TestAuthFlow:
 
     def test_auth_disabled_api_accessible(self, container_url: str):
         """With auth disabled, API endpoints require no token."""
-        resp = httpx.get(f"{container_url}/ingest/sources", timeout=10)
+        resp = httpx.get(f"{container_url}/api/ingest/sources", timeout=10)
         assert resp.status_code == 200
 
     def test_auth_me_returns_anonymous(self, container_url: str):
@@ -394,7 +394,7 @@ class TestAuthEnabled:
     def test_api_requires_auth(self, auth_container_url: str):
         """API endpoints should require a token when auth is enabled."""
         resp = httpx.get(
-            f"{auth_container_url}/ingest/sources",
+            f"{auth_container_url}/api/ingest/sources",
             headers={"Accept": "application/json"},
             timeout=10,
         )
@@ -403,7 +403,7 @@ class TestAuthEnabled:
     def test_api_rejects_invalid_token(self, auth_container_url: str):
         """API endpoints should reject invalid JWT tokens."""
         resp = httpx.get(
-            f"{auth_container_url}/ingest/sources",
+            f"{auth_container_url}/api/ingest/sources",
             headers={
                 "Authorization": "Bearer invalid-token",
                 "Accept": "application/json",

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -272,7 +272,7 @@ class TestProviderConfiguredStatus:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-from-env")
         get_settings.cache_clear()
         try:
-            resp = await client.get("/settings")
+            resp = await client.get("/api/settings")
             assert resp.status_code == 200
             providers = resp.json()["llm"]["providers"]
             assert providers["anthropic"]["configured"] is True
@@ -281,7 +281,7 @@ class TestProviderConfiguredStatus:
 
     async def test_provider_not_configured_by_default(self, client: AsyncClient):
         """Provider shows not configured when no key exists."""
-        resp = await client.get("/settings")
+        resp = await client.get("/api/settings")
         assert resp.status_code == 200
         providers = resp.json()["llm"]["providers"]
         # OpenAI has no env var set in test → not configured
@@ -311,7 +311,7 @@ class TestProviderEnabledStatus:
         )
         assert resp.status_code == 200
 
-        resp = await client.get("/settings")
+        resp = await client.get("/api/settings")
         assert resp.status_code == 200
         providers = resp.json()["llm"]["providers"]
         assert providers["openai"]["enabled"] is True
@@ -319,7 +319,7 @@ class TestProviderEnabledStatus:
 
     async def test_provider_without_key_stays_disabled(self, client: AsyncClient):
         """Provider without any key remains disabled."""
-        resp = await client.get("/settings")
+        resp = await client.get("/api/settings")
         assert resp.status_code == 200
         providers = resp.json()["llm"]["providers"]
         assert providers["openai"]["enabled"] is False
@@ -349,7 +349,7 @@ class TestSetDefaultProvider:
         assert resp.status_code == 200
 
         resp = await client.post(
-            "/settings/llm/default-provider",
+            "/api/settings/llm/default-provider",
             json={"provider": "openai"},
         )
         assert resp.status_code == 200
@@ -359,7 +359,7 @@ class TestSetDefaultProvider:
     async def test_set_default_rejects_no_key(self, client: AsyncClient):
         """Cannot set a provider with no key at all as default."""
         resp = await client.post(
-            "/settings/llm/default-provider",
+            "/api/settings/llm/default-provider",
             json={"provider": "google"},
         )
         assert resp.status_code == 400

--- a/tests/unit/test_article_edit.py
+++ b/tests/unit/test_article_edit.py
@@ -61,7 +61,7 @@ async def test_edit_article_content(
     await storage.write(article.file_path, "# Test\n\nOriginal content.")
 
     response = await client.patch(
-        f"/wiki/articles/{article.slug}",
+        f"/api/wiki/articles/{article.slug}",
         json={"content": "# Test\n\nUpdated content."},
     )
 
@@ -84,7 +84,7 @@ async def test_edit_article_title(
     await storage.write(article.file_path, "# Test\n\nOriginal content.")
 
     response = await client.patch(
-        f"/wiki/articles/{article.slug}",
+        f"/api/wiki/articles/{article.slug}",
         json={"title": "New Title"},
     )
 
@@ -106,7 +106,7 @@ async def test_edit_article_both(
     await storage.write(article.file_path, "# Test\n\nOriginal.")
 
     response = await client.patch(
-        f"/wiki/articles/{article.slug}",
+        f"/api/wiki/articles/{article.slug}",
         json={"content": "# Updated\n\nNew body.", "title": "Updated Title"},
     )
 
@@ -134,7 +134,7 @@ async def test_edit_article_empty_patch_no_side_effects(
     await storage.write(article.file_path, "# Test\n\nOriginal content.")
 
     response = await client.patch(
-        f"/wiki/articles/{article.slug}",
+        f"/api/wiki/articles/{article.slug}",
         json={},
     )
 
@@ -153,7 +153,7 @@ async def test_edit_article_empty_string_content_rejected(
     article = await _create_article_with_file(db_session)
 
     response = await client.patch(
-        f"/wiki/articles/{article.slug}",
+        f"/api/wiki/articles/{article.slug}",
         json={"content": ""},
     )
 
@@ -169,7 +169,7 @@ async def test_edit_article_empty_string_title_rejected(
     article = await _create_article_with_file(db_session)
 
     response = await client.patch(
-        f"/wiki/articles/{article.slug}",
+        f"/api/wiki/articles/{article.slug}",
         json={"title": ""},
     )
 
@@ -179,7 +179,7 @@ async def test_edit_article_empty_string_title_rejected(
 async def test_edit_article_not_found(client: AsyncClient) -> None:
     """PATCH for a non-existent article returns 404."""
     response = await client.patch(
-        "/wiki/articles/nonexistent-slug",
+        "/api/wiki/articles/nonexistent-slug",
         json={"content": "new content"},
     )
     assert response.status_code == 404
@@ -197,7 +197,7 @@ async def test_edit_article_by_id(
     await storage.write(article.file_path, "# Test\n\nOriginal.")
 
     response = await client.patch(
-        f"/wiki/articles/{article.id}",
+        f"/api/wiki/articles/{article.id}",
         json={"content": "# Test\n\nEdited by ID."},
     )
 
@@ -227,7 +227,7 @@ async def test_recompile_blocked_by_manual_edit(
     db_session.add(article)
     await db_session.commit()
 
-    response = await client.post(f"/wiki/articles/{article.id}/recompile")
+    response = await client.post(f"/api/wiki/articles/{article.id}/recompile")
 
     assert response.status_code == 409
     data = response.json()
@@ -259,7 +259,7 @@ async def test_recompile_force_overrides_manual_edit(
         mock_compiler = mock_bc.return_value
         mock_compiler.schedule_recompile = AsyncMock(return_value="job-1")
 
-        response = await client.post(f"/wiki/articles/{article.id}/recompile?force=true")
+        response = await client.post(f"/api/wiki/articles/{article.id}/recompile?force=true")
 
     assert response.status_code == 200
     data = response.json()
@@ -296,7 +296,7 @@ async def test_recompile_unedited_article_no_force_needed(
         mock_compiler = mock_bc.return_value
         mock_compiler.schedule_recompile = AsyncMock(return_value="job-1")
 
-        response = await client.post(f"/wiki/articles/{article.id}/recompile")
+        response = await client.post(f"/api/wiki/articles/{article.id}/recompile")
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -108,7 +108,7 @@ async def test_middleware_returns_401_when_no_token(client, monkeypatch):
     monkeypatch.setattr(settings.auth, "enabled", True)
     monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
 
-    response = await client.get("/wiki/articles")
+    response = await client.get("/api/wiki/articles")
     assert response.status_code == 401
     body = response.json()
     assert body["error"]["code"] == "UNAUTHORIZED"
@@ -130,7 +130,7 @@ async def test_middleware_returns_401_when_token_expired(client, monkeypatch):
     expired_token = jwt.encode(expired_payload, "test-secret", algorithm="HS256")
 
     response = await client.get(
-        "/wiki/articles",
+        "/api/wiki/articles",
         headers={"Authorization": f"Bearer {expired_token}"},
     )
     assert response.status_code == 401
@@ -152,7 +152,7 @@ async def test_middleware_returns_401_when_token_invalid(client, monkeypatch):
     )
 
     response = await client.get(
-        "/wiki/articles",
+        "/api/wiki/articles",
         headers={"Authorization": f"Bearer {bad_token}"},
     )
     assert response.status_code == 401

--- a/tests/unit/test_backlink_enforcer.py
+++ b/tests/unit/test_backlink_enforcer.py
@@ -255,7 +255,8 @@ async def test_resolve_contradiction_endpoint(client, async_engine):
         )
         await session.commit()
     response = await client.post(
-        "/wiki/backlinks/a1/a2/resolve", json={"resolution": "source_a_wins", "resolution_note": "More recent study"}
+        "/api/wiki/backlinks/a1/a2/resolve",
+        json={"resolution": "source_a_wins", "resolution_note": "More recent study"},
     )
     assert response.status_code == 200
     data = response.json()
@@ -272,7 +273,7 @@ async def test_resolve_contradiction_endpoint(client, async_engine):
 
 @pytest.mark.asyncio
 async def test_resolve_contradiction_404(client):
-    response = await client.post("/wiki/backlinks/x/y/resolve", json={"resolution": "both_valid"})
+    response = await client.post("/api/wiki/backlinks/x/y/resolve", json={"resolution": "both_valid"})
     assert response.status_code == 404
 
 
@@ -292,7 +293,7 @@ async def test_resolve_contradiction_422_invalid(client, async_engine):
             )
         )
         await session.commit()
-    response = await client.post("/wiki/backlinks/a1/a2/resolve", json={"resolution": "invalid_value"})
+    response = await client.post("/api/wiki/backlinks/a1/a2/resolve", json={"resolution": "invalid_value"})
     assert response.status_code == 422
 
 
@@ -313,7 +314,7 @@ async def test_graph_api_includes_relation_type(client, async_engine):
             )
         )
         await session.commit()
-    response = await client.get("/wiki/graph")
+    response = await client.get("/api/wiki/graph")
     assert response.status_code == 200
     data = response.json()
     edges = data["edges"]

--- a/tests/unit/test_contradictions.py
+++ b/tests/unit/test_contradictions.py
@@ -270,7 +270,7 @@ async def test_api_list_contradictions(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_articles_and_contradictions(factory)
 
-    response = await client.get("/wiki/contradictions")
+    response = await client.get("/api/wiki/contradictions")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
@@ -281,7 +281,7 @@ async def test_api_list_contradictions_filter_active(client, async_engine) -> No
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_articles_and_contradictions(factory)
 
-    response = await client.get("/wiki/contradictions", params={"status": "active"})
+    response = await client.get("/api/wiki/contradictions", params={"status": "active"})
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -293,7 +293,7 @@ async def test_api_get_single_contradiction(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_articles_and_contradictions(factory)
 
-    response = await client.get("/wiki/contradictions/ctr1")
+    response = await client.get("/api/wiki/contradictions/ctr1")
     assert response.status_code == 200
     data = response.json()
     assert data["claim_a"] == "The sky is blue"
@@ -304,7 +304,7 @@ async def test_api_get_single_contradiction(client, async_engine) -> None:
 
 @pytest.mark.asyncio
 async def test_api_get_contradiction_not_found(client) -> None:
-    response = await client.get("/wiki/contradictions/nonexistent")
+    response = await client.get("/api/wiki/contradictions/nonexistent")
     assert response.status_code == 404
 
 
@@ -314,7 +314,7 @@ async def test_api_resolve_contradiction(client, async_engine) -> None:
     await _seed_articles_and_contradictions(factory)
 
     response = await client.patch(
-        "/wiki/contradictions/ctr1",
+        "/api/wiki/contradictions/ctr1",
         json={"status": "resolved", "resolution": "Claim A is correct"},
     )
     assert response.status_code == 200
@@ -330,7 +330,7 @@ async def test_api_dismiss_contradiction(client, async_engine) -> None:
     await _seed_articles_and_contradictions(factory)
 
     response = await client.patch(
-        "/wiki/contradictions/ctr1",
+        "/api/wiki/contradictions/ctr1",
         json={"status": "dismissed"},
     )
     assert response.status_code == 200
@@ -341,7 +341,7 @@ async def test_api_dismiss_contradiction(client, async_engine) -> None:
 @pytest.mark.asyncio
 async def test_api_resolve_nonexistent_contradiction(client) -> None:
     response = await client.patch(
-        "/wiki/contradictions/nonexistent",
+        "/api/wiki/contradictions/nonexistent",
         json={"status": "resolved", "resolution": "test"},
     )
     assert response.status_code == 404
@@ -395,7 +395,7 @@ async def test_api_get_contradiction_cross_user_returns_404(client, async_engine
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_other_user_contradiction(factory)
 
-    response = await client.get("/wiki/contradictions/other-ctr1")
+    response = await client.get("/api/wiki/contradictions/other-ctr1")
     assert response.status_code == 404
 
 
@@ -406,7 +406,7 @@ async def test_api_patch_contradiction_cross_user_returns_404(client, async_engi
     await _seed_other_user_contradiction(factory)
 
     response = await client.patch(
-        "/wiki/contradictions/other-ctr1",
+        "/api/wiki/contradictions/other-ctr1",
         json={"status": "resolved", "resolution": "hijack attempt"},
     )
     assert response.status_code == 404

--- a/tests/unit/test_cost_breakdown.py
+++ b/tests/unit/test_cost_breakdown.py
@@ -52,7 +52,7 @@ def _make_fake_session_factory(total: float, provider_rows: list, task_rows: lis
 async def test_empty_cost_log_returns_zeros(client) -> None:
     session_factory = _make_fake_session_factory(total=0.0, provider_rows=[], task_rows=[])
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings/llm/cost/breakdown")
+        resp = await client.get("/api/settings/llm/cost/breakdown")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -72,7 +72,7 @@ async def test_seeded_entries_group_by_provider(client) -> None:
     ]
     session_factory = _make_fake_session_factory(total=12.50, provider_rows=provider_rows, task_rows=task_rows)
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings/llm/cost/breakdown")
+        resp = await client.get("/api/settings/llm/cost/breakdown")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -91,7 +91,7 @@ async def test_seeded_entries_group_by_task_type(client) -> None:
     ]
     session_factory = _make_fake_session_factory(total=8.20, provider_rows=provider_rows, task_rows=task_rows)
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings/llm/cost/breakdown")
+        resp = await client.get("/api/settings/llm/cost/breakdown")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -103,7 +103,7 @@ async def test_seeded_entries_group_by_task_type(client) -> None:
 async def test_budget_percentage_calculated_correctly(client) -> None:
     session_factory = _make_fake_session_factory(total=25.0, provider_rows=[], task_rows=[])
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings/llm/cost/breakdown")
+        resp = await client.get("/api/settings/llm/cost/breakdown")
 
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/unit/test_crystallization.py
+++ b/tests/unit/test_crystallization.py
@@ -276,7 +276,7 @@ class TestCrystallizeEndpoint:
             "wikimind.services.crystallization.get_llm_router",
             return_value=mock_router,
         ):
-            resp = await client.post("/query/conversations/conv-ep-1/crystallize")
+            resp = await client.post("/api/query/conversations/conv-ep-1/crystallize")
 
         assert resp.status_code == 200
         data = resp.json()
@@ -287,5 +287,5 @@ class TestCrystallizeEndpoint:
 
     async def test_crystallize_endpoint_404_nonexistent(self, client):
         """POST /query/conversations/{id}/crystallize returns 404 for missing conversation."""
-        resp = await client.post("/query/conversations/nonexistent/crystallize")
+        resp = await client.post("/api/query/conversations/nonexistent/crystallize")
         assert resp.status_code == 404

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -203,7 +203,7 @@ class TestExportRoute:
     async def test_export_pdf_returns_html(self, client, db_session, tmp_path):
         article = await _seed_article(db_session, tmp_path)
         resp = await client.post(
-            f"/wiki/articles/{article.slug}/export?format=pdf",
+            f"/api/wiki/articles/{article.slug}/export?format=pdf",
         )
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
@@ -213,7 +213,7 @@ class TestExportRoute:
     async def test_export_pdf_by_id(self, client, db_session, tmp_path):
         article = await _seed_article(db_session, tmp_path)
         resp = await client.post(
-            f"/wiki/articles/{article.id}/export?format=pdf",
+            f"/api/wiki/articles/{article.id}/export?format=pdf",
         )
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
@@ -227,7 +227,7 @@ class TestExportRoute:
             return_value="Great hook!\n\nInsight paragraph.\n\nWhat are your thoughts?",
         ):
             resp = await client.post(
-                f"/wiki/articles/{article.slug}/export?format=linkedin",
+                f"/api/wiki/articles/{article.slug}/export?format=linkedin",
             )
         assert resp.status_code == 200
         data = resp.json()
@@ -244,7 +244,7 @@ class TestExportRoute:
             return_value="---\nmarp: true\n---\n# Slides",
         ):
             resp = await client.post(
-                f"/wiki/articles/{article.slug}/export?format=slides",
+                f"/api/wiki/articles/{article.slug}/export?format=slides",
             )
         assert resp.status_code == 200
         data = resp.json()
@@ -253,13 +253,13 @@ class TestExportRoute:
 
     async def test_export_article_not_found(self, client):
         resp = await client.post(
-            "/wiki/articles/nonexistent-slug/export?format=pdf",
+            "/api/wiki/articles/nonexistent-slug/export?format=pdf",
         )
         assert resp.status_code == 404
 
     async def test_export_invalid_format(self, client, db_session, tmp_path):
         article = await _seed_article(db_session, tmp_path)
         resp = await client.post(
-            f"/wiki/articles/{article.slug}/export?format=docx",
+            f"/api/wiki/articles/{article.slug}/export?format=docx",
         )
         assert resp.status_code == 422

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -537,7 +537,7 @@ async def test_lint_run_endpoint_returns_in_progress(client) -> None:
     """POST /lint/run returns status in_progress."""
     with patch("wikimind.services.linter.get_background_compiler") as mock_bg:
         mock_bg.return_value.schedule_lint = AsyncMock(return_value="job-1")
-        response = await client.post("/lint/run")
+        response = await client.post("/api/lint/run")
 
     assert response.status_code == 200
     data = response.json()
@@ -547,7 +547,7 @@ async def test_lint_run_endpoint_returns_in_progress(client) -> None:
 @pytest.mark.asyncio
 async def test_lint_reports_endpoint(client) -> None:
     """GET /lint/reports returns an empty list when no reports exist."""
-    response = await client.get("/lint/reports")
+    response = await client.get("/api/lint/reports")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -555,7 +555,7 @@ async def test_lint_reports_endpoint(client) -> None:
 @pytest.mark.asyncio
 async def test_lint_latest_endpoint_returns_404_when_empty(client) -> None:
     """GET /lint/reports/latest returns 404 when no reports exist."""
-    response = await client.get("/lint/reports/latest")
+    response = await client.get("/api/lint/reports/latest")
     assert response.status_code == 404
 
 
@@ -585,12 +585,12 @@ async def test_get_report_rejects_other_user(db_session, _isolated_data_dir) -> 
 @pytest.mark.asyncio
 async def test_lint_report_by_id_endpoint(client) -> None:
     """GET /lint/reports/{report_id} returns 404 when report missing."""
-    response = await client.get("/lint/reports/nonexistent")
+    response = await client.get("/api/lint/reports/nonexistent")
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_lint_dismiss_endpoint_returns_404_for_missing(client) -> None:
     """POST /lint/findings/{kind}/{id}/dismiss returns 404 for missing finding."""
-    response = await client.post("/lint/findings/contradiction/nonexistent/dismiss")
+    response = await client.post("/api/lint/findings/contradiction/nonexistent/dismiss")
     assert response.status_code == 404

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -97,14 +97,14 @@ async def test_emit_helpers() -> None:
 
 
 async def test_settings_get_all(client) -> None:
-    resp = await client.get("/settings")
+    resp = await client.get("/api/settings")
     assert resp.status_code == 200
     assert "llm" in resp.json()
 
 
 async def test_settings_test_llm_error(client) -> None:
     # No API key configured -> raises -> caught -> error status
-    resp = await client.post("/settings/llm/test", params={"provider": "anthropic"})
+    resp = await client.post("/api/settings/llm/test", params={"provider": "anthropic"})
     assert resp.status_code == 200
     assert resp.json()["status"] in ("ok", "error")
 
@@ -130,7 +130,7 @@ async def test_settings_test_llm_uses_provider_safe_token_budget(client) -> None
             )
 
     with patch("wikimind.api.routes.settings.get_llm_router", return_value=_Router()):
-        resp = await client.post("/settings/llm/test", params={"provider": "openai_compatible"})
+        resp = await client.post("/api/settings/llm/test", params={"provider": "openai_compatible"})
 
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
@@ -140,7 +140,7 @@ async def test_settings_test_llm_uses_provider_safe_token_budget(client) -> None
 async def test_settings_get_cost(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     with patch("wikimind.api.routes.settings.get_session_factory", return_value=factory):
-        resp = await client.get("/settings/llm/cost")
+        resp = await client.get("/api/settings/llm/cost")
     assert resp.status_code == 200
     assert "cost_this_month_usd" in resp.json()
 

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -61,7 +61,7 @@ async def test_onboarding_status_default(client) -> None:
     session_factory = _make_multi_call_session_factory([None, None])
 
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings/onboarding-status")
+        resp = await client.get("/api/settings/onboarding-status")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -76,7 +76,7 @@ async def test_onboarding_status_completed(client) -> None:
     session_factory = _make_multi_call_session_factory([completed_pref, step_pref])
 
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings/onboarding-status")
+        resp = await client.get("/api/settings/onboarding-status")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -94,7 +94,7 @@ async def test_complete_onboarding(client) -> None:
     session_factory, _session = _make_session_with_pref(None)
 
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.post("/settings/onboarding-status")
+        resp = await client.post("/api/settings/onboarding-status")
 
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/unit/test_recompile.py
+++ b/tests/unit/test_recompile.py
@@ -36,7 +36,7 @@ async def test_recompile_source_article(client: AsyncClient, db_session: AsyncSe
         mock_compiler = mock_bc.return_value
         mock_compiler.schedule_recompile = AsyncMock(return_value="job-1")
 
-        response = await client.post(f"/wiki/articles/{article.id}/recompile")
+        response = await client.post(f"/api/wiki/articles/{article.id}/recompile")
 
     assert response.status_code == 200
     data = response.json()
@@ -47,7 +47,7 @@ async def test_recompile_source_article(client: AsyncClient, db_session: AsyncSe
 async def test_recompile_missing_article(client: AsyncClient) -> None:
     """POST recompile for a non-existent article returns 404."""
     fake_id = str(uuid.uuid4())
-    response = await client.post(f"/wiki/articles/{fake_id}/recompile")
+    response = await client.post(f"/api/wiki/articles/{fake_id}/recompile")
     assert response.status_code == 404
 
 
@@ -68,7 +68,7 @@ async def test_recompile_concept_article(client: AsyncClient, db_session: AsyncS
         mock_compiler = mock_bc.return_value
         mock_compiler.schedule_recompile = AsyncMock(return_value="job-1")
 
-        response = await client.post(f"/wiki/articles/{article.id}/recompile")
+        response = await client.post(f"/api/wiki/articles/{article.id}/recompile")
 
     assert response.status_code == 200
     data = response.json()
@@ -93,7 +93,7 @@ async def test_recompile_explicit_mode(client: AsyncClient, db_session: AsyncSes
         mock_compiler = mock_bc.return_value
         mock_compiler.schedule_recompile = AsyncMock(return_value="job-1")
 
-        response = await client.post(f"/wiki/articles/{article.id}/recompile?mode=source")
+        response = await client.post(f"/api/wiki/articles/{article.id}/recompile?mode=source")
 
     assert response.status_code == 200
     # Verify the background compiler was called with mode="source"
@@ -114,5 +114,5 @@ async def test_recompile_invalid_mode(client: AsyncClient, db_session: AsyncSess
     db_session.add(article)
     await db_session.commit()
 
-    response = await client.post(f"/wiki/articles/{article.id}/recompile?mode=invalid")
+    response = await client.post(f"/api/wiki/articles/{article.id}/recompile?mode=invalid")
     assert response.status_code == 422

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -145,7 +145,7 @@ async def test_ingest_route_text_auto_compile_false_skips_schedule(client) -> No
         schedule_compile = AsyncMock(return_value="job-r1")
         gbc.return_value.schedule_compile = schedule_compile
         resp = await client.post(
-            "/ingest/text",
+            "/api/ingest/text",
             json={"content": "hello", "title": "x", "auto_compile": False},
         )
     assert resp.status_code == 200
@@ -164,7 +164,7 @@ async def test_ingest_route_url_auto_compile_false_skips_schedule(client) -> Non
         schedule_compile = AsyncMock(return_value="job-r2")
         gbc.return_value.schedule_compile = schedule_compile
         resp = await client.post(
-            "/ingest/url",
+            "/api/ingest/url",
             json={"url": "http://x", "auto_compile": False},
         )
     assert resp.status_code == 200
@@ -183,7 +183,7 @@ async def test_ingest_route_pdf_auto_compile_false_skips_schedule(client) -> Non
         schedule_compile = AsyncMock(return_value="job-r3")
         gbc.return_value.schedule_compile = schedule_compile
         resp = await client.post(
-            "/ingest/pdf?auto_compile=false",
+            "/api/ingest/pdf?auto_compile=false",
             files={"file": ("doc.pdf", b"%PDF-1.4...", "application/pdf")},
         )
     assert resp.status_code == 200

--- a/tests/unit/test_source_content.py
+++ b/tests/unit/test_source_content.py
@@ -66,7 +66,7 @@ async def test_content_endpoint_returns_text(tmp_path: Path, source_with_content
     try:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/ingest/sources/src-abc/content")
+            resp = await client.get("/api/ingest/sources/src-abc/content")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)
@@ -91,7 +91,7 @@ async def test_content_endpoint_404_when_source_not_found() -> None:
     try:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/ingest/sources/nonexistent/content")
+            resp = await client.get("/api/ingest/sources/nonexistent/content")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)
@@ -112,7 +112,7 @@ async def test_content_endpoint_404_when_wrong_user() -> None:
     try:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/ingest/sources/src-abc/content")
+            resp = await client.get("/api/ingest/sources/src-abc/content")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)
@@ -139,7 +139,7 @@ async def test_content_endpoint_passes_user_id() -> None:
     try:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/ingest/sources/src-abc/content")
+            resp = await client.get("/api/ingest/sources/src-abc/content")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -152,7 +152,7 @@ async def test_refresh_endpoint(client, async_engine):
         )
         await session.commit()
 
-    response = await client.post("/wiki/articles/api-refresh-test/refresh")
+    response = await client.post("/api/wiki/articles/api-refresh-test/refresh")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "refreshed"
@@ -163,7 +163,7 @@ async def test_refresh_endpoint(client, async_engine):
 @pytest.mark.asyncio
 async def test_refresh_endpoint_not_found(client):
     """POST /wiki/articles/{slug}/refresh for missing article returns 404."""
-    response = await client.post("/wiki/articles/does-not-exist/refresh")
+    response = await client.post("/api/wiki/articles/does-not-exist/refresh")
     assert response.status_code == 404
 
 
@@ -189,7 +189,7 @@ async def test_list_articles_includes_staleness(client, async_engine):
         )
         await session.commit()
 
-    response = await client.get("/wiki/articles")
+    response = await client.get("/api/wiki/articles")
     assert response.status_code == 200
     data = response.json()
     assert len(data) >= 1

--- a/tests/unit/test_user_preference.py
+++ b/tests/unit/test_user_preference.py
@@ -93,7 +93,7 @@ async def test_set_default_provider_valid(client) -> None:
             patch.object(settings_mod, "get_session_factory", return_value=session_factory),
             patch.object(settings_mod, "get_api_key", return_value="sk-fake"),
         ):
-            resp = await client.post("/settings/llm/default-provider", json={"provider": "anthropic"})
+            resp = await client.post("/api/settings/llm/default-provider", json={"provider": "anthropic"})
     finally:
         settings.llm.anthropic.enabled = original_enabled
 
@@ -105,7 +105,7 @@ async def test_set_default_provider_valid(client) -> None:
 
 async def test_set_default_provider_invalid(client) -> None:
     """Sending an unknown provider name returns 400."""
-    resp = await client.post("/settings/llm/default-provider", json={"provider": "nonexistent"})
+    resp = await client.post("/api/settings/llm/default-provider", json={"provider": "nonexistent"})
     assert resp.status_code == 400
     assert "Unknown provider" in resp.json()["detail"]
 
@@ -113,7 +113,7 @@ async def test_set_default_provider_invalid(client) -> None:
 async def test_set_default_provider_not_enabled(client) -> None:
     """Requesting a known but disabled provider returns 400."""
     # mock provider is disabled by default (enabled=False in MockConfig)
-    resp = await client.post("/settings/llm/default-provider", json={"provider": "mock"})
+    resp = await client.post("/api/settings/llm/default-provider", json={"provider": "mock"})
     assert resp.status_code == 400
     assert "not enabled" in resp.json()["detail"]
 
@@ -128,7 +128,7 @@ async def test_patch_budget(client) -> None:
     session_factory, _ = _make_session_with_pref(None)
 
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.patch("/settings", json={"monthly_budget_usd": 99.5})
+        resp = await client.patch("/api/settings", json={"monthly_budget_usd": 99.5})
 
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
@@ -136,7 +136,7 @@ async def test_patch_budget(client) -> None:
 
 async def test_patch_budget_invalid(client) -> None:
     """A non-positive budget value returns 400."""
-    resp = await client.patch("/settings", json={"monthly_budget_usd": -1.0})
+    resp = await client.patch("/api/settings", json={"monthly_budget_usd": -1.0})
     assert resp.status_code == 400
     assert "positive" in resp.json()["detail"]
 
@@ -146,7 +146,7 @@ async def test_patch_fallback(client) -> None:
     session_factory, _ = _make_session_with_pref(None)
 
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.patch("/settings", json={"fallback_enabled": False})
+        resp = await client.patch("/api/settings", json={"fallback_enabled": False})
 
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
@@ -163,7 +163,7 @@ async def test_patch_openai_compatible_runtime_config(client) -> None:
     try:
         with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
             resp = await client.patch(
-                "/settings",
+                "/api/settings",
                 json={
                     "openai_compatible_base_url": "https://openrouter.ai/api/v1/",
                     "openai_compatible_model": "openai/gpt-4o-mini",
@@ -186,7 +186,7 @@ async def test_patch_openai_compatible_runtime_config(client) -> None:
 
 async def test_patch_openai_compatible_rejects_invalid_base_url(client) -> None:
     """OpenAI-compatible base URLs must be absolute HTTP(S) URLs."""
-    resp = await client.patch("/settings", json={"openai_compatible_base_url": "openrouter.ai/api/v1"})
+    resp = await client.patch("/api/settings", json={"openai_compatible_base_url": "openrouter.ai/api/v1"})
     assert resp.status_code == 400
     assert "base URL" in resp.json()["detail"]
 
@@ -224,7 +224,7 @@ async def test_patch_openai_compatible_runtime_config_rejected_when_auth_enabled
     )
 
     resp = await client.patch(
-        "/settings",
+        "/api/settings",
         json=payload,
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -235,7 +235,7 @@ async def test_patch_openai_compatible_runtime_config_rejected_when_auth_enabled
 
 async def test_patch_openai_compatible_rejects_invalid_reasoning_format(client) -> None:
     """OpenAI-compatible reasoning format must be one of the supported payload styles."""
-    resp = await client.patch("/settings", json={"openai_compatible_reasoning_format": "custom"})
+    resp = await client.patch("/api/settings", json={"openai_compatible_reasoning_format": "custom"})
     assert resp.status_code == 400
     assert "reasoning format" in resp.json()["detail"]
 
@@ -255,7 +255,7 @@ async def test_get_settings_reflects_overrides(client) -> None:
     session_factory = _make_multi_call_session_factory([provider_pref, budget_pref, fallback_pref])
 
     with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-        resp = await client.get("/settings")
+        resp = await client.get("/api/settings")
 
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/unit/test_view_original.py
+++ b/tests/unit/test_view_original.py
@@ -62,7 +62,7 @@ async def test_original_endpoint_streams_pdf(tmp_path: Path, source_with_pdf: So
         ):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                resp = await client.get("/ingest/sources/src-pdf/original")
+                resp = await client.get("/api/ingest/sources/src-pdf/original")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)
@@ -89,7 +89,7 @@ async def test_original_endpoint_404_for_text_source(tmp_path: Path, source_text
         ):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                resp = await client.get("/ingest/sources/src-text/original")
+                resp = await client.get("/api/ingest/sources/src-text/original")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)
@@ -117,7 +117,7 @@ async def test_original_endpoint_passes_user_id(tmp_path: Path, source_with_pdf:
         ):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                resp = await client.get("/ingest/sources/src-pdf/original")
+                resp = await client.get("/api/ingest/sources/src-pdf/original")
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_ingest_service, None)

--- a/tests/unit/test_wiki_routes.py
+++ b/tests/unit/test_wiki_routes.py
@@ -58,7 +58,7 @@ async def test_graph_no_filters_returns_all_edges(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph")
+    response = await client.get("/api/wiki/graph")
     assert response.status_code == 200
     data = response.json()
     assert len(data["nodes"]) == 3
@@ -70,7 +70,7 @@ async def test_graph_filter_by_relation_type(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"relation_type": "contradicts"})
+    response = await client.get("/api/wiki/graph", params={"relation_type": "contradicts"})
     assert response.status_code == 200
     data = response.json()
     edges = data["edges"]
@@ -85,7 +85,7 @@ async def test_graph_filter_by_from_article_id(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"from_article": "a1"})
+    response = await client.get("/api/wiki/graph", params={"from_article": "a1"})
     assert response.status_code == 200
     data = response.json()
     edges = data["edges"]
@@ -98,7 +98,7 @@ async def test_graph_filter_by_from_article_slug(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"from_article": "art-a"})
+    response = await client.get("/api/wiki/graph", params={"from_article": "art-a"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["edges"]) == 2
@@ -109,7 +109,7 @@ async def test_graph_filter_by_to_article(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"to_article": "a3"})
+    response = await client.get("/api/wiki/graph", params={"to_article": "a3"})
     assert response.status_code == 200
     data = response.json()
     edges = data["edges"]
@@ -124,7 +124,7 @@ async def test_graph_filters_compose_with_and(client, async_engine) -> None:
 
     # from a1 AND relation_type contradicts → only a1->a3.
     response = await client.get(
-        "/wiki/graph",
+        "/api/wiki/graph",
         params={"from_article": "a1", "relation_type": "contradicts"},
     )
     assert response.status_code == 200
@@ -141,7 +141,7 @@ async def test_graph_unknown_from_article_returns_empty(client, async_engine) ->
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"from_article": "no-such-thing"})
+    response = await client.get("/api/wiki/graph", params={"from_article": "no-such-thing"})
     assert response.status_code == 200
     data = response.json()
     assert data["edges"] == []
@@ -153,7 +153,7 @@ async def test_graph_invalid_relation_type_is_422(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"relation_type": "bogus"})
+    response = await client.get("/api/wiki/graph", params={"relation_type": "bogus"})
     assert response.status_code == 422
 
 
@@ -162,7 +162,7 @@ async def test_relationships_endpoint_groups_by_direction_and_type(client, async
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/articles/a1/relationships")
+    response = await client.get("/api/wiki/articles/a1/relationships")
     assert response.status_code == 200
     data = response.json()
 
@@ -187,7 +187,7 @@ async def test_relationships_endpoint_resolves_slug(client, async_engine) -> Non
     await _seed_three_article_graph(factory)
 
     # a3 has two incoming (a1 contradicts, a2 supersedes) and no outgoing.
-    response = await client.get("/wiki/articles/art-c/relationships")
+    response = await client.get("/api/wiki/articles/art-c/relationships")
     assert response.status_code == 200
     data = response.json()
     assert data["outgoing"] == {}
@@ -198,7 +198,7 @@ async def test_relationships_endpoint_resolves_slug(client, async_engine) -> Non
 
 @pytest.mark.asyncio
 async def test_relationships_endpoint_404_when_missing(client) -> None:
-    response = await client.get("/wiki/articles/does-not-exist/relationships")
+    response = await client.get("/api/wiki/articles/does-not-exist/relationships")
     assert response.status_code == 404
 
 
@@ -207,7 +207,7 @@ async def test_graph_unknown_to_article_returns_empty(client, async_engine) -> N
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"to_article": "no-such-thing"})
+    response = await client.get("/api/wiki/graph", params={"to_article": "no-such-thing"})
     assert response.status_code == 200
     data = response.json()
     assert data["edges"] == []
@@ -219,7 +219,7 @@ async def test_graph_filter_by_to_article_slug(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_three_article_graph(factory)
 
-    response = await client.get("/wiki/graph", params={"to_article": "art-c"})
+    response = await client.get("/api/wiki/graph", params={"to_article": "art-c"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["edges"]) == 2


### PR DESCRIPTION
## Summary

All API routes were mounted at the root path (`/ingest/text`, `/wiki/articles`, `/settings`, etc.), causing route collisions with the SPA's client-side routes and preventing clean API versioning.

This PR moves all API routes under an `/api` prefix by mounting sub-routers through a single `APIRouter(prefix="/api")`. Health, auth, and WebSocket endpoints remain at root level since they serve infrastructure concerns and OAuth redirect flows.

**Changes:**
- **`src/wikimind/main.py`** -- Created `api_router = APIRouter(prefix="/api")` that aggregates ingest, wiki, query, jobs, lint, settings, api-keys, admin, and export routers. Auth (`/auth/*`), WebSocket (`/ws`), and health (`/health`) stay at root.
- **`apps/web/src/api/*.ts`** -- Updated all 6 frontend API client modules (wiki, sources, query, settings, lint, auth) to use `/api/` prefix on route paths.
- **28 test files** -- Updated all HTTP client route assertions across unit, integration, and smoke tests.
- **`docs/openapi.yaml`** -- Auto-regenerated to reflect new path structure.

## Test plan

- [x] All 1167 unit + integration tests pass
- [x] mypy: no type errors
- [x] ruff format: no changes needed
- [x] OpenAPI spec regenerated and in sync
- [x] Manual verification: `/api/wiki/articles` returns 200, old `/wiki/articles` returns 404
- [x] `/health`, `/auth/me`, `/docs` remain at root (200)
- [x] Playwright screenshots confirm SPA loads

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)