### PR TITLE
fix: functional staging smoke tests + manual approval gate (#553)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -270,6 +270,41 @@ jobs:
 
             # 10. Compilation schemas
             curl -sf "$BASE/api/compilation-schemas" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"' 2>/dev/null && echo "PASS: compilation-schemas" || echo "SKIP: compilation-schemas endpoint not available"
+
+            # 11. End-to-end: ingest text → compile → verify article created
+            echo "--- E2E: ingest + compile round-trip ---"
+            INGEST=$(curl -sf -X POST "$BASE/api/ingest/text" \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{"content":"Staging smoke test: the pipeline works.","title":"Smoke Test E2E"}' 2>/dev/null) && {
+              SOURCE_ID=$(echo "$INGEST" | jq -r '.id // empty')
+              if [ -n "$SOURCE_ID" ]; then
+                echo "PASS: ingest created source $SOURCE_ID"
+                # Trigger compile
+                curl -sf -X POST "$BASE/api/jobs/compile/$SOURCE_ID" \
+                  -H "Authorization: Bearer $TOKEN" > /dev/null 2>&1 && echo "PASS: compile triggered" || echo "WARN: compile trigger failed"
+                # Poll for completion (max 60s)
+                for i in $(seq 1 12); do
+                  sleep 5
+                  STATUS=$(curl -sf "$BASE/api/ingest/sources/$SOURCE_ID" \
+                    -H "Authorization: Bearer $TOKEN" 2>/dev/null | jq -r '.status // empty')
+                  echo "  poll $i: status=$STATUS"
+                  if [ "$STATUS" = "compiled" ] || [ "$STATUS" = "done" ]; then
+                    echo "PASS: E2E compile completed via ARQ/Redis"
+                    break
+                  fi
+                  if [ "$STATUS" = "failed" ]; then
+                    echo "WARN: E2E compile failed (may be expected in staging)"
+                    break
+                  fi
+                  if [ "$i" -eq 12 ]; then
+                    echo "WARN: E2E compile did not complete in 60s"
+                  fi
+                done
+              else
+                echo "WARN: ingest returned no source ID"
+              fi
+            } || echo "SKIP: ingest endpoint not available"
           else
             echo "WARN: STAGING_DEV_TOKEN not set — skipping authenticated smoke tests"
             echo "::warning::Set STAGING_DEV_TOKEN secret for full functional smoke coverage"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,20 +23,25 @@
 #     │
 #     ▼
 #   2️⃣  smoke-test-staging
-#     │  • GET /health  → 200
-#     │  • GET /docs    → 200
-#     │  • GET /auth/me → 200 or 401
+#     │  • 10 functional checks (health, deep health, docs, auth, API data)
+#     │  • authenticated tests require STAGING_DEV_TOKEN secret
 #     │  ✖ failure → summary alert, prod skipped
 #     │
 #     ▼
 #   3️⃣  deploy-production
+#     │  • environment: production (manual approval gate)
 #     │  • same provisioning as staging
 #     │  • deploy docling-serve sidecar
 #     │  • deploy app from GHCR :latest
 #     │
 #     ▼
 #   4️⃣  verify-production
-#        • poll /health for 60s
+#     │  • poll /health for 60s
+#     │  • functional verification (same checks as staging)
+#     │
+#     ▼
+#   5️⃣  rollback-production (on verify failure)
+#        • rolls back to previous Fly.io release
 #
 # ---------------------------------------------------------------
 # Auto-provisioning (both environments)
@@ -66,6 +71,7 @@
 #   WIKIMIND_AUTH__JWT_SECRET_KEY        │ JWT signing key
 #   WIKIMIND_AUTH__GOOGLE_CLIENT_ID      │ OAuth client ID
 #   WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET  │ OAuth client secret
+#   STAGING_DEV_TOKEN                   │ Bearer token for authenticated smoke tests
 #
 # ---------------------------------------------------------------
 # Fly.io apps managed by this workflow
@@ -218,26 +224,58 @@ jobs:
             sleep 2
           done
 
-      - name: "🩺  Smoke: GET /health → 200"
+      - name: Functional smoke tests
+        env:
+          TOKEN: ${{ secrets.STAGING_DEV_TOKEN }}
         run: |
-          code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/health)
-          echo "/health -> $code"
-          [ "$code" = "200" ] || { echo "::error::/health returned $code"; exit 1; }
+          BASE="https://wikimind-staging.fly.dev"
 
