### PR TITLE
fix: stabilize main — Wave 1 (pyright, postgres FK, multi-user backfill)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,6 +70,7 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
+          cache-save: false  # skip expensive post-job uv cache prune
 
       # -----------------------------------------------------------
       # 2️⃣  Install Python dependencies (pinned by uv.lock)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -315,32 +315,25 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_user_service.py",
-        "hashed_secret": "f330c6bd79029b4cd1987ff8a7142e997dd02d63",
-        "is_verified": false,
-        "line_number": 20
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/test_user_service.py",
         "hashed_secret": "85f119928df1d84571fc6128390287b4da1e982f",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 49
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_user_service.py",
         "hashed_secret": "3b15a4ea80087c146ac83727ec872e1daa0d828e",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_user_service.py",
         "hashed_secret": "e4055de792e64bf8433b9c794f2611cb65f4c487",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 98
       }
     ]
   },
-  "generated_at": "2026-05-09T14:03:40Z"
+  "generated_at": "2026-05-09T15:55:49Z"
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3806,7 +3806,7 @@ components:
       properties:
         file:
           type: string
-          contentMediaType: application/octet-stream
+          format: binary
           title: File
       type: object
       required:
@@ -6586,11 +6586,6 @@ components:
         type:
           type: string
           title: Error Type
-        input:
-          title: Input
-        ctx:
-          type: object
-          title: Context
       type: object
       required:
       - loc

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3806,7 +3806,7 @@ components:
       properties:
         file:
           type: string
-          format: binary
+          contentMediaType: application/octet-stream
           title: File
       type: object
       required:
@@ -6586,6 +6586,11 @@ components:
         type:
           type: string
           title: Error Type
+        input:
+          title: Input
+        ctx:
+          type: object
+          title: Context
       type: object
       required:
       - loc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,11 @@ reportMissingTypeStubs = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+filterwarnings = [
+    "ignore::DeprecationWarning:importlib._bootstrap",  # SwigPy* builtin types
+    "ignore:coroutine.*was never awaited:RuntimeWarning:rich.text",  # rich formatting mock objects
+    "ignore::DeprecationWarning:wikimind",  # SQLModel session.exec() vs session.execute() false positive on AsyncSession
+]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "e2e: end-to-end tests requiring full stack",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning:importlib._bootstrap",  # SwigPy* builtin types
     "ignore:coroutine.*was never awaited:RuntimeWarning:rich.text",  # rich formatting mock objects
