### PR TITLE
fix: block compile retry for zombie sources (#554)

### DIFF
--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
-from wikimind.models import Job, JobTriggerResponse
+from wikimind.models import Job, JobTriggerResponse, Source
 from wikimind.services.compiler import CompilerService, get_compiler_service
 from wikimind.services.linter import LinterService, get_linter_service
 
@@ -44,10 +44,20 @@ async def get_job(
 @router.post("/compile/{source_id}", response_model=JobTriggerResponse)
 async def trigger_compile(
     source_id: str,
+    session: AsyncSession = Depends(get_session),
     service: CompilerService = Depends(get_compiler_service),
     user_id: str = Depends(get_current_user_id),
 ):
     """Trigger compilation for a source."""
+    source = await session.get(Source, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+    if not source.file_path:
+        raise HTTPException(
+            status_code=422,
+            detail="Source has no content file — ingestion may have failed after "
+            "creating the database record. Re-ingest the source to fix this.",
+        )
     return await service.trigger_compile(source_id, user_id=user_id)
 
 

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -141,7 +141,7 @@ class PDFAdapter:
     with ``Source.file_path`` pointing at the latter.
     """
 
-    async def ingest(
+    async def ingest(  # noqa: PLR0915
         self,
         file_bytes: bytes,
         filename: str,
@@ -194,8 +194,20 @@ class PDFAdapter:
         # worker only ever reads the .txt file (see issue #59), so file_path
         # always points at the cleaned text. The raw .pdf is kept for lineage
         # and future re-extraction (e.g. Docling — see issue #57).
-        raw_storage = get_raw_storage(user_id)
-        await raw_storage.write_bytes(f"{source.id}.pdf", file_bytes)
+        try:
+            raw_storage = get_raw_storage(user_id)
+            await raw_storage.write_bytes(f"{source.id}.pdf", file_bytes)
+        except Exception as exc:
+            log.error(
+                "File write failed after source commit — marking as failed",
+                source_id=source.id,
+                error=str(exc),
+            )
+            source.status = IngestStatus.FAILED
+            source.error_message = f"File write failed: {exc}"
+            session.add(source)
+            await session.commit()
+            raise
         # Docling and fitz need a filesystem Path to open the PDF.
         raw_pdf_path = raw_storage.resolve_path(f"{source.id}.pdf")
 
@@ -224,8 +236,20 @@ class PDFAdapter:
         except _LLM_PROVIDER_ERRORS:
             log.warning("Vision enhancement failed — using extracted text as-is", source_id=source.id)
 
-        await raw_storage.write(f"{source.id}.txt", clean_text)
-        source.file_path = f"{source.id}.txt"
+        try:
+            await raw_storage.write(f"{source.id}.txt", clean_text)
+            source.file_path = f"{source.id}.txt"
+        except Exception as exc:
+            log.error(
+                "File write failed after source commit — marking as failed",
+                source_id=source.id,
+                error=str(exc),
+            )
+            source.status = IngestStatus.FAILED
+            source.error_message = f"File write failed: {exc}"
+            session.add(source)
+            await session.commit()
+            raise
 
         # Image extraction (issue #378): extract embedded images from the
         # PDF and save them to a user-scoped directory. This runs after text

--- a/src/wikimind/ingest/adapters/text.py
+++ b/src/wikimind/ingest/adapters/text.py
@@ -61,9 +61,21 @@ class TextAdapter:
         # Pasted text is already plain text, so the raw and cleaned files are
         # the same .txt file. file_path always points at the .txt the worker
         # reads (see issue #59).
-        raw_storage = get_raw_storage(user_id)
-        await raw_storage.write(f"{source.id}.txt", content)
-        source.file_path = f"{source.id}.txt"
+        try:
+            raw_storage = get_raw_storage(user_id)
+            await raw_storage.write(f"{source.id}.txt", content)
+            source.file_path = f"{source.id}.txt"
+        except Exception as exc:
+            log.error(
+                "File write failed after source commit — marking as failed",
+                source_id=source.id,
+                error=str(exc),
+            )
+            source.status = IngestStatus.FAILED
+            source.error_message = f"File write failed: {exc}"
+            session.add(source)
+            await session.commit()
+            raise
         session.add(source)
         await session.commit()
 

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -91,10 +91,22 @@ class URLAdapter:
 
         # Save clean extracted text (used by the compiler worker) and
         # keep the raw HTML alongside it for reference/reprocessing.
-        raw_storage = get_raw_storage(user_id)
-        await raw_storage.write(f"{source.id}.html", html)
-        await raw_storage.write(f"{source.id}.txt", downloaded)
-        source.file_path = f"{source.id}.txt"
+        try:
+            raw_storage = get_raw_storage(user_id)
+            await raw_storage.write(f"{source.id}.html", html)
+            await raw_storage.write(f"{source.id}.txt", downloaded)
+            source.file_path = f"{source.id}.txt"
+        except Exception as exc:
+            log.error(
+                "File write failed after source commit — marking as failed",
+                source_id=source.id,
+                error=str(exc),
+            )
+            source.status = IngestStatus.FAILED
+            source.error_message = f"File write failed: {exc}"
+            session.add(source)
+            await session.commit()
+            raise
 
         # Normalize
         clean_text = downloaded

--- a/src/wikimind/ingest/adapters/youtube.py
+++ b/src/wikimind/ingest/adapters/youtube.py
@@ -78,9 +78,21 @@ class YouTubeAdapter:
 
         # YouTube transcripts are already plain text, so the raw and cleaned
         # files are the same .txt. There is no separate raw video payload.
-        raw_storage = get_raw_storage(user_id)
-        await raw_storage.write(f"{source.id}.txt", transcript_text)
-        source.file_path = f"{source.id}.txt"
+        try:
+            raw_storage = get_raw_storage(user_id)
+            await raw_storage.write(f"{source.id}.txt", transcript_text)
+            source.file_path = f"{source.id}.txt"
+        except Exception as exc:
+            log.error(
+                "File write failed after source commit — marking as failed",
+                source_id=source.id,
+                error=str(exc),
+            )
+            source.status = IngestStatus.FAILED
+            source.error_message = f"File write failed: {exc}"
+            session.add(source)
+            await session.commit()
+            raise
         session.add(source)
         await session.commit()
 

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -1506,6 +1506,15 @@ class OrphanArticle(BaseModel):
     file_path: str
 
 
+class ZombieSource(BaseModel):
+    """Source stuck in processing with no content file (zombie)."""
+
+    id: str
+    title: str | None
+    source_type: str
+    ingested_at: datetime
+
+
 class EligibleConcept(BaseModel):
     """Concept eligible for concept-page generation."""
 

--- a/src/wikimind/services/admin.py
+++ b/src/wikimind/services/admin.py
@@ -27,6 +27,7 @@ from wikimind.models import (
     StuckSource,
     SystemStats,
     User,
+    ZombieSource,
 )
 from wikimind.storage import get_wiki_storage
 
@@ -335,6 +336,47 @@ class AdminService:
                 )
             )
         return eligible
+
+    async def find_zombie_sources(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        stuck_minutes: int = 10,
+    ) -> list[ZombieSource]:
+        """Find sources stuck in processing with no file_path (zombies).
+
+        A zombie source is one that has been in ``processing`` status for longer
+        than *stuck_minutes* AND has a null ``file_path``. This indicates the
+        ingest adapter committed the Source row but failed before writing the
+        content file.
+
+        Args:
+            session: Async database session.
+            user_id: User ID filter.
+            stuck_minutes: Minimum minutes in processing before a source is
+                considered stuck. Defaults to 10.
+
+        Returns:
+            List of ZombieSource descriptors.
+        """
+        cutoff = utcnow_naive() - timedelta(minutes=stuck_minutes)
+        stmt = select(Source).where(
+            Source.status == IngestStatus.PROCESSING,
+            Source.file_path.is_(None),  # type: ignore[union-attr]
+            Source.ingested_at < cutoff,
+        )
+        if user_id:
+            stmt = stmt.where(Source.user_id == user_id)
+        result = await session.execute(stmt)
+        return [
+            ZombieSource(
+                id=s.id,
+                title=s.title,
+                source_type=s.source_type,
+                ingested_at=s.ingested_at,
+            )
+            for s in result.scalars().all()
+        ]
 
     async def trigger_sweep(
         self,

--- a/tests/unit/test_remaining_routes.py
+++ b/tests/unit/test_remaining_routes.py
@@ -79,6 +79,22 @@ class TestJobsRoutes:
 
     @pytest.mark.asyncio
     async def test_trigger_compile(self, client: AsyncClient):
+        from wikimind.database import get_session
+        from wikimind.main import app
+
+        # Create a source with file_path so the endpoint doesn't reject it
+        async for session in app.dependency_overrides[get_session]():
+            session.add(
+                Source(
+                    id="some-source-id",
+                    source_type=SourceType.TEXT,
+                    title="Test",
+                    file_path="some-source-id.txt",
+                    user_id=ANONYMOUS_USER_ID,
+                )
+            )
+            await session.commit()
+
         mock_bg = MagicMock()
         mock_bg.schedule_compile = AsyncMock(return_value="job-123")
         with patch("wikimind.services.compiler.get_background_compiler", return_value=mock_bg):

--- a/tests/unit/test_zombie_sources.py
+++ b/tests/unit/test_zombie_sources.py
@@ -1,0 +1,152 @@
+"""Tests for zombie source detection and compile retry blocking (#554)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from tests.conftest import TEST_USER_ID
+from wikimind._datetime import utcnow_naive
+from wikimind.models import IngestStatus, Source, SourceType
+from wikimind.services.admin import AdminService
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Admin zombie detection
+# ---------------------------------------------------------------------------
+
+
+async def test_find_zombie_sources_empty(db_session: AsyncSession) -> None:
+    """No sources — returns empty list."""
+    service = AdminService()
+    zombies = await service.find_zombie_sources(db_session, user_id=TEST_USER_ID)
+    assert zombies == []
+
+
+async def test_find_zombie_sources_detects_stuck(db_session: AsyncSession) -> None:
+    """Source in processing with no file_path and old ingested_at is a zombie."""
+    zombie = Source(
+        source_type=SourceType.TEXT,
+        title="Zombie",
+        status=IngestStatus.PROCESSING,
+        file_path=None,
+        ingested_at=utcnow_naive() - timedelta(minutes=15),
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(zombie)
+    await db_session.commit()
+
+    service = AdminService()
+    zombies = await service.find_zombie_sources(db_session, user_id=TEST_USER_ID)
+    assert len(zombies) == 1
+    assert zombies[0].id == zombie.id
+    assert zombies[0].title == "Zombie"
+
+
+async def test_find_zombie_sources_ignores_recent(db_session: AsyncSession) -> None:
+    """Source in processing with no file_path but recent ingested_at is not a zombie."""
+    recent = Source(
+        source_type=SourceType.TEXT,
+        title="Recent",
+        status=IngestStatus.PROCESSING,
+        file_path=None,
+        ingested_at=utcnow_naive() - timedelta(minutes=2),
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(recent)
+    await db_session.commit()
+
+    service = AdminService()
+    zombies = await service.find_zombie_sources(db_session, user_id=TEST_USER_ID)
+    assert zombies == []
+
+
+async def test_find_zombie_sources_ignores_with_file_path(db_session: AsyncSession) -> None:
+    """Source in processing WITH file_path is not a zombie (just slow compile)."""
+    normal = Source(
+        source_type=SourceType.TEXT,
+        title="Normal",
+        status=IngestStatus.PROCESSING,
+        file_path="abc.txt",
+        ingested_at=utcnow_naive() - timedelta(minutes=15),
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(normal)
+    await db_session.commit()
+
+    service = AdminService()
+    zombies = await service.find_zombie_sources(db_session, user_id=TEST_USER_ID)
+    assert zombies == []
+
+
+# ---------------------------------------------------------------------------
+# Compile route blocks zombie sources
+# ---------------------------------------------------------------------------
+
+
+async def test_compile_route_rejects_zombie_source(client) -> None:
+    """POST /api/jobs/compile/{id} returns 422 for zombie sources."""
+    from wikimind.database import get_session
+    from wikimind.main import app
+
+    # Insert a zombie source via the test database
+    async for session in app.dependency_overrides[get_session]():
+        zombie = Source(
+            id="zombie-123",
+            source_type=SourceType.TEXT,
+            title="Zombie",
+            status=IngestStatus.PROCESSING,
+            file_path=None,
+            user_id=TEST_USER_ID,
+        )
+        session.add(zombie)
+        await session.commit()
+
+    resp = await client.post(
+        "/api/jobs/compile/zombie-123",
+        headers={"X-User-Id": TEST_USER_ID},
+    )
+    assert resp.status_code == 422
+    assert "no content file" in resp.json()["detail"].lower()
+
+
+async def test_compile_route_allows_valid_source(client) -> None:
+    """POST /api/jobs/compile/{id} succeeds for sources with file_path."""
+    from wikimind.database import get_session
+    from wikimind.main import app
+
+    async for session in app.dependency_overrides[get_session]():
+        valid = Source(
+            id="valid-123",
+            source_type=SourceType.TEXT,
+            title="Valid",
+            status=IngestStatus.PROCESSING,
+            file_path="valid-123.txt",
+            user_id=TEST_USER_ID,
+        )
+        session.add(valid)
+        await session.commit()
+
+    with patch(
+        "wikimind.services.compiler.CompilerService.trigger_compile",
+        new_callable=AsyncMock,
+        return_value={"job_id": "j-1", "status": "queued"},
+    ):
+        resp = await client.post(
+            "/api/jobs/compile/valid-123",
+            headers={"X-User-Id": TEST_USER_ID},
+        )
+    assert resp.status_code == 200
+
+
+async def test_compile_route_returns_404_for_missing_source(client) -> None:
+    """POST /api/jobs/compile/{id} returns 404 for non-existent source."""
+    resp = await client.post(
+        "/api/jobs/compile/nonexistent-id",
+        headers={"X-User-Id": TEST_USER_ID},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Block compile retry for sources without `file_path` (return 422 with clear message)
- Mark sources as `failed` if file write fails after DB commit in all ingest adapters
- Add `find_zombie_sources()` to AdminService for admin monitoring (sources stuck in processing >10min with null file_path)

Closes #554

## Test plan
- [x] POST /api/jobs/compile/{source_id} returns 422 for zombie sources
- [x] POST /api/jobs/compile/{source_id} returns 404 for non-existent sources
- [x] Existing compile retry still works for valid sources with file_path
- [x] Zombie detection query finds stuck sources correctly
- [x] Zombie detection ignores recently-created sources and sources with file_path
- [x] All 1538 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)