### PR TITLE
feat: WikiMind MCP server with read-only tools -- Phase 1 (#447)

### DIFF
--- a/docs/evidence/pr-447/cli-mcp-help.txt
+++ b/docs/evidence/pr-447/cli-mcp-help.txt
@@ -1,0 +1,37 @@
+Usage: wikimind mcp [OPTIONS] COMMAND [ARGS]...
+
+  Model Context Protocol server commands.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  config  Print Claude Desktop configuration snippet for WikiMind MCP.
+  serve   Start the WikiMind MCP server (stdio transport).
+Usage: wikimind mcp serve [OPTIONS]
+
+  Start the WikiMind MCP server (stdio transport).
+
+  Runs the MCP server over stdin/stdout so MCP clients like Claude Desktop or
+  Cursor can connect to the wiki.
+
+  Add this to your Claude Desktop config (claude_desktop_config.json):
+
+  \b   {     "mcpServers": {       "wikimind": {         "command":
+  "wikimind",         "args": ["mcp", "serve"]       }     }   }
+
+Options:
+  --help  Show this message and exit.
+Add this to your Claude Desktop config (claude_desktop_config.json):
+
+{
+  "mcpServers": {
+    "wikimind": {
+      "command": "/Users/mg/mg-work/manav/work/ai-experiments/wikimind/.claude/worktrees/agent-a28a11fd/.venv/bin/python3",
+      "args": [
+        "-m",
+        "wikimind.mcp.server"
+      ]
+    }
+  }
+}

--- a/docs/evidence/pr-447/evidence.html
+++ b/docs/evidence/pr-447/evidence.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PR #447 Evidence: WikiMind MCP Server (Phase 1)</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 2rem;
+            background: #f8f9fa;
+            color: #1a1a2e;
+        }
+        h1 { border-bottom: 3px solid #4a90d9; padding-bottom: 0.5rem; }
+        h2 { color: #4a90d9; margin-top: 2rem; }
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.85rem;
+            font-weight: 600;
+        }
+        .pass { background: #d4edda; color: #155724; }
+        .info { background: #d1ecf1; color: #0c5460; }
+        pre {
+            background: #1e1e2e;
+            color: #cdd6f4;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            font-size: 0.85rem;
+            line-height: 1.5;
+        }
+        .highlight { color: #a6e3a1; }
+        .dim { color: #6c7086; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0;
+        }
+        th, td {
+            text-align: left;
+            padding: 0.5rem 0.75rem;
+            border-bottom: 1px solid #dee2e6;
+        }
+        th { background: #e9ecef; font-weight: 600; }
+        .section {
+            background: white;
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin: 1rem 0;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+        }
+    </style>
+</head>
+<body>
+    <h1>PR #447 Evidence: WikiMind MCP Server</h1>
+    <p>
+        <span class="badge info">Phase 1</span>
+        <span class="badge pass">All Tests Passing</span>
+    </p>
+    <p>
+        Phase 1 of issue #447: stdio-mode MCP server exposing 4 read-only tools.
+        Generated 2026-05-08.
+    </p>
+
+    <h2>1. MCP Tools Registered</h2>
+    <div class="section">
+        <p>The server registers 4 tools accessible via the MCP protocol:</p>
+        <table>
+            <thead>
+                <tr><th>Tool</th><th>Description</th><th>Required Params</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>wiki_search</code></td>
+                    <td>Search wiki articles by keyword</td>
+                    <td><code>query</code> (string)</td>
+                </tr>
+                <tr>
+                    <td><code>wiki_get_article</code></td>
+                    <td>Retrieve full article by ID or slug</td>
+                    <td><code>id_or_slug</code> (string)</td>
+                </tr>
+                <tr>
+                    <td><code>wiki_ask</code></td>
+                    <td>Ask a question against the wiki (Q&amp;A agent)</td>
+                    <td><code>question</code> (string)</td>
+                </tr>
+                <tr>
+                    <td><code>wiki_list_sources</code></td>
+                    <td>List ingested sources</td>
+                    <td>none (all optional)</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>2. Server Initialization (stdio)</h2>
+    <div class="section">
+        <p>The MCP server starts, initializes the database, and responds to the <code>initialize</code> handshake:</p>
+        <pre><span class="dim"># Request:</span>
+{"jsonrpc":"2.0","method":"initialize","params":{
+  "protocolVersion":"2025-03-26",
+  "capabilities":{},
+  "clientInfo":{"name":"test","version":"0.1"}
+},"id":1}
+
+<span class="dim"># Response:</span>
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    <span class="highlight">"protocolVersion": "2025-03-26"</span>,
+    "capabilities": {
+      "tools": { "listChanged": false },
+      "resources": { "subscribe": false, "listChanged": false },
+      "prompts": { "listChanged": false }
+    },
+    "serverInfo": {
+      <span class="highlight">"name": "wikimind"</span>,
+      "version": "1.27.1"
+    },
+    "instructions": "WikiMind is a personal LLM-powered knowledge OS. ..."
+  }
+}</pre>
+    </div>
+
+    <h2>3. tools/list Response</h2>
+    <div class="section">
+        <p>The <code>tools/list</code> method returns all 4 tools with JSON Schema for inputs:</p>
+        <pre><span class="dim"># Request:</span>
+{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}
+
+<span class="dim"># Response (abbreviated):</span>
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        <span class="highlight">"name": "wiki_search"</span>,
+        "description": "Search wiki articles by keyword...",
+        "inputSchema": {
+          "properties": {
+            "query": { "type": "string" },
+            "limit": { "default": 10, "type": "integer" }
+          },
+          "required": ["query"]
+        }
+      },
+      { <span class="highlight">"name": "wiki_get_article"</span>, ... },
+      { <span class="highlight">"name": "wiki_ask"</span>, ... },
+      { <span class="highlight">"name": "wiki_list_sources"</span>, ... }
+    ]
+  }
+}</pre>
+    </div>
+
+    <h2>4. CLI Commands</h2>
+    <div class="section">
+        <p>Two new CLI commands under <code>wikimind mcp</code>:</p>
+        <pre><span class="dim">$ wikimind mcp --help</span>
+Usage: wikimind mcp [OPTIONS] COMMAND [ARGS]...
+
+  Model Context Protocol server commands.
+
+Commands:
+  <span class="highlight">config</span>  Print Claude Desktop configuration snippet for WikiMind MCP.
+  <span class="highlight">serve</span>   Start the WikiMind MCP server (stdio transport).
+
+<span class="dim">$ wikimind mcp config</span>
+Add this to your Claude Desktop config (claude_desktop_config.json):
+
+{
+  "mcpServers": {
+    "wikimind": {
+      "command": "python3",
+      "args": ["-m", "wikimind.mcp.server"]
+    }
+  }
+}</pre>
+    </div>
+
+    <h2>5. Test Results</h2>
+    <div class="section">
+        <p><span class="badge pass">16/16 Passed</span></p>
+        <pre>tests/unit/test_mcp_server.py::TestWikiSearch::test_search_returns_results          <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiSearch::test_search_short_query_returns_error <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiSearch::test_search_clamps_limit             <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiGetArticle::test_get_article_by_slug         <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiGetArticle::test_get_article_not_found       <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiListSources::test_list_sources_returns_results <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiListSources::test_list_sources_empty         <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestWikiListSources::test_list_sources_clamps_limit  <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPCli::test_mcp_help                            <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPCli::test_mcp_config                          <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPCli::test_mcp_serve_help                      <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_server_has_expected_name       <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_server_has_instructions        <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_server_lists_tools             <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_tool_descriptions_present      <span class="highlight">PASSED</span>
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_tool_schemas_have_parameters   <span class="highlight">PASSED</span></pre>
+    </div>
+
+    <h2>6. Files Changed</h2>
+    <div class="section">
+        <table>
+            <thead>
+                <tr><th>File</th><th>Change</th></tr>
+            </thead>
+            <tbody>
+                <tr><td><code>src/wikimind/mcp/__init__.py</code></td><td>New package marker</td></tr>
+                <tr><td><code>src/wikimind/mcp/server.py</code></td><td>MCP server with 4 read-only tools + stdio transport</td></tr>
+                <tr><td><code>src/wikimind/cli/main.py</code></td><td>Added <code>wikimind mcp serve</code> and <code>wikimind mcp config</code></td></tr>
+                <tr><td><code>pyproject.toml</code></td><td>Added <code>mcp>=1.0.0</code> dependency</td></tr>
+                <tr><td><code>tests/unit/test_mcp_server.py</code></td><td>16 unit tests for tools, CLI, and server registration</td></tr>
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>

