### PR TITLE
fix: resolve CI failures on main (mypy, tests, doc-sync)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -249,6 +249,82 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/ingest/sources/{source_id}/images:
+    get:
+      tags:
+      - Ingest
+      summary: List Source Images
+      description: 'List extracted images for a PDF source.
+
+
+        Returns a list of image entries with filename, kind (figure/table),
+
+        and label. The actual image bytes are served by the
+
+        ``/sources/{source_id}/images/{filename}`` endpoint.'
+      operationId: list_source_images_api_ingest_sources__source_id__images_get
+      parameters:
+      - name: source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Source Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: Source not found or no images available
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/ingest/sources/{source_id}/images/{filename}:
+    get:
+      tags:
+      - Ingest
+      summary: Get Source Image
+      description: 'Serve an extracted image file for a PDF source.
+
+
+        Verifies the source belongs to the authenticated user before serving
+
+        the image. Path traversal is prevented by resolving the path and
+
+        checking it stays within the expected directory.'
+      operationId: get_source_image_api_ingest_sources__source_id__images__filename__get
+      parameters:
+      - name: source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Source Id
+      - name: filename
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Filename
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: Image not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/wiki/contradiction-resolutions:
     get:
       tags:

--- a/src/wikimind/cli/ingest.py
+++ b/src/wikimind/cli/ingest.py
@@ -39,7 +39,7 @@ def url(url: str) -> None:
 @ingest.command()
 @click.argument("path", type=click.Path(exists=True))
 def file(path: str) -> None:
-    """Ingest a local file (PDF)."""
+    """Ingest a local PDF document into the wiki."""
     file_path = Path(path)
     if file_path.suffix.lower() != ".pdf":
         click.echo("Error: Only PDF files are currently supported.", err=True)

--- a/src/wikimind/cli/main.py
+++ b/src/wikimind/cli/main.py
@@ -19,7 +19,7 @@ from wikimind.cli.wiki import wiki
 @click.group()
 @click.version_option(version="0.1.0", prog_name="wikimind")
 def cli() -> None:
-    """WikiMind -- personal LLM-powered knowledge OS.
+    """Run the WikiMind personal LLM-powered knowledge OS.
 
     Terminal interface for ingesting sources, browsing articles,
     and asking questions against your wiki.

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -21,7 +21,7 @@ from sqlmodel import select
 
 from wikimind._datetime import utcnow_naive
 from wikimind.api.routes.ws import emit_linter_alert
-from wikimind.config import get_settings
+from wikimind.config import Settings, get_settings
 from wikimind.database import get_session_factory
 from wikimind.engine.backlink_enforcer import enforce_backlinks
 from wikimind.engine.linter.contradictions import detect_contradictions
@@ -239,7 +239,7 @@ async def _persist_and_finalize(
     orphans: list,
     structurals: list,
     existing_contradiction_hashes: set,
-    settings: object,
+    settings: Settings,
     user_id: str,
 ) -> None:
     """Persist findings, update report counts, emit alerts, and trigger recompile."""
