### PR TITLE
fix: Docker build triggers on apps/web, fly.toml, and Dockerfile changes (#568)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,19 +35,36 @@ on:
     branches: ["main"]
     paths:
       - "Dockerfile"
+      - "docker/**"
       - "docker-compose.yml"
+      - "docker-entrypoint.sh"
       - ".dockerignore"
       - "pyproject.toml"
+      - "uv.lock"
       - "src/**"
+      - "apps/web/**"
+      - "fly.toml"
+      - "fly.staging.toml"
+      - "fly.docling.toml"
+      - "gunicorn.conf.py"
       - ".github/workflows/docker.yml"
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
     paths:
       - "Dockerfile"
+      - "docker/**"
       - "docker-compose.yml"
+      - "docker-entrypoint.sh"
       - ".dockerignore"
       - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - "apps/web/**"
+      - "fly.toml"
+      - "fly.staging.toml"
+      - "fly.docling.toml"
+      - "gunicorn.conf.py"
       - ".github/workflows/docker.yml"
   schedule:
     # Weekly rebuild against the latest base image — catches bit-rot.


### PR DESCRIPTION
## Summary
- Docker workflow now triggers on `apps/web/**`, `fly*.toml`, `gunicorn.conf.py`, `docker-entrypoint.sh`, `docker/**`, and `uv.lock`
- Added `src/**` to the `pull_request` trigger (was already present on `push` but missing from PR paths)
- Previously, frontend-only or deploy-config-only changes would pass CI but never rebuild/deploy the Docker image

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)