-    "ignore::DeprecationWarning:wikimind",  # SQLModel session.exec() vs session.execute() false positive on AsyncSession
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ lint = [
     "pydocstyle>=6.3.0",
     "pre-commit>=3.8.0",
     "types-toml>=0.10.0",
+    "types-PyYAML>=6.0",
     "bandit[toml]>=1.7",
     "vulture>=2.11",
     "interrogate>=1.7.0",

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -405,19 +405,26 @@ def _parse_concept_names_from_json(raw: str) -> list[str]:
 
 def _collect_concept_names(
     rows: list,
-) -> tuple[dict[str, str], list[list[str]]]:
-    """Collect normalized concept names from article rows.
+) -> tuple[dict[tuple[str, str], str], list[tuple[str, list[str]]]]:
+    """Collect normalized concept names per user from article rows.
 
-    Returns a tuple of (all_names mapping, per-article normalized lists).
+    Returns a tuple of:
+    - ``all_names``: mapping ``(user_id, normalized) -> first raw name seen``.
+    - ``article_concepts``: per-article list of ``(user_id, [normalized, ...])``.
+
+    Concepts are partitioned by user because ``concept`` has a NOT NULL
+    ``user_id`` FK and a ``UNIQUE(user_id, name)`` constraint — the same
+    normalized name owned by two different users is two distinct rows.
     """
-    all_names: dict[str, str] = {}  # normalized -> first raw name seen
-    article_concepts: list[list[str]] = []
+    all_names: dict[tuple[str, str], str] = {}
+    article_concepts: list[tuple[str, list[str]]] = []
     for row in rows:
-        _article_id, concept_ids_raw = row
+        _article_id, user_id, concept_ids_raw = row
         normalized_names = _parse_concept_names_from_json(concept_ids_raw)
-        article_concepts.append(normalized_names)
+        article_concepts.append((user_id, normalized_names))
         for name in normalized_names:
-            if name not in all_names:
+            key = (user_id, name)
+            if key not in all_names:
                 # Store the original raw value for the description
                 try:
                     raw_list = json.loads(concept_ids_raw)
@@ -427,7 +434,7 @@ def _collect_concept_names(
                     )
                 except (json.JSONDecodeError, TypeError):
                     raw_match = name
-                all_names[name] = raw_match
+                all_names[key] = raw_match
     return all_names, article_concepts
 
 
@@ -445,7 +452,7 @@ async def _backfill_concepts_from_articles(engine) -> None:
 
         def _select_articles(sync_conn):
             return sync_conn.execute(
-                sa_text("SELECT id, concept_ids FROM article WHERE concept_ids IS NOT NULL")
+                sa_text("SELECT id, user_id, concept_ids FROM article WHERE concept_ids IS NOT NULL")
             ).fetchall()
 
         rows = await conn.run_sync(_select_articles)
@@ -455,39 +462,48 @@ async def _backfill_concepts_from_articles(engine) -> None:
             return
 
         def _select_existing_concepts(sync_conn):
-            return sync_conn.execute(sa_text("SELECT name FROM concept")).fetchall()
+            return sync_conn.execute(sa_text("SELECT user_id, name FROM concept")).fetchall()
 
         existing_rows = await conn.run_sync(_select_existing_concepts)
-        existing_names = {row[0] for row in existing_rows}
+        existing_keys = {(row[0], row[1]) for row in existing_rows}
 
-        for normalized, raw_name in all_names.items():
-            if normalized not in existing_names:
+        for (user_id, normalized), raw_name in all_names.items():
+            if (user_id, normalized) not in existing_keys:
                 concept_id = str(uuid.uuid4())
                 await conn.execute(
                     sa_text(
-                        "INSERT INTO concept (id, name, description, article_count, created_at) "
-                        "VALUES (:id, :name, :desc, 0, :created_at)"
+                        "INSERT INTO concept "
+                        "(id, user_id, name, description, article_count, created_at, concept_kind) "
+                        "VALUES (:id, :user_id, :name, :desc, 0, :created_at, :concept_kind)"
                     ),
-                    {"id": concept_id, "name": normalized, "desc": raw_name, "created_at": utcnow_naive().isoformat()},
+                    {
+                        "id": concept_id,
+                        "user_id": user_id,
+                        "name": normalized,
+                        "desc": raw_name,
+                        "created_at": utcnow_naive(),
+                        "concept_kind": "topic",
+                    },
                 )
 
-        # Recalculate article counts
-        counts: dict[str, int] = {}
-        for names in article_concepts:
+        # Recalculate article counts per (user_id, name)
+        counts: dict[tuple[str, str], int] = {}
+        for user_id, names in article_concepts:
             for name in names:
-                counts[name] = counts.get(name, 0) + 1
+                key = (user_id, name)
+                counts[key] = counts.get(key, 0) + 1
 
-        for normalized, count in counts.items():
+        for (user_id, normalized), count in counts.items():
             await conn.execute(
-                sa_text("UPDATE concept SET article_count = :count WHERE name = :name"),
-                {"count": count, "name": normalized},
+                sa_text("UPDATE concept SET article_count = :count WHERE user_id = :user_id AND name = :name"),
+                {"count": count, "user_id": user_id, "name": normalized},
             )
 
-        unreferenced = (existing_names | set(all_names.keys())) - set(counts.keys())
-        for name in unreferenced:
+        unreferenced = (existing_keys | set(all_names.keys())) - set(counts.keys())
+        for user_id, name in unreferenced:
             await conn.execute(
-                sa_text("UPDATE concept SET article_count = 0 WHERE name = :name"),
-                {"name": name},
+                sa_text("UPDATE concept SET article_count = 0 WHERE user_id = :user_id AND name = :name"),
+                {"user_id": user_id, "name": name},
             )
 
 

--- a/src/wikimind/engine/frontmatter_validator.py
+++ b/src/wikimind/engine/frontmatter_validator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import structlog
-import yaml  # type: ignore[import-untyped]
+import yaml
 from pydantic import ValidationError
 
 from wikimind.models import (

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -651,8 +651,6 @@ class CompiledClaim(SQLModel, table=True):
     and carry their own embedding for semantic similarity.
     """
 
-    __tablename__ = "compiled_claim"
-
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     article_id: str = Field(foreign_key="article.id", index=True)
     user_id: str = Field(foreign_key="user.id", index=True)
@@ -679,8 +677,6 @@ class ConceptCluster(SQLModel, table=True):
     (reconciled) by the batch reconciler.
     """
 
-    __tablename__ = "concept_cluster"
-
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     user_id: str = Field(foreign_key="user.id", index=True)
     canonical_text: str  # canonical subject name
@@ -688,7 +684,7 @@ class ConceptCluster(SQLModel, table=True):
     embedding_version: str | None = None  # centroid valid only for this version
     member_count: int = 0
     status: str = Field(default=ClusterStatus.CANDIDATE)  # ClusterStatus enum value
-    superseded_by: str | None = Field(default=None, foreign_key="concept_cluster.id")
+    superseded_by: str | None = Field(default=None, foreign_key="conceptcluster.id")
     last_reinforced_at: datetime = Field(default_factory=utcnow_naive)
     last_reconciled_at: datetime | None = None
     created_at: datetime = Field(default_factory=utcnow_naive)
@@ -703,10 +699,8 @@ class ClaimConcept(SQLModel, table=True):
     ``CompiledClaim.cluster_assignment_reconciled=True``.
     """
 
-    __tablename__ = "claim_concept"
-
-    claim_id: str = Field(foreign_key="compiled_claim.id", primary_key=True)
-    concept_id: str = Field(foreign_key="concept_cluster.id", primary_key=True, index=True)
+    claim_id: str = Field(foreign_key="compiledclaim.id", primary_key=True)
+    concept_id: str = Field(foreign_key="conceptcluster.id", primary_key=True, index=True)
     role: str = Field(primary_key=True)  # ClaimConceptRole enum value
     advisory: bool = True  # TRUE until offline reconciler confirms
     created_at: datetime = Field(default_factory=utcnow_naive)

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -217,7 +217,7 @@ async def maybe_trigger_concept_pages(
     stmt = select(Concept).where(Concept.article_count >= min_sources)
     if user_id:
         stmt = stmt.where(Concept.user_id == user_id)
-    result = await session.execute(stmt)  # noqa: E711  # AsyncSession, not SQLModel Session
+    result = await session.execute(stmt)  # AsyncSession, not SQLModel Session
     eligible = list(result.scalars().all())
     if not eligible:
         return []

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -217,7 +217,7 @@ async def maybe_trigger_concept_pages(
     stmt = select(Concept).where(Concept.article_count >= min_sources)
     if user_id:
         stmt = stmt.where(Concept.user_id == user_id)
-    result = await session.execute(stmt)
+    result = await session.execute(stmt)  # noqa: E711  # AsyncSession, not SQLModel Session
     eligible = list(result.scalars().all())
     if not eligible:
         return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 TEST_USER_ID = "test-user"
+TEST_JWT_SECRET = "test-secret-key-for-unit-tests!!"  # pragma: allowlist secret  # 32 bytes
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +136,10 @@ async def db_session(async_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, 
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
     async with factory() as session:
         yield session
+        # Explicitly close the session connection before the event loop ends,
+        # giving aiosqlite's background thread time to finish. Without this,
+        # the thread tries to post results to an already-closed loop.
+        await session.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 import keyring
 import pytest
-
 from httpx import ASGITransport, AsyncClient
 from keyring.backend import KeyringBackend
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import keyring
 import pytest
+
 from httpx import ASGITransport, AsyncClient
 from keyring.backend import KeyringBackend
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine

--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -15,7 +15,7 @@ from sqlmodel import SQLModel, select
 
 from tests.conftest import TEST_USER_ID
 from wikimind.database import _backfill_concepts_from_articles
-from wikimind.models import Article, ConfidenceLevel, Query, Source, SourceType
+from wikimind.models import Article, ConfidenceLevel, Query, Source, SourceType, User
 
 POSTGRES_URL = os.environ.get("WIKIMIND_TEST_POSTGRES_URL")
 
@@ -40,9 +40,25 @@ async def pg_engine():
 
 @pytest.fixture
 async def pg_session(pg_engine) -> AsyncSession:
-    """Async session backed by Postgres test database."""
+    """Async session backed by Postgres test database.
+
+    Seeds the canonical ``TEST_USER_ID`` row before yielding so tests can
+    insert rows whose ``user_id`` FK points at it without violating
+    Postgres' foreign-key constraints (SQLite tests get away without this
+    because FKs are off by default in SQLite).
+    """
     factory = async_sessionmaker(pg_engine, expire_on_commit=False)
     async with factory() as session:
+        session.add(
+            User(
+                id=TEST_USER_ID,
+                email=f"{TEST_USER_ID}@test.local",
+                name="Postgres Integration Test User",
+                auth_provider="jwt",
+                auth_provider_id=TEST_USER_ID,
+            )
+        )
+        await session.commit()
         yield session
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -18,6 +18,7 @@ from wikimind.api.routes.auth import (
     _consume_oauth_state,
     _generate_oauth_state,
 )
+from tests.conftest import TEST_JWT_SECRET
 from wikimind.config import get_settings
 from wikimind.models import OAuthUserInfo, User
 from wikimind.services.user import UserService
@@ -32,7 +33,7 @@ _service = UserService()
 def test_create_jwt_contains_expected_claims():
     """JWT payload should contain sub, email, iat, and exp claims."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
     settings.auth.jwt_algorithm = "HS256"
     settings.auth.jwt_expiry_minutes = 60
 
@@ -44,7 +45,7 @@ def test_create_jwt_contains_expected_claims():
     )
 
     token = _service.create_jwt(user, settings)
-    payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
+    payload = jwt.decode(token, TEST_JWT_SECRET, algorithms=["HS256"])
 
     assert payload["sub"] == "user-1"
     assert payload["email"] == "alice@example.com"
@@ -55,7 +56,7 @@ def test_create_jwt_contains_expected_claims():
 def test_create_jwt_expiry():
     """JWT should expire after the configured number of minutes."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
     settings.auth.jwt_algorithm = "HS256"
     settings.auth.jwt_expiry_minutes = 30
 
@@ -67,7 +68,7 @@ def test_create_jwt_expiry():
     )
 
     token = _service.create_jwt(user, settings)
-    payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
+    payload = jwt.decode(token, TEST_JWT_SECRET, algorithms=["HS256"])
 
     now = datetime.now(UTC)
     exp = datetime.fromtimestamp(payload["exp"], tz=UTC)
@@ -106,7 +107,7 @@ async def test_middleware_returns_401_when_no_token(client, monkeypatch):
     """When auth is enabled, missing token should return 401."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     response = await client.get("/api/wiki/articles")
     assert response.status_code == 401
@@ -119,7 +120,7 @@ async def test_middleware_returns_401_when_token_expired(client, monkeypatch):
     """An expired JWT should return a TOKEN_EXPIRED error."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     expired_payload = {
         "sub": "user-1",
@@ -127,7 +128,7 @@ async def test_middleware_returns_401_when_token_expired(client, monkeypatch):
         "exp": datetime.now(UTC) - timedelta(hours=1),
         "iat": datetime.now(UTC) - timedelta(hours=2),
     }
-    expired_token = jwt.encode(expired_payload, "test-secret", algorithm="HS256")
+    expired_token = jwt.encode(expired_payload, TEST_JWT_SECRET, algorithm="HS256")
 
     response = await client.get(
         "/api/wiki/articles",
@@ -143,11 +144,11 @@ async def test_middleware_returns_401_when_token_invalid(client, monkeypatch):
     """A token signed with the wrong key should return INVALID_TOKEN."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     bad_token = jwt.encode(
         {"sub": "user-1", "email": "a@b.com", "exp": datetime.now(UTC) + timedelta(hours=1)},
-        "wrong-secret",
+        "wrong-secret-key-for-unit-tests!!",
         algorithm="HS256",
     )
 
@@ -165,7 +166,7 @@ async def test_middleware_passes_with_valid_token(client, monkeypatch):
     """A valid JWT should allow the request through."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     valid_token = jwt.encode(
         {
@@ -173,7 +174,7 @@ async def test_middleware_passes_with_valid_token(client, monkeypatch):
             "email": "alice@example.com",
             "exp": datetime.now(UTC) + timedelta(hours=1),
         },
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithm="HS256",
     )
 
@@ -189,7 +190,7 @@ async def test_middleware_skips_exempt_paths(client, monkeypatch):
     """Exempt paths should not require authentication even when auth is enabled."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     # /health is exempt
     response = await client.get("/health")
@@ -206,7 +207,7 @@ async def test_auth_me_returns_user_profile(client, db_session: AsyncSession, mo
     """GET /auth/me should return the authenticated user's profile."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     # Create a user directly in the DB
     user = User(
@@ -226,7 +227,7 @@ async def test_auth_me_returns_user_profile(client, db_session: AsyncSession, mo
             "email": "alice@example.com",
             "exp": datetime.now(UTC) + timedelta(hours=1),
         },
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithm="HS256",
     )
 
@@ -257,7 +258,7 @@ async def test_auth_me_returns_401_when_auth_enabled_no_token(client, monkeypatc
     """GET /auth/me with auth enabled but no token returns 401."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret-key-32chars-long!!")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     response = await client.get("/auth/me")
     assert response.status_code == 401
@@ -339,7 +340,7 @@ async def test_get_ws_user_id_extracts_user_from_jwt_cookie(monkeypatch):
     """When auth is enabled, get_ws_user_id should decode user_id from the session cookie."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
     monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
 
     token = jwt.encode(
@@ -348,7 +349,7 @@ async def test_get_ws_user_id_extracts_user_from_jwt_cookie(monkeypatch):
             "email": "ws@example.com",
             "exp": datetime.now(UTC) + timedelta(hours=1),
         },
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithm="HS256",
     )
 
@@ -362,7 +363,7 @@ async def test_get_ws_user_id_falls_back_to_token_query_param(monkeypatch):
     """When no cookie is present, get_ws_user_id should try the ``token`` query param."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
     monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
 
     token = jwt.encode(
@@ -370,7 +371,7 @@ async def test_get_ws_user_id_falls_back_to_token_query_param(monkeypatch):
             "sub": "user-77",
             "exp": datetime.now(UTC) + timedelta(hours=1),
         },
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithm="HS256",
     )
 
@@ -384,7 +385,7 @@ async def test_get_ws_user_id_returns_anonymous_for_missing_token(monkeypatch):
     """When auth is enabled but no token is provided, return ANONYMOUS_USER_ID."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     ws = _make_ws_mock()
     result = await get_ws_user_id(ws)
@@ -396,12 +397,12 @@ async def test_get_ws_user_id_returns_anonymous_for_invalid_token(monkeypatch):
     """An invalid JWT should result in ANONYMOUS_USER_ID, not an exception."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
     monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
 
     bad_token = jwt.encode(
         {"sub": "user-1", "exp": datetime.now(UTC) + timedelta(hours=1)},
-        "wrong-secret",
+        "wrong-secret-key-for-unit-tests!!",
         algorithm="HS256",
     )
 
@@ -415,7 +416,7 @@ async def test_get_ws_user_id_returns_anonymous_for_expired_token(monkeypatch):
     """An expired JWT should result in ANONYMOUS_USER_ID."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
     monkeypatch.setattr(settings.auth, "jwt_algorithm", "HS256")
 
     expired_token = jwt.encode(
@@ -424,7 +425,7 @@ async def test_get_ws_user_id_returns_anonymous_for_expired_token(monkeypatch):
             "exp": datetime.now(UTC) - timedelta(hours=1),
             "iat": datetime.now(UTC) - timedelta(hours=2),
         },
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithm="HS256",
     )
 
@@ -459,7 +460,7 @@ def _build_state_token(provider: str, timestamp: int, secret: str) -> str:
 def test_generate_oauth_state_returns_unique_tokens(monkeypatch):
     """_generate_oauth_state should return distinct tokens for successive calls."""
     settings = get_settings()
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     token1 = _generate_oauth_state("google")
     # Advance time by 1 second to guarantee a different timestamp
@@ -473,7 +474,7 @@ def test_generate_oauth_state_returns_unique_tokens(monkeypatch):
 def test_generate_oauth_state_encodes_provider(monkeypatch):
     """The generated token should encode the provider name (verifiable via consume)."""
     settings = get_settings()
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     token = _generate_oauth_state("github")
     result = _consume_oauth_state(token)
@@ -483,7 +484,7 @@ def test_generate_oauth_state_encodes_provider(monkeypatch):
 def test_consume_oauth_state_returns_provider(monkeypatch):
     """_consume_oauth_state should return the provider for a valid token."""
     settings = get_settings()
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     token = _generate_oauth_state("google")
     result = _consume_oauth_state(token)
@@ -493,7 +494,7 @@ def test_consume_oauth_state_returns_provider(monkeypatch):
 def test_consume_oauth_state_rejects_unknown_token(monkeypatch):
     """An unknown/garbage state token should return None."""
     settings = get_settings()
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     result = _consume_oauth_state("bogus-token")
     assert result is None
@@ -502,7 +503,7 @@ def test_consume_oauth_state_rejects_unknown_token(monkeypatch):
 def test_consume_oauth_state_rejects_tampered_token(monkeypatch):
     """A token with a tampered payload should be rejected."""
     settings = get_settings()
-    secret = "test-secret"  # pragma: allowlist secret
+    secret = TEST_JWT_SECRET  # pragma: allowlist secret
     monkeypatch.setattr(settings.auth, "jwt_secret_key", secret)
 
     token = _generate_oauth_state("google")
@@ -517,7 +518,7 @@ def test_consume_oauth_state_rejects_tampered_token(monkeypatch):
 def test_consume_oauth_state_rejects_expired_token(monkeypatch):
     """A state token older than oauth_state_ttl_seconds should be rejected."""
     settings = get_settings()
-    secret = "test-secret"  # pragma: allowlist secret
+    secret = TEST_JWT_SECRET  # pragma: allowlist secret
     monkeypatch.setattr(settings.auth, "jwt_secret_key", secret)
     monkeypatch.setattr(settings.auth, "oauth_state_ttl_seconds", 600)
 
@@ -534,7 +535,7 @@ def test_consume_oauth_state_rejects_wrong_signature(monkeypatch):
     monkeypatch.setattr(settings.auth, "jwt_secret_key", "correct-secret")
 
     # Build a token signed with a different secret
-    token = _build_state_token("google", int(time.time()), "wrong-secret")
+    token = _build_state_token("google", int(time.time()), "wrong-secret-key-for-unit-tests!!")
     result = _consume_oauth_state(token)
     assert result is None
 
@@ -542,7 +543,7 @@ def test_consume_oauth_state_rejects_wrong_signature(monkeypatch):
 def test_login_state_is_not_provider_name(monkeypatch):
     """The state parameter in the authorize URL must not be the provider name."""
     settings = get_settings()
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     token = _generate_oauth_state("google")
     assert token != "google"
@@ -575,7 +576,7 @@ async def test_login_sets_next_cookie_for_safe_path(client, monkeypatch):
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
     monkeypatch.setattr(settings.auth, "google_client_id", "fake-id")
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     resp = await client.get("/auth/login/google?next=/auth/tokens", follow_redirects=False)
     assert resp.status_code == 307
@@ -589,7 +590,7 @@ async def test_login_ignores_unsafe_next_url(client, monkeypatch):
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
     monkeypatch.setattr(settings.auth, "google_client_id", "fake-id")
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     resp = await client.get("/auth/login/google?next=//evil.com", follow_redirects=False)
     assert resp.status_code == 307
@@ -607,7 +608,7 @@ async def test_login_uses_x_forwarded_proto(client, monkeypatch):
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
     monkeypatch.setattr(settings.auth, "google_client_id", "fake-id")
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     resp = await client.get(
         "/auth/login/google",
@@ -626,7 +627,7 @@ async def test_login_uses_x_forwarded_proto(client, monkeypatch):
 
 def _auth_header(
     user_id: str = "user-1",
-    secret: str = "test-secret",  # pragma: allowlist secret
+    secret: str = TEST_JWT_SECRET,  # pragma: allowlist secret
 ) -> dict[str, str]:
     """Build an Authorization header with a valid session JWT."""
     token = jwt.encode(
@@ -646,7 +647,7 @@ async def test_create_api_token_returns_jwt(client, db_session: AsyncSession, mo
     """POST /auth/token should return a valid JWT with the expected response shape."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     user = User(
         id="user-1",
@@ -673,7 +674,7 @@ async def test_create_api_token_returns_jwt(client, db_session: AsyncSession, mo
     # The access_token should be a valid JWT
     decoded = jwt.decode(
         body["access_token"],
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithms=["HS256"],
         options={"verify_aud": False},
     )
@@ -685,7 +686,7 @@ async def test_api_token_has_correct_claims(client, db_session: AsyncSession, mo
     """The API token JWT should contain all expected claims."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     user = User(
         id="user-1",
@@ -706,7 +707,7 @@ async def test_api_token_has_correct_claims(client, db_session: AsyncSession, mo
 
     decoded = jwt.decode(
         response.json()["access_token"],
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithms=["HS256"],
         options={"verify_aud": False},
     )
@@ -727,7 +728,7 @@ async def test_api_token_expires_in_requested_days(client, db_session: AsyncSess
     """The API token exp claim should match the requested expires_in_days."""
     settings = get_settings()
     monkeypatch.setattr(settings.auth, "enabled", True)
-    monkeypatch.setattr(settings.auth, "jwt_secret_key", "test-secret")
+    monkeypatch.setattr(settings.auth, "jwt_secret_key", TEST_JWT_SECRET)
 
     user = User(
         id="user-1",
@@ -749,7 +750,7 @@ async def test_api_token_expires_in_requested_days(client, db_session: AsyncSess
 
     decoded = jwt.decode(
         response.json()["access_token"],
-        "test-secret",
+        TEST_JWT_SECRET,
         algorithms=["HS256"],
         options={"verify_aud": False},
     )

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -12,13 +12,13 @@ import jwt
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.conftest import TEST_JWT_SECRET
 from wikimind.api.deps import ANONYMOUS_USER_ID, get_ws_user_id
 from wikimind.api.routes import ws as ws_mod
 from wikimind.api.routes.auth import (
     _consume_oauth_state,
     _generate_oauth_state,
 )
-from tests.conftest import TEST_JWT_SECRET
 from wikimind.config import get_settings
 from wikimind.models import OAuthUserInfo, User
 from wikimind.services.user import UserService

--- a/tests/unit/test_auto_recompile_contradiction.py
+++ b/tests/unit/test_auto_recompile_contradiction.py
@@ -262,6 +262,7 @@ async def test_auto_recompile_disabled_by_setting() -> None:
             ) as mock_queue,
         ):
             mock_session = AsyncMock()
+            mock_session.add = MagicMock()  # add() is sync
             mock_session.execute = AsyncMock()
             # Return 0 for article count
             mock_result = AsyncMock()

--- a/tests/unit/test_batch_contradictions.py
+++ b/tests/unit/test_batch_contradictions.py
@@ -181,6 +181,7 @@ async def test_run_batch_success(tmp_path: Path) -> None:
     settings.linter.contradiction_llm_temperature = 0.2
 
     session = AsyncMock()
+    session.add = MagicMock()  # add() is sync — avoid unawaited coroutine warning
     session.execute = AsyncMock(
         return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
@@ -208,6 +209,7 @@ async def test_run_batch_retries_then_falls_back(tmp_path: Path) -> None:
     settings.linter.contradiction_llm_temperature = 0.2
 
     session = AsyncMock()
+    session.add = MagicMock()  # add() is sync — avoid unawaited coroutine warning
     session.execute = AsyncMock(
         return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
@@ -251,6 +253,7 @@ async def test_run_batch_retry_succeeds_on_second_attempt(tmp_path: Path) -> Non
     settings.linter.contradiction_llm_temperature = 0.2
 
     session = AsyncMock()
+    session.add = MagicMock()  # add() is sync — avoid unawaited coroutine warning
     session.execute = AsyncMock(
         return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )
@@ -285,6 +288,7 @@ async def test_run_batch_parse_error_triggers_fallback(tmp_path: Path) -> None:
     settings.linter.contradiction_llm_temperature = 0.2
 
     session = AsyncMock()
+    session.add = MagicMock()  # add() is sync — avoid unawaited coroutine warning
     session.execute = AsyncMock(
         return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None))))
     )

--- a/tests/unit/test_cli_create_token.py
+++ b/tests/unit/test_cli_create_token.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import jwt
 import pytest
 
+from tests.conftest import TEST_JWT_SECRET
 from wikimind.cli.create_token import _lookup_user_by_email, main
 from wikimind.models import User
 
@@ -87,7 +88,7 @@ def test_main_generates_token_with_user_uuid(monkeypatch):
     """main() should produce a JWT whose sub claim is the user's UUID, not the email."""
     monkeypatch.setattr(
         "sys.argv",
-        ["create_token", "--email", "alice@example.com", "--secret", "test-secret"],
+        ["create_token", "--email", "alice@example.com", "--secret", TEST_JWT_SECRET],
     )
 
     # Patch _lookup_user_by_email to return a known UUID
@@ -112,7 +113,7 @@ def test_main_generates_token_with_user_uuid(monkeypatch):
     main()
 
     token = captured["token"]
-    decoded = jwt.decode(token, "test-secret", algorithms=["HS256"], options={"verify_aud": False})
+    decoded = jwt.decode(token, TEST_JWT_SECRET, algorithms=["HS256"], options={"verify_aud": False})
 
     # The critical fix: sub must be the UUID, not the email
     assert decoded["sub"] == "uuid-abc-123"
@@ -133,7 +134,7 @@ def test_main_uses_custom_token_name(monkeypatch):
             "--email",
             "alice@example.com",
             "--secret",
-            "test-secret",
+            TEST_JWT_SECRET,
             "--name",
             "my-custom-name",
         ],
@@ -157,5 +158,5 @@ def test_main_uses_custom_token_name(monkeypatch):
 
     main()
 
-    decoded = jwt.decode(captured["token"], "test-secret", algorithms=["HS256"], options={"verify_aud": False})
+    decoded = jwt.decode(captured["token"], TEST_JWT_SECRET, algorithms=["HS256"], options={"verify_aud": False})
     assert decoded["user"]["name"] == "my-custom-name"

--- a/tests/unit/test_database_helpers.py
+++ b/tests/unit/test_database_helpers.py
@@ -34,12 +34,19 @@ class TestCollectConceptNames:
         assert _collect_concept_names([]) == ({}, [])
 
     def test_single(self):
-        names, concepts = _collect_concept_names([("a1", '["ML"]')])
-        assert "ml" in names
+        names, concepts = _collect_concept_names([("a1", "u1", '["ML"]')])
+        assert ("u1", "ml") in names
+        assert concepts == [("u1", ["ml"])]
 
     def test_invalid(self):
-        names, concepts = _collect_concept_names([("a1", "bad")])
+        names, concepts = _collect_concept_names([("a1", "u1", "bad")])
         assert names == {}
+
+    def test_partitions_by_user(self):
+        names, _ = _collect_concept_names([("a1", "u1", '["ML"]'), ("a2", "u2", '["ML"]')])
+        # Same normalized name owned by two users → two distinct keys
+        assert ("u1", "ml") in names
+        assert ("u2", "ml") in names
 
 
 class TestParseSsl:

--- a/tests/unit/test_magic_link.py
+++ b/tests/unit/test_magic_link.py
@@ -10,6 +10,7 @@ import jwt
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.conftest import TEST_JWT_SECRET
 from wikimind.config import get_settings
 from wikimind.models import User
 from wikimind.services.user import UserService
@@ -58,7 +59,7 @@ async def test_request_magic_link_disabled(client, monkeypatch):
 async def test_magic_link_verify_creates_session(client):
     """Verifying a valid token should return an access_token and user info."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
 
     # Request a magic link
     response = await client.post(
@@ -92,7 +93,7 @@ async def test_magic_link_verify_creates_session(client):
 async def test_magic_link_verify_rejects_expired_token(client, monkeypatch):
     """An expired magic link token should be rejected with 401."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
     settings.auth.magic_link_ttl_seconds = 600
 
     # Create a token with a timestamp in the past
@@ -119,7 +120,7 @@ async def test_magic_link_verify_rejects_expired_token(client, monkeypatch):
 async def test_magic_link_verify_rejects_tampered_token(client):
     """A tampered magic link token should be rejected with 401."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
 
     # Create a valid token, then tamper with it
     email = "tamper@example.com"
@@ -146,7 +147,7 @@ async def test_magic_link_verify_rejects_tampered_token(client):
 async def test_magic_link_verify_creates_user_if_not_exists(client, db_session: AsyncSession):
     """Verifying a magic link for a new email should auto-create the user."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
 
     # Request and verify a magic link for a new user
     response = await client.post(
@@ -184,7 +185,7 @@ async def test_magic_link_verify_rejects_garbage_token(client):
 def test_create_and_verify_magic_link_token():
     """Round-trip: create a token and verify it returns the email."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
     settings.auth.magic_link_ttl_seconds = 600
 
     token = _service.create_magic_link_token("round@trip.com", settings)
@@ -195,7 +196,7 @@ def test_create_and_verify_magic_link_token():
 def test_verify_magic_link_token_expired():
     """Expired tokens should raise ValueError."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
     settings.auth.magic_link_ttl_seconds = 1  # 1 second TTL
 
     token = _service.create_magic_link_token("exp@test.com", settings)
@@ -210,7 +211,7 @@ def test_verify_magic_link_token_expired():
 def test_verify_magic_link_token_tampered():
     """Tampered tokens should raise ValueError."""
     settings = get_settings()
-    settings.auth.jwt_secret_key = "test-secret"  # pragma: allowlist secret
+    settings.auth.jwt_secret_key = TEST_JWT_SECRET
 
     token = _service.create_magic_link_token("ok@test.com", settings)
 

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -8,6 +8,7 @@ from unittest.mock import patch as mock_patch
 
 import pytest
 
+from tests.conftest import TEST_JWT_SECRET
 from wikimind.config import AuthConfig
 from wikimind.errors import NotFoundError
 from wikimind.models import Article, Conversation, OAuthUserInfo, PageType, Source, SourceType, User
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
-def _settings(jwt_secret="test-secret-key-for-jwt-32b", ttl=600):
+def _settings(jwt_secret=TEST_JWT_SECRET, ttl=600):
     s = MagicMock()
     s.auth = AuthConfig(jwt_secret_key=jwt_secret, magic_link_ttl_seconds=ttl)
     return s

--- a/uv.lock
+++ b/uv.lock
@@ -4888,6 +4888,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/6b/f9d82598121b2f0532238381aec27734c24a0ff548ac352b358c2857a176/types_pyyaml-6.0.12.20260508.tar.gz", hash = "sha256:5ae42149c3ebf7aaaf6c65ee49af590c80f0ba52e9e3f75a75c5564b33556fa6", size = 17776 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/80/96690460fe7f4e4b4ab0ecd79a8609aec2ae63927ad97625f3c747ca6a1d/types_pyyaml-6.0.12.20260508-py3-none-any.whl", hash = "sha256:edc094ed3a918b0c6232f71a5b67fdf38e76e17517b7d87bfbb9fc27d442fb51", size = 20309 },
+]
+
+[[package]]
 name = "types-toml"
 version = "0.10.8.20260408"
 source = { registry = "https://pypi.org/simple" }
@@ -5262,6 +5271,7 @@ dev = [
     { name = "python-semantic-release" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "types-toml" },
     { name = "vulture" },
 ]
@@ -5278,6 +5288,7 @@ lint = [
     { name = "pylint-pydantic" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "types-toml" },
     { name = "vulture" },
 ]
@@ -5356,6 +5367,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.4.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "trafilatura", specifier = ">=1.12.2" },
+    { name = "types-pyyaml", marker = "extra == 'lint'", specifier = ">=6.0" },
     { name = "types-toml", marker = "extra == 'lint'", specifier = ">=0.10.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6" },
     { name = "vulture", marker = "extra == 'lint'", specifier = ">=2.11" },


### PR DESCRIPTION
Wave 1 of the stabilization plan tracked in #534. Single green commit landing on main by fixing the four lanes that were red on 0499fc1: **Full Verify (pyright)**, **Tests & Coverage**, **Postgres Integration**, **Doc Sync**.

## Closes

- Closes #535 — pyright errors on `__tablename__`
- Closes #536 — Postgres FK fixtures + multi-user backfill bugs
- Refs #534 (Wave 1 of 2)
- #537 will be closed separately as obsolete: the threshold is already 85% (real coverage 89.20%); #510's 90% bump was rolled back in b494812 before this branch was cut

## #535 — pyright on `__tablename__`

Real fix per the discussion in #534: drop the snake_case override and adopt the existing repo convention (concatenated lowercase, like `articleconcept`, `articlesource`, `reinforcementevent`). The new tables become `compiledclaim`, `conceptcluster`, `claimconcept`. FK references updated. No migration needed because these tables aren't in any Alembic migration yet — they're created via `SQLModel.metadata.create_all()`. We're 0.1.0; no production data to migrate.

Why not suppress with `# pyright: ignore` or `# type: ignore`? Both rejected in #534 as code smell. Why not an intermediate base class? Same — adding a class purely to placate the type checker is the wrong shape of fix.

Why was the override needed at all? SQLModel's base class has internally inconsistent typing — class annotation says `ClassVar[str | Callable[..., str]]` (sqlmodel/main.py:810) but the `@declared_attr`-decorated default (line 871) makes pyright infer `declared_attr[Unknown]`. Removing the override sidesteps the SQLModel typing bug entirely.

## #536 — Postgres FK fixtures + latent backfill bugs

Two real bugs surfaced once the FK violations stopped masking them:

1. `tests/integration/test_postgres_integration.py::pg_session` didn't seed a `User` row, so all four tests violated the `user_id` FK. SQLite tolerates this (FKs off by default); Postgres rejects. Fixture now seeds `TEST_USER_ID` before yielding.

2. `_backfill_concepts_from_articles` in `src/wikimind/database.py` was never updated when #520 made `concept.user_id` a NOT NULL FK with `UNIQUE(user_id, name)`. The raw INSERT omitted `user_id` and `concept_kind`, and passed `utcnow_naive().isoformat()` (str) to a `TIMESTAMP` column. Rewritten to:
   - select articles with their `user_id`
   - partition concept names per `(user_id, name)` (same normalized name owned by two users is two distinct rows, matching the unique constraint)
   - INSERT all NOT NULL columns with a real `datetime`

   `_collect_concept_names` signature changed: `dict[name -> raw]` → `dict[(user_id, name) -> raw]`. Unit test updated and a new test added for per-user partitioning.

## Bonus — pre-existing mypy hole

`src/wikimind/engine/frontmatter_validator.py` had `import yaml  # type: ignore[import-untyped]`. Mypy locally flagged the ignore as unused, CI didn't (stub resolution difference). Real fix: add `types-PyYAML` to the lint dev deps and drop the suppression. `uv lock` regenerated.

## Verification

```
$ make verify       # exit 0
pyright             0 errors
mypy                clean (114 source files)
ruff lint+format    clean (233 files)
unit tests          1566 passed, 4 skipped
coverage            89.20% (threshold 85%)
postgres integ.     4/4 passed (local Postgres on :5433)
```

## Risk

- **Table renames** (`compiled_claim` → `compiledclaim` etc.): anyone running a local DB built from #522/#529 needs to drop those three tables; they'll be recreated on next startup. No production users at 0.1.0.
- **Backfill rewrite**: behavioral change for multi-user — concepts are now partitioned per user. This is the documented intent of the schema (`UNIQUE(user_id, name)`); the previous behavior was simply broken on Postgres and would have silently merged users' concepts on SQLite.
