### PR TITLE
refactor: enforce strict typing on public API functions (#394)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2159,9 +2159,7 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                type: object
-                title: Response Me Auth Me Get
+                $ref: '#/components/schemas/UserProfileResponse'
   /auth/magic-link:
     post:
       tags:
@@ -2313,9 +2311,7 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                type: object
-                title: Response Delete Account Auth Account Delete
+                $ref: '#/components/schemas/DeleteAccountResponse'
   /health:
     get:
       summary: Health
@@ -3234,6 +3230,16 @@ components:
       - status
       title: DefaultProviderResponse
       description: Response after setting default provider.
+    DeleteAccountResponse:
+      properties:
+        deleted:
+          type: string
+          title: Deleted
+      type: object
+      required:
+      - deleted
+      title: DeleteAccountResponse
+      description: Confirmation of account deletion.
     DismissFindingResponse:
       properties:
         dismissed:
@@ -4661,6 +4667,31 @@ components:
       - turn_indices
       title: TurnSelection
       description: A selection of specific turns from a single conversation.
+    UserProfileResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        email:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Email
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+        avatar_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Avatar Url
+      type: object
+      required:
+      - id
+      title: UserProfileResponse
+      description: Public user profile returned by GET /auth/me.
     ValidationError:
       properties:
         loc:

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -30,12 +30,14 @@ from wikimind.api.deps import ANONYMOUS_USER_ID, require_user_id
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.models import (
+    DeleteAccountResponse,
     MagicLinkRequest,
     MagicLinkResponse,
     MagicLinkVerifyRequest,
     MagicLinkVerifyResponse,
     TokenCreateRequest,
     TokenCreateResponse,
+    UserProfileResponse,
 )
 from wikimind.services.user import UserService, get_user_service
 
@@ -182,10 +184,10 @@ async def callback(
 
     if provider == "google":
         token_resp = await service.exchange_google_token(code, settings, callback_url)
-        user_info = await service.fetch_google_userinfo(token_resp["access_token"])
+        user_info = await service.fetch_google_userinfo(token_resp.access_token)
     elif provider == "github":
         token_resp = await service.exchange_github_token(code, settings)
-        user_info = await service.fetch_github_userinfo(token_resp["access_token"])
+        user_info = await service.fetch_github_userinfo(token_resp.access_token)
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
 
@@ -218,23 +220,23 @@ async def me(
     request: Request,
     session: AsyncSession = Depends(get_session),
     service: UserService = Depends(get_user_service),
-) -> dict:
+) -> UserProfileResponse:
     """Return current user profile, auto-provisioning if needed."""
     settings = get_settings()
     if not request.state.user_id:
         if not settings.auth.enabled:
-            return {"id": ANONYMOUS_USER_ID, "email": "", "name": "Anonymous", "avatar_url": None}
+            return UserProfileResponse(id=ANONYMOUS_USER_ID, email="", name="Anonymous", avatar_url=None)
         raise HTTPException(status_code=401)
 
     email = getattr(request.state, "user_email", None)
     user = await service.get_or_create(session, request.state.user_id, email=email)
 
-    return {
-        "id": user.id,
-        "email": user.email,
-        "name": user.name,
-        "avatar_url": user.avatar_url,
-    }
+    return UserProfileResponse(
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        avatar_url=user.avatar_url,
+    )
 
 
 @router.post("/magic-link")
@@ -551,7 +553,7 @@ async def delete_account(
     session: AsyncSession = Depends(get_session),
     user_id: str = Depends(require_user_id),
     service: UserService = Depends(get_user_service),
-) -> dict:
+) -> DeleteAccountResponse:
     """Delete the current user's account and all owned data."""
     await service.delete_account(session, user_id)
-    return {"deleted": user_id}
+    return DeleteAccountResponse(deleted=user_id)

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -247,18 +247,18 @@ async def search(
     user_id: str = Depends(get_current_user_id),
 ):
     """Full-text search across wiki articles using BM25 ranking."""
-    raw_results, total = await search_service.search(q, session, user_id=user_id, limit=limit, offset=offset)
+    fts_response = await search_service.search(q, session, user_id=user_id, limit=limit, offset=offset)
     results = [
         SearchResult(
-            article_id=r["article_id"],
-            slug=r["slug"],
-            title=r["title"],
-            snippet=r["snippet"],
-            rank=r["rank"],
+            article_id=r.article_id,
+            slug=r.slug,
+            title=r.title,
+            snippet=r.snippet,
+            rank=r.rank,
         )
-        for r in raw_results
+        for r in fts_response.results
     ]
-    return SearchResponse(results=results, total=total, query=q)
+    return SearchResponse(results=results, total=fts_response.total, query=q)
 
 
 @router.get("/concepts")

