### PR TITLE
fix: consolidate Alembic migration heads into linear chain

### DIFF
--- a/alembic/versions/0008b_add_contradiction_table.py
+++ b/alembic/versions/0008b_add_contradiction_table.py
@@ -1,7 +1,7 @@
 """Add Contradiction table for persisted navigable contradictions.
 
-Revision ID: 0008
-Revises: 0007
+Revision ID: 0008b
+Revises: 0008
 Create Date: 2026-05-07
 
 Persists linter contradiction findings as first-class wiki content so users
@@ -16,8 +16,8 @@ from sqlalchemy import inspect as sa_inspect
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0008"
-down_revision: str = "0007"
+revision: str = "0008b"
+down_revision: str = "0008"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/0008c_add_conversation_crystallized_article_id.py
+++ b/alembic/versions/0008c_add_conversation_crystallized_article_id.py
@@ -1,7 +1,7 @@
 """Add crystallized_article_id to conversation table.
 
-Revision ID: 0008
-Revises: 0007
+Revision ID: 0008c
+Revises: 0008b
 Create Date: 2026-05-07
 
 Tracks which synthesis article was created when a conversation is
@@ -16,8 +16,8 @@ from sqlalchemy import inspect as sa_inspect
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0008"
-down_revision: str = "0007"
+revision: str = "0008c"
+down_revision: str = "0008b"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/0008d_add_staleness_and_reinforcement_event.py
+++ b/alembic/versions/0008d_add_staleness_and_reinforcement_event.py
@@ -1,7 +1,7 @@
 """Add source_newest_at to article and create reinforcement_event table.
 
-Revision ID: 0008
-Revises: 0007
+Revision ID: 0008d
+Revises: 0008c
 Create Date: 2026-05-07
 
 Adds staleness detection infrastructure (issue #425):
@@ -17,8 +17,8 @@ from sqlalchemy import inspect as sa_inspect
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0008"
-down_revision: str = "0007"
+revision: str = "0008d"
+down_revision: str = "0008c"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/0009_add_article_is_stub.py
+++ b/alembic/versions/0009_add_article_is_stub.py
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0009"
-down_revision: str = "0008"
+down_revision: str = "0008d"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary

- Four migrations all shared revision `0008` (merged from separate PRs that each branched off `0007`), creating multiple Alembic heads that block staging deploys
- Renumbered into a linear chain: `0007 -> 0008 -> 0008b -> 0008c -> 0008d -> 0009`
- `alembic heads` now returns exactly one head; migration history is fully linear

## Test plan

- [x] `alembic heads` shows exactly 1 head (`0009`)
- [x] `alembic history` shows correct linear chain with no branches
- [x] ruff lint, ruff format, mypy all pass
- [x] 1576 tests pass (4 pre-existing failures unrelated to migrations)
- [ ] Staging deploy succeeds with `alembic upgrade head`

🤖 Generated with [Claude Code](https://claude.com/claude-code)