### PR TITLE
fix: separate staging and production Redis (#570)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,8 @@
 #   wikimind-docling    │ fly.docling.toml   │ PDF sidecar (production)
 #   wikimind-staging-db │ (Postgres cluster) │ Staging database
 #   wikimind-db         │ (Postgres cluster) │ Production database
+#   wikimind-staging-redis │ (Upstash Redis)  │ Staging queue
+#   wikimind-redis         │ (Upstash Redis)  │ Production queue
 #
 # ---------------------------------------------------------------
 
@@ -169,17 +171,17 @@ jobs:
             fi
           }
 
-          # Redis (Upstash) — created if missing
-          if ! flyctl redis status wikimind-redis 2>/dev/null; then
-            echo "Creating Redis instance..."
-            flyctl redis create --name wikimind-redis --region ord --no-eviction --plan free
+          # Redis (Upstash) — staging-specific instance
+          if ! flyctl redis status wikimind-staging-redis 2>/dev/null; then
+            echo "Creating staging Redis instance..."
+            flyctl redis create --name wikimind-staging-redis --region ord --no-eviction --plan free
             # Get the private URL and set as secret
-            REDIS_URL=$(flyctl redis status wikimind-redis --json 2>/dev/null | jq -r '.private_url // empty')
+            REDIS_URL=$(flyctl redis status wikimind-staging-redis --json 2>/dev/null | jq -r '.private_url // empty')
             if [ -n "$REDIS_URL" ]; then
               flyctl secrets set --stage --app wikimind-staging WIKIMIND_REDIS_URL="$REDIS_URL"
-              echo "Redis provisioned and secret staged"
+              echo "Staging Redis provisioned and secret staged"
             else
-              echo "::warning::Redis created but could not retrieve URL — set WIKIMIND_REDIS_URL manually"
+              echo "::warning::Staging Redis created but could not retrieve URL — set WIKIMIND_REDIS_URL manually"
             fi
           fi
         env:
@@ -391,17 +393,17 @@ jobs:
             fi
           }
 
-          # Redis (Upstash) — reuse staging Redis or create if missing
+          # Redis (Upstash) — production-specific instance
           if ! flyctl redis status wikimind-redis 2>/dev/null; then
-            echo "Creating Redis instance..."
+            echo "Creating production Redis instance..."
             flyctl redis create --name wikimind-redis --region ord --no-eviction --plan free
           fi
           REDIS_URL=$(flyctl redis status wikimind-redis --json 2>/dev/null | jq -r '.private_url // empty')
           if [ -n "$REDIS_URL" ]; then
             flyctl secrets set --stage --app wikimind WIKIMIND_REDIS_URL="$REDIS_URL"
-            echo "Redis secret staged for production"
+            echo "Production Redis secret staged"
           else
-            echo "::warning::Could not retrieve Redis URL — set WIKIMIND_REDIS_URL manually"
+            echo "::warning::Could not retrieve production Redis URL — set WIKIMIND_REDIS_URL manually"
           fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Staging was sharing `wikimind-redis` with production, so staging job queue activity could interfere with the production worker
- Staging now provisions its own `wikimind-staging-redis` instance
- Production continues using `wikimind-redis`
- Mirrors the Postgres separation done in #565

## Changes
- `.github/workflows/deploy.yml`: staging Redis renamed from `wikimind-redis` to `wikimind-staging-redis`
- Production Redis comment updated to clarify it is production-specific (no longer says "reuse staging")
- Header infrastructure table updated to list both Redis instances

## Test plan
- [ ] Trigger a staging deploy and verify `wikimind-staging-redis` is created
- [ ] Verify staging app receives correct `WIKIMIND_REDIS_URL` pointing to the staging instance
- [ ] Verify production deploy still provisions/uses `wikimind-redis`

Closes #570