### PR TITLE
feat: tags and saved searches for user-asserted organization (#454)

### DIFF
--- a/apps/web/src/api/tags.ts
+++ b/apps/web/src/api/tags.ts
@@ -1,0 +1,102 @@
+// Endpoints for tags and saved searches (issue #454).
+
+import { apiFetch } from "./client";
+
+export interface TagResponse {
+  id: string;
+  name: string;
+  color: string;
+  created_at: string;
+}
+
+export interface SavedSearchResponse {
+  id: string;
+  name: string;
+  query: string;
+  filters_json: string;
+  created_at: string;
+}
+
+export interface SavedSearchExecuteResponse {
+  saved_search: SavedSearchResponse;
+  articles: unknown[];
+}
+
+// --- Tag CRUD ---
+
+export function createTag(
+  name: string,
+  color: string = "#6366f1",
+): Promise<TagResponse> {
+  return apiFetch<TagResponse>("/tags", {
+    method: "POST",
+    body: { name, color },
+  });
+}
+
+export function listTags(): Promise<TagResponse[]> {
+  return apiFetch<TagResponse[]>("/tags");
+}
+
+export function deleteTag(tagId: string): Promise<void> {
+  return apiFetch<void>(`/tags/${tagId}`, { method: "DELETE" });
+}
+
+// --- Article tagging ---
+
+export function tagArticle(
+  articleId: string,
+  tagId: string,
+): Promise<{ article_id: string; tag_id: string }> {
+  return apiFetch(`/wiki/articles/${articleId}/tags`, {
+    method: "POST",
+    body: { tag_id: tagId },
+  });
+}
+
+export function untagArticle(
+  articleId: string,
+  tagId: string,
+): Promise<void> {
+  return apiFetch<void>(`/wiki/articles/${articleId}/tags/${tagId}`, {
+    method: "DELETE",
+  });
+}
+
+export function getArticleTags(articleId: string): Promise<TagResponse[]> {
+  return apiFetch<TagResponse[]>(`/wiki/articles/${articleId}/tags`);
+}
+
+export function getArticlesByTag(tagId: string): Promise<unknown[]> {
+  return apiFetch<unknown[]>(`/tags/${tagId}/articles`);
+}
+
+// --- Saved searches ---
+
+export function createSavedSearch(
+  name: string,
+  query: string = "",
+  filtersJson: string = "{}",
+): Promise<SavedSearchResponse> {
+  return apiFetch<SavedSearchResponse>("/saved-searches", {
+    method: "POST",
+    body: { name, query, filters_json: filtersJson },
+  });
+}
+
+export function listSavedSearches(): Promise<SavedSearchResponse[]> {
+  return apiFetch<SavedSearchResponse[]>("/saved-searches");
+}
+
+export function deleteSavedSearch(id: string): Promise<void> {
+  return apiFetch<void>(`/saved-searches/${id}`, { method: "DELETE" });
+}
+
+export function executeSavedSearch(
+  id: string,
+): Promise<SavedSearchExecuteResponse> {
+  return apiFetch<SavedSearchExecuteResponse>(
+    `/saved-searches/${id}/execute`,
+    { method: "POST" },
+  );
+}

--- a/apps/web/src/components/shared/TagPill.tsx
+++ b/apps/web/src/components/shared/TagPill.tsx
@@ -1,0 +1,59 @@
+interface TagPillProps {
+  name: string;
+  color: string;
+  onRemove?: () => void;
+  onClick?: () => void;
+  className?: string;
+}
+
+/**
+ * Pill-shaped badge for user tags. Renders with the tag's chosen color
+ * as a left border accent and a subtle tinted background.
+ */
+export function TagPill({
+  name,
+  color,
+  onRemove,
+  onClick,
+  className = "",
+}: TagPillProps) {
+  const bgColor = `${color}18`; // ~10% opacity hex suffix
+
+  return (
+    <span
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") onClick();
+            }
+          : undefined
+      }
+      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+        onClick ? "cursor-pointer hover:opacity-80" : ""
+      } ${className}`}
+      style={{
+        borderColor: color,
+        backgroundColor: bgColor,
+        color: color,
+      }}
+    >
+      {name}
+      {onRemove ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="ml-0.5 opacity-60 hover:opacity-100"
+          aria-label={`Remove tag ${name}`}
+        >
+          x
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -11,6 +11,7 @@ import { editArticle } from "../../api/wiki";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 import { PageTypeIndicator } from "./PageTypeIndicator";
 import { Badge } from "../shared/Badge";
+import { TagSelector } from "./TagSelector";
 
 interface ArticleReaderProps {
   article: ArticleResponse;
@@ -152,6 +153,13 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
               {concept}
             </Badge>
           ))}
+        </div>
+        <div className="mt-2">
+          <TagSelector
+            articleId={article.id}
+            currentTags={article.tags ?? []}
+            onTagsChanged={onArticleUpdated ? () => onArticleUpdated(article) : undefined}
+          />
         </div>
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold tracking-tight text-slate-900">

--- a/apps/web/src/components/wiki/SavedSearches.tsx
+++ b/apps/web/src/components/wiki/SavedSearches.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createSavedSearch,
+  deleteSavedSearch,
+  listSavedSearches,
+} from "../../api/tags";
+
+interface SavedSearchesProps {
+  onExecute: (searchId: string) => void;
+}
+
+export function SavedSearches({ onExecute }: SavedSearchesProps) {
+  const queryClient = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+  const [name, setName] = useState("");
+  const [query, setQuery] = useState("");
+
+  const { data: searches = [] } = useQuery({
+    queryKey: ["saved-searches"],
+    queryFn: listSavedSearches,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => createSavedSearch(name.trim(), query.trim()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
+      setName("");
+      setQuery("");
+      setShowCreate(false);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSavedSearch(id),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["saved-searches"] }),
+  });
+
+  return (
+    <div className="border-t border-slate-200 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+          Saved Searches
+        </h3>
+        <button
+          type="button"
+          onClick={() => setShowCreate(!showCreate)}
+          className="text-xs text-slate-400 hover:text-slate-700"
+          title="Create a saved search"
+        >
+          +
+        </button>
+      </div>
+
+      {showCreate ? (
+        <div className="mb-2 space-y-1.5 rounded border border-slate-200 bg-slate-50 p-2">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Search name"
+            className="w-full rounded border border-slate-200 px-2 py-1 text-xs focus:border-brand-400 focus:outline-none"
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search query"
+            className="w-full rounded border border-slate-200 px-2 py-1 text-xs focus:border-brand-400 focus:outline-none"
+          />
+          <div className="flex gap-1">
+            <button
+              type="button"
+              disabled={!name.trim()}
+              onClick={() => createMutation.mutate()}
+              className="rounded bg-brand-600 px-2 py-0.5 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-40"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowCreate(false)}
+              className="rounded border border-slate-200 px-2 py-0.5 text-xs text-slate-600 hover:bg-slate-100"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {searches.length === 0 ? (
+        <p className="text-xs text-slate-400">No saved searches yet.</p>
+      ) : (
+        <ul className="space-y-0.5">
+          {searches.map((s) => (
+            <li
+              key={s.id}
+              className="group flex items-center justify-between rounded px-2 py-1 text-sm text-slate-600 hover:bg-slate-100"
+            >
+              <button
+                type="button"
+                onClick={() => onExecute(s.id)}
+                className="flex-1 truncate text-left text-xs"
+                title={`Query: ${s.query || "(all)"}`}
+              >
+                {s.name}
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(s.id)}
+                className="ml-1 hidden text-xs text-slate-400 hover:text-rose-500 group-hover:block"
+                aria-label={`Delete saved search ${s.name}`}
+              >
+                x
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/TagSelector.tsx
+++ b/apps/web/src/components/wiki/TagSelector.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { TagRef } from "../../types/api";
+import { createTag, listTags, tagArticle, untagArticle } from "../../api/tags";
+import { TagPill } from "../shared/TagPill";
+
+const PRESET_COLORS = [
+  "#6366f1", // indigo
+  "#ef4444", // red
+  "#f59e0b", // amber
+  "#22c55e", // green
+  "#3b82f6", // blue
+  "#a855f7", // purple
+  "#ec4899", // pink
+  "#14b8a6", // teal
+  "#f97316", // orange
+  "#64748b", // slate
+];
+
+interface TagSelectorProps {
+  articleId: string;
+  currentTags: TagRef[];
+  onTagsChanged?: () => void;
+}
+
+export function TagSelector({
+  articleId,
+  currentTags,
+  onTagsChanged,
+}: TagSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [newTagName, setNewTagName] = useState("");
+  const [selectedColor, setSelectedColor] = useState(PRESET_COLORS[0]);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+
+  const { data: allTags = [] } = useQuery({
+    queryKey: ["tags"],
+    queryFn: listTags,
+  });
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () =>
+      document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const currentTagIds = new Set(currentTags.map((t) => t.id));
+  const availableTags = allTags.filter((t) => !currentTagIds.has(t.id));
+
+  const invalidateTags = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["tags"] });
+    onTagsChanged?.();
+  }, [queryClient, onTagsChanged]);
+
+  const addTagMutation = useMutation({
+    mutationFn: (tagId: string) => tagArticle(articleId, tagId),
+    onSuccess: invalidateTags,
+  });
+
+  const removeTagMutation = useMutation({
+    mutationFn: (tagId: string) => untagArticle(articleId, tagId),
+    onSuccess: invalidateTags,
+  });
+
+  const createAndAddMutation = useMutation({
+    mutationFn: async () => {
+      const tag = await createTag(newTagName.trim(), selectedColor);
+      await tagArticle(articleId, tag.id);
+      return tag;
+    },
+    onSuccess: () => {
+      setNewTagName("");
+      invalidateTags();
+    },
+  });
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {currentTags.map((tag) => (
+        <TagPill
+          key={tag.id}
+          name={tag.name}
+          color={tag.color}
+          onRemove={() => removeTagMutation.mutate(tag.id)}
+        />
+      ))}
+
+      <div className="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          onClick={() => setIsOpen(!isOpen)}
+          className="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 px-2.5 py-0.5 text-xs text-slate-500 hover:border-slate-400 hover:text-slate-700"
+        >
+          + Tag
+        </button>
+
+        {isOpen ? (
+          <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-md border border-slate-200 bg-white p-2 shadow-lg">
+            {availableTags.length > 0 ? (
+              <div className="mb-2">
+                <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+                  Existing tags
+                </p>
+                <div className="flex flex-wrap gap-1">
+                  {availableTags.map((tag) => (
+                    <TagPill
+                      key={tag.id}
+                      name={tag.name}
+                      color={tag.color}
+                      onClick={() => {
+                        addTagMutation.mutate(tag.id);
+                        setIsOpen(false);
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="border-t border-slate-100 pt-2">
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+                Create new
+              </p>
+              <input
+                type="text"
+                value={newTagName}
+                onChange={(e) => setNewTagName(e.target.value)}
+                placeholder="Tag name"
+                className="mb-1.5 w-full rounded border border-slate-200 px-2 py-1 text-xs focus:border-brand-400 focus:outline-none"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && newTagName.trim()) {
+                    createAndAddMutation.mutate();
+                    setIsOpen(false);
+                  }
+                }}
+              />
+              <div className="mb-1.5 flex flex-wrap gap-1">
+                {PRESET_COLORS.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setSelectedColor(c)}
+                    className={`h-4 w-4 rounded-full border-2 ${
+                      selectedColor === c
+                        ? "border-slate-800"
+                        : "border-transparent"
+                    }`}
+                    style={{ backgroundColor: c }}
+                    aria-label={`Select color ${c}`}
+                  />
+                ))}
+              </div>
+              <button
+                type="button"
+                disabled={!newTagName.trim()}
+                onClick={() => {
+                  createAndAddMutation.mutate();
+                  setIsOpen(false);
+                }}
+                className="w-full rounded bg-brand-600 px-2 py-1 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-40"
+              >
+                Create & Add
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/WikiExplorerView.tsx
+++ b/apps/web/src/components/wiki/WikiExplorerView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { executeSavedSearch } from "../../api/tags";
 import { useArticle } from "../../hooks/useArticle";
 import { getRandomArticle } from "../../api/wiki";
 import { Spinner } from "../shared/Spinner";
@@ -10,6 +11,7 @@ import { ArticleReader } from "./ArticleReader";
 import { BacklinkPanel } from "./BacklinkPanel";
 import { ConceptTree } from "./ConceptTree";
 import { FiguresPanel } from "./FiguresPanel";
+import { SavedSearches } from "./SavedSearches";
 import { SearchBar } from "./SearchBar";
 import { SourcePanel } from "./SourcePanel";
 
@@ -22,6 +24,12 @@ export function WikiExplorerView() {
   const [figureCount, setFigureCount] = useState(0);
   const navigate = useNavigate();
   const [showSources, setShowSources] = useState(false);
+  const executeSavedSearchMutation = useMutation({
+    mutationFn: (searchId: string) => executeSavedSearch(searchId),
+    onSuccess: () => {
+      setActiveConcept(null);
+    },
+  });
 
   const hasSources =
     articleQuery.data?.sources && articleQuery.data.sources.length > 0;
@@ -110,6 +118,9 @@ export function WikiExplorerView() {
               activeConcept={activeConcept}
               onSelectConcept={setActiveConcept}
             />
+            <SavedSearches
+              onExecute={(id) => executeSavedSearchMutation.mutate(id)}
+            />
           </aside>
 
           <section className="overflow-y-auto bg-slate-50">
@@ -171,6 +182,9 @@ export function WikiExplorerView() {
             <ConceptTree
               activeConcept={activeConcept}
               onSelectConcept={setActiveConcept}
+            />
+            <SavedSearches
+              onExecute={(id) => executeSavedSearchMutation.mutate(id)}
             />
           </aside>
 

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -58,6 +58,13 @@ export interface SourceContentResponse {
   title: string | null;
 }
 
+export interface TagRef {
+  id: string;
+  name: string;
+  color: string;
+  created_at: string;
+}
+
 export interface Article {
   id: string;
   slug: string;
@@ -70,6 +77,7 @@ export interface Article {
   backlink_count: number;
   created_at: string;
   updated_at: string;
+  tags?: TagRef[];
 }
 
 export interface BacklinkEntry {
@@ -94,6 +102,7 @@ export interface ArticleResponse extends Article {
   backlinks_in: BacklinkEntry[];
   backlinks_out: BacklinkEntry[];
   concepts: string[];
+  tags: TagRef[];
   sources: ArticleSourceRef[];
   manually_edited: boolean;
   edited_at: string | null;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WikiMind Gateway
-  description: Local LLM Knowledge OS — Personal API
+  description: "Local LLM Knowledge OS \u2014 Personal API"
   version: 0.1.0
 paths:
   /api/ingest/url:
@@ -223,12 +223,9 @@ paths:
       tags:
       - Ingest
       summary: Get Source Original
-      description: 'Stream the original source document (PDF, HTML, etc.).
-
-
-        Returns the raw binary stored during ingest — not the extracted text.
-
-        Sources that have no original (text, YouTube) return 404.'
+      description: "Stream the original source document (PDF, HTML, etc.).\n\nReturns\
+        \ the raw binary stored during ingest \u2014 not the extracted text.\nSources\
+        \ that have no original (text, YouTube) return 404."
       operationId: get_source_original_api_ingest_sources__source_id__original_get
       parameters:
       - name: source_id
@@ -530,20 +527,11 @@ paths:
       tags:
       - Wiki
       summary: Get Graph
-      description: 'Full knowledge graph -- nodes and edges.
-
-
-        Optional query parameters filter the returned edge set:
-
-
-        * ``relation_type`` — keep only edges of one semantic relation type.
-
-        * ``from_article`` — id or slug of the source article.
-
-        * ``to_article`` — id or slug of the target article.
-
-
-        Filters compose with AND. Filtering is pushed down into SQL.'
+      description: "Full knowledge graph -- nodes and edges.\n\nOptional query parameters\
+        \ filter the returned edge set:\n\n* ``relation_type`` \u2014 keep only edges\
+        \ of one semantic relation type.\n* ``from_article`` \u2014 id or slug of\
+        \ the source article.\n* ``to_article`` \u2014 id or slug of the target article.\n\
+        \nFilters compose with AND. Filtering is pushed down into SQL."
       operationId: get_graph_api_wiki_graph_get
       parameters:
       - name: relation_type
@@ -925,6 +913,104 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/articles/{article_id}/tags:
+    post:
+      tags:
+      - Wiki
+      summary: Tag Article
+      description: Apply a tag to an article.
+      operationId: tag_article_api_wiki_articles__article_id__tags_post
+      parameters:
+      - name: article_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Article Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagArticleRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleTagResponse'
+        '404':
+          description: Article or tag not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Wiki
+      summary: Get Article Tags
+      description: Get all tags applied to an article.
+      operationId: get_article_tags_api_wiki_articles__article_id__tags_get
+      parameters:
+      - name: article_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Article Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TagResponse'
+                title: Response Get Article Tags Api Wiki Articles  Article Id  Tags
+                  Get
+        '404':
+          description: Article not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/articles/{article_id}/tags/{tag_id}:
+    delete:
+      tags:
+      - Wiki
+      summary: Untag Article
+      description: Remove a tag from an article.
+      operationId: untag_article_api_wiki_articles__article_id__tags__tag_id__delete
+      parameters:
+      - name: article_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Article Id
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tag Id
+      responses:
+        '204':
+          description: Successful Response
+        '404':
+          description: Tag association not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/query:
     post:
       tags:
@@ -995,7 +1081,8 @@ paths:
       tags:
       - Query
       summary: Query History
-      description: List past queries (legacy endpoint — UI uses /conversations instead).
+      description: "List past queries (legacy endpoint \u2014 UI uses /conversations\
+        \ instead)."
       operationId: query_history_api_query_history_get
       parameters:
       - name: limit
@@ -1602,14 +1689,10 @@ paths:
       tags:
       - Settings
       summary: Get Onboarding Status
-      description: 'Return onboarding wizard progress for the current user.
-
-
-        If the user has never explicitly completed onboarding but already has
-
-        articles in the wiki, treat onboarding as implicitly complete — they
-
-        are clearly past the first-run stage.'
+      description: "Return onboarding wizard progress for the current user.\n\nIf\
+        \ the user has never explicitly completed onboarding but already has\narticles\
+        \ in the wiki, treat onboarding as implicitly complete \u2014 they\nare clearly\
+        \ past the first-run stage."
       operationId: get_onboarding_status_api_settings_onboarding_status_get
       responses:
         '200':
@@ -1810,6 +1893,200 @@ paths:
           description: Article not found
         '422':
           description: Invalid export format
+  /api/tags:
+    get:
+      tags:
+      - Tags
+      summary: List Tags
+      description: List all tags for the current user.
+      operationId: list_tags_api_tags_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TagResponse'
+                type: array
+                title: Response List Tags Api Tags Get
+    post:
+      tags:
+      - Tags
+      summary: Create Tag
+      description: Create a new user tag.
+      operationId: create_tag_api_tags_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTagRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/tags/{tag_id}:
+    delete:
+      tags:
+      - Tags
+      summary: Delete Tag
+      description: Delete a tag and all its article associations.
+      operationId: delete_tag_api_tags__tag_id__delete
+      parameters:
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tag Id
+      responses:
+        '204':
+          description: Successful Response
+        '404':
+          description: Tag not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/tags/{tag_id}/articles:
+    get:
+      tags:
+      - Tags
+      summary: Get Articles By Tag
+      description: Get articles tagged with a specific tag.
+      operationId: get_articles_by_tag_api_tags__tag_id__articles_get
+      parameters:
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tag Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+                title: Response Get Articles By Tag Api Tags  Tag Id  Articles Get
+        '404':
+          description: Tag not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/saved-searches:
+    get:
+      tags:
+      - SavedSearches
+      summary: List Saved Searches
+      description: List all saved searches for the current user.
+      operationId: list_saved_searches_api_saved_searches_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/SavedSearchResponse'
+                type: array
+                title: Response List Saved Searches Api Saved Searches Get
+    post:
+      tags:
+      - SavedSearches
+      summary: Create Saved Search
+      description: Create a new saved search.
+      operationId: create_saved_search_api_saved_searches_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSavedSearchRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedSearchResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/saved-searches/{search_id}:
+    delete:
+      tags:
+      - SavedSearches
+      summary: Delete Saved Search
+      description: Delete a saved search.
+      operationId: delete_saved_search_api_saved_searches__search_id__delete
+      parameters:
+      - name: search_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Search Id
+      responses:
+        '204':
+          description: Successful Response
+        '404':
+          description: Saved search not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/saved-searches/{search_id}/execute:
+    post:
+      tags:
+      - SavedSearches
+      summary: Execute Saved Search
+      description: Execute a saved search and return matching articles.
+      operationId: execute_saved_search_api_saved_searches__search_id__execute_post
+      parameters:
+      - name: search_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Search Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedSearchExecuteResponse'
+        '404':
+          description: Saved search not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /auth/login/{provider}:
     get:
       tags:
@@ -1841,8 +2118,8 @@ paths:
       tags:
       - Auth
       summary: Auth Callback
-      description: Handle OAuth2 callback — exchange code for token, upsert user,
-        set cookie.
+      description: "Handle OAuth2 callback \u2014 exchange code for token, upsert\
+        \ user, set cookie."
       operationId: auth_callback_auth_callback_get
       parameters:
       - name: code
@@ -2042,7 +2319,7 @@ paths:
   /health:
     get:
       summary: Health
-      description: Health check — used by Electron to confirm daemon is ready.
+      description: "Health check \u2014 used by Electron to confirm daemon is ready."
       operationId: health_health_get
       responses:
         '200':
@@ -2232,6 +2509,12 @@ components:
           type: array
           title: Concepts
           default: []
+        tags:
+          items:
+            $ref: '#/components/schemas/TagResponse'
+          type: array
+          title: Tags
+          default: []
         backlinks_in:
           items:
             $ref: '#/components/schemas/BacklinkEntry'
@@ -2305,12 +2588,9 @@ components:
       - source_type
       - title
       title: ArticleSourceSummary
-      description: 'Minimal source descriptor returned with listing/search endpoints.
-
-
-        A lightweight summary used when the full :class:`SourceResponse` is
-
-        overkill — e.g. article list and search result payloads.'
+      description: "Minimal source descriptor returned with listing/search endpoints.\n\
+        \nA lightweight summary used when the full :class:`SourceResponse` is\noverkill\
+        \ \u2014 e.g. article list and search result payloads."
     ArticleSummaryResponse:
       properties:
         id:
@@ -2380,6 +2660,12 @@ components:
           type: array
           title: Concepts
           default: []
+        tags:
+          items:
+            $ref: '#/components/schemas/TagResponse'
+          type: array
+          title: Tags
+          default: []
         source_ids:
           items:
             type: string
@@ -2414,6 +2700,20 @@ components:
         provenance directly in search/listing views without fetching the full
 
         article content.'
+    ArticleTagResponse:
+      properties:
+        article_id:
+          type: string
+          title: Article Id
+        tag_id:
+          type: string
+          title: Tag Id
+      type: object
+      required:
+      - article_id
+      - tag_id
+      title: ArticleTagResponse
+      description: Confirmation that a tag was applied to an article.
     AskResponse:
       properties:
         query:
@@ -2425,8 +2725,8 @@ components:
       - query
       - conversation
       title: AskResponse
-      description: Response shape for POST /query — wraps both the new query and its
-        parent conversation.
+      description: "Response shape for POST /query \u2014 wraps both the new query\
+        \ and its parent conversation."
     BacklinkEntry:
       properties:
         id:
@@ -2784,7 +3084,8 @@ components:
       - updated_at
       - turn_count
       title: ConversationSummary
-      description: Conversation summary for the history sidebar — adds turn count.
+      description: "Conversation summary for the history sidebar \u2014 adds turn\
+        \ count."
     CostBreakdownEntry:
       properties:
         cost_usd:
@@ -2851,6 +3152,42 @@ components:
       - budget_remaining_usd
       title: CostSummaryResponse
       description: Simple cost summary for current month.
+    CreateSavedSearchRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 200
+          minLength: 1
+          title: Name
+        query:
+          type: string
+          title: Query
+          default: ''
+        filters_json:
+          type: string
+          title: Filters Json
+          default: '{}'
+      type: object
+      required:
+      - name
+      title: CreateSavedSearchRequest
+      description: Request to create a saved search.
+    CreateTagRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Name
+        color:
+          type: string
+          title: Color
+          default: '#6366f1'
+      type: object
+      required:
+      - name
+      title: CreateTagRequest
+      description: Request to create a new tag.
     CrystallizeResponse:
       properties:
         article_id:
@@ -3311,13 +3648,10 @@ components:
       - orphan
       - structural
       title: LintFindingKind
-      description: 'Kind of lint finding — maps 1:1 to a detection function AND a
-        table.
-
-
-        Used as the content_hash prefix (so dismiss state is keyed by kind + content)
-
-        and as the discriminator field in the frontend API response union.'
+      description: "Kind of lint finding \u2014 maps 1:1 to a detection function AND\
+        \ a table.\n\nUsed as the content_hash prefix (so dismiss state is keyed by\
+        \ kind + content)\nand as the discriminator field in the frontend API response\
+        \ union."
     LintReport:
       properties:
         id:
@@ -3590,8 +3924,8 @@ components:
       - meta
       - synthesis
       title: PageType
-      description: Type of wiki page — determines compilation pipeline and validation
-        rules.
+      description: "Type of wiki page \u2014 determines compilation pipeline and validation\
+        \ rules."
     ProviderDetail:
       properties:
         enabled:
@@ -3703,15 +4037,10 @@ components:
       - filed_article_id
       - created_at
       title: QueryResponse
-      description: 'Q&A response enriched with a full Answer → Article → Source citation
-        chain.
-
-
-        Mirrors the persisted :class:`Query` record fields while adding a
-
-        resolved ``citations`` list so clients can see which articles were
-
-        used and which original sources those articles came from.'
+      description: "Q&A response enriched with a full Answer \u2192 Article \u2192\
+        \ Source citation chain.\n\nMirrors the persisted :class:`Query` record fields\
+        \ while adding a\nresolved ``citations`` list so clients can see which articles\
+        \ were\nused and which original sources those articles came from."
     RebuildConceptsResponse:
       properties:
         status:
@@ -3851,6 +4180,48 @@ components:
       - resolution
       title: ResolveContradictionResponse
       description: Response after resolving a contradiction.
+    SavedSearchExecuteResponse:
+      properties:
+        saved_search:
+          $ref: '#/components/schemas/SavedSearchResponse'
+        articles:
+          items:
+            $ref: '#/components/schemas/ArticleSummaryResponse'
+          type: array
+          title: Articles
+      type: object
+      required:
+      - saved_search
+      - articles
+      title: SavedSearchExecuteResponse
+      description: Response when executing a saved search.
+    SavedSearchResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        query:
+          type: string
+          title: Query
+        filters_json:
+          type: string
+          title: Filters Json
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - name
+      - query
+      - filters_json
+      - created_at
+      title: SavedSearchResponse
+      description: API response for a saved search.
     SearchResponse:
       properties:
         results:
@@ -4048,7 +4419,7 @@ components:
       - source_type
       - has_original
       title: Source
-      description: Raw ingested source — before compilation.
+      description: "Raw ingested source \u2014 before compilation."
     SourceContentResponse:
       properties:
         content:
@@ -4203,6 +4574,39 @@ components:
       - bucket
       title: SyncSettingsResponse
       description: Cloud sync configuration section.
+    TagArticleRequest:
+      properties:
+        tag_id:
+          type: string
+          title: Tag Id
+      type: object
+      required:
+      - tag_id
+      title: TagArticleRequest
+      description: Request to tag an article.
+    TagResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        color:
+          type: string
+          title: Color
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - name
+      - color
+      - created_at
+      title: TagResponse
+      description: API response for a user tag.
     TokenCreateRequest:
       properties:
         name:
@@ -4340,5 +4744,9 @@ tags:
   description: OAuth2 authentication
 - name: Export
   description: Export wiki articles as PDF, LinkedIn, or slides
+- name: Tags
+  description: User-created organizational tags
+- name: SavedSearches
+  description: Saved searches with tag and concept filters
 - name: WebSocket
   description: Real-time progress streams

--- a/src/wikimind/api/routes/saved_searches.py
+++ b/src/wikimind/api/routes/saved_searches.py
@@ -1,0 +1,90 @@
+"""Endpoints for user-saved searches with tag and concept filters."""
+
+import structlog
+from fastapi import APIRouter, Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.api.deps import get_current_user_id
+from wikimind.database import get_session
+from wikimind.models import (
+    CreateSavedSearchRequest,
+    SavedSearchExecuteResponse,
+    SavedSearchResponse,
+)
+from wikimind.services.saved_searches import SavedSearchService, get_saved_search_service
+from wikimind.services.wiki import WikiService, get_wiki_service
+
+log = structlog.get_logger()
+
+router = APIRouter()
+
+
+@router.post("", response_model=SavedSearchResponse, status_code=201)
+async def create_saved_search(
+    body: CreateSavedSearchRequest,
+    session: AsyncSession = Depends(get_session),
+    service: SavedSearchService = Depends(get_saved_search_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Create a new saved search."""
+    return await service.create(
+        session,
+        user_id=user_id,
+        name=body.name,
+        query=body.query,
+        filters_json=body.filters_json,
+    )
+
+
+@router.get("", response_model=list[SavedSearchResponse])
+async def list_saved_searches(
+    session: AsyncSession = Depends(get_session),
+    service: SavedSearchService = Depends(get_saved_search_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """List all saved searches for the current user."""
+    return await service.list_searches(session, user_id=user_id)
+
+
+@router.delete(
+    "/{search_id}",
+    status_code=204,
+    responses={404: {"description": "Saved search not found"}},
+)
+async def delete_saved_search(
+    search_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: SavedSearchService = Depends(get_saved_search_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Delete a saved search."""
+    await service.delete(session, search_id=search_id, user_id=user_id)
+
+
+@router.post(
+    "/{search_id}/execute",
+    response_model=SavedSearchExecuteResponse,
+    responses={404: {"description": "Saved search not found"}},
+)
+async def execute_saved_search(
+    search_id: str,
+    session: AsyncSession = Depends(get_session),
+    search_service: SavedSearchService = Depends(get_saved_search_service),
+    wiki_service: WikiService = Depends(get_wiki_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Execute a saved search and return matching articles."""
+    saved_response, article_ids = await search_service.execute(
+        session,
+        search_id=search_id,
+        user_id=user_id,
+    )
+    articles = await wiki_service.list_articles(
+        session,
+        user_id=user_id,
+        article_ids=article_ids,
+    )
+    return SavedSearchExecuteResponse(
+        saved_search=saved_response,
+        articles=articles,
+    )

--- a/src/wikimind/api/routes/tags.py
+++ b/src/wikimind/api/routes/tags.py
@@ -1,0 +1,79 @@
+"""Endpoints for user-created tags and article-tag associations."""
+
+import structlog
+from fastapi import APIRouter, Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.api.deps import get_current_user_id
+from wikimind.database import get_session
+from wikimind.models import (
+    CreateTagRequest,
+    TagResponse,
+)
+from wikimind.services.tags import TagService, get_tag_service
+from wikimind.services.wiki import WikiService, get_wiki_service
+
+log = structlog.get_logger()
+
+router = APIRouter()
+
+
+@router.post("", response_model=TagResponse, status_code=201)
+async def create_tag(
+    body: CreateTagRequest,
+    session: AsyncSession = Depends(get_session),
+    service: TagService = Depends(get_tag_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Create a new user tag."""
+    return await service.create_tag(session, user_id=user_id, name=body.name, color=body.color)
+
+
+@router.get("", response_model=list[TagResponse])
+async def list_tags(
+    session: AsyncSession = Depends(get_session),
+    service: TagService = Depends(get_tag_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """List all tags for the current user."""
+    return await service.list_tags(session, user_id=user_id)
+
+
+@router.delete(
+    "/{tag_id}",
+    status_code=204,
+    responses={404: {"description": "Tag not found"}},
+)
+async def delete_tag(
+    tag_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: TagService = Depends(get_tag_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Delete a tag and all its article associations."""
+    await service.delete_tag(session, tag_id=tag_id, user_id=user_id)
+
+
+@router.get(
+    "/{tag_id}/articles",
+    response_model=list,
+    responses={404: {"description": "Tag not found"}},
+)
+async def get_articles_by_tag(
+    tag_id: str,
+    session: AsyncSession = Depends(get_session),
+    tag_service: TagService = Depends(get_tag_service),
+    wiki_service: WikiService = Depends(get_wiki_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Get articles tagged with a specific tag."""
+    article_ids = await tag_service.get_articles_by_tag(
+        session,
+        tag_id=tag_id,
+        user_id=user_id,
+    )
+    return await wiki_service.list_articles(
+        session,
+        user_id=user_id,
+        article_ids=article_ids,
+    )

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -17,6 +17,7 @@ from wikimind.models import (
     ArticleRelationshipsResponse,
     ArticleResponse,
     ArticleSummaryResponse,
+    ArticleTagResponse,
     Backlink,
     Contradiction,
     ContradictionResolution,
@@ -38,10 +39,13 @@ from wikimind.models import (
     ResolveContradictionResponse,
     SearchResponse,
     SearchResult,
+    TagArticleRequest,
+    TagResponse,
 )
 from wikimind.services.contradiction import ContradictionService, get_contradiction_service
 from wikimind.services.linter import LinterService, get_linter_service
 from wikimind.services.search import SearchService, get_search_service
+from wikimind.services.tags import TagService, get_tag_service
 from wikimind.services.taxonomy import rebuild_taxonomy
 from wikimind.services.wiki import WikiService, _staleness_score, get_wiki_service
 
@@ -503,3 +507,67 @@ async def recompile_article(
     await compiler.schedule_recompile(article_id, effective_mode, job.id, user_id=user_id)
 
     return RecompileResponse(status="scheduled", job_id=job.id)
+
+
+# ---------------------------------------------------------------------------
+# Article tagging endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/articles/{article_id}/tags",
+    response_model=ArticleTagResponse,
+    status_code=201,
+    responses={404: {"description": "Article or tag not found"}},
+)
+async def tag_article(
+    article_id: str,
+    body: TagArticleRequest,
+    session: AsyncSession = Depends(get_session),
+    tag_service: TagService = Depends(get_tag_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Apply a tag to an article."""
+    await tag_service.tag_article(
+        session,
+        article_id=article_id,
+        tag_id=body.tag_id,
+        user_id=user_id,
+    )
+    return ArticleTagResponse(article_id=article_id, tag_id=body.tag_id)
+
+
+@router.delete(
+    "/articles/{article_id}/tags/{tag_id}",
+    status_code=204,
+    responses={404: {"description": "Tag association not found"}},
+)
+async def untag_article(
+    article_id: str,
+    tag_id: str,
+    session: AsyncSession = Depends(get_session),
+    tag_service: TagService = Depends(get_tag_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Remove a tag from an article."""
+    await tag_service.untag_article(
+        session,
+        article_id=article_id,
+        tag_id=tag_id,
+        user_id=user_id,
+    )
+
+
+@router.get(
+    "/articles/{article_id}/tags",
+    response_model=list[TagResponse],
+    responses={404: {"description": "Article not found"}},
+)
+async def get_article_tags(
+    article_id: str,
+    session: AsyncSession = Depends(get_session),
+    tag_service: TagService = Depends(get_tag_service),
+    _user_id: str = Depends(get_current_user_id),
+):
+    """Get all tags applied to an article."""
+    return await tag_service.get_tags_for_article(session, article_id=article_id)

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -17,7 +17,20 @@ from starlette.responses import FileResponse, HTMLResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-from wikimind.api.routes import admin, api_keys, auth, export, ingest, jobs, lint, query, wiki, ws
+from wikimind.api.routes import (
+    admin,
+    api_keys,
+    auth,
+    export,
+    ingest,
+    jobs,
+    lint,
+    query,
+    saved_searches,
+    tags,
+    wiki,
+    ws,
+)
 from wikimind.api.routes import settings as settings_router
 from wikimind.api.routes.settings import apply_runtime_llm_preferences
 from wikimind.api.routes.ws import _start_redis_subscriber, stop_redis_subscriber
@@ -163,6 +176,8 @@ app = FastAPI(
         {"name": "Admin", "description": "System diagnostics and maintenance"},
         {"name": "Auth", "description": "OAuth2 authentication"},
         {"name": "Export", "description": "Export wiki articles as PDF, LinkedIn, or slides"},
+        {"name": "Tags", "description": "User-created organizational tags"},
+        {"name": "SavedSearches", "description": "Saved searches with tag and concept filters"},
         {"name": "WebSocket", "description": "Real-time progress streams"},
     ],
 )
@@ -214,6 +229,8 @@ api_router.include_router(settings_router.router, prefix="/settings", tags=["Set
 api_router.include_router(api_keys.router, prefix="/settings/api-keys", tags=["Settings"])
 api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])
 api_router.include_router(export.router, prefix="/wiki", tags=["Export"])
+api_router.include_router(tags.router, prefix="/tags", tags=["Tags"])
+api_router.include_router(saved_searches.router, prefix="/saved-searches", tags=["SavedSearches"])
 app.include_router(api_router)
 
 # Auth and WebSocket remain at root — auth redirects require stable paths,

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -466,6 +466,49 @@ class Contradiction(SQLModel, table=True):
     user_id: str = Field(foreign_key="user.id", index=True)
 
 
+class Tag(SQLModel, table=True):
+    """User-created organizational tag (separate from LLM-derived concepts).
+
+    Tags like ``read-later``, ``favorite``, ``to-revisit`` give users their own
+    retrieval layer. Each tag has a display color for pill-badge rendering.
+    """
+
+    __table_args__ = (UniqueConstraint("user_id", "name", name="uq_tag_user_name"),)
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
+    name: str
+    color: str = "#6366f1"  # Default indigo
+    created_at: datetime = Field(default_factory=utcnow_naive)
+
+
+class ArticleTag(SQLModel, table=True):
+    """Join table linking articles to user-created tags."""
+
+    __table_args__ = (UniqueConstraint("article_id", "tag_id", name="uq_articletag_article_tag"),)
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    article_id: str = Field(foreign_key="article.id", index=True)
+    tag_id: str = Field(foreign_key="tag.id", index=True)
+    created_at: datetime = Field(default_factory=utcnow_naive)
+
+
+class SavedSearch(SQLModel, table=True):
+    """User-saved search with optional tag and concept filters.
+
+    Stores a search query string plus a JSON blob of filters so users can
+    one-click re-execute common searches like "Q2 Research" or "read-later
+    items about prompt caching".
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
+    name: str
+    query: str
+    filters_json: str = "{}"  # JSON: {"tags": ["read-later"], "concepts": [...]}
+    created_at: datetime = Field(default_factory=utcnow_naive)
+
+
 # ---------------------------------------------------------------------------
 # Pydantic Models (not persisted — used for processing pipeline)
 # ---------------------------------------------------------------------------
@@ -934,6 +977,7 @@ class ArticleResponse(BaseModel):
     effective_confidence: float = 0.5
     staleness_score: float | None = None
     concepts: list[str] = []
+    tags: list["TagResponse"] = []
     backlinks_in: list[BacklinkEntry] = []
     backlinks_out: list[BacklinkEntry] = []
     content: str  # Full .md content
@@ -969,6 +1013,7 @@ class ArticleSummaryResponse(BaseModel):
     updated_at: datetime
     page_type: PageType = PageType.SOURCE
     concepts: list[str] = []
+    tags: list["TagResponse"] = []
     source_ids: list[str] = []
     user_id: str | None = None
     manually_edited: bool = False
@@ -1435,3 +1480,62 @@ class TokenCreateResponse(BaseModel):
     token_type: str = "bearer"
     expires_at: str
     name: str
+
+
+# ---------------------------------------------------------------------------
+# Tag + Saved Search request/response models
+# ---------------------------------------------------------------------------
+
+
+class TagResponse(BaseModel):
+    """API response for a user tag."""
+
+    id: str
+    name: str
+    color: str
+    created_at: datetime
+
+
+class CreateTagRequest(BaseModel):
+    """Request to create a new tag."""
+
+    name: str = Field(min_length=1, max_length=100)
+    color: str = "#6366f1"
+
+
+class TagArticleRequest(BaseModel):
+    """Request to tag an article."""
+
+    tag_id: str
+
+
+class ArticleTagResponse(BaseModel):
+    """Confirmation that a tag was applied to an article."""
+
+    article_id: str
+    tag_id: str
+
+
+class SavedSearchResponse(BaseModel):
+    """API response for a saved search."""
+
+    id: str
+    name: str
+    query: str
+    filters_json: str
+    created_at: datetime
+
+
+class CreateSavedSearchRequest(BaseModel):
+    """Request to create a saved search."""
+
+    name: str = Field(min_length=1, max_length=200)
+    query: str = ""
+    filters_json: str = "{}"
+
+
+class SavedSearchExecuteResponse(BaseModel):
+    """Response when executing a saved search."""
+
+    saved_search: SavedSearchResponse
+    articles: list[ArticleSummaryResponse]

--- a/src/wikimind/services/saved_searches.py
+++ b/src/wikimind/services/saved_searches.py
@@ -1,0 +1,206 @@
+"""Saved search service — CRUD and execution for user-saved searches.
+
+Saved searches store a query string plus optional tag/concept filters so
+users can one-click re-execute common queries.
+"""
+
+import functools
+import json
+
+import structlog
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.errors import NotFoundError
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    ArticleTag,
+    SavedSearch,
+    SavedSearchResponse,
+)
+
+log = structlog.get_logger()
+
+
+def _to_response(search: SavedSearch) -> SavedSearchResponse:
+    """Project a SavedSearch row into the API-facing response."""
+    return SavedSearchResponse(
+        id=search.id,
+        name=search.name,
+        query=search.query,
+        filters_json=search.filters_json,
+        created_at=search.created_at,
+    )
+
+
+class SavedSearchService:
+    """Manage user-saved searches with optional tag and concept filters."""
+
+    async def create(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        name: str,
+        query: str = "",
+        filters_json: str = "{}",
+    ) -> SavedSearchResponse:
+        """Create a new saved search.
+
+        Args:
+            session: Async database session.
+            user_id: Owner of the saved search.
+            name: Display name for the sidebar.
+            query: The search query string.
+            filters_json: JSON string of filters (tags, concepts).
+
+        Returns:
+            The newly created saved search.
+        """
+        saved = SavedSearch(
+            user_id=user_id,
+            name=name,
+            query=query,
+            filters_json=filters_json,
+        )
+        session.add(saved)
+        await session.flush()
+        await session.refresh(saved)
+        return _to_response(saved)
+
+    async def list_searches(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> list[SavedSearchResponse]:
+        """List all saved searches for a user.
+
+        Args:
+            session: Async database session.
+            user_id: Owner of the searches.
+
+        Returns:
+            List of saved searches ordered by creation time.
+        """
+        result = await session.execute(
+            select(SavedSearch)
+            .where(SavedSearch.user_id == user_id)
+            .order_by(SavedSearch.created_at)  # type: ignore[arg-type]
+        )
+        return [_to_response(s) for s in result.scalars().all()]
+
+    async def delete(
+        self,
+        session: AsyncSession,
+        search_id: str,
+        user_id: str,
+    ) -> None:
+        """Delete a saved search.
+
+        Args:
+            session: Async database session.
+            search_id: Saved search to delete.
+            user_id: Must match the owner.
+
+        Raises:
+            NotFoundError: If the saved search does not exist for this user.
+        """
+        saved = await self._get(session, search_id, user_id)
+        await session.delete(saved)
+
+    async def execute(
+        self,
+        session: AsyncSession,
+        search_id: str,
+        user_id: str,
+    ) -> tuple[SavedSearchResponse, list[str]]:
+        """Execute a saved search and return matching article IDs.
+
+        The search applies tag and concept filters from ``filters_json``.
+        The query string is matched against article titles using a simple
+        substring (case-insensitive) match.
+
+        Args:
+            session: Async database session.
+            search_id: Saved search to execute.
+            user_id: Must match the owner.
+
+        Returns:
+            Tuple of (saved search response, list of matching article IDs).
+
+        Raises:
+            NotFoundError: If the saved search does not exist for this user.
+        """
+        saved = await self._get(session, search_id, user_id)
+        response = _to_response(saved)
+
+        try:
+            filters = json.loads(saved.filters_json)
+        except (json.JSONDecodeError, TypeError):
+            filters = {}
+
+        tag_names: list[str] = filters.get("tags", [])
+        concept_names: list[str] = filters.get("concepts", [])
+
+        # Start with all user articles
+        query = select(Article.id).where(Article.user_id == user_id)
+
+        # Apply query string filter (substring match on title)
+        if saved.query.strip():
+            query = query.where(
+                Article.title.ilike(f"%{saved.query.strip()}%")  # type: ignore[attr-defined]
+            )
+
+        result = await session.execute(query)
+        candidate_ids = {row[0] for row in result.all()}
+
+        # Apply tag filter — articles must have ALL specified tags
+        if tag_names:
+            from wikimind.models import Tag  # noqa: PLC0415
+
+            tag_result = await session.execute(
+                select(Tag.id).where(
+                    Tag.user_id == user_id,
+                    Tag.name.in_(tag_names),  # type: ignore[attr-defined]
+                )
+            )
+            tag_ids = [row[0] for row in tag_result.all()]
+            for tid in tag_ids:
+                at_result = await session.execute(select(ArticleTag.article_id).where(ArticleTag.tag_id == tid))
+                tagged_ids = {row[0] for row in at_result.all()}
+                candidate_ids &= tagged_ids
+
+        # Apply concept filter — articles must have ALL specified concepts
+        for concept_name in concept_names:
+            ac_result = await session.execute(
+                select(ArticleConcept.article_id).where(ArticleConcept.concept_name == concept_name)
+            )
+            concept_ids = {row[0] for row in ac_result.all()}
+            candidate_ids &= concept_ids
+
+        return response, list(candidate_ids)
+
+    async def _get(
+        self,
+        session: AsyncSession,
+        search_id: str,
+        user_id: str,
+    ) -> SavedSearch:
+        """Look up a saved search by ID, scoped to the user."""
+        result = await session.execute(
+            select(SavedSearch).where(
+                SavedSearch.id == search_id,
+                SavedSearch.user_id == user_id,
+            )
+        )
+        saved = result.scalar_one_or_none()
+        if saved is None:
+            msg = "Saved search not found"
+            raise NotFoundError(msg)
+        return saved
+
+
+@functools.lru_cache(maxsize=1)
+def get_saved_search_service() -> SavedSearchService:
+    """Return a singleton SavedSearchService for FastAPI dependency injection."""
+    return SavedSearchService()

--- a/src/wikimind/services/tags.py
+++ b/src/wikimind/services/tags.py
@@ -1,0 +1,274 @@
+"""Tag management service — CRUD for user-created organizational tags.
+
+Tags are user-asserted labels (``read-later``, ``favorite``, ``to-revisit``)
+that provide an organizational layer separate from LLM-derived concepts.
+"""
+
+import functools
+
+import structlog
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.errors import NotFoundError
+from wikimind.models import (
+    Article,
+    ArticleTag,
+    Tag,
+    TagResponse,
+)
+
+log = structlog.get_logger()
+
+
+def _to_tag_response(tag: Tag) -> TagResponse:
+    """Project a Tag row into the API-facing TagResponse."""
+    return TagResponse(
+        id=tag.id,
+        name=tag.name,
+        color=tag.color,
+        created_at=tag.created_at,
+    )
+
+
+class TagService:
+    """Manage user-created tags and article-tag associations."""
+
+    async def create_tag(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        name: str,
+        color: str = "#6366f1",
+    ) -> TagResponse:
+        """Create a new tag for the user.
+
+        Args:
+            session: Async database session.
+            user_id: Owner of the tag.
+            name: Display name (must be unique per user).
+            color: Hex color for pill badge rendering.
+
+        Returns:
+            The newly created tag.
+        """
+        tag = Tag(user_id=user_id, name=name, color=color)
+        session.add(tag)
+        await session.flush()
+        await session.refresh(tag)
+        return _to_tag_response(tag)
+
+    async def list_tags(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> list[TagResponse]:
+        """List all tags belonging to a user.
+
+        Args:
+            session: Async database session.
+            user_id: Owner of the tags.
+
+        Returns:
+            List of tags ordered by creation time.
+        """
+        result = await session.execute(
+            select(Tag).where(Tag.user_id == user_id).order_by(Tag.created_at)  # type: ignore[arg-type]
+        )
+        return [_to_tag_response(t) for t in result.scalars().all()]
+
+    async def delete_tag(
+        self,
+        session: AsyncSession,
+        tag_id: str,
+        user_id: str,
+    ) -> None:
+        """Delete a tag and all its article associations.
+
+        Args:
+            session: Async database session.
+            tag_id: Tag to delete.
+            user_id: Must match the tag owner.
+
+        Raises:
+            NotFoundError: If the tag does not exist for this user.
+        """
+        tag = await self._get_tag(session, tag_id, user_id)
+        # Remove all article-tag associations first
+        result = await session.execute(select(ArticleTag).where(ArticleTag.tag_id == tag.id))
+        for at in result.scalars().all():
+            await session.delete(at)
+        await session.delete(tag)
+
+    async def tag_article(
+        self,
+        session: AsyncSession,
+        article_id: str,
+        tag_id: str,
+        user_id: str,
+    ) -> None:
+        """Apply a tag to an article.
+
+        Args:
+            session: Async database session.
+            article_id: Article to tag.
+            tag_id: Tag to apply.
+            user_id: Must own both the tag and the article.
+
+        Raises:
+            NotFoundError: If the tag or article does not exist for this user.
+        """
+        await self._get_tag(session, tag_id, user_id)
+        await self._get_article(session, article_id, user_id)
+
+        # Check for existing association
+        existing = await session.execute(
+            select(ArticleTag).where(
+                ArticleTag.article_id == article_id,
+                ArticleTag.tag_id == tag_id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return  # Already tagged
+
+        association = ArticleTag(article_id=article_id, tag_id=tag_id)
+        session.add(association)
+
+    async def untag_article(
+        self,
+        session: AsyncSession,
+        article_id: str,
+        tag_id: str,
+        user_id: str,
+    ) -> None:
+        """Remove a tag from an article.
+
+        Args:
+            session: Async database session.
+            article_id: Article to untag.
+            tag_id: Tag to remove.
+            user_id: Must own the tag.
+
+        Raises:
+            NotFoundError: If the association does not exist.
+        """
+        await self._get_tag(session, tag_id, user_id)
+        result = await session.execute(
+            select(ArticleTag).where(
+                ArticleTag.article_id == article_id,
+                ArticleTag.tag_id == tag_id,
+            )
+        )
+        association = result.scalar_one_or_none()
+        if association is None:
+            msg = "Article is not tagged with this tag"
+            raise NotFoundError(msg)
+        await session.delete(association)
+
+    async def get_articles_by_tag(
+        self,
+        session: AsyncSession,
+        tag_id: str,
+        user_id: str,
+    ) -> list[str]:
+        """Return article IDs tagged with the given tag.
+
+        Args:
+            session: Async database session.
+            tag_id: Tag to filter by.
+            user_id: Must own the tag.
+
+        Returns:
+            List of article IDs.
+
+        Raises:
+            NotFoundError: If the tag does not exist for this user.
+        """
+        await self._get_tag(session, tag_id, user_id)
+        result = await session.execute(select(ArticleTag.article_id).where(ArticleTag.tag_id == tag_id))
+        return [row[0] for row in result.all()]
+
+    async def get_tags_for_article(
+        self,
+        session: AsyncSession,
+        article_id: str,
+    ) -> list[TagResponse]:
+        """Return all tags applied to an article.
+
+        Args:
+            session: Async database session.
+            article_id: Article to look up.
+
+        Returns:
+            List of TagResponse records.
+        """
+        result = await session.execute(
+            select(Tag)
+            .join(ArticleTag, ArticleTag.tag_id == Tag.id)  # type: ignore[arg-type]
+            .where(ArticleTag.article_id == article_id)
+        )
+        return [_to_tag_response(t) for t in result.scalars().all()]
+
+    async def get_tags_for_articles(
+        self,
+        session: AsyncSession,
+        article_ids: list[str],
+    ) -> dict[str, list[TagResponse]]:
+        """Batch-fetch tags for multiple articles.
+
+        Args:
+            session: Async database session.
+            article_ids: Articles to look up.
+
+        Returns:
+            Dict mapping article_id to list of TagResponse.
+        """
+        result_map: dict[str, list[TagResponse]] = {aid: [] for aid in article_ids}
+        if not article_ids:
+            return result_map
+        result = await session.execute(
+            select(ArticleTag.article_id, Tag)
+            .join(Tag, Tag.id == ArticleTag.tag_id)  # type: ignore[arg-type]
+            .where(
+                ArticleTag.article_id.in_(article_ids)  # type: ignore[attr-defined]
+            )
+        )
+        for row in result.all():
+            article_id = row[0]
+            tag = row[1]
+            result_map[article_id].append(_to_tag_response(tag))
+        return result_map
+
+    async def _get_tag(
+        self,
+        session: AsyncSession,
+        tag_id: str,
+        user_id: str,
+    ) -> Tag:
+        """Look up a tag by ID, scoped to the user."""
+        result = await session.execute(select(Tag).where(Tag.id == tag_id, Tag.user_id == user_id))
+        tag = result.scalar_one_or_none()
+        if tag is None:
+            msg = "Tag not found"
+            raise NotFoundError(msg)
+        return tag
+
+    async def _get_article(
+        self,
+        session: AsyncSession,
+        article_id: str,
+        user_id: str,
+    ) -> Article:
+        """Look up an article by ID, scoped to the user."""
+        result = await session.execute(select(Article).where(Article.id == article_id, Article.user_id == user_id))
+        article = result.scalar_one_or_none()
+        if article is None:
+            msg = "Article not found"
+            raise NotFoundError(msg)
+        return article
+
+
+@functools.lru_cache(maxsize=1)
+def get_tag_service() -> TagService:
+    """Return a singleton TagService instance for FastAPI dependency injection."""
+    return TagService()

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -46,6 +46,7 @@ from wikimind.models import (
     SourceResponse,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
+from wikimind.services.tags import get_tag_service
 from wikimind.storage import get_wiki_storage, read_article_content
 
 log = structlog.get_logger()
@@ -227,6 +228,8 @@ async def _build_article_summary(article: Article, session: AsyncSession) -> Art
     concepts = await _fetch_concept_names_from_join(session, article.id)
     sources = await _fetch_sources(session, source_ids)
     backlink_count = len(article.backlinks_in) + len(article.backlinks_out)
+    tag_service = get_tag_service()
+    tags = await tag_service.get_tags_for_article(session, article.id)
     return ArticleSummaryResponse(
         id=article.id,
         slug=article.slug,
@@ -244,6 +247,7 @@ async def _build_article_summary(article: Article, session: AsyncSession) -> Art
         effective_confidence=_effective_confidence(article),
         staleness_score=_staleness_score(article),
         concepts=concepts,
+        tags=tags,
         source_ids=source_ids,
         user_id=article.user_id,
         manually_edited=article.manually_edited,
@@ -302,6 +306,7 @@ class WikiService:
         page_type: str | None = None,
         limit: int = 50,
         offset: int = 0,
+        article_ids: list[str] | None = None,
     ) -> list[ArticleSummaryResponse]:
         """List wiki articles with optional filtering by concept, confidence, or page_type.
 
@@ -319,14 +324,22 @@ class WikiService:
             limit: Maximum number of results.
             offset: Pagination offset.
             user_id: Optional user ID filter.
+            article_ids: Optional list of article IDs to restrict results to.
 
         Returns:
             List of :class:`ArticleSummaryResponse` records with sources
             populated.
         """
+        # Short-circuit: if article_ids filter is an empty list, return early
+        if article_ids is not None and len(article_ids) == 0:
+            return []
         query = select(Article).offset(offset).limit(limit)
         if user_id:
             query = query.where(Article.user_id == user_id)
+        if article_ids is not None:
+            query = query.where(
+                Article.id.in_(article_ids)  # type: ignore[attr-defined]
+            )
         if concept:
             query = query.where(
                 Article.id.in_(  # type: ignore[attr-defined]
@@ -409,6 +422,9 @@ class WikiService:
 
         concepts = await _fetch_concept_names_from_join(session, article.id)
 
+        tag_service = get_tag_service()
+        tags = await tag_service.get_tags_for_article(session, article.id)
+
         return ArticleResponse(
             id=article.id,
             slug=article.slug,
@@ -421,6 +437,7 @@ class WikiService:
             staleness_score=_staleness_score(article),
             page_type=article.page_type,
             concepts=concepts,
+            tags=tags,
             backlinks_in=backlinks_in,
             backlinks_out=backlinks_out,
             content=await read_article_content(article.file_path, user_id=article.user_id),

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -1,0 +1,337 @@
+"""Tests for tags and saved searches (issue #454)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from wikimind.api.deps import ANONYMOUS_USER_ID
+from wikimind.config import get_settings
+from wikimind.models import Article
+
+# ---------------------------------------------------------------------------
+# Tag CRUD via API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_tag(client, async_engine) -> None:
+    resp = await client.post("/tags", json={"name": "read-later", "color": "#ef4444"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "read-later"
+    assert data["color"] == "#ef4444"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_list_tags_empty(client) -> None:
+    resp = await client.get("/tags")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_tags_after_create(client) -> None:
+    await client.post("/tags", json={"name": "favorite"})
+    await client.post("/tags", json={"name": "to-revisit"})
+    resp = await client.get("/tags")
+    assert resp.status_code == 200
+    tags = resp.json()
+    assert len(tags) == 2
+    names = {t["name"] for t in tags}
+    assert names == {"favorite", "to-revisit"}
+
+
+@pytest.mark.asyncio
+async def test_delete_tag(client) -> None:
+    create_resp = await client.post("/tags", json={"name": "temp"})
+    tag_id = create_resp.json()["id"]
+    delete_resp = await client.delete(f"/tags/{tag_id}")
+    assert delete_resp.status_code == 204
+    # Verify it's gone
+    list_resp = await client.get("/tags")
+    assert list_resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_tag_returns_404(client) -> None:
+    resp = await client.delete("/tags/nonexistent-id")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Article tagging
+# ---------------------------------------------------------------------------
+
+
+async def _seed_article(factory) -> str:
+    """Create a test article and return its ID."""
+    async with factory() as session:
+        article = Article(
+            id="art-1",
+            slug="test-article",
+            title="Test Article",
+            file_path="/tmp/test.md",
+            user_id=ANONYMOUS_USER_ID,
+        )
+        session.add(article)
+        await session.commit()
+    return "art-1"
+
+
+@pytest.mark.asyncio
+async def test_tag_article(client, async_engine) -> None:
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "important"})
+    tag_id = tag_resp.json()["id"]
+
+    resp = await client.post(
+        "/wiki/articles/art-1/tags",
+        json={"tag_id": tag_id},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["article_id"] == "art-1"
+    assert data["tag_id"] == tag_id
+
+
+@pytest.mark.asyncio
+async def test_tag_article_idempotent(client, async_engine) -> None:
+    """Tagging the same article twice should not raise an error."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "star"})
+    tag_id = tag_resp.json()["id"]
+
+    resp1 = await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    assert resp1.status_code == 201
+
+    resp2 = await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    assert resp2.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_untag_article(client, async_engine) -> None:
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "remove-me"})
+    tag_id = tag_resp.json()["id"]
+
+    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    resp = await client.delete(f"/wiki/articles/art-1/tags/{tag_id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_untag_nonexistent_returns_404(client, async_engine) -> None:
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "nope"})
+    tag_id = tag_resp.json()["id"]
+
+    resp = await client.delete(f"/wiki/articles/art-1/tags/{tag_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_article_tags(client, async_engine) -> None:
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "alpha", "color": "#22c55e"})
+    tag_id = tag_resp.json()["id"]
+    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+
+    resp = await client.get("/wiki/articles/art-1/tags")
+    assert resp.status_code == 200
+    tags = resp.json()
+    assert len(tags) == 1
+    assert tags[0]["name"] == "alpha"
+    assert tags[0]["color"] == "#22c55e"
+
+
+@pytest.mark.asyncio
+async def test_get_articles_by_tag(client, async_engine) -> None:
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "special"})
+    tag_id = tag_resp.json()["id"]
+    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+
+    resp = await client.get(f"/tags/{tag_id}/articles")
+    assert resp.status_code == 200
+    articles = resp.json()
+    assert len(articles) == 1
+    assert articles[0]["id"] == "art-1"
+
+
+@pytest.mark.asyncio
+async def test_article_response_includes_tags(client, async_engine) -> None:
+    """Article detail should include tags in the response."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    # Seed article with a file that can be read
+    settings = get_settings()
+    wiki_dir = Path(settings.data_dir) / "wiki" / ANONYMOUS_USER_ID
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    md_file = wiki_dir / "test.md"
+    md_file.write_text("# Test\nSome content")
+
+    async with factory() as session:
+        article = Article(
+            id="art-tagged",
+            slug="tagged-article",
+            title="Tagged Article",
+            file_path="test.md",
+            user_id=ANONYMOUS_USER_ID,
+        )
+        session.add(article)
+        await session.commit()
+
+    tag_resp = await client.post("/tags", json={"name": "tagged"})
+    tag_id = tag_resp.json()["id"]
+    await client.post("/wiki/articles/art-tagged/tags", json={"tag_id": tag_id})
+
+    resp = await client.get("/wiki/articles/tagged-article")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["tags"]) == 1
+    assert data["tags"][0]["name"] == "tagged"
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_cascades_to_associations(client, async_engine) -> None:
+    """Deleting a tag should remove all article-tag associations."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_article(factory)
+
+    tag_resp = await client.post("/tags", json={"name": "cascade-test"})
+    tag_id = tag_resp.json()["id"]
+    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+
+    await client.delete(f"/tags/{tag_id}")
+
+    # Verify article no longer has the tag
+    resp = await client.get("/wiki/articles/art-1/tags")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Saved searches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_saved_search(client) -> None:
+    resp = await client.post(
+        "/saved-searches",
+        json={
+            "name": "Q2 Research",
+            "query": "machine learning",
+            "filters_json": json.dumps({"tags": ["read-later"]}),
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Q2 Research"
+    assert data["query"] == "machine learning"
+
+
+@pytest.mark.asyncio
+async def test_list_saved_searches(client) -> None:
+    await client.post("/saved-searches", json={"name": "Search 1", "query": "test"})
+    await client.post("/saved-searches", json={"name": "Search 2", "query": "demo"})
+    resp = await client.get("/saved-searches")
+    assert resp.status_code == 200
+    searches = resp.json()
+    assert len(searches) == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_saved_search(client) -> None:
+    create_resp = await client.post(
+        "/saved-searches",
+        json={"name": "Temp", "query": "temporary"},
+    )
+    search_id = create_resp.json()["id"]
+    del_resp = await client.delete(f"/saved-searches/{search_id}")
+    assert del_resp.status_code == 204
+
+    list_resp = await client.get("/saved-searches")
+    assert list_resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_execute_saved_search_empty(client) -> None:
+    """Executing a search with no matching articles returns empty list."""
+    create_resp = await client.post(
+        "/saved-searches",
+        json={"name": "Empty", "query": "nonexistent-title"},
+    )
+    search_id = create_resp.json()["id"]
+
+    resp = await client.post(f"/saved-searches/{search_id}/execute")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["articles"] == []
+    assert data["saved_search"]["name"] == "Empty"
+
+
+@pytest.mark.asyncio
+async def test_execute_saved_search_with_tag_filter(client, async_engine) -> None:
+    """Executing a search with tag filter returns only tagged articles."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Article(
+                id="art-a",
+                slug="alpha",
+                title="Alpha Article",
+                file_path="/tmp/a.md",
+                user_id=ANONYMOUS_USER_ID,
+            )
+        )
+        session.add(
+            Article(
+                id="art-b",
+                slug="beta",
+                title="Beta Article",
+                file_path="/tmp/b.md",
+                user_id=ANONYMOUS_USER_ID,
+            )
+        )
+        await session.commit()
+
+    # Create tag and apply to art-a only
+    tag_resp = await client.post("/tags", json={"name": "research"})
+    tag_id = tag_resp.json()["id"]
+    await client.post("/wiki/articles/art-a/tags", json={"tag_id": tag_id})
+
+    # Create saved search that filters by tag
+    create_resp = await client.post(
+        "/saved-searches",
+        json={
+            "name": "Research",
+            "query": "",
+            "filters_json": json.dumps({"tags": ["research"]}),
+        },
+    )
+    search_id = create_resp.json()["id"]
+
+    resp = await client.post(f"/saved-searches/{search_id}/execute")
+    assert resp.status_code == 200
+    articles = resp.json()["articles"]
+    assert len(articles) == 1
+    assert articles[0]["id"] == "art-a"


### PR DESCRIPTION
## Summary

Concepts in WikiMind are LLM-derived. Users need their own organizational layer -- tags like `read-later`, `favorite`, `to-revisit` -- for user-driven retrieval. Without this, the only way to organize articles is through auto-generated concepts.

This PR adds:

- **User-created tags** with custom colors, applied to articles via a pill-badge UI
- **Saved searches** with tag and concept filters for one-click re-execution from the sidebar
- Tags surfaced in both article detail and article list responses

## Changes

### Backend
- `Tag`, `ArticleTag`, `SavedSearch` SQLModel tables with unique constraints and indexes
- `TagService` — CRUD for tags, tag/untag articles, batch-fetch tags per article
- `SavedSearchService` — CRUD for saved searches, execute with tag/concept filters
- REST routes: `POST/GET/DELETE /tags`, `POST/DELETE /wiki/articles/{id}/tags`, `GET /tags/{id}/articles`, `POST/GET/DELETE /saved-searches`, `POST /saved-searches/{id}/execute`
- `ArticleResponse` and `ArticleSummaryResponse` now include `tags` field
- `WikiService.list_articles` gains `article_ids` filter for saved search execution

### Frontend
- `TagPill` — pill-shaped badge with user-chosen color accent
- `TagSelector` — dropdown on article detail for adding/removing/creating tags with 10 preset colors
- `SavedSearches` — sidebar section with create form and click-to-execute
- TypeScript types updated with `TagRef`

### Tests
- 18 new tests covering tag CRUD, article tagging/untagging, cascading deletes, saved search CRUD, and execution with tag filters
- All 1205 tests pass

## Test plan
- [x] `make verify` passes (all 1205 tests pass, only pre-existing PLR0915 lint warning)
- [x] OpenAPI spec regenerated and in sync
- [x] Frontend TypeScript compiles cleanly
- [x] Frontend builds successfully
- [x] Playwright screenshots captured in `/tmp/wikimind-evidence-454/report.html`

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)