--- a/src/wikimind/engine/frontmatter_validator.py
+++ b/src/wikimind/engine/frontmatter_validator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import structlog
 import yaml  # type: ignore[import-untyped]
 from pydantic import ValidationError
@@ -25,7 +27,7 @@ _FRONTMATTER_MODELS: dict[str, type] = {
 }
 
 
-def parse_frontmatter(content: str) -> dict | None:
+def parse_frontmatter(content: str) -> dict[str, Any] | None:
     """Extract YAML frontmatter from markdown content."""
     if not content.startswith("---"):
         return None

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -14,7 +14,7 @@ import hashlib
 import itertools
 import json
 import random
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import structlog
 from sqlalchemy import delete
@@ -234,13 +234,13 @@ def _build_batch_prompt(
     return BatchPrompt(CONTRADICTION_BATCH_SYSTEM, user_msg)
 
 
-def _parse_batch_response(response_data: list[dict], expected_count: int) -> dict[int, list[dict]]:
+def _parse_batch_response(response_data: list[dict[str, Any]], expected_count: int) -> dict[int, list[dict[str, Any]]]:
     """Map LLM batch response back to individual pairs by pair_index.
 
     Returns a dict from pair_index to list of contradiction dicts.
     Missing indices get an empty list.
     """
-    result: dict[int, list[dict]] = {i: [] for i in range(expected_count)}
+    result: dict[int, list[dict[str, Any]]] = {i: [] for i in range(expected_count)}
     for item in response_data:
         idx = item.get("pair_index")
         if idx is not None and 0 <= idx < expected_count:

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -24,7 +24,9 @@ from wikimind.models import (
     CompletionRequest,
     Conversation,
     CostLog,
+    FileBackArticlePair,
     PageType,
+    QAResult,
     Query,
     QueryRequest,
     QueryResult,
@@ -75,7 +77,7 @@ class _PreparedContext:
     conversation: Conversation
     next_turn_index: int
     prior_turns: list[Query]
-    wiki_context: list[dict]
+    wiki_context: list[dict[str, str | int]]
     completion_request: CompletionRequest | None  # None when wiki_context is empty
     no_context_result: QueryResult | None  # non-None when wiki_context is empty
 
@@ -338,7 +340,7 @@ class QAAgent:
     def _build_completion_request(
         self,
         question: str,
-        context: list[dict],
+        context: list[dict[str, str | int]],
         prior_turns: list[Query],
     ) -> CompletionRequest:
         """Build the CompletionRequest for the LLM call.
@@ -394,7 +396,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         ctx: _PreparedContext,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Query, Conversation, WikiWorthinessScore | None]:
+    ) -> QAResult:
         """Persist the Query row and handle file-back.
 
         Shared by ``answer()`` and the ``answer_stream()`` completion path.
@@ -407,9 +409,10 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (the new Query row, the parent Conversation, optional
-            wiki-worthiness score). The score is non-None only when the
-            ``auto_file_back_enabled`` config flag is set.
+            QAResult NamedTuple of (the new Query row, the parent
+            Conversation, optional wiki-worthiness score). The score is
+            non-None only when the ``auto_file_back_enabled`` config flag
+            is set.
         """
         query_record = Query(
             question=request.question,
@@ -487,14 +490,18 @@ conversation context contradicts the wiki, prefer the wiki."""
         await session.refresh(query_record)
         await session.refresh(ctx.conversation)
 
-        return query_record, ctx.conversation, score
+        return QAResult(
+            query=query_record,
+            conversation=ctx.conversation,
+            wiki_worthiness_score=score,
+        )
 
     async def answer(
         self,
         request: QueryRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Query, Conversation, WikiWorthinessScore | None]:
+    ) -> QAResult:
         """Answer a question against the wiki.
 
         Conversation-aware: if request.conversation_id is None a new
@@ -508,9 +515,10 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Returns:
-            Tuple of (the new Query row, the parent Conversation, optional
-            wiki-worthiness score). The score is non-None only when the
-            ``auto_file_back_enabled`` config flag is set.
+            QAResult NamedTuple of (the new Query row, the parent
+            Conversation, optional wiki-worthiness score). The score is
+            non-None only when the ``auto_file_back_enabled`` config
+            flag is set.
         """
         ctx = await self._prepare_context(request, session, user_id=user_id)
 
@@ -532,16 +540,16 @@ conversation context contradicts the wiki, prefer the wiki."""
         request: QueryRequest,
         session: AsyncSession,
         user_id: str,
-    ) -> AsyncIterator[str | tuple[Query, Conversation, WikiWorthinessScore | None]]:
-        """Stream LLM tokens, then yield the persisted result tuple.
+    ) -> AsyncIterator[str | QAResult]:
+        """Stream LLM tokens, then yield the persisted QAResult.
 
         Yields text chunk strings during streaming. After all tokens have been
-        yielded, yields a single ``(Query, Conversation, WikiWorthinessScore | None)``
-        tuple as the final item. The caller (service layer) is responsible for
-        constructing SSE events from these values.
+        yielded, yields a single :class:`QAResult` NamedTuple as the final
+        item. The caller (service layer) is responsible for constructing SSE
+        events from these values.
 
         If wiki context is empty, yields the canned answer text as one chunk
-        followed by the persisted tuple.
+        followed by the persisted QAResult.
 
         Raises:
             RuntimeError: When all LLM providers fail.
@@ -552,18 +560,14 @@ conversation context contradicts the wiki, prefer the wiki."""
             user_id: User ID for data isolation.
 
         Yields:
