### PR TITLE
ci: add PR automation workflows (review, rebase, sweep, prune)

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,83 @@
+# ===============================================================
+# 🔄  Auto-Rebase — keep open PRs up to date with main
+# ===============================================================
+#
+#   - triggers on push to main
+#   - finds all open PRs and rebases each onto updated main
+#   - skips PRs with merge conflicts (adds 'needs-rebase' label)
+#   - removes 'needs-rebase' label on successful rebase
+# ---------------------------------------------------------------
+
+name: Auto-Rebase
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Rebase open PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          prs=$(gh pr list --state open --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs to rebase"
+            exit 0
+          fi
+
+          echo "$prs" | while read -r pr_number branch; do
+            echo "::group::PR #${pr_number} (${branch})"
+
+            git fetch origin "$branch" 2>/dev/null || {
+              echo "Could not fetch branch ${branch}, skipping"
+              echo "::endgroup::"
+              continue
+            }
+
+            git checkout "$branch" 2>/dev/null || {
+              echo "Could not checkout branch ${branch}, skipping"
+              echo "::endgroup::"
+              continue
+            }
+
+            if git rebase origin/main; then
+              git push --force-with-lease origin "$branch"
+              # Remove needs-rebase label if present
+              gh pr edit "$pr_number" --remove-label "needs-rebase" 2>/dev/null || true
+              echo "Rebased PR #${pr_number}"
+            else
+              git rebase --abort
+              # Add needs-rebase label
+              gh label create "needs-rebase" --color "D93F0B" --description "PR has merge conflicts with main" 2>/dev/null || true
+              gh pr edit "$pr_number" --add-label "needs-rebase"
+              echo "PR #${pr_number} has conflicts — labeled needs-rebase"
+            fi
+
+            git checkout main
+            echo "::endgroup::"
+          done

--- a/.github/workflows/claude-review-address.yml
+++ b/.github/workflows/claude-review-address.yml
@@ -1,0 +1,44 @@
+# ===============================================================
+# 🤖  Claude Review Address — AI-assisted code review response
+# ===============================================================
+#
+#   - triggers when @claude is mentioned in a PR comment or review
+#   - Claude reads the feedback, checks out the branch, pushes fixes
+#   - uses anthropics/claude-code-action@v1 with ANTHROPIC_API_KEY
+#   - respects CLAUDE.md project conventions
+#   - opt-in: only activates on explicit @claude mention
+# ---------------------------------------------------------------
+
+name: Claude Review Address
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  address-review:
+    # Only run when @claude is mentioned in a PR context
+    if: |
+      contains(github.event.comment.body || github.event.review.body || '', '@claude') &&
+      (github.event.issue.pull_request || github.event.pull_request)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_bedrock: false
+          use_vertex: false

--- a/.github/workflows/post-merge-sweep.yml
+++ b/.github/workflows/post-merge-sweep.yml
@@ -1,0 +1,95 @@
+# ===============================================================
+# 🧹  Post-Merge Sweep — clean up after PR merge
+# ===============================================================
+#
+#   - triggers when a PR is merged
+#   - deletes the head branch (since delete_branch_on_merge is off)
+#   - resolves any outstanding review threads
+# ---------------------------------------------------------------
+
+name: Post-Merge Sweep
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sweep:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          REPO="${{ github.repository }}"
+
+          # Don't delete main/master
+          if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+            echo "Skipping protected branch: $BRANCH"
+            exit 0
+          fi
+
+          # Delete the remote branch
+          if gh api "repos/${REPO}/git/refs/heads/${BRANCH}" --method DELETE 2>/dev/null; then
+            echo "Deleted branch: $BRANCH"
+          else
+            echo "Branch already deleted or not found: $BRANCH"
+          fi
+
+      - name: Resolve outstanding review threads
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
+          QUERY='
+          query($owner: String!, $repo: String!, $pr: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $pr) {
+                reviewThreads(first: 100) {
+                  nodes {
+                    id
+                    isResolved
+                  }
+                }
+              }
+            }
+          }'
+
+          OWNER=$(echo "$REPO" | cut -d/ -f1)
+          REPO_NAME=$(echo "$REPO" | cut -d/ -f2)
+
+          THREADS=$(gh api graphql -f query="$QUERY" \
+            -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id' 2>/dev/null || true)
+
+          if [ -z "$THREADS" ]; then
+            echo "No unresolved threads"
+            exit 0
+          fi
+
+          RESOLVED=0
+          echo "$THREADS" | while read -r thread_id; do
+            MUTATION='
+            mutation($threadId: ID!) {
+              resolveReviewThread(input: {threadId: $threadId}) {
+                thread { isResolved }
+              }
+            }'
+
+            if gh api graphql -f query="$MUTATION" -f threadId="$thread_id" >/dev/null 2>&1; then
+              RESOLVED=$((RESOLVED + 1))
+            fi
+          done
+
+          echo "Resolved review thread(s)"

--- a/.github/workflows/prune-stale.yml
+++ b/.github/workflows/prune-stale.yml
@@ -1,0 +1,91 @@
+# ===============================================================
+# 🗑️  Prune Stale — close idle PRs, delete merged branches
+# ===============================================================
+#
+#   - runs weekly (Sunday midnight UTC) + manual trigger
+#   - labels PRs with no activity for 21+ days as 'stale'
+#   - closes PRs with no activity for 30+ days
+#   - deletes remote branches whose PRs are already merged
+#   - never touches main or master
+# ---------------------------------------------------------------
+
+name: Prune Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"   # Every Sunday at midnight UTC
+  workflow_dispatch:       # Manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Label and close stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Ensure labels exist
+          gh label create "stale" --color "EDEDED" --description "No activity for 21+ days" 2>/dev/null || true
+
+          NOW=$(date +%s)
+          STALE_DAYS=21
+          CLOSE_DAYS=30
+
+          gh pr list --state open --json number,updatedAt,labels \
+            --jq '.[] | "\(.number) \(.updatedAt) \([.labels[].name] | join(","))"' | \
+          while read -r pr_number updated_at labels; do
+            updated_epoch=$(date -d "$updated_at" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || echo 0)
+            age_days=$(( (NOW - updated_epoch) / 86400 ))
+
+            if [ "$age_days" -ge "$CLOSE_DAYS" ]; then
+              gh pr close "$pr_number" --comment "Closing: no activity for ${age_days} days. Reopen if still needed."
+              echo "Closed PR #${pr_number} (${age_days} days idle)"
+            elif [ "$age_days" -ge "$STALE_DAYS" ]; then
+              if ! echo "$labels" | grep -q "stale"; then
+                gh pr edit "$pr_number" --add-label "stale"
+                gh pr comment "$pr_number" --body "Marking stale: no activity for ${age_days} days. Will auto-close at ${CLOSE_DAYS} days."
+                echo "Labeled PR #${pr_number} as stale (${age_days} days idle)"
+              fi
+            fi
+          done
+
+      - name: Delete branches from merged PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+
+          # Get all remote branches
+          BRANCHES=$(git branch -r --list 'origin/*' | sed 's|origin/||' | grep -v 'HEAD' | xargs)
+
+          DELETED=0
+          for branch in $BRANCHES; do
+            # Skip protected branches
+            if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+              continue
+            fi
+
+            # Check if this branch has a merged PR
+            MERGED=$(gh pr list --state merged --head "$branch" --json number --jq 'length' 2>/dev/null || echo 0)
+
+            if [ "$MERGED" -gt 0 ]; then
+              if gh api "repos/${REPO}/git/refs/heads/${branch}" --method DELETE 2>/dev/null; then
+                DELETED=$((DELETED + 1))
+                echo "Deleted merged branch: $branch"
+              fi
+            fi
+          done
+
+          echo "Deleted ${DELETED} merged branch(es)"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Tests & Coverage](https://github.com/manavgup/wikimind/actions/workflows/test.yml/badge.svg)](https://github.com/manavgup/wikimind/actions/workflows/test.yml)
 [![Lint & Static Analysis](https://github.com/manavgup/wikimind/actions/workflows/lint.yml/badge.svg)](https://github.com/manavgup/wikimind/actions/workflows/lint.yml)
 [![Deploy](https://github.com/manavgup/wikimind/actions/workflows/deploy.yml/badge.svg)](https://github.com/manavgup/wikimind/actions/workflows/deploy.yml)
+[![Claude Review](https://github.com/manavgup/wikimind/actions/workflows/claude-review-address.yml/badge.svg)](https://github.com/manavgup/wikimind/actions/workflows/claude-review-address.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 > I feed it everything I read. It writes my wiki for me. When I ask questions, it cites its sources.
@@ -36,6 +37,7 @@ Feed → Compile → Query → Answer files back → Wiki gets smarter → Repea
 | **Export** | PDF, LinkedIn draft, Marp slides |
 | **Browser extension** | Chrome + Firefox clipper — save any page in one click |
 | **Self-hosted** | Your data, your API keys, your models |
+| **PR automation** | Claude-powered review response, auto-rebase, stale cleanup |
 
 ## Compare
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@ considered, and the consequences.
 | [019](adr-019-runtime-user-preferences.md) | Runtime User Preferences via DB Override Table | Accepted |
 | [021](adr-021-postgres-compatibility.md) | PostgreSQL compatibility for production deployments | Accepted |
 | [022](adr-022-multi-user-authentication.md) | Multi-User Authentication via OAuth2 | Accepted (revised — BFF cookie auth, April 2026) |
+| [022](adr-022-pr-automation-workflows.md) | PR automation workflows with Claude-in-CI | Accepted |
 | [023](adr-023-production-container-architecture.md) | Production Container Architecture | Unknown |
 | [024](adr-024-gunicorn-autoscaling-horizontal-readiness.md) | Gunicorn Auto-Scaling and Horizontal Scaling Readiness | Unknown |
 | [025](adr-025-docling-serve-sidecar.md) | Docling-Serve Sidecar for PDF Extraction | Unknown |

--- a/docs/adr/adr-022-pr-automation-workflows.md
+++ b/docs/adr/adr-022-pr-automation-workflows.md
@@ -1,0 +1,68 @@
+# ADR-022: PR automation workflows with Claude-in-CI
+
+## Status
+
+Accepted
+
+## Context
+
+WikiMind is primarily developed by a single contributor using Claude Code for
+feature development. PRs are created by subagents in worktrees and merged after
+local verification. This workflow has two friction points:
+
+1. **Review feedback requires manual context-switching.** When a reviewer (human
+   or CI bot) leaves comments, the developer must re-read the PR, understand
+   each comment, switch to the branch, make changes, and push — even for
+   straightforward fixes.
+
+2. **Branch hygiene degrades over time.** Merged branches are not auto-deleted
+   (`delete_branch_on_merge` is off), open PRs fall behind main and need
+   rebasing, and stale PRs accumulate without intervention.
+
+## Decision
+
+Add four GitHub Actions workflows to automate the PR lifecycle:
+
+### 1. Claude Review Address (`claude-review-address.yml`)
+
+Uses `anthropics/claude-code-action@v1` to respond to `@claude` mentions in
+PR comments and reviews. Claude reads the feedback, checks out the branch,
+and pushes fix commits. This is opt-in per comment — only activates on
+explicit mention.
+
+### 2. Auto-Rebase (`auto-rebase.yml`)
+
+Triggers on push to `main`. Iterates over all open PRs, rebases each onto
+the updated main branch using `--force-with-lease`. PRs with merge conflicts
+are labeled `needs-rebase` instead.
+
+### 3. Post-Merge Sweep (`post-merge-sweep.yml`)
+
+Triggers on PR merge. Deletes the head branch and resolves any outstanding
+review threads via the GraphQL API. This compensates for
+`delete_branch_on_merge` being disabled.
+
+### 4. Prune Stale (`prune-stale.yml`)
+
+Runs weekly on a cron schedule. Labels PRs with no activity for 21+ days as
+`stale`, closes them at 30 days, and deletes remote branches whose PRs have
+already been merged.
+
+## Consequences
+
+**Positive:**
+- Review feedback can be addressed without manual context-switching
+- Open PRs stay rebased on main automatically
+- Branch count stays bounded without manual cleanup
+- Stale PRs are surfaced and eventually closed
+
+**Negative:**
+- Claude review-address consumes API credits per invocation
+- Auto-rebase force-pushes, which can disrupt collaborators working on the
+  same branch (acceptable for single-contributor workflow)
+- Resolved review threads may hide feedback that warranted manual attention
+
+**Mitigations:**
+- Review-address is opt-in (requires `@claude` mention)
+- Auto-rebase uses `--force-with-lease` to prevent overwriting unexpected changes
+- Post-merge sweep only resolves threads on *merged* PRs — open PRs are untouched


### PR DESCRIPTION
## Summary

Automated PR lifecycle management — eliminates manual branch cleanup, review context-switching, and stale PR accumulation.

- **Claude Review Address** — `@claude` in any PR comment triggers `anthropics/claude-code-action@v1` to read feedback and push fix commits
- **Auto-Rebase** — rebases all open PRs onto main after each push; labels conflicts as `needs-rebase`
- **Post-Merge Sweep** — deletes head branch + resolves outstanding review threads on merge (compensates for `delete_branch_on_merge=false`)
- **Prune Stale** — weekly: labels idle PRs at 21 days, closes at 30 days, deletes all merged branches

Also adds ADR-022 documenting the decision and updates README with badge + feature row.

## Doc Impact

- [x] ADR-022 added (`docs/adr/adr-022-pr-automation-workflows.md`)
- [x] README updated (badge + feature row)
- [x] ADR index regenerated
- [x] OpenAPI: N/A — no API changes
- [x] CLAUDE.md: N/A — no convention changes

## Test Plan

- [x] All four workflow YAML files parse correctly
- [x] `make check-docs` passes
- [ ] Verify workflows appear in Actions tab after merge
- [ ] Create a test PR, add `@claude` comment, verify review-address triggers
- [ ] Merge a PR, verify post-merge-sweep deletes branch + resolves threads
- [ ] Manually trigger prune-stale via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)