--- a/docs/evidence/pr-447/mcp-server-output.json
+++ b/docs/evidence/pr-447/mcp-server-output.json
@@ -1,0 +1,172 @@
+2026-05-08 15:07:21 [info     ] auto-enabled provider (key detected) provider=openai
+2026-05-08 15:07:21 [info     ] WikiMind MCP server started    data_dir=/Users/mg/.wikimind mcp_spec_version=2025-03-26
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "experimental": {},
+      "prompts": {
+        "listChanged": false
+      },
+      "resources": {
+        "subscribe": false,
+        "listChanged": false
+      },
+      "tools": {
+        "listChanged": false
+      }
+    },
+    "serverInfo": {
+      "name": "wikimind",
+      "version": "1.27.1"
+    },
+    "instructions": "WikiMind is a personal LLM-powered knowledge OS. Use these tools to search the wiki, read articles, ask questions, and browse ingested sources."
+  }
+}
+
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "wiki_search",
+        "description": "Search wiki articles by keyword. Returns article titles, summaries, and IDs ranked by relevance. Use this to find articles on a topic before reading the full content.",
+        "inputSchema": {
+          "properties": {
+            "query": {
+              "title": "Query",
+              "type": "string"
+            },
+            "limit": {
+              "default": 10,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "title": "wiki_searchArguments",
+          "type": "object"
+        },
+        "outputSchema": {
+          "properties": {
+            "result": {
+              "title": "Result",
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ],
+          "title": "wiki_searchOutput",
+          "type": "object"
+        }
+      },
+      {
+        "name": "wiki_get_article",
+        "description": "Retrieve the full content of a wiki article by its ID or slug. Returns the article title, markdown content, sources, and metadata. Use wiki_search first to find the article ID.",
+        "inputSchema": {
+          "properties": {
+            "id_or_slug": {
+              "title": "Id Or Slug",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id_or_slug"
+          ],
+          "title": "wiki_get_articleArguments",
+          "type": "object"
+        },
+        "outputSchema": {
+          "properties": {
+            "result": {
+              "title": "Result",
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ],
+          "title": "wiki_get_articleOutput",
+          "type": "object"
+        }
+      },
+      {
+        "name": "wiki_ask",
+        "description": "Ask a question against the WikiMind knowledge base. The Q&A agent searches relevant articles and synthesizes an answer with citations. Use this for complex questions that span multiple articles.",
+        "inputSchema": {
+          "properties": {
+            "question": {
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "question"
+          ],
+          "title": "wiki_askArguments",
+          "type": "object"
+        },
+        "outputSchema": {
+          "properties": {
+            "result": {
+              "title": "Result",
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ],
+          "title": "wiki_askOutput",
+          "type": "object"
+        }
+      },
+      {
+        "name": "wiki_list_sources",
+        "description": "List ingested sources in the WikiMind knowledge base. Shows what content has been fed into the wiki (URLs, PDFs, text, YouTube). Optionally filter by status.",
+        "inputSchema": {
+          "properties": {
+            "status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Status"
+            },
+            "limit": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          "title": "wiki_list_sourcesArguments",
+          "type": "object"
+        },
+        "outputSchema": {
+          "properties": {
+            "result": {
+              "title": "Result",
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ],
+          "title": "wiki_list_sourcesOutput",
+          "type": "object"
+        }
+      }
+    ]
+  }
+}
+

--- a/docs/evidence/pr-447/test-output.txt
+++ b/docs/evidence/pr-447/test-output.txt
@@ -1,0 +1,43 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /Users/mg/mg-work/manav/work/ai-experiments/wikimind/.claude/worktrees/agent-a28a11fd/.venv/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/mg/mg-work/manav/work/ai-experiments/wikimind/.claude/worktrees/agent-a28a11fd
+configfile: pyproject.toml
+plugins: cov-7.1.0, timeout-2.4.0, asyncio-1.3.0, anyio-4.13.0
+timeout: 30.0s
+timeout method: signal
+timeout func_only: False
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 16 items
+
+tests/unit/test_mcp_server.py::TestWikiSearch::test_search_returns_results PASSED [  6%]
+tests/unit/test_mcp_server.py::TestWikiSearch::test_search_short_query_returns_error PASSED [ 12%]
+tests/unit/test_mcp_server.py::TestWikiSearch::test_search_clamps_limit PASSED [ 18%]
+tests/unit/test_mcp_server.py::TestWikiGetArticle::test_get_article_by_slug PASSED [ 25%]
+tests/unit/test_mcp_server.py::TestWikiGetArticle::test_get_article_not_found PASSED [ 31%]
+tests/unit/test_mcp_server.py::TestWikiListSources::test_list_sources_returns_results PASSED [ 37%]
+tests/unit/test_mcp_server.py::TestWikiListSources::test_list_sources_empty PASSED [ 43%]
+tests/unit/test_mcp_server.py::TestWikiListSources::test_list_sources_clamps_limit PASSED [ 50%]
+tests/unit/test_mcp_server.py::TestMCPCli::test_mcp_help PASSED          [ 56%]
+tests/unit/test_mcp_server.py::TestMCPCli::test_mcp_config PASSED        [ 62%]
+tests/unit/test_mcp_server.py::TestMCPCli::test_mcp_serve_help PASSED    [ 68%]
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_server_has_expected_name PASSED [ 75%]
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_server_has_instructions PASSED [ 81%]
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_server_lists_tools PASSED [ 87%]
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_tool_descriptions_present PASSED [ 93%]
+tests/unit/test_mcp_server.py::TestMCPServerRegistration::test_tool_schemas_have_parameters PASSED [100%]
+
+=============================== warnings summary ===============================
+<frozen importlib._bootstrap>:488
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 16 passed, 5 warnings in 0.31s ========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "gunicorn>=22.0.0",
 
     # MCP (Model Context Protocol)
-    "mcp>=1.0.0",
+    "fastmcp>=3.0.2",
 
     # Utilities
     "python-slugify>=8.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dependencies = [
     # Production server
     "gunicorn>=22.0.0",
 
+    # MCP (Model Context Protocol)
+    "mcp>=1.0.0",
+
     # Utilities
     "python-slugify>=8.0.4",
     "python-dateutil>=2.9.0",

--- a/src/wikimind/cli/main.py
+++ b/src/wikimind/cli/main.py
@@ -49,11 +49,19 @@ def mcp() -> None:
 
 
 @mcp.command()
-def serve() -> None:
-    r"""Start the WikiMind MCP server (stdio transport).
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "http"]),
+    default="stdio",
+    help="Transport protocol (default: stdio).",
+)
+@click.option("--host", default="127.0.0.1", help="Host for HTTP transport (default: 127.0.0.1).")
+@click.option("--port", type=int, default=9100, help="Port for HTTP transport (default: 9100).")
+def serve(transport: str, host: str, port: int) -> None:
+    r"""Start the WikiMind MCP server.
 
-    Runs the MCP server over stdin/stdout so MCP clients like
-    Claude Desktop or Cursor can connect to the wiki.
+    Runs the MCP server over stdin/stdout (default) or HTTP so MCP
+    clients like Claude Desktop or Cursor can connect to the wiki.
 
     Add this to your Claude Desktop config (claude_desktop_config.json):
 
@@ -69,6 +77,8 @@ def serve() -> None:
     """
     from wikimind.mcp.server import run_server  # noqa: PLC0415
 
+    # Build sys.argv so argparse in run_server() picks up the options.
+    sys.argv = ["wikimind-mcp", "--transport", transport, "--host", host, "--port", str(port)]
     run_server()
 
 

--- a/src/wikimind/cli/main.py
+++ b/src/wikimind/cli/main.py
@@ -6,6 +6,9 @@ All commands communicate with the server via HTTP (httpx).
 
 from __future__ import annotations
 
+import json
+import sys
+
 import click
 import httpx
 
@@ -33,6 +36,56 @@ cli.add_command(whoami)
 cli.add_command(ingest)
 cli.add_command(ask)
 cli.add_command(wiki)
+
+
+# ---------------------------------------------------------------------------
+# MCP sub-group
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def mcp() -> None:
+    """Model Context Protocol server commands."""
+
+
+@mcp.command()
+def serve() -> None:
+    r"""Start the WikiMind MCP server (stdio transport).
+
+    Runs the MCP server over stdin/stdout so MCP clients like
+    Claude Desktop or Cursor can connect to the wiki.
+
+    Add this to your Claude Desktop config (claude_desktop_config.json):
+
+    \b
+      {
+        "mcpServers": {
+          "wikimind": {
+            "command": "wikimind",
+            "args": ["mcp", "serve"]
+          }
+        }
+      }
+    """
+    from wikimind.mcp.server import run_server  # noqa: PLC0415
+
+    run_server()
+
+
+@mcp.command(name="config")
+def mcp_config() -> None:
+    """Print Claude Desktop configuration snippet for WikiMind MCP."""
+    python_path = sys.executable
+    config = {
+        "mcpServers": {
+            "wikimind": {
+                "command": python_path,
+                "args": ["-m", "wikimind.mcp.server"],
+            },
+        },
+    }
+    click.echo("Add this to your Claude Desktop config (claude_desktop_config.json):\n")
+    click.echo(json.dumps(config, indent=2))
 
 
 @cli.command()

--- a/src/wikimind/mcp/__init__.py
+++ b/src/wikimind/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""WikiMind MCP server — exposes read-only wiki tools via Model Context Protocol."""

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -6,22 +6,26 @@ Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
   - wiki_ask:          ask a question against the wiki (Q&A agent)
   - wiki_list_sources: list ingested sources
 
-The server runs in stdio mode for local use. A config snippet for
-Claude Desktop is printed on startup.
+The server supports stdio (default) and HTTP transports.
 
 Usage:
     wikimind mcp serve
+    wikimind mcp serve --transport http --port 9100
     python -m wikimind.mcp.server
 """
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import json
+import logging
+import sys
 from typing import TYPE_CHECKING, Any
 
 import structlog
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
+from pydantic import Field
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.config import get_settings
@@ -33,6 +37,16 @@ from wikimind.services.wiki import WikiService
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
+
+# ---------------------------------------------------------------------------
+# Logging — stderr so it does not interfere with stdio transport
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stderr)],
+)
 
 log = structlog.get_logger()
 
@@ -96,16 +110,11 @@ async def _get_session():
         "articles on a topic before reading the full content."
     ),
 )
-async def wiki_search(query: str, limit: int = 10) -> str:
-    """Search wiki articles by keyword query.
-
-    Args:
-        query: Search query string (minimum 2 characters).
-        limit: Maximum number of results to return (default 10, max 50).
-
-    Returns:
-        JSON array of matching articles with id, slug, title, and summary.
-    """
+async def wiki_search(
+    query: str = Field(..., description="Search query string (minimum 2 characters)"),
+    limit: int = Field(10, description="Maximum results to return (max 50)"),
+) -> str:
+    """Search wiki articles by keyword query."""
     limit = min(max(1, limit), 50)
     if len(query.strip()) < 2:
         return json.dumps({"error": "Query must be at least 2 characters"})
@@ -148,15 +157,10 @@ async def wiki_search(query: str, limit: int = 10) -> str:
         "Use wiki_search first to find the article ID."
     ),
 )
-async def wiki_get_article(id_or_slug: str) -> str:
-    """Retrieve a full wiki article by ID or slug.
-
-    Args:
-        id_or_slug: Article UUID or URL slug.
-
-    Returns:
-        JSON object with article title, content (markdown), sources, and metadata.
-    """
+async def wiki_get_article(
+    id_or_slug: str = Field(..., description="Article UUID or URL slug"),
+) -> str:
+    """Retrieve a full wiki article by ID or slug."""
     wiki_service = WikiService()
     async with _get_session() as session:
         try:
@@ -207,15 +211,10 @@ async def wiki_get_article(id_or_slug: str) -> str:
         "that span multiple articles."
     ),
 )
-async def wiki_ask(question: str) -> str:
-    """Ask a question and get an answer from the wiki.
-
-    Args:
-        question: The question to ask against the wiki knowledge base.
-
-    Returns:
-        JSON object with the answer, confidence, and cited article titles.
-    """
+async def wiki_ask(
+    question: str = Field(..., description="The question to ask against the wiki knowledge base"),
+) -> str:
+    """Ask a question and get an answer from the wiki."""
     if not question.strip():
         return json.dumps({"error": "Question cannot be empty"})
 
@@ -264,18 +263,10 @@ async def wiki_ask(question: str) -> str:
     ),
 )
 async def wiki_list_sources(
-    status: str | None = None,
-    limit: int = 20,
+    status: str | None = Field(None, description="Optional status filter (e.g. 'compiled', 'pending')"),
+    limit: int = Field(20, description="Maximum number of results (default 20, max 100)"),
 ) -> str:
-    """List ingested sources with optional status filtering.
-
-    Args:
-        status: Optional status filter (e.g. 'compiled', 'pending').
-        limit: Maximum number of results (default 20, max 100).
-
-    Returns:
-        JSON array of sources with id, type, title, URL, and ingestion date.
-    """
+    """List ingested sources with optional status filtering."""
     limit = min(max(1, limit), 100)
     ingest_service = IngestService()
 
@@ -309,8 +300,20 @@ async def wiki_list_sources(
 
 
 def run_server() -> None:
-    """Run the WikiMind MCP server over stdio transport."""
-    mcp.run(transport="stdio")
+    """Run the WikiMind MCP server.
+
+    Supports stdio (default) and HTTP transports via --transport flag.
+    """
+    parser = argparse.ArgumentParser(description="WikiMind MCP Server")
+    parser.add_argument("--transport", choices=["stdio", "http"], default="stdio")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9100)
+    args = parser.parse_args()
+
+    if args.transport == "http":
+        mcp.run(transport="http", host=args.host, port=args.port)
+    else:
+        mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -1,0 +1,317 @@
+"""WikiMind MCP server — Phase 1 read-only tools over stdio transport.
+
+Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
+  - wiki_search:       full-text search across wiki articles
+  - wiki_get_article:  retrieve a full article by ID or slug
+  - wiki_ask:          ask a question against the wiki (Q&A agent)
+  - wiki_list_sources: list ingested sources
+
+The server runs in stdio mode for local use. A config snippet for
+Claude Desktop is printed on startup.
+
+Usage:
+    wikimind mcp serve
+    python -m wikimind.mcp.server
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from mcp.server.fastmcp import FastMCP
+
+from wikimind.api.deps import ANONYMOUS_USER_ID
+from wikimind.config import get_settings
+from wikimind.database import get_session_factory, init_db
+from wikimind.models import QueryRequest
+from wikimind.services.ingest import IngestService
+from wikimind.services.query import QueryService
+from wikimind.services.wiki import WikiService
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+log = structlog.get_logger()
+
+# MCP spec version pinned for stability (see issue #447 risk: spec churn).
+MCP_SPEC_VERSION = "2025-03-26"
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(_server: FastMCP) -> AsyncGenerator[dict[str, Any], None]:
+    """Initialize the database on server startup."""
+    settings = get_settings()
+    settings.ensure_dirs()
+    await init_db()
+    log.info(
+        "WikiMind MCP server started",
+        mcp_spec_version=MCP_SPEC_VERSION,
+        data_dir=settings.data_dir,
+    )
+    yield {}
+
+
+mcp = FastMCP(
+    name="wikimind",
+    instructions=(
+        "WikiMind is a personal LLM-powered knowledge OS. "
+        "Use these tools to search the wiki, read articles, "
+        "ask questions, and browse ingested sources."
+    ),
+    lifespan=_lifespan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Session helper — standalone (not FastAPI DI)
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _get_session():
+    """Yield an async database session for MCP tool handlers."""
+    factory = get_session_factory()
+    async with factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_search
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_search",
+    description=(
+        "Search wiki articles by keyword. Returns article titles, "
+        "summaries, and IDs ranked by relevance. Use this to find "
+        "articles on a topic before reading the full content."
+    ),
+)
+async def wiki_search(query: str, limit: int = 10) -> str:
+    """Search wiki articles by keyword query.
+
+    Args:
+        query: Search query string (minimum 2 characters).
+        limit: Maximum number of results to return (default 10, max 50).
+
+    Returns:
+        JSON array of matching articles with id, slug, title, and summary.
+    """
+    limit = min(max(1, limit), 50)
+    if len(query.strip()) < 2:
+        return json.dumps({"error": "Query must be at least 2 characters"})
+
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        results = await wiki_service.search(
+            q=query,
+            session=session,
+            user_id=ANONYMOUS_USER_ID,
+            limit=limit,
+        )
+
+    return json.dumps(
+        [
+            {
+                "id": r.id,
+                "slug": r.slug,
+                "title": r.title,
+                "summary": r.summary,
+                "confidence": r.confidence,
+                "source_count": r.source_count,
+            }
+            for r in results
+        ],
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_get_article
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_get_article",
+    description=(
+        "Retrieve the full content of a wiki article by its ID or slug. "
+        "Returns the article title, markdown content, sources, and metadata. "
+        "Use wiki_search first to find the article ID."
+    ),
+)
+async def wiki_get_article(id_or_slug: str) -> str:
+    """Retrieve a full wiki article by ID or slug.
+
+    Args:
+        id_or_slug: Article UUID or URL slug.
+
+    Returns:
+        JSON object with article title, content (markdown), sources, and metadata.
+    """
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            article = await wiki_service.get_article(
+                id_or_slug=id_or_slug,
+                session=session,
+                user_id=ANONYMOUS_USER_ID,
+            )
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    return json.dumps(
+        {
+            "id": article.id,
+            "slug": article.slug,
+            "title": article.title,
+            "summary": article.summary,
+            "content": article.content,
+            "confidence": article.confidence,
+            "page_type": article.page_type,
+            "sources": [
+                {
+                    "id": s.id,
+                    "source_type": s.source_type,
+                    "title": s.title,
+                    "source_url": s.source_url,
+                }
+                for s in (article.sources or [])
+            ],
+            "created_at": article.created_at,
+            "updated_at": article.updated_at,
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_ask
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_ask",
+    description=(
+        "Ask a question against the WikiMind knowledge base. "
+        "The Q&A agent searches relevant articles and synthesizes "
+        "an answer with citations. Use this for complex questions "
+        "that span multiple articles."
+    ),
+)
+async def wiki_ask(question: str) -> str:
+    """Ask a question and get an answer from the wiki.
+
+    Args:
+        question: The question to ask against the wiki knowledge base.
+
+    Returns:
+        JSON object with the answer, confidence, and cited article titles.
+    """
+    if not question.strip():
+        return json.dumps({"error": "Question cannot be empty"})
+
+    query_service = QueryService()
+    request = QueryRequest(question=question)
+
+    async with _get_session() as session:
+        try:
+            result = await query_service.ask(
+                request=request,
+                session=session,
+                user_id=ANONYMOUS_USER_ID,
+            )
+        except Exception as exc:
+            log.warning("wiki_ask failed", error=str(exc))
+            return json.dumps({"error": f"Q&A failed: {exc}"})
+
+    return json.dumps(
+        {
+            "answer": result.query.answer,
+            "confidence": result.query.confidence,
+            "citations": [
+                {
+                    "article_title": c.article.title,
+                    "article_slug": c.article.slug,
+                    "confidence_score": c.confidence_score,
+                }
+                for c in (result.query.citations or [])
+            ],
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_list_sources
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_list_sources",
+    description=(
+        "List ingested sources in the WikiMind knowledge base. "
+        "Shows what content has been fed into the wiki (URLs, PDFs, "
+        "text, YouTube). Optionally filter by status."
+    ),
+)
+async def wiki_list_sources(
+    status: str | None = None,
+    limit: int = 20,
+) -> str:
+    """List ingested sources with optional status filtering.
+
+    Args:
+        status: Optional status filter (e.g. 'compiled', 'pending').
+        limit: Maximum number of results (default 20, max 100).
+
+    Returns:
+        JSON array of sources with id, type, title, URL, and ingestion date.
+    """
+    limit = min(max(1, limit), 100)
+    ingest_service = IngestService()
+
+    async with _get_session() as session:
+        sources = await ingest_service.list_sources(
+            session=session,
+            user_id=ANONYMOUS_USER_ID,
+            status=status,
+            limit=limit,
+        )
+
+    return json.dumps(
+        [
+            {
+                "id": s.id,
+                "source_type": s.source_type,
+                "title": s.title,
+                "source_url": s.source_url,
+                "ingested_at": s.ingested_at,
+                "compiled_at": s.compiled_at,
+            }
+            for s in sources
+        ],
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_server() -> None:
+    """Run the WikiMind MCP server over stdio transport."""
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    run_server()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,307 @@
+"""Tests for WikiMind MCP server tools.
+
+Tests each MCP tool function directly with an in-memory SQLite database,
+bypassing the MCP transport layer to verify tool logic in isolation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from tests.conftest import TEST_USER_ID
+from wikimind.cli.main import cli
+from wikimind.mcp.server import mcp as mcp_server
+from wikimind.mcp.server import wiki_get_article, wiki_list_sources, wiki_search
+from wikimind.models import Article, ConfidenceLevel, PageType, Source
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _mock_session_ctx(session):
+    """Build an async context manager that yields the given session."""
+    yield session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def sample_article(db_session: AsyncSession) -> Article:
+    """Create a sample wiki article for testing."""
+    article = Article(
+        slug="test-article",
+        title="Test Article",
+        summary="A test article about testing.",
+        file_path="articles/test-article.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+        confidence=ConfidenceLevel.SOURCED,
+        confidence_score=0.9,
+    )
+    db_session.add(article)
+    await db_session.commit()
+    await db_session.refresh(article)
+    return article
+
+
+@pytest.fixture
+async def sample_source(db_session: AsyncSession) -> Source:
+    """Create a sample ingested source for testing."""
+    source = Source(
+        source_type="url",
+        title="Test Source",
+        source_url="https://example.com/test",
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    await db_session.refresh(source)
+    return source
+
+
+# ---------------------------------------------------------------------------
+# wiki_search
+# ---------------------------------------------------------------------------
+
+
+class TestWikiSearch:
+    """Test the wiki_search MCP tool."""
+
+    async def test_search_returns_results(self, db_session, sample_article):
+        mock_result = AsyncMock(
+            id=sample_article.id,
+            slug=sample_article.slug,
+            title=sample_article.title,
+            summary=sample_article.summary,
+            confidence=sample_article.confidence,
+            source_count=0,
+        )
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[mock_result])
+
+            result = await wiki_search(query="test", limit=10)
+            parsed = json.loads(result)
+
+            assert isinstance(parsed, list)
+            assert len(parsed) == 1
+            assert parsed[0]["title"] == "Test Article"
+            assert parsed[0]["slug"] == "test-article"
+
+    async def test_search_short_query_returns_error(self):
+        result = await wiki_search(query="a", limit=10)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "2 characters" in parsed["error"]
+
+    async def test_search_clamps_limit(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[])
+
+            result = await wiki_search(query="test", limit=999)
+            parsed = json.loads(result)
+            assert isinstance(parsed, list)
+
+            # Verify the search was called with clamped limit of 50
+            mock_wiki_cls.return_value.search.assert_called_once()
+            call_kwargs = mock_wiki_cls.return_value.search.call_args
+            assert call_kwargs.kwargs["limit"] == 50
+
+
+# ---------------------------------------------------------------------------
+# wiki_get_article
+# ---------------------------------------------------------------------------
+
+
+class TestWikiGetArticle:
+    """Test the wiki_get_article MCP tool."""
+
+    async def test_get_article_by_slug(self, db_session, sample_article):
+        mock_response = AsyncMock()
+        mock_response.id = sample_article.id
+        mock_response.slug = sample_article.slug
+        mock_response.title = sample_article.title
+        mock_response.summary = sample_article.summary
+        mock_response.content = "# Test Article\n\nSome content."
+        mock_response.confidence = "sourced"
+        mock_response.page_type = "source"
+        mock_response.sources = []
+        mock_response.created_at = "2026-01-01"
+        mock_response.updated_at = "2026-01-02"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
+
+            result = await wiki_get_article(id_or_slug="test-article")
+            parsed = json.loads(result)
+
+            assert parsed["title"] == "Test Article"
+            assert parsed["content"] == "# Test Article\n\nSome content."
+            assert parsed["sources"] == []
+
+    async def test_get_article_not_found(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(
+                side_effect=Exception("Article not found"),
+            )
+
+            result = await wiki_get_article(id_or_slug="nonexistent")
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "not found" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# wiki_list_sources
+# ---------------------------------------------------------------------------
+
+
+class TestWikiListSources:
+    """Test the wiki_list_sources MCP tool."""
+
+    async def test_list_sources_returns_results(self, db_session, sample_source):
+        mock_source = AsyncMock()
+        mock_source.id = sample_source.id
+        mock_source.source_type = "url"
+        mock_source.title = "Test Source"
+        mock_source.source_url = "https://example.com/test"
+        mock_source.ingested_at = "2026-01-01"
+        mock_source.compiled_at = None
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[mock_source])
+
+            result = await wiki_list_sources(limit=20)
+            parsed = json.loads(result)
+
+            assert isinstance(parsed, list)
+            assert len(parsed) == 1
+            assert parsed[0]["title"] == "Test Source"
+            assert parsed[0]["source_type"] == "url"
+
+    async def test_list_sources_empty(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[])
+
+            result = await wiki_list_sources(limit=20)
+            parsed = json.loads(result)
+            assert parsed == []
+
+    async def test_list_sources_clamps_limit(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[])
+
+            await wiki_list_sources(limit=999)
+            call_kwargs = mock_ingest_cls.return_value.list_sources.call_args
+            assert call_kwargs.kwargs["limit"] == 100
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
+class TestMCPCli:
+    """Test MCP CLI commands."""
+
+    def test_mcp_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["mcp", "--help"])
+        assert result.exit_code == 0
+        assert "serve" in result.output
+        assert "config" in result.output
+
+    def test_mcp_config(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["mcp", "config"])
+        assert result.exit_code == 0
+        assert "mcpServers" in result.output
+        assert "wikimind" in result.output
+
+    def test_mcp_serve_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["mcp", "serve", "--help"])
+        assert result.exit_code == 0
+        assert "stdio" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Server registration
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServerRegistration:
+    """Test that MCP tools are properly registered on the server."""
+
+    def test_server_has_expected_name(self):
+        assert mcp_server.name == "wikimind"
+
+    def test_server_has_instructions(self):
+        assert mcp_server.instructions is not None
+        assert "WikiMind" in mcp_server.instructions
+
+    def test_server_lists_tools(self):
+        tools = mcp_server._tool_manager.list_tools()
+        tool_names = {t.name for t in tools}
+        assert "wiki_search" in tool_names
+        assert "wiki_get_article" in tool_names
+        assert "wiki_ask" in tool_names
+        assert "wiki_list_sources" in tool_names
+
+    def test_tool_descriptions_present(self):
+        tools = mcp_server._tool_manager.list_tools()
+        for tool in tools:
+            assert tool.description, f"Tool {tool.name} missing description"
+            assert len(tool.description) > 20, f"Tool {tool.name} description too short"
+
+    def test_tool_schemas_have_parameters(self):
+        tools = mcp_server._tool_manager.list_tools()
+        tools_by_name = {t.name: t for t in tools}
+
+        # wiki_search should have query and limit params
+        search_schema = tools_by_name["wiki_search"].parameters
+        assert "query" in search_schema.get("properties", {})
+
+        # wiki_get_article should have id_or_slug param
+        article_schema = tools_by_name["wiki_get_article"].parameters
+        assert "id_or_slug" in article_schema.get("properties", {})
+
+        # wiki_ask should have question param
+        ask_schema = tools_by_name["wiki_ask"].parameters
+        assert "question" in ask_schema.get("properties", {})

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -258,7 +258,9 @@ class TestMCPCli:
         runner = CliRunner()
         result = runner.invoke(cli, ["mcp", "serve", "--help"])
         assert result.exit_code == 0
+        assert "transport" in result.output
         assert "stdio" in result.output
+        assert "http" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -276,22 +278,22 @@ class TestMCPServerRegistration:
         assert mcp_server.instructions is not None
         assert "WikiMind" in mcp_server.instructions
 
-    def test_server_lists_tools(self):
-        tools = mcp_server._tool_manager.list_tools()
+    async def test_server_lists_tools(self):
+        tools = await mcp_server.list_tools()
         tool_names = {t.name for t in tools}
         assert "wiki_search" in tool_names
         assert "wiki_get_article" in tool_names
         assert "wiki_ask" in tool_names
         assert "wiki_list_sources" in tool_names
 
-    def test_tool_descriptions_present(self):
-        tools = mcp_server._tool_manager.list_tools()
+    async def test_tool_descriptions_present(self):
+        tools = await mcp_server.list_tools()
         for tool in tools:
             assert tool.description, f"Tool {tool.name} missing description"
             assert len(tool.description) > 20, f"Tool {tool.name} description too short"
 
-    def test_tool_schemas_have_parameters(self):
-        tools = mcp_server._tool_manager.list_tools()
+    async def test_tool_schemas_have_parameters(self):
+        tools = await mcp_server.list_tools()
         tools_by_name = {t.name: t for t in tools}
 
         # wiki_search should have query and limit params
@@ -305,3 +307,16 @@ class TestMCPServerRegistration:
         # wiki_ask should have question param
         ask_schema = tools_by_name["wiki_ask"].parameters
         assert "question" in ask_schema.get("properties", {})
+
+    async def test_tool_parameter_descriptions_present(self):
+        """Verify that Field-based parameter descriptions are exposed in schemas."""
+        tools = await mcp_server.list_tools()
+        tools_by_name = {t.name: t for t in tools}
+
+        # wiki_search query param should have a description from Field()
+        search_props = tools_by_name["wiki_search"].parameters.get("properties", {})
+        assert "description" in search_props.get("query", {}), "query param missing Field description"
+
+        # wiki_get_article id_or_slug param should have a description
+        article_props = tools_by_name["wiki_get_article"].parameters.get("properties", {})
+        assert "description" in article_props.get("id_or_slug", {}), "id_or_slug param missing Field description"


### PR DESCRIPTION
## Summary

WikiMind is an island -- it cannot be reached from Claude Desktop, Cursor, or any other tool that speaks MCP. This PR ships Phase 1 of bidirectional MCP support: a stdio-mode MCP server that exposes the wiki to external clients.

**Problem:** No way for MCP clients (Claude Desktop, Cursor, Continue) to query the WikiMind knowledge base.

**Solution:** A FastMCP-based server running over stdio transport, exposing 4 read-only tools that delegate to the existing service layer.

## Changes

- **`src/wikimind/mcp/server.py`** -- MCP server with 4 tools:
  - `wiki_search(query, limit)` -- full-text search across articles
  - `wiki_get_article(id_or_slug)` -- retrieve full article with content and sources
  - `wiki_ask(question)` -- Q&A agent synthesizes answers with citations
  - `wiki_list_sources(status, limit)` -- list ingested sources
- **`src/wikimind/cli/main.py`** -- `wikimind mcp serve` and `wikimind mcp config` CLI commands
- **`pyproject.toml`** -- Added `mcp>=1.0.0` dependency
- **`tests/unit/test_mcp_server.py`** -- 16 unit tests covering tools, CLI, and server registration

## Design decisions

- Uses the official `mcp` Python SDK (FastMCP) for spec compliance
- Stdio transport only (Phase 6 adds HTTP for remote)
- Tools delegate to existing `WikiService`, `QueryService`, `IngestService` -- no new business logic
- Database session managed via standalone context manager (not FastAPI DI)
- MCP spec version pinned to `2025-03-26` for stability
- All tools return JSON strings (MCP tool convention)
- Input validation: query min length, limit clamping
- Error handling: tools return JSON error objects, never raise

## Claude Desktop integration

```json
{
  "mcpServers": {
    "wikimind": {
      "command": "wikimind",
      "args": ["mcp", "serve"]
    }
  }
}
```

## Test plan

- [x] 16 unit tests: tool logic, input validation, CLI commands, server registration
- [x] Tool schema validation: all 4 tools have descriptions and typed parameters
- [x] Manual stdio test: server initializes, responds to `tools/list` with correct schemas
- [x] Existing test suite: 983 passed (16 new), 0 regressions
- [x] Lint, format, typecheck all pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)