-            ``str`` text chunks, then a final
-            ``tuple[Query, Conversation, WikiWorthinessScore | None]``.
+            ``str`` text chunks, then a final :class:`QAResult`.
         """
         ctx = await self._prepare_context(request, session, user_id=user_id)
 
         if ctx.no_context_result is not None:
             result = ctx.no_context_result
             yield result.answer
-            query_record, conversation, score = await self._persist_query(
-                request, result, ctx, session, user_id=user_id
-            )
-            yield (query_record, conversation, score)
+            yield await self._persist_query(request, result, ctx, session, user_id=user_id)
             return
 
         assert ctx.completion_request is not None
@@ -624,10 +628,9 @@ conversation context contradicts the wiki, prefer the wiki."""
                 related_articles=[],
             )
 
-        query_record, conversation, score = await self._persist_query(request, result, ctx, session, user_id=user_id)
-        yield (query_record, conversation, score)
+        yield await self._persist_query(request, result, ctx, session, user_id=user_id)
 
-    async def _retrieve_context(self, question: str, session: AsyncSession, user_id: str) -> list[dict]:
+    async def _retrieve_context(self, question: str, session: AsyncSession, user_id: str) -> list[dict[str, str | int]]:
         """Retrieve relevant wiki articles for the question."""
         # Extract key terms from question (simple approach for Phase 1)
         terms = [t for t in question.lower().split() if len(t) > 3]
@@ -662,7 +665,7 @@ conversation context contradicts the wiki, prefer the wiki."""
     async def _query_llm(
         self,
         question: str,
-        context: list[dict],
+        context: list[dict[str, str | int]],
         prior_turns: list[Query],
         session: AsyncSession,
         user_id: str,
@@ -689,7 +692,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         conversation_id: str,
         session: AsyncSession,
         user_id: str,
-    ) -> tuple[Article, bool]:
+    ) -> FileBackArticlePair:
         """File a whole conversation back to the wiki as a single article.
 
         STAGES changes but does NOT commit — the caller owns the
@@ -771,7 +774,7 @@ conversation context contradicts the wiki, prefer the wiki."""
                 conversation_id=conversation_id,
                 article_id=article.id,
             )
-            return article, False
+            return FileBackArticlePair(article=article, is_update=False)
 
         # Update path: overwrite the existing Article's file in place
         wiki_storage = get_wiki_storage(user_id)
@@ -789,4 +792,4 @@ conversation context contradicts the wiki, prefer the wiki."""
             conversation_id=conversation_id,
             article_id=existing_article.id,
         )
-        return existing_article, True
+        return FileBackArticlePair(article=existing_article, is_update=True)

--- a/src/wikimind/engine/wikilink_resolver.py
+++ b/src/wikimind/engine/wikilink_resolver.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 from sqlmodel import select
 
 from wikimind.engine.title_normalizer import normalize_title
-from wikimind.models import Article
+from wikimind.models import Article, ResolvedBacklinks
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -56,7 +56,7 @@ async def resolve_backlink_candidates(
     user_id: str,
     exclude_article_id: str | None = None,
     relation_types: dict[str, str] | None = None,
-) -> tuple[list[ResolvedBacklink], list[str]]:
+) -> ResolvedBacklinks:
     """Resolve wikilink candidates against the Article table.
 
     Args:
@@ -75,18 +75,16 @@ async def resolve_backlink_candidates(
             considered for resolution. Prevents cross-user link leakage.
 
     Returns:
-        A tuple ``(resolved, unresolved)``. Resolved contains one
-        :class:`ResolvedBacklink` per unique target article (so two
-        candidates pointing at the same article produce one row).
-        Unresolved is the list of candidate strings that matched no
-        article, in input order.
+        A :class:`ResolvedBacklinks` NamedTuple with ``resolved``
+        (:class:`ResolvedBacklink` per unique target article) and
+        ``unresolved`` (candidate strings that matched no article).
     """
     rel_map = relation_types or {}
 
     # Drop empty / whitespace-only candidates up front.
     cleaned = [c.strip() for c in candidates if c and c.strip()]
     if not cleaned:
-        return [], []
+        return ResolvedBacklinks(resolved=[], unresolved=[])
 
     # Load articles for resolution. When user_id is provided, only that
     # user's articles are considered — prevents cross-user link leakage.
@@ -127,4 +125,7 @@ async def resolve_backlink_candidates(
                 relation_type=rel_map.get(candidate.lower(), "references"),
             )
 
-    return list(resolved_by_target.values()), unresolved
+    return ResolvedBacklinks(
+        resolved=list(resolved_by_target.values()),
+        unresolved=unresolved,
+    )

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -8,7 +8,7 @@ Pydantic models carry data through the ingest → compile → query pipeline.
 import uuid
 from datetime import date, datetime
 from enum import StrEnum
-from typing import Literal
+from typing import Any, Literal, NamedTuple
 
 from pydantic import BaseModel, computed_field
 from sqlalchemy import Column, String, UniqueConstraint
@@ -1539,3 +1539,112 @@ class SavedSearchExecuteResponse(BaseModel):
 
     saved_search: SavedSearchResponse
     articles: list[ArticleSummaryResponse]
+
+
+# ---------------------------------------------------------------------------
+# Typed return models for public service/route functions (issue #394)
+# ---------------------------------------------------------------------------
+
+
+class OAuthTokenResponse(BaseModel):
+    """OAuth token exchange response from an external provider.
+
+    Contains at minimum an ``access_token`` field. Additional fields
+    vary by provider (e.g. ``token_type``, ``scope``, ``id_token``).
+    """
+
+    model_config = {"extra": "allow"}
+
+    access_token: str
+    token_type: str | None = None
+    scope: str | None = None
+
+
+class OAuthUserInfo(BaseModel):
+    """User profile from an OAuth provider (Google or GitHub).
+
+    Only ``id`` is guaranteed; other fields may be absent depending
+    on the provider and scopes.
+    """
+
+    model_config = {"extra": "allow"}
+
+    id: int | str
+    email: str | None = None
+    name: str | None = None
+    login: str | None = None
+    picture: str | None = None
+    avatar_url: str | None = None
+
+
+class UserProfileResponse(BaseModel):
+    """Public user profile returned by GET /auth/me."""
+
+    id: str
+    email: str | None = None
+    name: str | None = None
+    avatar_url: str | None = None
+
+
+class DeleteAccountResponse(BaseModel):
+    """Confirmation of account deletion."""
+
+    deleted: str
+
+
+class FTSResultItem(BaseModel):
+    """A single full-text search result from the FTS index (internal)."""
+
+    article_id: str
+    slug: str
+    title: str
+    snippet: str
+    rank: float
+
+
+class FTSResponse(NamedTuple):
+    """Result of a full-text search query: paginated results and total count."""
+
+    results: list[FTSResultItem]
+    total: int
+
+
+class WikiHealthReport(BaseModel):
+    """Health report returned by WikiService.get_health.
+
+    Uses ``extra="allow"`` because the on-disk ``health.json`` may contain
+    additional fields written by different linter versions.
+    """
+
+    model_config = {"extra": "allow"}
+
+    generated_at: datetime | None = None
+    total_articles: int = 0
+    total_sources: int = 0
+    total_findings: int | None = None
+    contradictions_count: int | None = None
+    orphans_count: int | None = None
+    status: str | None = None
+    message: str | None = None
+
+
+class QAResult(NamedTuple):
+    """Result of a Q&A answer call: query row, conversation, and optional score."""
+
+    query: "Query"
+    conversation: "Conversation"
+    wiki_worthiness_score: WikiWorthinessScore | None
+
+
+class FileBackArticlePair(NamedTuple):
+    """Result of filing a conversation back to the wiki."""
+
+    article: "Article"
+    is_update: bool
+
+
+class ResolvedBacklinks(NamedTuple):
+    """Result of resolving wikilink candidates against the article table."""
+
+    resolved: list[Any]  # list[ResolvedBacklink] — avoids circular import
+    unresolved: list[str]

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -317,7 +317,7 @@ class QueryService:
                 if isinstance(item, str):
                     yield (f"event: chunk\ndata: {json.dumps({'text': item})}\n\n")
                 else:
-                    # Final tuple: (Query, Conversation, WikiWorthinessScore | None)
+                    # Final QAResult NamedTuple
                     query_record, conversation, wiki_worthiness = item
                     citations = await _build_citations(query_record, session, user_id=user_id)
                     done_payload = AskResponse(

--- a/src/wikimind/services/search.py
+++ b/src/wikimind/services/search.py
@@ -20,7 +20,7 @@ from sqlmodel import select
 
 from wikimind.config import get_settings
 from wikimind.db_compat import is_postgres
-from wikimind.models import Article
+from wikimind.models import Article, FTSResponse, FTSResultItem
 from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
@@ -194,12 +194,12 @@ async def search_articles(
     user_id: str,
     limit: int = 20,
     offset: int = 0,
-) -> tuple[list[dict], int]:
+) -> FTSResponse:
     """Execute a full-text search and return ranked results with total count.
 
-    Returns a tuple of (results, total) where results is a list of dicts
-    with keys: article_id, title, slug, snippet, rank; and total is the
-    count of all matches before pagination.
+    Returns an :class:`FTSResponse` NamedTuple of (results, total) where
+    results is a list of :class:`FTSResultItem` and total is the count of
+    all matches before pagination.
 
     Args:
         session: Active database session.
@@ -209,10 +209,10 @@ async def search_articles(
         offset: Pagination offset.
 
     Returns:
-        Tuple of (result dicts ordered by relevance, total match count).
+        FTSResponse with typed result items ordered by relevance and total count.
     """
     if not _fts_ready:
-        return [], 0
+        return FTSResponse(results=[], total=0)
 
     url = get_settings().database_url
 
@@ -227,17 +227,16 @@ async def _search_sqlite(
     user_id: str,
     limit: int,
     offset: int,
-) -> tuple[list[dict], int]:
+) -> FTSResponse:
     """FTS5 search with BM25 ranking and snippet extraction.
 
     Uses a two-step approach: query the FTS5 table first for rowids and
     snippets, then join against the article table for user scoping.
-    Returns (results, total_count) where total_count is the number of
-    user-scoped matches before pagination.
+    Returns an FTSResponse with typed results and total count.
     """
     fts_query = _sanitize_fts5_query(query)
     if not fts_query:
-        return [], 0
+        return FTSResponse(results=[], total=0)
 
     # Fetch all FTS matches (no LIMIT) so we can compute accurate total
     # after user-scoping.  The FTS5 query itself is fast; the bottleneck
