### PR TITLE
feat: stub pages and wikilink resolution (#451)

### DIFF
--- a/alembic/versions/0009_add_article_is_stub.py
+++ b/alembic/versions/0009_add_article_is_stub.py
@@ -1,0 +1,61 @@
+"""Add is_stub column to article.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-05-08
+
+Supports stub pages (issue #451). Stub articles are user-created
+placeholder pages for concepts not yet covered by compiled sources.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0009"
+down_revision: str = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _column_exists(conn: sa.engine.Connection, table: str, column: str) -> bool:
+    """Return True if *column* exists on *table* (works on SQLite + Postgres)."""
+    inspector = sa_inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    """Add ``is_stub`` to ``article``.
+
+    Idempotent: skips column if it already exists (e.g. when a fresh DB
+    was created from the current SQLModel definitions in 0001).
+    """
+    conn = op.get_bind()
+
+    if not _column_exists(conn, "article", "is_stub"):
+        op.add_column(
+            "article",
+            sa.Column(
+                "is_stub",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Drop the column added in :func:`upgrade`."""
+    conn = op.get_bind()
+
+    if conn.dialect.name == "sqlite":
+        with op.batch_alter_table("article") as batch_op:
+            if _column_exists(conn, "article", "is_stub"):
+                batch_op.drop_column("is_stub")
+    else:
+        if _column_exists(conn, "article", "is_stub"):
+            op.drop_column("article", "is_stub")

--- a/apps/web/src/api/wiki.ts
+++ b/apps/web/src/api/wiki.ts
@@ -6,7 +6,10 @@ import type {
   ArticleResponse,
   Concept,
   ConfidenceLevel,
+  CreateStubRequest,
+  CreateStubResponse,
   GraphResponse,
+  WikilinkMatch,
 } from "../types/api";
 
 export interface ListArticlesParams {
@@ -56,4 +59,22 @@ export function editArticle(
 
 export function getGraph(): Promise<GraphResponse> {
   return apiFetch<GraphResponse>("/api/wiki/graph");
+}
+
+export function createStubArticle(
+  body: CreateStubRequest,
+): Promise<CreateStubResponse> {
+  return apiFetch<CreateStubResponse>("/wiki/articles/stub", {
+    method: "POST",
+    body,
+  });
+}
+
+export function resolveWikilinks(
+  q: string,
+  limit = 10,
+): Promise<WikilinkMatch[]> {
+  return apiFetch<WikilinkMatch[]>("/wiki/wikilinks/resolve", {
+    query: { q, limit },
+  });
 }

--- a/apps/web/src/components/wiki/ArticleCardGrid.tsx
+++ b/apps/web/src/components/wiki/ArticleCardGrid.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useArticles } from "../../hooks/useArticles";
 import type { Article, ConfidenceLevel } from "../../types/api";
+import { Badge } from "../shared/Badge";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 import { PageTypeIndicator } from "./PageTypeIndicator";
 import { Spinner } from "../shared/Spinner";
@@ -71,10 +72,17 @@ function ArticleCard({ article }: { article: Article }) {
   return (
     <Link
       to={`/wiki/${encodeURIComponent(article.slug)}`}
-      className="group block rounded-lg border border-slate-200 bg-white p-4 shadow-sm transition hover:border-brand-300 hover:shadow-md"
+      className={`group block rounded-lg border p-4 shadow-sm transition hover:shadow-md ${
+        article.is_stub
+          ? "border-dashed border-amber-300 bg-amber-50/30 hover:border-amber-400"
+          : "border-slate-200 bg-white hover:border-brand-300"
+      }`}
     >
       <div className="mb-2 flex items-center gap-2">
         <PageTypeIndicator pageType={article.page_type} />
+        {article.is_stub ? (
+          <Badge tone="warning">Stub</Badge>
+        ) : null}
         {article.confidence ? (
           <ConfidenceBadge level={article.confidence as ConfidenceLevel} />
         ) : null}

--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -145,6 +145,9 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
           {isConcept && conceptKind ? (
             <Badge tone="neutral">{conceptKind}</Badge>
           ) : null}
+          {article.is_stub ? (
+            <Badge tone="warning">Stub</Badge>
+          ) : null}
           {article.manually_edited ? (
             <Badge tone="neutral">Edited</Badge>
           ) : null}

--- a/apps/web/src/components/wiki/CreateStubModal.tsx
+++ b/apps/web/src/components/wiki/CreateStubModal.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+
+interface CreateStubModalProps {
+  onClose: () => void;
+  onCreate: (title: string, body: string) => Promise<void>;
+}
+
+export function CreateStubModal({ onClose, onCreate }: CreateStubModalProps) {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    setIsCreating(true);
+    setError(null);
+    try {
+      await onCreate(title.trim(), body);
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create stub page.",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/30 animate-overlay-fade"
+        onClick={onClose}
+      />
+      <div className="animate-card-rise relative w-full max-w-lg rounded-xl bg-white p-6 shadow-2xl">
+        <h2 className="text-lg font-semibold text-slate-900">
+          Create New Page
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Create a stub page for a concept not yet covered by any source.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div>
+            <label
+              htmlFor="stub-title"
+              className="block text-sm font-medium text-slate-700"
+            >
+              Title
+            </label>
+            <input
+              id="stub-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Transformer Architecture"
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              autoFocus
+              disabled={isCreating}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="stub-body"
+              className="block text-sm font-medium text-slate-700"
+            >
+              Body{" "}
+              <span className="font-normal text-slate-400">(optional)</span>
+            </label>
+            <textarea
+              id="stub-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Add initial notes, links, or context..."
+              rows={4}
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              disabled={isCreating}
+            />
+          </div>
+
+          {error ? (
+            <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isCreating}
+              className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!title.trim() || isCreating}
+              className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+            >
+              {isCreating ? "Creating..." : "Create Page"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/PageTypeIndicator.tsx
+++ b/apps/web/src/components/wiki/PageTypeIndicator.tsx
@@ -10,6 +10,7 @@ const PAGE_TYPE_CONFIG: Record<
   answer: { label: "Answer", tone: "success" },
   index: { label: "Index", tone: "neutral" },
   meta: { label: "Meta", tone: "neutral" },
+  synthesis: { label: "Synthesis", tone: "brand" },
 };
 
 interface PageTypeIndicatorProps {

--- a/apps/web/src/components/wiki/WikiExplorerView.tsx
+++ b/apps/web/src/components/wiki/WikiExplorerView.tsx
@@ -3,13 +3,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { executeSavedSearch } from "../../api/tags";
 import { useArticle } from "../../hooks/useArticle";
-import { getRandomArticle } from "../../api/wiki";
+import { createStubArticle, getRandomArticle } from "../../api/wiki";
 import { Spinner } from "../shared/Spinner";
 import { ArticleCardGrid } from "./ArticleCardGrid";
 import { ArticleOutline } from "./ArticleOutline";
 import { ArticleReader } from "./ArticleReader";
 import { BacklinkPanel } from "./BacklinkPanel";
 import { ConceptTree } from "./ConceptTree";
+import { CreateStubModal } from "./CreateStubModal";
 import { FiguresPanel } from "./FiguresPanel";
 import { SavedSearches } from "./SavedSearches";
 import { SearchBar } from "./SearchBar";
@@ -30,6 +31,7 @@ export function WikiExplorerView() {
       setActiveConcept(null);
     },
   });
+  const [showStubModal, setShowStubModal] = useState(false);
 
   const hasSources =
     articleQuery.data?.sources && articleQuery.data.sources.length > 0;
@@ -41,6 +43,12 @@ export function WikiExplorerView() {
     } catch {
       // No articles available — silently ignore
     }
+  };
+
+  const handleCreateStub = async (title: string, body: string) => {
+    const stub = await createStubArticle({ title, body_markdown: body });
+    queryClient.invalidateQueries({ queryKey: ["articles"] });
+    navigate(`/wiki/${encodeURIComponent(stub.slug)}`);
   };
 
   const handleArticleUpdated = useCallback(() => {
@@ -75,6 +83,28 @@ export function WikiExplorerView() {
               />
             </svg>
             Random
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowStubModal(true)}
+            className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-600 shadow-sm transition hover:bg-slate-50 hover:text-slate-900"
+            title="Create a new stub page"
+            data-testid="new-page-btn"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 4.5v15m7.5-7.5h-15"
+              />
+            </svg>
+            New Page
           </button>
           {slug && hasSources && (
             <button
@@ -193,6 +223,13 @@ export function WikiExplorerView() {
           </section>
         </div>
       )}
+
+      {showStubModal ? (
+        <CreateStubModal
+          onClose={() => setShowStubModal(false)}
+          onCreate={handleCreateStub}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -25,8 +25,8 @@ body {
 }
 
 .wikilink-unresolved {
-  color: rgb(148 163 184); /* slate-400 */
-  text-decoration: underline dotted rgb(148 163 184);
+  color: rgb(225 29 72); /* rose-600 — classic wiki red link */
+  text-decoration: underline dashed rgb(225 29 72 / 0.5);
   text-underline-offset: 2px;
   cursor: help;
 }

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -15,7 +15,7 @@ export type IngestStatus = "pending" | "processing" | "compiled" | "failed";
 
 export type ConfidenceLevel = "sourced" | "mixed" | "inferred" | "opinion";
 
-export type PageType = "source" | "concept" | "answer" | "index" | "meta";
+export type PageType = "source" | "concept" | "answer" | "index" | "meta" | "synthesis";
 
 export type RelationType =
   | "references"
@@ -78,6 +78,7 @@ export interface Article {
   created_at: string;
   updated_at: string;
   tags?: TagRef[];
+  is_stub?: boolean;
 }
 
 export interface BacklinkEntry {
@@ -106,6 +107,26 @@ export interface ArticleResponse extends Article {
   sources: ArticleSourceRef[];
   manually_edited: boolean;
   edited_at: string | null;
+  is_stub: boolean;
+}
+
+export interface CreateStubRequest {
+  title: string;
+  body_markdown?: string;
+}
+
+export interface CreateStubResponse {
+  id: string;
+  slug: string;
+  title: string;
+  is_stub: boolean;
+}
+
+export interface WikilinkMatch {
+  id: string;
+  slug: string;
+  title: string;
+  is_stub: boolean;
 }
 
 export interface Concept {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WikiMind Gateway
-  description: "Local LLM Knowledge OS \u2014 Personal API"
+  description: Local LLM Knowledge OS — Personal API
   version: 0.1.0
 paths:
   /api/ingest/url:
@@ -223,9 +223,12 @@ paths:
       tags:
       - Ingest
       summary: Get Source Original
-      description: "Stream the original source document (PDF, HTML, etc.).\n\nReturns\
-        \ the raw binary stored during ingest \u2014 not the extracted text.\nSources\
-        \ that have no original (text, YouTube) return 404."
+      description: 'Stream the original source document (PDF, HTML, etc.).
+
+
+        Returns the raw binary stored during ingest — not the extracted text.
+
+        Sources that have no original (text, YouTube) return 404.'
       operationId: get_source_original_api_ingest_sources__source_id__original_get
       parameters:
       - name: source_id
@@ -437,6 +440,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/articles/stub:
+    post:
+      tags:
+      - Wiki
+      summary: Create Stub Article
+      description: Create a stub wiki article — a placeholder page for a concept not
+        yet compiled.
+      operationId: create_stub_article_api_wiki_articles_stub_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateStubRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateStubResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/wikilinks/resolve:
+    get:
+      tags:
+      - Wiki
+      summary: Resolve Wikilinks
+      description: Search articles by partial title for wikilink autocomplete.
+      operationId: resolve_wikilinks_api_wiki_wikilinks_resolve_get
+      parameters:
+      - name: q
+        in: query
+        required: true
+        schema:
+          type: string
+          minLength: 1
+          title: Q
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 50
+          minimum: 1
+          default: 10
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WikilinkMatch'
+                title: Response Resolve Wikilinks Api Wiki Wikilinks Resolve Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/wiki/articles/random:
     get:
       tags:
@@ -527,11 +597,20 @@ paths:
       tags:
       - Wiki
       summary: Get Graph
-      description: "Full knowledge graph -- nodes and edges.\n\nOptional query parameters\
-        \ filter the returned edge set:\n\n* ``relation_type`` \u2014 keep only edges\
-        \ of one semantic relation type.\n* ``from_article`` \u2014 id or slug of\
-        \ the source article.\n* ``to_article`` \u2014 id or slug of the target article.\n\
-        \nFilters compose with AND. Filtering is pushed down into SQL."
+      description: 'Full knowledge graph -- nodes and edges.
+
+
+        Optional query parameters filter the returned edge set:
+
+
+        * ``relation_type`` — keep only edges of one semantic relation type.
+
+        * ``from_article`` — id or slug of the source article.
+
+        * ``to_article`` — id or slug of the target article.
+
+
+        Filters compose with AND. Filtering is pushed down into SQL.'
       operationId: get_graph_api_wiki_graph_get
       parameters:
       - name: relation_type
@@ -1081,8 +1160,7 @@ paths:
       tags:
       - Query
       summary: Query History
-      description: "List past queries (legacy endpoint \u2014 UI uses /conversations\
-        \ instead)."
+      description: List past queries (legacy endpoint — UI uses /conversations instead).
       operationId: query_history_api_query_history_get
       parameters:
       - name: limit
@@ -1689,10 +1767,14 @@ paths:
       tags:
       - Settings
       summary: Get Onboarding Status
-      description: "Return onboarding wizard progress for the current user.\n\nIf\
-        \ the user has never explicitly completed onboarding but already has\narticles\
-        \ in the wiki, treat onboarding as implicitly complete \u2014 they\nare clearly\
-        \ past the first-run stage."
+      description: 'Return onboarding wizard progress for the current user.
+
+
+        If the user has never explicitly completed onboarding but already has
+
+        articles in the wiki, treat onboarding as implicitly complete — they
+
+        are clearly past the first-run stage.'
       operationId: get_onboarding_status_api_settings_onboarding_status_get
       responses:
         '200':
@@ -2118,8 +2200,8 @@ paths:
       tags:
       - Auth
       summary: Auth Callback
-      description: "Handle OAuth2 callback \u2014 exchange code for token, upsert\
-        \ user, set cookie."
+      description: Handle OAuth2 callback — exchange code for token, upsert user,
+        set cookie.
       operationId: auth_callback_auth_callback_get
       parameters:
       - name: code
@@ -2315,7 +2397,7 @@ paths:
   /health:
     get:
       summary: Health
-      description: "Health check \u2014 used by Electron to confirm daemon is ready."
+      description: Health check — used by Electron to confirm daemon is ready.
       operationId: health_health_get
       responses:
         '200':
@@ -2553,6 +2635,10 @@ components:
             format: date-time
           - type: 'null'
           title: Edited At
+        is_stub:
+          type: boolean
+          title: Is Stub
+          default: false
       type: object
       required:
       - id
@@ -2584,9 +2670,12 @@ components:
       - source_type
       - title
       title: ArticleSourceSummary
-      description: "Minimal source descriptor returned with listing/search endpoints.\n\
-        \nA lightweight summary used when the full :class:`SourceResponse` is\noverkill\
-        \ \u2014 e.g. article list and search result payloads."
+      description: 'Minimal source descriptor returned with listing/search endpoints.
+
+
+        A lightweight summary used when the full :class:`SourceResponse` is
+
+        overkill — e.g. article list and search result payloads.'
     ArticleSummaryResponse:
       properties:
         id:
@@ -2677,6 +2766,10 @@ components:
           type: boolean
           title: Manually Edited
           default: false
+        is_stub:
+          type: boolean
+          title: Is Stub
+          default: false
       type: object
       required:
       - id
@@ -2721,8 +2814,8 @@ components:
       - query
       - conversation
       title: AskResponse
-      description: "Response shape for POST /query \u2014 wraps both the new query\
-        \ and its parent conversation."
+      description: Response shape for POST /query — wraps both the new query and its
+        parent conversation.
     BacklinkEntry:
       properties:
         id:
@@ -3080,8 +3173,7 @@ components:
       - updated_at
       - turn_count
       title: ConversationSummary
-      description: "Conversation summary for the history sidebar \u2014 adds turn\
-        \ count."
+      description: Conversation summary for the history sidebar — adds turn count.
     CostBreakdownEntry:
       properties:
         cost_usd:
@@ -3168,6 +3260,43 @@ components:
       - name
       title: CreateSavedSearchRequest
       description: Request to create a saved search.
+    CreateStubRequest:
+      properties:
+        title:
+          type: string
+          minLength: 1
+          title: Title
+        body_markdown:
+          type: string
+          title: Body Markdown
+          default: ''
+      type: object
+      required:
+      - title
+      title: CreateStubRequest
+      description: 'Request to create a stub wiki article (issue #451).'
+    CreateStubResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+        is_stub:
+          type: boolean
+          title: Is Stub
+          default: true
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      title: CreateStubResponse
+      description: Response after creating a stub article.
     CreateTagRequest:
       properties:
         name:
@@ -3654,10 +3783,13 @@ components:
       - orphan
       - structural
       title: LintFindingKind
-      description: "Kind of lint finding \u2014 maps 1:1 to a detection function AND\
-        \ a table.\n\nUsed as the content_hash prefix (so dismiss state is keyed by\
-        \ kind + content)\nand as the discriminator field in the frontend API response\
-        \ union."
+      description: 'Kind of lint finding — maps 1:1 to a detection function AND a
+        table.
+
+
+        Used as the content_hash prefix (so dismiss state is keyed by kind + content)
+
+        and as the discriminator field in the frontend API response union.'
     LintReport:
       properties:
         id:
@@ -3930,8 +4062,8 @@ components:
       - meta
       - synthesis
       title: PageType
-      description: "Type of wiki page \u2014 determines compilation pipeline and validation\
-        \ rules."
+      description: Type of wiki page — determines compilation pipeline and validation
+        rules.
     ProviderDetail:
       properties:
         enabled:
@@ -4043,10 +4175,15 @@ components:
       - filed_article_id
       - created_at
       title: QueryResponse
-      description: "Q&A response enriched with a full Answer \u2192 Article \u2192\
-        \ Source citation chain.\n\nMirrors the persisted :class:`Query` record fields\
-        \ while adding a\nresolved ``citations`` list so clients can see which articles\
-        \ were\nused and which original sources those articles came from."
+      description: 'Q&A response enriched with a full Answer → Article → Source citation
+        chain.
+
+
+        Mirrors the persisted :class:`Query` record fields while adding a
+
+        resolved ``citations`` list so clients can see which articles were
+
+        used and which original sources those articles came from.'
     RebuildConceptsResponse:
       properties:
         status:
@@ -4425,7 +4562,7 @@ components:
       - source_type
       - has_original
       title: Source
-      description: "Raw ingested source \u2014 before compilation."
+      description: Raw ingested source — before compilation.
     SourceContentResponse:
       properties:
         content:
@@ -4756,6 +4893,28 @@ components:
         overall verdict; ``auto_filed`` records whether a wiki article was
 
         actually created as a result of this score.'
+    WikilinkMatch:
+      properties:
+        id:
+          type: string
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+        is_stub:
+          type: boolean
+          title: Is Stub
+          default: false
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      title: WikilinkMatch
+      description: A single article match for wikilink resolution autocomplete.
 tags:
 - name: Wiki
   description: Browse wiki articles, knowledge graph, and search

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -24,6 +24,8 @@ from wikimind.models import (
     ContradictionResolutionOption,
     ContradictionResponse,
     ContradictionStatus,
+    CreateStubRequest,
+    CreateStubResponse,
     GraphResponse,
     HealthSummaryResponse,
     Job,
@@ -41,6 +43,7 @@ from wikimind.models import (
     SearchResult,
     TagArticleRequest,
     TagResponse,
+    WikilinkMatch,
 )
 from wikimind.services.contradiction import ContradictionService, get_contradiction_service
 from wikimind.services.linter import LinterService, get_linter_service
@@ -137,6 +140,41 @@ async def list_articles(
         offset=offset,
         user_id=user_id,
     )
+
+
+@router.post(
+    "/articles/stub",
+    response_model=CreateStubResponse,
+    status_code=201,
+)
+async def create_stub_article(
+    body: CreateStubRequest,
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Create a stub wiki article — a placeholder page for a concept not yet compiled."""
+    return await service.create_stub_article(
+        title=body.title,
+        body_markdown=body.body_markdown,
+        session=session,
+        user_id=user_id,
+    )
+
+
+@router.get(
+    "/wikilinks/resolve",
+    response_model=list[WikilinkMatch],
+)
+async def resolve_wikilinks(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=50),
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Search articles by partial title for wikilink autocomplete."""
+    return await service.resolve_wikilinks(q, session, user_id=user_id, limit=limit)
 
 
 @router.get(

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -223,6 +223,10 @@ class Article(SQLModel, table=True):
     # parameter is required to overwrite user edits.
     manually_edited: bool = False
     edited_at: datetime | None = None
+    # Stub page support (issue #451). Stub articles are user-created
+    # placeholder pages for concepts that have no source coverage yet.
+    # They appear in article lists but are visually differentiated.
+    is_stub: bool = False
 
     # ORM relationships — used for eager-loading backlinks
     backlinks_out: list["Backlink"] = Relationship(
@@ -957,6 +961,31 @@ class BacklinkEntry(BaseModel):
     resolution: str | None = None
 
 
+class CreateStubRequest(BaseModel):
+    """Request to create a stub wiki article (issue #451)."""
+
+    title: str = Field(min_length=1)
+    body_markdown: str = ""
+
+
+class CreateStubResponse(BaseModel):
+    """Response after creating a stub article."""
+
+    id: str
+    slug: str
+    title: str
+    is_stub: bool = True
+
+
+class WikilinkMatch(BaseModel):
+    """A single article match for wikilink resolution autocomplete."""
+
+    id: str
+    slug: str
+    title: str
+    is_stub: bool = False
+
+
 class ArticleEditRequest(BaseModel):
     """Request to manually edit an article's content or title."""
 
@@ -987,6 +1016,7 @@ class ArticleResponse(BaseModel):
     page_type: PageType = PageType.SOURCE
     manually_edited: bool = False
     edited_at: datetime | None = None
+    is_stub: bool = False
 
 
 class ArticleSummaryResponse(BaseModel):
@@ -1017,6 +1047,7 @@ class ArticleSummaryResponse(BaseModel):
     source_ids: list[str] = []
     user_id: str | None = None
     manually_edited: bool = False
+    is_stub: bool = False
 
 
 class ContradictionResolutionOption(BaseModel):

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -13,8 +13,10 @@ scoring. Otherwise the service falls back to keyword-only search.
 
 import functools
 import json
+import re
 
 import structlog
+from slugify import slugify
 from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -35,6 +37,7 @@ from wikimind.models import (
     BacklinkEntry,
     Concept,
     ConceptDetailResponse,
+    CreateStubResponse,
     GraphEdge,
     GraphNode,
     GraphResponse,
@@ -45,6 +48,7 @@ from wikimind.models import (
     Source,
     SourceResponse,
     WikiHealthReport,
+    WikilinkMatch,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE, get_embedding_service
 from wikimind.services.tags import get_tag_service
@@ -252,6 +256,7 @@ async def _build_article_summary(article: Article, session: AsyncSession) -> Art
         source_ids=source_ids,
         user_id=article.user_id,
         manually_edited=article.manually_edited,
+        is_stub=article.is_stub,
     )
 
 
@@ -447,6 +452,7 @@ class WikiService:
             updated_at=article.updated_at,
             manually_edited=article.manually_edited,
             edited_at=article.edited_at,
+            is_stub=article.is_stub,
         )
 
     async def edit_article(
@@ -1024,6 +1030,181 @@ class WikiService:
             total_sources=0,
             message="Run the linter to generate a health report",
         )
+
+    async def _generate_unique_slug(
+        self,
+        title: str,
+        session: AsyncSession,
+        user_id: str,
+    ) -> str:
+        """Generate a URL-safe slug from a title, avoiding collisions per user.
+
+        Tries the base slug first; if it already exists for this user,
+        appends ``-2``, ``-3``, etc. until a unique value is found.
+        """
+        base = slugify(title, max_length=80)
+        candidate = base
+        suffix = 2
+        while True:
+            existing = (
+                (
+                    await session.execute(
+                        select(Article).where(
+                            Article.slug == candidate,
+                            Article.user_id == user_id,
+                        )
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if existing is None:
+                return candidate
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+
+    async def create_stub_article(
+        self,
+        title: str,
+        body_markdown: str,
+        session: AsyncSession,
+        user_id: str,
+    ) -> CreateStubResponse:
+        """Create a stub wiki article.
+
+        A stub is a user-created placeholder page for a concept that has
+        no compiled source yet. The article is written to disk as a minimal
+        markdown file and stored in the database with ``is_stub=True``.
+
+        Args:
+            title: Article title.
+            body_markdown: Optional body markdown content.
+            session: Async database session.
+            user_id: Owner user ID.
+
+        Returns:
+            :class:`CreateStubResponse` with the new article's id, slug, and title.
+        """
+        slug = await self._generate_unique_slug(title, session, user_id)
+
+        # Write markdown file to disk
+        relative_path = f"stubs/{slug}.md"
+        storage = get_wiki_storage(user_id)
+        content = f'---\ntitle: "{title}"\nslug: {slug}\npage_type: source\nis_stub: true\n---\n\n'
+        if body_markdown:
+            content += body_markdown
+        await storage.write(relative_path, content)
+
+        # Create database record
+        article = Article(
+            slug=slug,
+            title=title,
+            file_path=relative_path,
+            page_type=PageType.SOURCE,
+            is_stub=True,
+            user_id=user_id,
+        )
+        session.add(article)
+        await session.commit()
+        await session.refresh(article)
+
+        return CreateStubResponse(
+            id=article.id,
+            slug=article.slug,
+            title=article.title,
+            is_stub=True,
+        )
+
+    async def resolve_wikilinks(
+        self,
+        query: str,
+        session: AsyncSession,
+        user_id: str,
+        limit: int = 10,
+    ) -> list[WikilinkMatch]:
+        """Search articles by partial title for wikilink autocomplete.
+
+        Case-insensitive partial match against article titles.
+
+        Args:
+            query: Partial title string to search for.
+            session: Async database session.
+            user_id: User scope.
+            limit: Maximum number of matches to return.
+
+        Returns:
+            List of matching :class:`WikilinkMatch` entries.
+        """
+        # Strip [[ ]] wrapper if present
+        q = query.strip().strip("[").strip("]").strip()
+        if not q:
+            return []
+
+        stmt = (
+            select(Article)
+            .where(Article.user_id == user_id)
+            .where(func.lower(Article.title).contains(q.lower()))
+            .order_by(Article.title)
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        articles = result.scalars().all()
+        return [
+            WikilinkMatch(
+                id=a.id,
+                slug=a.slug,
+                title=a.title,
+                is_stub=a.is_stub,
+            )
+            for a in articles
+        ]
+
+    async def process_wikilinks(
+        self,
+        markdown: str,
+        session: AsyncSession,
+        user_id: str,
+    ) -> str:
+        """Resolve ``[[article title]]`` patterns in markdown content.
+
+        Finds all ``[[...]]`` patterns and replaces them:
+        - If a matching article exists: ``[title](/wiki/articles/{slug})``
+        - If no match: leaves the ``[[title]]`` as-is (the frontend renders
+          these as red/stub links).
+
+        Args:
+            markdown: Raw markdown content.
+            session: Async database session.
+            user_id: User scope.
+
+        Returns:
+            Markdown with resolved wikilinks replaced by standard links.
+        """
+        pattern = re.compile(r"\[\[([^\]]+)\]\]")
+        matches = pattern.findall(markdown)
+        if not matches:
+            return markdown
+
+        # Load all articles for this user once
+        stmt = select(Article).where(Article.user_id == user_id)
+        result = await session.execute(stmt)
+        all_articles = list(result.scalars().all())
+
+        by_lower: dict[str, Article] = {}
+        for article in all_articles:
+            lower_key = article.title.lower()
+            if lower_key not in by_lower:
+                by_lower[lower_key] = article
+
+        def replace_wikilink(match: re.Match) -> str:
+            title = match.group(1).strip()
+            target = by_lower.get(title.lower())
+            if target is not None:
+                return f"[{title}](/wiki/articles/{target.slug})"
+            # Leave unresolved — frontend renders as red link
+            return match.group(0)
+
+        return pattern.sub(replace_wikilink, markdown)
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/unit/test_stub_and_wikilinks.py
+++ b/tests/unit/test_stub_and_wikilinks.py
@@ -1,0 +1,346 @@
+"""Tests for stub page creation and wikilink resolution (issue #451)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlmodel import select
+
+from wikimind.api.deps import ANONYMOUS_USER_ID
+from wikimind.models import Article, PageType
+from wikimind.services.wiki import WikiService
+from wikimind.storage import get_wiki_storage
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncEngine
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tests.conftest import TEST_USER_ID
+
+# When auth is disabled (as in tests), get_current_user_id returns ANONYMOUS_USER_ID.
+_CLIENT_USER_ID = ANONYMOUS_USER_ID
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests (direct WikiService calls)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_stub_article(db_session: AsyncSession, _isolated_data_dir) -> None:
+    """WikiService.create_stub_article creates a stub with is_stub=True."""
+    service = WikiService()
+    result = await service.create_stub_article(
+        title="Quantum Computing",
+        body_markdown="",
+        session=db_session,
+        user_id=TEST_USER_ID,
+    )
+    assert result.title == "Quantum Computing"
+    assert result.slug == "quantum-computing"
+    assert result.is_stub is True
+
+    # Verify the article is in the database
+    stmt = select(Article).where(Article.id == result.id)
+    db_result = await db_session.execute(stmt)
+    article = db_result.scalar_one()
+    assert article.is_stub is True
+    assert article.page_type == PageType.SOURCE
+
+
+@pytest.mark.asyncio
+async def test_create_stub_with_body(db_session: AsyncSession, _isolated_data_dir) -> None:
+    """Stub creation writes body_markdown to disk."""
+    service = WikiService()
+    result = await service.create_stub_article(
+        title="Neural Networks",
+        body_markdown="Some initial notes about NNs.",
+        session=db_session,
+        user_id=TEST_USER_ID,
+    )
+
+    storage = get_wiki_storage(TEST_USER_ID)
+
+    stmt = select(Article).where(Article.id == result.id)
+    db_result = await db_session.execute(stmt)
+    article = db_result.scalar_one()
+    content = await storage.read(article.file_path)
+    assert "Some initial notes about NNs." in content
+
+
+@pytest.mark.asyncio
+async def test_create_stub_slug_collision(db_session: AsyncSession, _isolated_data_dir) -> None:
+    """When a slug already exists, a suffix is appended."""
+    service = WikiService()
+    result1 = await service.create_stub_article(
+        title="Test Article",
+        body_markdown="",
+        session=db_session,
+        user_id=TEST_USER_ID,
+    )
+    result2 = await service.create_stub_article(
+        title="Test Article",
+        body_markdown="",
+        session=db_session,
+        user_id=TEST_USER_ID,
+    )
+    assert result1.slug == "test-article"
+    assert result2.slug == "test-article-2"
+
+
+@pytest.mark.asyncio
+async def test_resolve_wikilinks_finds_matches(db_session: AsyncSession) -> None:
+    """resolve_wikilinks returns partial title matches."""
+    service = WikiService()
+    db_session.add(
+        Article(
+            id=str(uuid.uuid4()),
+            slug="machine-learning",
+            title="Machine Learning",
+            file_path="/tmp/ml.md",
+            user_id=TEST_USER_ID,
+        )
+    )
+    db_session.add(
+        Article(
+            id=str(uuid.uuid4()),
+            slug="machine-translation",
+            title="Machine Translation",
+            file_path="/tmp/mt.md",
+            user_id=TEST_USER_ID,
+        )
+    )
+    await db_session.commit()
+
+    matches = await service.resolve_wikilinks("Machine", db_session, user_id=TEST_USER_ID)
+    assert len(matches) == 2
+    titles = {m.title for m in matches}
+    assert "Machine Learning" in titles
+    assert "Machine Translation" in titles
+
+
+@pytest.mark.asyncio
+async def test_resolve_wikilinks_case_insensitive(db_session: AsyncSession) -> None:
+    """Wikilink resolution is case-insensitive."""
+    service = WikiService()
+    db_session.add(
+        Article(
+            id=str(uuid.uuid4()),
+            slug="react",
+            title="React",
+            file_path="/tmp/react.md",
+            user_id=TEST_USER_ID,
+        )
+    )
+    await db_session.commit()
+
+    matches = await service.resolve_wikilinks("react", db_session, user_id=TEST_USER_ID)
+    assert len(matches) == 1
+    assert matches[0].title == "React"
+
+
+@pytest.mark.asyncio
+async def test_resolve_wikilinks_strips_brackets(db_session: AsyncSession) -> None:
+    """Leading/trailing brackets are stripped from the query."""
+    service = WikiService()
+    db_session.add(
+        Article(
+            id=str(uuid.uuid4()),
+            slug="react",
+            title="React",
+            file_path="/tmp/react.md",
+            user_id=TEST_USER_ID,
+        )
+    )
+    await db_session.commit()
+
+    matches = await service.resolve_wikilinks("[[React]]", db_session, user_id=TEST_USER_ID)
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_wikilinks_empty_query(db_session: AsyncSession) -> None:
+    """Empty query returns no results."""
+    service = WikiService()
+    matches = await service.resolve_wikilinks("", db_session, user_id=TEST_USER_ID)
+    assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_process_wikilinks_resolves_existing(db_session: AsyncSession) -> None:
+    """process_wikilinks replaces [[title]] with markdown links for existing articles."""
+    service = WikiService()
+    db_session.add(
+        Article(
+            id=str(uuid.uuid4()),
+            slug="react",
+            title="React",
+            file_path="/tmp/react.md",
+            user_id=TEST_USER_ID,
+        )
+    )
+    await db_session.commit()
+
+    result = await service.process_wikilinks(
+        "Check out [[React]] for more info.",
+        db_session,
+        user_id=TEST_USER_ID,
+    )
+    assert "[React](/wiki/articles/react)" in result
+    assert "[[React]]" not in result
+
+
+@pytest.mark.asyncio
+async def test_process_wikilinks_leaves_unresolved(db_session: AsyncSession) -> None:
+    """process_wikilinks leaves [[unknown]] as-is when no article matches."""
+    service = WikiService()
+    result = await service.process_wikilinks(
+        "See [[Unknown Topic]] for details.",
+        db_session,
+        user_id=TEST_USER_ID,
+    )
+    assert "[[Unknown Topic]]" in result
+
+
+@pytest.mark.asyncio
+async def test_process_wikilinks_mixed(db_session: AsyncSession) -> None:
+    """process_wikilinks handles a mix of resolved and unresolved links."""
+    service = WikiService()
+    db_session.add(
+        Article(
+            id=str(uuid.uuid4()),
+            slug="react",
+            title="React",
+            file_path="/tmp/react.md",
+            user_id=TEST_USER_ID,
+        )
+    )
+    await db_session.commit()
+
+    result = await service.process_wikilinks(
+        "Learn [[React]] and [[Vue]] frameworks.",
+        db_session,
+        user_id=TEST_USER_ID,
+    )
+    assert "[React](/wiki/articles/react)" in result
+    assert "[[Vue]]" in result
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests (HTTP endpoints via test client)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_articles(factory) -> None:
+    """Create a few articles for the anonymous user."""
+    async with factory() as session:
+        session.add(
+            Article(
+                id="a1",
+                slug="machine-learning",
+                title="Machine Learning",
+                file_path="/tmp/ml.md",
+                user_id=_CLIENT_USER_ID,
+            )
+        )
+        session.add(
+            Article(
+                id="a2",
+                slug="deep-learning",
+                title="Deep Learning",
+                file_path="/tmp/dl.md",
+                user_id=_CLIENT_USER_ID,
+                is_stub=True,
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_post_stub_endpoint(client: AsyncClient, _isolated_data_dir) -> None:
+    """POST /wiki/articles/stub creates a stub article and returns 201."""
+    response = await client.post(
+        "/wiki/articles/stub",
+        json={"title": "Quantum Computing", "body_markdown": ""},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Quantum Computing"
+    assert data["is_stub"] is True
+    assert data["slug"] == "quantum-computing"
+
+
+@pytest.mark.asyncio
+async def test_post_stub_with_body(client: AsyncClient, _isolated_data_dir) -> None:
+    """POST /wiki/articles/stub with body_markdown creates file on disk."""
+    response = await client.post(
+        "/wiki/articles/stub",
+        json={"title": "Neural Nets", "body_markdown": "Notes about NNs."},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["slug"] == "neural-nets"
+
+
+@pytest.mark.asyncio
+async def test_post_stub_empty_title_rejected(client: AsyncClient) -> None:
+    """POST /wiki/articles/stub with empty title returns 422."""
+    response = await client.post(
+        "/wiki/articles/stub",
+        json={"title": ""},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_wikilink_resolve_endpoint(client: AsyncClient, async_engine: AsyncEngine) -> None:
+    """GET /wiki/wikilinks/resolve returns matching articles."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    response = await client.get("/wiki/wikilinks/resolve", params={"q": "learning"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    titles = {m["title"] for m in data}
+    assert "Machine Learning" in titles
+    assert "Deep Learning" in titles
+
+
+@pytest.mark.asyncio
+async def test_wikilink_resolve_shows_stub_flag(client: AsyncClient, async_engine: AsyncEngine) -> None:
+    """Wikilink resolve response includes is_stub field."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    response = await client.get("/wiki/wikilinks/resolve", params={"q": "Deep"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["is_stub"] is True
+
+
+@pytest.mark.asyncio
+async def test_wikilink_resolve_empty_query_rejected(client: AsyncClient) -> None:
+    """GET /wiki/wikilinks/resolve with empty q returns 422."""
+    response = await client.get("/wiki/wikilinks/resolve", params={"q": ""})
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_article_list_includes_stub_flag(client: AsyncClient, async_engine: AsyncEngine) -> None:
+    """GET /wiki/articles returns is_stub in the response for each article."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    response = await client.get("/wiki/articles")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    by_slug = {a["slug"]: a for a in data}
+    assert by_slug["machine-learning"]["is_stub"] is False
+    assert by_slug["deep-learning"]["is_stub"] is True


### PR DESCRIPTION
## Summary

Users cannot currently create wiki pages manually or add wikilinks that the LLM compiler missed. This PR adds stub page creation and wikilink resolution so users can curate the knowledge graph alongside the compiler.

- **Stub pages**: `POST /wiki/articles/stub` creates placeholder pages with `is_stub=True`, auto-generated slugs, and minimal markdown files on disk
- **Wikilink resolution**: `GET /wiki/wikilinks/resolve?q=...` provides case-insensitive partial title search for autocomplete; `process_wikilinks()` service method resolves `[[title]]` patterns to standard markdown links
- **Frontend**: "+ New Page" button with modal dialog, "Stub" badge on article cards/reader, dashed amber card borders for stubs, rose-colored red links for unresolved `[[wikilinks]]`

## Changes

**Backend**
- `src/wikimind/models.py` — Added `is_stub` field to Article, `CreateStubRequest`/`CreateStubResponse`/`WikilinkMatch` request/response models, `is_stub` on `ArticleResponse` and `ArticleSummaryResponse`
- `src/wikimind/services/wiki.py` — Added `create_stub_article()`, `resolve_wikilinks()`, `process_wikilinks()` service methods with slug generation
- `src/wikimind/api/routes/wiki.py` — Added `POST /wiki/articles/stub` and `GET /wiki/wikilinks/resolve` endpoints
- `alembic/versions/0009_add_article_is_stub.py` — Idempotent migration for the `is_stub` column

**Frontend**
- `apps/web/src/components/wiki/CreateStubModal.tsx` — New modal component for stub creation
- `apps/web/src/components/wiki/WikiExplorerView.tsx` — "+ New Page" button and modal integration
- `apps/web/src/components/wiki/ArticleCardGrid.tsx` — Stub badge and dashed amber border styling
- `apps/web/src/components/wiki/ArticleReader.tsx` — Stub badge in article header
- `apps/web/src/index.css` — Red/dashed wikilink styling (classic wiki red-link convention)
- `apps/web/src/types/api.ts` — TypeScript types for stub and wikilink features

**Tests**
- `tests/unit/test_stub_and_wikilinks.py` — 17 tests covering service-layer and route-level behavior

Closes #451

## Test plan

- [x] `make verify` passes (lint, format, typecheck, 1204 tests)
- [x] `POST /wiki/articles/stub` creates stub with correct slug and `is_stub=True`
- [x] Slug collision appends `-2`, `-3` suffix
- [x] `GET /wiki/wikilinks/resolve?q=...` returns partial matches with `is_stub` flag
- [x] `process_wikilinks()` resolves existing articles and leaves unknown titles as `[[...]]`
- [x] Empty/invalid requests return 422
- [x] Article list and detail endpoints include `is_stub` field
- [x] Frontend TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Playwright screenshots confirm UI rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)