### PR TITLE
fix: harden production config — fail loudly when Redis missing (#556)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,20 @@ jobs:
               exit 1
             fi
           }
+
+          # Redis (Upstash) — created if missing
+          if ! flyctl redis status wikimind-redis 2>/dev/null; then
+            echo "Creating Redis instance..."
+            flyctl redis create --name wikimind-redis --region ord --no-eviction --plan free
+            # Get the private URL and set as secret
+            REDIS_URL=$(flyctl redis status wikimind-redis --json 2>/dev/null | jq -r '.private_url // empty')
+            if [ -n "$REDIS_URL" ]; then
+              flyctl secrets set --stage --app wikimind-staging WIKIMIND_REDIS_URL="$REDIS_URL"
+              echo "Redis provisioned and secret staged"
+            else
+              echo "::warning::Redis created but could not retrieve URL — set WIKIMIND_REDIS_URL manually"
+            fi
+          fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -291,6 +305,19 @@ jobs:
               exit 1
             fi
           }
+
+          # Redis (Upstash) — reuse staging Redis or create if missing
+          if ! flyctl redis status wikimind-redis 2>/dev/null; then
+            echo "Creating Redis instance..."
+            flyctl redis create --name wikimind-redis --region ord --no-eviction --plan free
+          fi
+          REDIS_URL=$(flyctl redis status wikimind-redis --json 2>/dev/null | jq -r '.private_url // empty')
+          if [ -n "$REDIS_URL" ]; then
+            flyctl secrets set --stage --app wikimind WIKIMIND_REDIS_URL="$REDIS_URL"
+            echo "Redis secret staged for production"
+          else
+            echo "::warning::Could not retrieve Redis URL — set WIKIMIND_REDIS_URL manually"
+          fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
       - name: 🔐  Validate required secrets
         run: |
           missing=0
-          for var in ANTHROPIC_API_KEY JWT_SECRET_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET; do
+          for var in ANTHROPIC_API_KEY JWT_SECRET_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET WIKIMIND_REDIS_URL; do
             if [ -z "${!var}" ]; then
               echo "::error::Required secret ${var} is empty or not configured"
               missing=1
@@ -133,6 +133,7 @@ jobs:
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
+          WIKIMIND_REDIS_URL: ${{ secrets.WIKIMIND_REDIS_URL }}
 
       # 1️⃣  Ensure staging infrastructure exists
       - name: 🏗️  Ensure staging app exists
@@ -169,13 +170,15 @@ jobs:
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
+            WIKIMIND_REDIS_URL="${WIKIMIND_REDIS_URL}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
+          WIKIMIND_REDIS_URL: ${{ secrets.WIKIMIND_REDIS_URL }}
 
       # 3️⃣  Deploy sidecar + app
       - name: 🧠  Deploy docling-serve sidecar
@@ -297,13 +300,15 @@ jobs:
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
+            WIKIMIND_REDIS_URL="${WIKIMIND_REDIS_URL}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
+          WIKIMIND_REDIS_URL: ${{ secrets.WIKIMIND_REDIS_URL }}
 
       - name: 🧠  Deploy docling-serve sidecar
         run: |

--- a/src/wikimind/jobs/background.py
+++ b/src/wikimind/jobs/background.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import os
 import uuid
 from typing import TYPE_CHECKING
 
@@ -30,10 +31,33 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 
+class ProductionConfigError(RuntimeError):
+    """Raised when production environment is missing required configuration."""
+
+
+def _check_production_redis_guard() -> None:
+    """Raise if running on Fly.io without Redis configured.
+
+    On Fly.io (FLY_APP_NAME is set), Redis is required for the ARQ job
+    queue. In-process fallback is only allowed for local development.
+    """
+    on_fly = bool(os.environ.get("FLY_APP_NAME"))
+    redis_url = get_settings().redis_url
+    if on_fly and not redis_url:
+        msg = (
+            "Production environment (FLY_APP_NAME set) requires Redis. "
+            "Set WIKIMIND_REDIS_URL or REDIS_URL to a valid Redis URL. "
+            "Refusing to start with in-process fallback on Fly.io."
+        )
+        log.error("production_config_error", error=msg)
+        raise ProductionConfigError(msg)
+
+
 class BackgroundCompiler:
     """Schedule compilation and lint jobs in dev (in-process) or prod (ARQ/Redis) mode."""
 
     def __init__(self) -> None:
