### PR TITLE
refactor: unify _create_article and _replace_article_in_place in compiler.py

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -302,9 +302,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         """Persist a compiled article, replacing any prior same-provider build."""
         provider = self._last_provider_used
         existing = await self._find_article_for_source_and_provider(session, source.id, provider)
-        if existing is not None:
-            return await self._replace_article_in_place(existing, result, source, session)
-        return await self._create_article(result, source, session, provider)
+        return await self._upsert_article(result, source, session, provider, existing=existing)
 
     async def save_article_in_place(
         self,
@@ -318,7 +316,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         Use this when the caller already holds the article row that should be
         updated (e.g. the force-recompile path).
         """
-        return await self._replace_article_in_place(existing, result, source, session)
+        return await self._upsert_article(result, source, session, existing.provider, existing=existing)
 
     async def _find_article_for_source_and_provider(
         self,
@@ -338,26 +336,6 @@ Compile this into a wiki article following the JSON schema exactly."""
             if article.provider == provider:
                 return article
         return None
-
-    async def _create_article(
-        self,
-        result: CompilationResult,
-        source: Source,
-        session: AsyncSession,
-        provider: Provider | None,
-    ) -> Article:
-        """Create a brand-new article (no existing same-provider article)."""
-        return await self._upsert_article(result, source, session, provider, existing=None)
-
-    async def _replace_article_in_place(
-        self,
-        existing: Article,
-        result: CompilationResult,
-        source: Source,
-        session: AsyncSession,
-    ) -> Article:
-        """Replace an existing same-source same-provider article in place."""
-        return await self._upsert_article(result, source, session, existing.provider, existing=existing)
 
     async def _upsert_article(
         self,

--- a/tests/unit/test_concept_recompilation.py
+++ b/tests/unit/test_concept_recompilation.py
@@ -3,7 +3,7 @@
 Verifies that:
 1. Concept pages are NOT recompiled when the source set is unchanged.
 2. Concept pages ARE recompiled when a new source article is added.
-3. ``_replace_article_in_place`` triggers concept page compilation.
+3. ``_upsert_article`` triggers concept page compilation when replacing.
 """
 
 from __future__ import annotations
@@ -219,10 +219,10 @@ class TestSourceSetChangedTriggersRecompilation:
 
 @pytest.mark.asyncio
 class TestReplaceArticleTriggersConceptPages:
-    """``_replace_article_in_place`` must trigger concept page compilation."""
+    """``_upsert_article`` must trigger concept page compilation when replacing."""
 
     async def test_replace_calls_maybe_trigger(self, db_session, tmp_path):
-        """Verify that _replace_article_in_place invokes maybe_trigger_concept_pages."""
+        """Verify that _upsert_article invokes maybe_trigger_concept_pages when replacing."""
         # Create a source.
         source = Source(
             title="Test Source",
@@ -295,7 +295,7 @@ class TestReplaceArticleTriggersConceptPages:
             patch("wikimind.engine.compiler.append_log_entry"),
             patch("wikimind.engine.compiler.validate_frontmatter"),
         ):
-            await compiler._replace_article_in_place(existing, result, source, db_session)
+            await compiler._upsert_article(result, source, db_session, existing.provider, existing=existing)
 
         # The key assertion: maybe_trigger_concept_pages was called.
         mock_trigger.assert_called_once_with(mock_concept_session, user_id=source.user_id)


### PR DESCRIPTION
## Summary

Closes #317.

The compiler had two thin wrapper methods (`_create_article` and `_replace_article_in_place`) that were one-line delegates to `_upsert_article`. This PR removes them and has callers invoke `_upsert_article` directly, eliminating unnecessary indirection.

- **`save_article`** now calls `_upsert_article` directly, passing the looked-up `existing` (which may be `None` for creates)
- **`save_article_in_place`** now calls `_upsert_article` directly with the provided `existing` article
- Test docstrings updated to reference `_upsert_article` instead of the removed wrappers

No behavioral changes -- this is a pure structural refactor that reduces the file by 22 lines.

## Test plan

- [ ] `make test` passes with the same result as main (1213 passed, 26 pre-existing failures unrelated to compiler)
- [ ] All 51 compiler-specific tests pass (`test_engine_compiler.py`, `test_concept_recompilation.py`, `test_phase2_compiler.py`)
- [ ] `make lint` passes (ruff check clean)
- [ ] `TestReplaceArticleTriggersConceptPages::test_replace_calls_maybe_trigger` still verifies that replacing an article triggers concept page compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)