-      - name: "📖  Smoke: GET /docs → 200"
-        run: |
-          code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/docs)
-          echo "/docs -> $code"
-          [ "$code" = "200" ] || { echo "::error::/docs returned $code"; exit 1; }
+          # 1. Basic health
+          curl -sf "$BASE/health" | jq -e '.status == "ok"'
+          echo "PASS: health"
 
-      - name: "🔐  Smoke: GET /auth/me → 200 or 401"
-        run: |
-          code=$(curl -s -o /dev/null -w '%{http_code}' https://wikimind-staging.fly.dev/auth/me)
-          echo "/auth/me -> $code"
-          if [ "$code" != "200" ] && [ "$code" != "401" ]; then
-            echo "::error::/auth/me returned $code (expected 200 or 401)"
-            exit 1
+          # 2. Deep health — DB, migrations, LLM, stuck sources
+          DEEP=$(curl -sf "$BASE/health/deep" 2>/dev/null) && {
+            echo "$DEEP" | jq -e '.status != "unhealthy"'
+            echo "PASS: deep health"
+          } || echo "SKIP: /health/deep not available yet"
+
+          # 3. Background mode check
+          curl -sf "$BASE/health" | jq -e '.background_mode == "arq"' || echo "WARN: background_mode not arq"
+
+          # 4. Swagger docs load
+          curl -sf "$BASE/docs" | grep -q "swagger"
+          echo "PASS: docs"
+
+          # 5. Auth endpoint responds
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/auth/me")
+          [ "$STATUS" = "200" ] || [ "$STATUS" = "401" ]
+          echo "PASS: auth ($STATUS)"
+
+          # 6. API returns data (not just 200)
+          if [ -n "$TOKEN" ]; then
+            curl -sf "$BASE/api/wiki/articles" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"'
+            echo "PASS: articles endpoint returns array"
+
+            # 7. Sources endpoint
+            curl -sf "$BASE/api/ingest/sources" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"'
+            echo "PASS: sources endpoint returns array"
+
+            # 8. Admin stats (if available)
+            ADMIN=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/admin/stats" -H "Authorization: Bearer $TOKEN")
+            echo "INFO: admin stats responded $ADMIN"
+
+            # 9. Concepts endpoint (tests new tables from #546)
+            curl -sf "$BASE/api/concepts" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"' 2>/dev/null && echo "PASS: concepts" || echo "SKIP: concepts endpoint not available"
+
+            # 10. Compilation schemas
+            curl -sf "$BASE/api/compilation-schemas" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"' 2>/dev/null && echo "PASS: compilation-schemas" || echo "SKIP: compilation-schemas endpoint not available"
+          else
+            echo "WARN: STAGING_DEV_TOKEN not set — skipping authenticated smoke tests"
+            echo "::warning::Set STAGING_DEV_TOKEN secret for full functional smoke coverage"
           fi
+
+          echo "Staging smoke tests complete"
 
       - name: 🚨  Create alert on failure
         if: failure()
@@ -255,6 +293,7 @@ jobs:
     name: deploy to production
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: production
     permissions:
       contents: read
     needs: smoke-test-staging
@@ -336,9 +375,79 @@ jobs:
               2>/dev/null || echo "")
             if [ "$status" = "ok" ]; then
               echo "Production healthy after $((i*2))s"
-              exit 0
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Production health check failed after 60s"
+              exit 1
             fi
             sleep 2
           done