+        _check_production_redis_guard()
         self._redis_url: str | None = get_settings().redis_url
 
     @property

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -275,7 +275,9 @@ async def wikimind_error_handler(request: Request, exc: WikiMindError) -> JSONRe
 @app.get("/health")
 async def health():
     """Health check — used by Electron to confirm daemon is ready."""
-    return {"status": "ok", "version": "0.1.0"}
+    settings = get_settings()
+    background_mode = "arq" if settings.redis_url else "in-process"
+    return {"status": "ok", "version": "0.1.0", "background_mode": background_mode}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/_snapshots/health_response.json
+++ b/tests/_snapshots/health_response.json
@@ -1,4 +1,5 @@
 {
   "status": "ok",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "background_mode": "in-process"
 }

--- a/tests/unit/test_prod_config_guard.py
+++ b/tests/unit/test_prod_config_guard.py
@@ -1,0 +1,57 @@
+"""Tests for production config guard — Redis required on Fly.io."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from wikimind.jobs.background import (
+    BackgroundCompiler,
+    ProductionConfigError,
+    _check_production_redis_guard,
+)
+
+
+class TestProductionRedisGuard:
+    """Verify the startup guard enforces Redis on Fly.io."""
+
+    def test_fly_without_redis_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When FLY_APP_NAME is set and redis_url is None, guard raises."""
+        monkeypatch.setenv("FLY_APP_NAME", "wikimind")
+        with patch("wikimind.jobs.background.get_settings") as mock_settings:
+            mock_settings.return_value.redis_url = None
+            with pytest.raises(ProductionConfigError, match="requires Redis"):
+                _check_production_redis_guard()
+
+    def test_fly_with_redis_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When FLY_APP_NAME is set and redis_url is configured, no error."""
+        monkeypatch.setenv("FLY_APP_NAME", "wikimind")
+        with patch("wikimind.jobs.background.get_settings") as mock_settings:
+            mock_settings.return_value.redis_url = "redis://localhost:6379"
+            # Should not raise
+            _check_production_redis_guard()
+
+    def test_local_without_redis_allows_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When FLY_APP_NAME is NOT set, in-process fallback is allowed."""
+        monkeypatch.delenv("FLY_APP_NAME", raising=False)
+        with patch("wikimind.jobs.background.get_settings") as mock_settings:
+            mock_settings.return_value.redis_url = None
+            # Should not raise — local dev is fine without Redis
+            _check_production_redis_guard()
+
+    def test_background_compiler_init_checks_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BackgroundCompiler.__init__ triggers the guard."""
+        monkeypatch.setenv("FLY_APP_NAME", "wikimind")
+        with patch("wikimind.jobs.background.get_settings") as mock_settings:
+            mock_settings.return_value.redis_url = None
+            with pytest.raises(ProductionConfigError):
+                BackgroundCompiler()
+
+    def test_background_compiler_arq_mode_on_fly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BackgroundCompiler uses ARQ mode when redis_url is configured."""
+        monkeypatch.setenv("FLY_APP_NAME", "wikimind")
+        with patch("wikimind.jobs.background.get_settings") as mock_settings:
+            mock_settings.return_value.redis_url = "redis://localhost:6379"
+            compiler = BackgroundCompiler()
+            assert compiler.is_prod is True


### PR DESCRIPTION
## Summary
- **Startup guard**: `BackgroundCompiler` raises `ProductionConfigError` on Fly.io (`FLY_APP_NAME` set) when `redis_url` is not configured, preventing silent in-process fallback that caused slow requests and health check failures
- **Deploy preflight**: CI validates `WIKIMIND_REDIS_URL` secret exists before deploying to staging or production
- **Secrets staging**: `WIKIMIND_REDIS_URL` added to Fly secrets for both environments
- **Operator visibility**: `/health` endpoint now includes `background_mode` field (`"arq"` or `"in-process"`)
- **Unit tests**: 5 tests covering all guard branches (Fly+no Redis, Fly+Redis, local+no Redis)

Closes #556

## Test plan
- [ ] App refuses to start when `FLY_APP_NAME` is set but `WIKIMIND_REDIS_URL` is missing
- [ ] Local dev still works without Redis (in-process fallback)
- [ ] Deploy workflow fails early if `WIKIMIND_REDIS_URL` secret is missing
- [ ] `/health` response includes `background_mode` field
- [ ] All unit tests pass (`pytest tests/unit/test_prod_config_guard.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)