@@ -255,7 +254,7 @@ async def _search_sqlite(
     fts_rows = fts_result.all()
 
     if not fts_rows:
-        return [], 0
+        return FTSResponse(results=[], total=0)
 
     # Build rowid -> (snippet, rank) map
     rowid_map: dict[int, tuple[str, float]] = {}
@@ -277,7 +276,7 @@ async def _search_sqlite(
             id_to_rowid[aid] = rowid
 
     if not matched_ids:
-        return [], 0
+        return FTSResponse(results=[], total=0)
 
     # Load only the matched articles from the database
     article_result = await session.execute(
@@ -288,24 +287,24 @@ async def _search_sqlite(
     )
     matched_articles = list(article_result.scalars().all())
 
-    results: list[dict] = []
+    results: list[FTSResultItem] = []
     for article in matched_articles:
         rowid = id_to_rowid[article.id]
         snippet, rank = rowid_map[rowid]
         results.append(
-            {
-                "article_id": article.id,
-                "slug": article.slug,
-                "title": article.title,
-                "snippet": snippet,
-                "rank": rank,
-            }
+            FTSResultItem(
+                article_id=article.id,
+                slug=article.slug,
+                title=article.title,
+                snippet=snippet,
+                rank=rank,
+            )
         )
 
     # Sort by BM25 rank (lower is better in FTS5)
-    results.sort(key=lambda r: r["rank"])
+    results.sort(key=lambda r: r.rank)
     total = len(results)
-    return results[offset : offset + limit], total
+    return FTSResponse(results=results[offset : offset + limit], total=total)
 
 
 async def _search_postgres(
@@ -314,11 +313,11 @@ async def _search_postgres(
     user_id: str,
     limit: int,
     offset: int,
-) -> tuple[list[dict], int]:
+) -> FTSResponse:
     """Postgres full-text search with ts_rank and ts_headline."""
     tsquery = _sanitize_postgres_query(query)
     if not tsquery:
-        return [], 0
+        return FTSResponse(results=[], total=0)
 
     # Count total matches before pagination
     count_sql = sa_text(
@@ -361,16 +360,16 @@ async def _search_postgres(
     )
 
     results = [
-        {
-            "article_id": row[0],
-            "slug": row[1],
-            "title": row[2],
-            "snippet": row[3],
-            "rank": row[4],
-        }
+        FTSResultItem(
+            article_id=row[0],
+            slug=row[1],
+            title=row[2],
+            snippet=row[3],
+            rank=row[4],
+        )
         for row in result.all()
     ]
-    return results, total
+    return FTSResponse(results=results, total=total)
 
 
 # ---------------------------------------------------------------------------
@@ -452,8 +451,8 @@ class SearchService:
         user_id: str,
         limit: int = 20,
         offset: int = 0,
-    ) -> tuple[list[dict], int]:
-        """Execute full-text search, returning (ranked result dicts, total)."""
+    ) -> FTSResponse:
+        """Execute full-text search, returning FTSResponse with typed results."""
         return await search_articles(session, query, user_id, limit, offset)
 
 

--- a/src/wikimind/services/user.py
+++ b/src/wikimind/services/user.py
@@ -32,6 +32,8 @@ from wikimind.models import (
     CostLog,
     Job,
     LintReport,
+    OAuthTokenResponse,
+    OAuthUserInfo,
     OrphanFinding,
     Query,
     Source,
@@ -50,7 +52,7 @@ class UserService:
     # OAuth token exchange
     # ------------------------------------------------------------------
 
-    async def exchange_google_token(self, code: str, settings: Settings, redirect_uri: str) -> dict:
+    async def exchange_google_token(self, code: str, settings: Settings, redirect_uri: str) -> OAuthTokenResponse:
         """Exchange a Google authorization code for an access token."""
         async with httpx.AsyncClient() as client:
             resp = await client.post(
@@ -64,9 +66,9 @@ class UserService:
                 },
             )
             resp.raise_for_status()
-            return resp.json()
+            return OAuthTokenResponse(**resp.json())
 
-    async def exchange_github_token(self, code: str, settings: Settings) -> dict:
+    async def exchange_github_token(self, code: str, settings: Settings) -> OAuthTokenResponse:
         """Exchange a GitHub authorization code for an access token."""
         async with httpx.AsyncClient() as client:
             resp = await client.post(
@@ -79,13 +81,13 @@ class UserService:
                 headers={"Accept": "application/json"},
             )
             resp.raise_for_status()
-            return resp.json()
+            return OAuthTokenResponse(**resp.json())
 
     # ------------------------------------------------------------------
     # OAuth user info
     # ------------------------------------------------------------------
 
-    async def fetch_google_userinfo(self, access_token: str) -> dict:
+    async def fetch_google_userinfo(self, access_token: str) -> OAuthUserInfo:
         """Fetch the authenticated user's profile from Google."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -93,9 +95,9 @@ class UserService:
                 headers={"Authorization": f"Bearer {access_token}"},
             )
             resp.raise_for_status()
-            return resp.json()
+            return OAuthUserInfo(**resp.json())
 
-    async def fetch_github_userinfo(self, access_token: str) -> dict:
+    async def fetch_github_userinfo(self, access_token: str) -> OAuthUserInfo:
         """Fetch the authenticated user's profile from GitHub.
 
         GitHub's ``/user`` endpoint may not include a public email, so we
@@ -108,23 +110,23 @@ class UserService:
         async with httpx.AsyncClient() as client:
             user_resp = await client.get("https://api.github.com/user", headers=headers)
             user_resp.raise_for_status()
-            user_data = user_resp.json()
+            user_data: dict[str, str | int | None] = user_resp.json()
 
             if not user_data.get("email"):
                 email_resp = await client.get("https://api.github.com/user/emails", headers=headers)
                 email_resp.raise_for_status()
-                emails = email_resp.json()
+                emails: list[dict[str, str | bool]] = email_resp.json()
                 primary = next((e for e in emails if e.get("primary") and e.get("verified")), None)
                 if primary:
                     user_data["email"] = primary["email"]
 
-            return user_data
+            return OAuthUserInfo(**user_data)
 
     # ------------------------------------------------------------------
     # User upsert + JWT creation
     # ------------------------------------------------------------------
 
-    async def upsert_oauth_user(self, session: AsyncSession, provider: str, user_info: dict) -> User:
+    async def upsert_oauth_user(self, session: AsyncSession, provider: str, user_info: OAuthUserInfo) -> User:
         """Find or create a user from OAuth provider info.
 
         Looks up by ``(auth_provider, auth_provider_id)`` first, then falls
@@ -135,21 +137,21 @@ class UserService:
         Args:
             session: Async database session.
             provider: OAuth provider name (``"google"`` or ``"github"``).
-            user_info: User profile dict from the provider API.
+            user_info: Typed user profile from the provider API.
 
         Returns:
             The existing or newly created User record.
         """
         if provider == "google":
-            provider_id = str(user_info["id"])
-            email = user_info["email"]
-            name = user_info.get("name")
-            avatar_url = user_info.get("picture")
+            provider_id = str(user_info.id)
+            email = user_info.email
+            name = user_info.name
+            avatar_url = user_info.picture
         else:
-            provider_id = str(user_info["id"])
-            email = user_info["email"]
-            name = user_info.get("name") or user_info.get("login")
-            avatar_url = user_info.get("avatar_url")
+            provider_id = str(user_info.id)
+            email = user_info.email
+            name = user_info.name or user_info.login
+            avatar_url = user_info.avatar_url
 
         result = await session.execute(
             select(User).where(User.auth_provider == provider, User.auth_provider_id == provider_id)

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -44,6 +44,7 @@ from wikimind.models import (
     RelationType,
     Source,
     SourceResponse,
+    WikiHealthReport,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
 from wikimind.services.tags import get_tag_service
@@ -991,7 +992,7 @@ class WikiService:
         self,
         session: AsyncSession,
         user_id: str,
-    ) -> dict:
+    ) -> WikiHealthReport:
         """Return the latest wiki health report from the linter.
 
         If no linter run has been performed yet, returns a stub report
@@ -1002,14 +1003,14 @@ class WikiService:
             user_id: Optional user ID for path scoping.
 
         Returns:
-            Health report dict.
+            Typed WikiHealthReport.
         """
         storage = get_wiki_storage(user_id)
         health_relative = "_meta/health.json"
 
         if await storage.exists(health_relative):
             content = await storage.read(health_relative)
-            return json.loads(content)
+            return WikiHealthReport(**json.loads(content))
 
         article_stmt = select(Article)
         if user_id:
@@ -1017,12 +1018,12 @@ class WikiService:
         articles_result = await session.execute(article_stmt)
         articles = articles_result.scalars().all()
 
-        return {
-            "generated_at": None,
-            "total_articles": len(articles),
-            "total_sources": 0,
-            "message": "Run the linter to generate a health report",
-        }
+        return WikiHealthReport(
+            generated_at=None,
+            total_articles=len(articles),
+            total_sources=0,
+            message="Run the linter to generate a health report",
+        )
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -19,7 +19,7 @@ from wikimind.api.routes.auth import (
     _generate_oauth_state,
 )
 from wikimind.config import get_settings
-from wikimind.models import User
+from wikimind.models import OAuthUserInfo, User
 from wikimind.services.user import UserService
 
 _service = UserService()
@@ -271,12 +271,12 @@ async def test_auth_me_returns_401_when_auth_enabled_no_token(client, monkeypatc
 @pytest.mark.asyncio
 async def test_upsert_user_creates_new_user(db_session: AsyncSession):
     """First login should create a new User record."""
-    user_info = {
-        "id": "google-id-1",
-        "email": "new@example.com",
-        "name": "New User",
-        "picture": "https://example.com/pic.jpg",
-    }
+    user_info = OAuthUserInfo(
+        id="google-id-1",
+        email="new@example.com",
+        name="New User",
+        picture="https://example.com/pic.jpg",
+    )
     user = await _service.upsert_oauth_user(db_session, "google", user_info)
     assert user.email == "new@example.com"
     assert user.auth_provider == "google"
@@ -286,17 +286,21 @@ async def test_upsert_user_creates_new_user(db_session: AsyncSession):
 @pytest.mark.asyncio
 async def test_upsert_user_updates_existing_user(db_session: AsyncSession):
     """Re-login should update the existing User record."""
-    user_info = {
-        "id": "google-id-2",
-        "email": "existing@example.com",
-        "name": "Old Name",
-        "picture": None,
-    }
+    user_info = OAuthUserInfo(
+        id="google-id-2",
+        email="existing@example.com",
+        name="Old Name",
+        picture=None,
+    )
     user1 = await _service.upsert_oauth_user(db_session, "google", user_info)
 
-    user_info["name"] = "New Name"
-    user_info["picture"] = "https://example.com/new.jpg"
-    user2 = await _service.upsert_oauth_user(db_session, "google", user_info)
+    user_info_updated = OAuthUserInfo(
+        id="google-id-2",
+        email="existing@example.com",
+        name="New Name",
+        picture="https://example.com/new.jpg",
+    )
+    user2 = await _service.upsert_oauth_user(db_session, "google", user_info_updated)
 
     assert user1.id == user2.id
     assert user2.name == "New Name"

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -162,10 +162,10 @@ class TestFtsSearch:
         results, total = await search_articles(fts_session, "python", TEST_USER_ID)
         assert len(results) == 1
         assert total == 1
-        assert results[0]["title"] == "Python Programming Guide"
-        assert results[0]["slug"] == "python-programming-guide"
-        assert "snippet" in results[0]
-        assert "rank" in results[0]
+        assert results[0].title == "Python Programming Guide"
+        assert results[0].slug == "python-programming-guide"
+        assert results[0].snippet is not None
+        assert results[0].rank is not None
 
     @pytest.mark.asyncio
     async def test_search_does_not_find_unrelated(self, fts_session: AsyncSession):
@@ -222,11 +222,11 @@ class TestFtsSearch:
 
         assert len(results_a) == 1
         assert total_a == 1
-        assert results_a[0]["title"] == "User A Secret"
+        assert results_a[0].title == "User A Secret"
 
         assert len(results_b) == 1
         assert total_b == 1
-        assert results_b[0]["title"] == "User B Public"
+        assert results_b[0].title == "User B Public"
 
     @pytest.mark.asyncio
     async def test_search_content_match(self, fts_session: AsyncSession):
@@ -240,7 +240,7 @@ class TestFtsSearch:
 
         results, _total = await search_articles(fts_session, "transformer", TEST_USER_ID)
         assert len(results) == 1
-        assert results[0]["title"] == "Generic Title"
+        assert results[0].title == "Generic Title"
 
     @pytest.mark.asyncio
     async def test_search_title_match(self, fts_session: AsyncSession):
@@ -304,7 +304,7 @@ class TestFtsSearch:
         # New content should match
         results, _total = await search_articles(fts_session, "microservices", TEST_USER_ID)
         assert len(results) == 1
-        assert results[0]["title"] == "Original Title"
+        assert results[0].title == "Original Title"
 
     @pytest.mark.asyncio
     async def test_search_pagination(self, fts_session: AsyncSession):

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -567,7 +567,7 @@ async def test_wiki_get_concepts(db_session) -> None:
 async def test_wiki_get_health_default(db_session) -> None:
     svc = WikiService()
     h = await svc.get_health(db_session, user_id=TEST_USER_ID)
-    assert "total_articles" in h
+    assert h.total_articles is not None
 
 
 async def test_wiki_get_health_from_file(db_session, tmp_path, monkeypatch) -> None:
@@ -576,9 +576,10 @@ async def test_wiki_get_health_from_file(db_session, tmp_path, monkeypatch) -> N
     get_settings.cache_clear()
     meta = tmp_path / "wiki" / TEST_USER_ID / "_meta"
     meta.mkdir(parents=True)
-    (meta / "health.json").write_text(json.dumps({"foo": "bar"}))
+    (meta / "health.json").write_text(json.dumps({"total_articles": 42, "message": "test"}))
     h = await svc.get_health(db_session, user_id=TEST_USER_ID)
-    assert h["foo"] == "bar"
+    assert h.total_articles == 42
+    assert h.message == "test"
 
 
 def test_wiki_service_singleton() -> None:


### PR DESCRIPTION
## Problem

Several functions across services, routes, and engine modules used loose return types (`dict`, `tuple`, `Any`) instead of typed models. This prevented mypy from catching type mismatches at function boundaries and made it harder to understand what data flows between layers.

**Before:** 7 bare `-> dict` returns, 8 bare `-> tuple` returns across public service methods, route handlers, and engine functions.

## Solution

Replace all bare `dict` and `tuple` return types with Pydantic models or NamedTuples. Add 10 new typed models to `models.py` that precisely describe the shape of data at each boundary. No behavior changes -- only types added.

## Changes

**New models in `models.py`:**
- `OAuthTokenResponse` / `OAuthUserInfo` -- typed OAuth provider responses
- `UserProfileResponse` / `DeleteAccountResponse` -- auth route return types
- `FTSResultItem` / `FTSResponse` -- full-text search result types (replaces `list[dict]`)
- `WikiHealthReport` -- health endpoint return type
- `QAResult` / `FileBackArticlePair` -- QA agent NamedTuples (replaces `tuple[Query, Conversation, ...]`)
- `ResolvedBacklinks` -- wikilink resolver NamedTuple

**Updated across 11 source files:**
- `services/user.py` -- 4 OAuth methods + `upsert_oauth_user` parameter
- `services/search.py` -- 4 functions: `dict` -> `FTSResultItem`, `tuple` -> `FTSResponse`
- `services/wiki.py` -- `get_health`: `dict` -> `WikiHealthReport`
- `api/routes/auth.py` -- `me()` and `delete_account()` return types
- `api/routes/wiki.py` -- search route updated for typed results
- `engine/qa_agent.py` -- 4 methods: `tuple` -> `QAResult` / `FileBackArticlePair`
- `engine/wikilink_resolver.py` -- `tuple` -> `ResolvedBacklinks`
- `engine/frontmatter_validator.py` -- `dict` -> `dict[str, Any]`
- `engine/linter/contradictions.py` -- `dict` -> `dict[str, Any]`

**After:** 0 bare `-> dict`, 0 bare `-> tuple` in scope. mypy passes clean.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)