-          echo "::error::Production health check failed after 60s"
-          exit 1
+
+      - name: Functional verification
+        env:
+          TOKEN: ${{ secrets.STAGING_DEV_TOKEN }}
+        run: |
+          BASE="https://wikimind.fly.dev"
+
+          # 1. Basic health
+          curl -sf "$BASE/health" | jq -e '.status == "ok"'
+          echo "PASS: health"
+
+          # 2. Deep health
+          DEEP=$(curl -sf "$BASE/health/deep" 2>/dev/null) && {
+            echo "$DEEP" | jq -e '.status != "unhealthy"'
+            echo "PASS: deep health"
+          } || echo "SKIP: /health/deep not available yet"
+
+          # 3. Background mode check
+          curl -sf "$BASE/health" | jq -e '.background_mode == "arq"' || echo "WARN: background_mode not arq"
+
+          # 4. Swagger docs load
+          curl -sf "$BASE/docs" | grep -q "swagger"
+          echo "PASS: docs"
+
+          # 5. Auth endpoint responds
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/auth/me")
+          [ "$STATUS" = "200" ] || [ "$STATUS" = "401" ]
+          echo "PASS: auth ($STATUS)"
+
+          # 6. Authenticated checks
+          if [ -n "$TOKEN" ]; then
+            curl -sf "$BASE/api/wiki/articles" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"'
+            echo "PASS: articles endpoint returns array"
+
+            curl -sf "$BASE/api/ingest/sources" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"'
+            echo "PASS: sources endpoint returns array"
+          else
+            echo "WARN: STAGING_DEV_TOKEN not set — skipping authenticated checks"
+          fi
+
+          echo "Production functional verification complete"
+
+  # -----------------------------------------------------------
+  # 5️⃣  Rollback production (if verify fails)
+  # -----------------------------------------------------------
+  rollback-production:
+    name: rollback production
+    runs-on: ubuntu-latest
+    needs: verify-production
+    if: failure()
+
+    steps:
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
+
+      - name: Rollback to previous release
+        run: |
+          PREV=$(flyctl releases -a wikimind --json | jq -r '.[1].ImageRef // empty')
+          if [ -n "$PREV" ]; then
+            echo "Rolling back to: $PREV"
+            flyctl deploy -a wikimind --image "$PREV"
+            echo "::warning::Production rolled back to previous release"
+          else
+            echo "::error::No previous release found for rollback"
+            exit 1
+          fi
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -291,6 +291,15 @@ jobs:
                   echo "  poll $i: status=$STATUS"
                   if [ "$STATUS" = "compiled" ] || [ "$STATUS" = "done" ]; then
                     echo "PASS: E2E compile completed via ARQ/Redis"
+                    # Verify side effects: article was created for this source
+                    ARTICLES=$(curl -sf "$BASE/api/wiki/articles" \
+                      -H "Authorization: Bearer $TOKEN" 2>/dev/null | \
+                      jq -r --arg sid "$SOURCE_ID" '[.[] | select(.source_ids // "" | contains($sid))] | length')
+                    if [ "$ARTICLES" -gt 0 ] 2>/dev/null; then
+                      echo "PASS: E2E article created from compiled source ($ARTICLES article(s))"
+                    else
+                      echo "WARN: compile completed but no article found for source"
+                    fi
                     break
                   fi
                   if [ "$STATUS" = "failed" ]; then


### PR DESCRIPTION
## Summary
- Replace 3 HTTP-only staging smoke tests with 10 functional checks (deep health, API data validation, new tables, background mode)
- Add `environment: production` for manual approval gate before prod deploy
- Add automatic rollback job if production verification fails
- Expand production verification to match staging smoke tests

Closes #553

## Test plan
- [ ] Staging smoke tests catch a functionally broken deploy (not just HTTP 200)
- [ ] Production deploy requires manual approval via GitHub environment
- [ ] Failed production verification triggers automatic rollback
- [ ] Unauthenticated smoke tests pass without STAGING_DEV_TOKEN (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)