@@ -381,8 +381,14 @@ async def run_lint(
         await _apply_dismiss_suppression(session, contradictions, orphans, structurals)
 
         await _persist_and_finalize(
-            session, report, contradictions, orphans, structurals,
-            existing_contradiction_hashes, settings, user_id,
+            session,
+            report,
+            contradictions,
+            orphans,
+            structurals,
+            existing_contradiction_hashes,
+            settings,
+            user_id,
         )
 
     except Exception as e:  # Intentional broad catch — job runner must not crash

--- a/src/wikimind/services/saved_searches.py
+++ b/src/wikimind/services/saved_searches.py
@@ -83,9 +83,7 @@ class SavedSearchService:
             List of saved searches ordered by creation time.
         """
         result = await session.execute(
-            select(SavedSearch)
-            .where(SavedSearch.user_id == user_id)
-            .order_by(SavedSearch.created_at)  # type: ignore[arg-type]
+            select(SavedSearch).where(SavedSearch.user_id == user_id).order_by(SavedSearch.created_at)  # type: ignore[arg-type]
         )
         return [_to_response(s) for s in result.scalars().all()]
 

--- a/src/wikimind/services/user.py
+++ b/src/wikimind/services/user.py
@@ -120,7 +120,7 @@ class UserService:
                 if primary:
                     user_data["email"] = primary["email"]
 
-            return OAuthUserInfo(**user_data)
+            return OAuthUserInfo.model_validate(user_data)
 
     # ------------------------------------------------------------------
     # User upsert + JWT creation
@@ -169,7 +169,7 @@ class UserService:
             session.add(user)
         else:
             user = User(
-                email=email,
+                email=email or f"{provider}:{provider_id}@noemail",
                 name=name,
                 avatar_url=avatar_url,
                 auth_provider=provider,

--- a/tests/unit/test_stub_and_wikilinks.py
+++ b/tests/unit/test_stub_and_wikilinks.py
@@ -262,9 +262,9 @@ async def _seed_articles(factory) -> None:
 
 @pytest.mark.asyncio
 async def test_post_stub_endpoint(client: AsyncClient, _isolated_data_dir) -> None:
-    """POST /wiki/articles/stub creates a stub article and returns 201."""
+    """POST /api/wiki/articles/stub creates a stub article and returns 201."""
     response = await client.post(
-        "/wiki/articles/stub",
+        "/api/wiki/articles/stub",
         json={"title": "Quantum Computing", "body_markdown": ""},
     )
     assert response.status_code == 201
@@ -276,9 +276,9 @@ async def test_post_stub_endpoint(client: AsyncClient, _isolated_data_dir) -> No
 
 @pytest.mark.asyncio
 async def test_post_stub_with_body(client: AsyncClient, _isolated_data_dir) -> None:
-    """POST /wiki/articles/stub with body_markdown creates file on disk."""
+    """POST /api/wiki/articles/stub with body_markdown creates file on disk."""
     response = await client.post(
-        "/wiki/articles/stub",
+        "/api/wiki/articles/stub",
         json={"title": "Neural Nets", "body_markdown": "Notes about NNs."},
     )
     assert response.status_code == 201
@@ -288,9 +288,9 @@ async def test_post_stub_with_body(client: AsyncClient, _isolated_data_dir) -> N
 
 @pytest.mark.asyncio
 async def test_post_stub_empty_title_rejected(client: AsyncClient) -> None:
-    """POST /wiki/articles/stub with empty title returns 422."""
+    """POST /api/wiki/articles/stub with empty title returns 422."""
     response = await client.post(
-        "/wiki/articles/stub",
+        "/api/wiki/articles/stub",
         json={"title": ""},
     )
     assert response.status_code == 422
@@ -298,11 +298,11 @@ async def test_post_stub_empty_title_rejected(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_wikilink_resolve_endpoint(client: AsyncClient, async_engine: AsyncEngine) -> None:
-    """GET /wiki/wikilinks/resolve returns matching articles."""
+    """GET /api/wiki/wikilinks/resolve returns matching articles."""
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_articles(factory)
 
-    response = await client.get("/wiki/wikilinks/resolve", params={"q": "learning"})
+    response = await client.get("/api/wiki/wikilinks/resolve", params={"q": "learning"})
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
@@ -317,7 +317,7 @@ async def test_wikilink_resolve_shows_stub_flag(client: AsyncClient, async_engin
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_articles(factory)
 
-    response = await client.get("/wiki/wikilinks/resolve", params={"q": "Deep"})
+    response = await client.get("/api/wiki/wikilinks/resolve", params={"q": "Deep"})
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -326,18 +326,18 @@ async def test_wikilink_resolve_shows_stub_flag(client: AsyncClient, async_engin
 
 @pytest.mark.asyncio
 async def test_wikilink_resolve_empty_query_rejected(client: AsyncClient) -> None:
-    """GET /wiki/wikilinks/resolve with empty q returns 422."""
-    response = await client.get("/wiki/wikilinks/resolve", params={"q": ""})
+    """GET /api/wiki/wikilinks/resolve with empty q returns 422."""
+    response = await client.get("/api/wiki/wikilinks/resolve", params={"q": ""})
     assert response.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_article_list_includes_stub_flag(client: AsyncClient, async_engine: AsyncEngine) -> None:
-    """GET /wiki/articles returns is_stub in the response for each article."""
+    """GET /api/wiki/articles returns is_stub in the response for each article."""
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_articles(factory)
 
-    response = await client.get("/wiki/articles")
+    response = await client.get("/api/wiki/articles")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -19,7 +19,7 @@ from wikimind.models import Article
 
 @pytest.mark.asyncio
 async def test_create_tag(client, async_engine) -> None:
-    resp = await client.post("/tags", json={"name": "read-later", "color": "#ef4444"})
+    resp = await client.post("/api/tags", json={"name": "read-later", "color": "#ef4444"})
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "read-later"
@@ -29,16 +29,16 @@ async def test_create_tag(client, async_engine) -> None:
 
 @pytest.mark.asyncio
 async def test_list_tags_empty(client) -> None:
-    resp = await client.get("/tags")
+    resp = await client.get("/api/tags")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
 @pytest.mark.asyncio
 async def test_list_tags_after_create(client) -> None:
-    await client.post("/tags", json={"name": "favorite"})
-    await client.post("/tags", json={"name": "to-revisit"})
-    resp = await client.get("/tags")
+    await client.post("/api/tags", json={"name": "favorite"})
+    await client.post("/api/tags", json={"name": "to-revisit"})
+    resp = await client.get("/api/tags")
     assert resp.status_code == 200
     tags = resp.json()
     assert len(tags) == 2
@@ -48,18 +48,18 @@ async def test_list_tags_after_create(client) -> None:
 
 @pytest.mark.asyncio
 async def test_delete_tag(client) -> None:
-    create_resp = await client.post("/tags", json={"name": "temp"})
+    create_resp = await client.post("/api/tags", json={"name": "temp"})
     tag_id = create_resp.json()["id"]
-    delete_resp = await client.delete(f"/tags/{tag_id}")
+    delete_resp = await client.delete(f"/api/tags/{tag_id}")
     assert delete_resp.status_code == 204
     # Verify it's gone
-    list_resp = await client.get("/tags")
+    list_resp = await client.get("/api/tags")
     assert list_resp.json() == []
 
 
 @pytest.mark.asyncio
 async def test_delete_nonexistent_tag_returns_404(client) -> None:
-    resp = await client.delete("/tags/nonexistent-id")
+    resp = await client.delete("/api/tags/nonexistent-id")
     assert resp.status_code == 404
 
 
@@ -88,11 +88,11 @@ async def test_tag_article(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "important"})
+    tag_resp = await client.post("/api/tags", json={"name": "important"})
     tag_id = tag_resp.json()["id"]
 
     resp = await client.post(
-        "/wiki/articles/art-1/tags",
+        "/api/wiki/articles/art-1/tags",
         json={"tag_id": tag_id},
     )
     assert resp.status_code == 201
@@ -107,13 +107,13 @@ async def test_tag_article_idempotent(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "star"})
+    tag_resp = await client.post("/api/tags", json={"name": "star"})
     tag_id = tag_resp.json()["id"]
 
-    resp1 = await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    resp1 = await client.post("/api/wiki/articles/art-1/tags", json={"tag_id": tag_id})
     assert resp1.status_code == 201
 
-    resp2 = await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    resp2 = await client.post("/api/wiki/articles/art-1/tags", json={"tag_id": tag_id})
     assert resp2.status_code == 201
 
 
@@ -122,11 +122,11 @@ async def test_untag_article(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "remove-me"})
+    tag_resp = await client.post("/api/tags", json={"name": "remove-me"})
     tag_id = tag_resp.json()["id"]
 
-    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
-    resp = await client.delete(f"/wiki/articles/art-1/tags/{tag_id}")
+    await client.post("/api/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    resp = await client.delete(f"/api/wiki/articles/art-1/tags/{tag_id}")
     assert resp.status_code == 204
 
 
@@ -135,10 +135,10 @@ async def test_untag_nonexistent_returns_404(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "nope"})
+    tag_resp = await client.post("/api/tags", json={"name": "nope"})
     tag_id = tag_resp.json()["id"]
 
-    resp = await client.delete(f"/wiki/articles/art-1/tags/{tag_id}")
+    resp = await client.delete(f"/api/wiki/articles/art-1/tags/{tag_id}")
     assert resp.status_code == 404
 
 
@@ -147,11 +147,11 @@ async def test_get_article_tags(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "alpha", "color": "#22c55e"})
+    tag_resp = await client.post("/api/tags", json={"name": "alpha", "color": "#22c55e"})
     tag_id = tag_resp.json()["id"]
-    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    await client.post("/api/wiki/articles/art-1/tags", json={"tag_id": tag_id})
 
-    resp = await client.get("/wiki/articles/art-1/tags")
+    resp = await client.get("/api/wiki/articles/art-1/tags")
     assert resp.status_code == 200
     tags = resp.json()
     assert len(tags) == 1
@@ -164,11 +164,11 @@ async def test_get_articles_by_tag(client, async_engine) -> None:
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "special"})
+    tag_resp = await client.post("/api/tags", json={"name": "special"})
     tag_id = tag_resp.json()["id"]
-    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    await client.post("/api/wiki/articles/art-1/tags", json={"tag_id": tag_id})
 
-    resp = await client.get(f"/tags/{tag_id}/articles")
+    resp = await client.get(f"/api/tags/{tag_id}/articles")
     assert resp.status_code == 200
     articles = resp.json()
     assert len(articles) == 1
@@ -198,11 +198,11 @@ async def test_article_response_includes_tags(client, async_engine) -> None:
         session.add(article)
         await session.commit()
 
-    tag_resp = await client.post("/tags", json={"name": "tagged"})
+    tag_resp = await client.post("/api/tags", json={"name": "tagged"})
     tag_id = tag_resp.json()["id"]
-    await client.post("/wiki/articles/art-tagged/tags", json={"tag_id": tag_id})
+    await client.post("/api/wiki/articles/art-tagged/tags", json={"tag_id": tag_id})
 
-    resp = await client.get("/wiki/articles/tagged-article")
+    resp = await client.get("/api/wiki/articles/tagged-article")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data["tags"]) == 1
@@ -215,14 +215,14 @@ async def test_delete_tag_cascades_to_associations(client, async_engine) -> None
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     await _seed_article(factory)
 
-    tag_resp = await client.post("/tags", json={"name": "cascade-test"})
+    tag_resp = await client.post("/api/tags", json={"name": "cascade-test"})
     tag_id = tag_resp.json()["id"]
-    await client.post("/wiki/articles/art-1/tags", json={"tag_id": tag_id})
+    await client.post("/api/wiki/articles/art-1/tags", json={"tag_id": tag_id})
 
-    await client.delete(f"/tags/{tag_id}")
+    await client.delete(f"/api/tags/{tag_id}")
 
     # Verify article no longer has the tag
-    resp = await client.get("/wiki/articles/art-1/tags")
+    resp = await client.get("/api/wiki/articles/art-1/tags")
     assert resp.status_code == 200
     assert resp.json() == []
 
@@ -235,7 +235,7 @@ async def test_delete_tag_cascades_to_associations(client, async_engine) -> None
 @pytest.mark.asyncio
 async def test_create_saved_search(client) -> None:
     resp = await client.post(
-        "/saved-searches",
+        "/api/saved-searches",
         json={
             "name": "Q2 Research",
             "query": "machine learning",
@@ -250,9 +250,9 @@ async def test_create_saved_search(client) -> None:
 
 @pytest.mark.asyncio
 async def test_list_saved_searches(client) -> None:
-    await client.post("/saved-searches", json={"name": "Search 1", "query": "test"})
-    await client.post("/saved-searches", json={"name": "Search 2", "query": "demo"})
-    resp = await client.get("/saved-searches")
+    await client.post("/api/saved-searches", json={"name": "Search 1", "query": "test"})
+    await client.post("/api/saved-searches", json={"name": "Search 2", "query": "demo"})
+    resp = await client.get("/api/saved-searches")
     assert resp.status_code == 200
     searches = resp.json()
     assert len(searches) == 2
@@ -261,14 +261,14 @@ async def test_list_saved_searches(client) -> None:
 @pytest.mark.asyncio
 async def test_delete_saved_search(client) -> None:
     create_resp = await client.post(
-        "/saved-searches",
+        "/api/saved-searches",
         json={"name": "Temp", "query": "temporary"},
     )
     search_id = create_resp.json()["id"]
-    del_resp = await client.delete(f"/saved-searches/{search_id}")
+    del_resp = await client.delete(f"/api/saved-searches/{search_id}")
     assert del_resp.status_code == 204
 
-    list_resp = await client.get("/saved-searches")
+    list_resp = await client.get("/api/saved-searches")
     assert list_resp.json() == []
 
 
@@ -276,12 +276,12 @@ async def test_delete_saved_search(client) -> None:
 async def test_execute_saved_search_empty(client) -> None:
     """Executing a search with no matching articles returns empty list."""
     create_resp = await client.post(
-        "/saved-searches",
+        "/api/saved-searches",
         json={"name": "Empty", "query": "nonexistent-title"},
     )
     search_id = create_resp.json()["id"]
 
-    resp = await client.post(f"/saved-searches/{search_id}/execute")
+    resp = await client.post(f"/api/saved-searches/{search_id}/execute")
     assert resp.status_code == 200
     data = resp.json()
     assert data["articles"] == []
@@ -315,13 +315,13 @@ async def test_execute_saved_search_with_tag_filter(client, async_engine) -> Non
         await session.commit()
 
     # Create tag and apply to art-a only
-    tag_resp = await client.post("/tags", json={"name": "research"})
+    tag_resp = await client.post("/api/tags", json={"name": "research"})
     tag_id = tag_resp.json()["id"]
-    await client.post("/wiki/articles/art-a/tags", json={"tag_id": tag_id})
+    await client.post("/api/wiki/articles/art-a/tags", json={"tag_id": tag_id})
 
     # Create saved search that filters by tag
     create_resp = await client.post(
-        "/saved-searches",
+        "/api/saved-searches",
         json={
             "name": "Research",
             "query": "",
@@ -330,7 +330,7 @@ async def test_execute_saved_search_with_tag_filter(client, async_engine) -> Non
     )
     search_id = create_resp.json()["id"]
 
-    resp = await client.post(f"/saved-searches/{search_id}/execute")
+    resp = await client.post(f"/api/saved-searches/{search_id}/execute")
     assert resp.status_code == 200
     articles = resp.json()["articles"]
     assert len(articles) == 1


### PR DESCRIPTION
## Summary

Pre-existing CI failures on `main` are blocking all 9 open PRs. This fixes them:

- **mypy** (`linter/runner.py:299`): `_persist_and_finalize` param `settings` was typed `object`, causing `"object" has no attribute "linter"`. Changed to `Settings`.
- **pytest** (`test_stub_and_wikilinks.py`, `test_tags.py`): Route-level tests used bare paths like `/wiki/articles/stub` instead of `/api/wiki/articles/stub`. These tests were added after the `/api` prefix migration (#500) but didn't account for it.
- **pyright** (`user.py`): `OAuthUserInfo(**user_data)` failed type checking because dict value types didn't match constructor params. Switched to `model_validate()`. Also added email fallback for nullable `User.email`.
- **pydocstyle** (`cli/ingest.py`, `cli/main.py`): D402 (function signature in docstring) and D403 (capitalization) violations in new CLI module.
- **format** (`saved_searches.py`, `runner.py`): Pre-existing ruff format drift.
- **doc-sync** (`openapi.yaml`): Regenerated to include new PDF image extraction endpoints.

## Test plan

- [x] `make verify` passes locally (exit code 0) -- all 1234 tests pass, mypy clean, pyright clean, docs in sync
- [ ] CI `full-verify` passes on this PR
- [ ] Merge to main unblocks the 9 pending PRs

Generated with [Claude Code](https://claude.com/claude-code)