### PR TITLE
fix: dynamic alembic head + full production verification (#550 follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -513,6 +513,18 @@ jobs:
           curl -sf "$BASE/api/ingest/sources" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"'
           echo "PASS: sources endpoint returns array"
 
+          # 7. Concepts endpoint (new tables from #546)
+          curl -sf "$BASE/api/concepts" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"' || { echo "::error::/api/concepts failed"; exit 1; }
+          echo "PASS: concepts"
+
+          # 8. Compilation schemas
+          curl -sf "$BASE/api/compilation-schemas" -H "Authorization: Bearer $TOKEN" | jq -e 'type == "array"' || { echo "::error::/api/compilation-schemas failed"; exit 1; }
+          echo "PASS: compilation-schemas"
+
+          # 9. Admin stats responds (may be 403 if token user is not admin — that's OK)
+          ADMIN=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/admin/stats" -H "Authorization: Bearer $TOKEN")
+          echo "INFO: admin stats responded $ADMIN"
+
           echo "Production functional verification complete"
 
   # -----------------------------------------------------------

--- a/src/wikimind/api/routes/health.py
+++ b/src/wikimind/api/routes/health.py
@@ -24,8 +24,23 @@ from wikimind.models import IngestStatus, Source
 router = APIRouter()
 log = structlog.get_logger()
 
-# Alembic head revision — update when new migrations are added.
-_EXPECTED_ALEMBIC_HEAD = "0009"
+# Alembic head revision — derived from the migration files at import time
+# so it never goes stale when new migrations are added.
+def _get_alembic_head() -> str:
+    """Read the latest revision from alembic's script directory."""
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        cfg = Config("alembic.ini")
+        script = ScriptDirectory.from_config(cfg)
+        heads = script.get_heads()
+        return heads[0] if heads else "unknown"
+    except Exception:
+        return "unknown"
+
+
+_EXPECTED_ALEMBIC_HEAD = _get_alembic_head()
 
 # Sources stuck in PROCESSING for longer than this are considered unhealthy.
 _STUCK_SOURCE_THRESHOLD = timedelta(minutes=10)


### PR DESCRIPTION
## Summary
- `_EXPECTED_ALEMBIC_HEAD` now reads from alembic script directory instead of hardcoded "0009" (was causing false degradation on /health/deep)
- Production verification now checks /api/concepts, /api/compilation-schemas, and /api/admin/stats (mirrors staging)

## Test plan
- [ ] /health/deep reports correct migration head (0011, not 0009)
- [ ] Production verification checks all endpoints staging checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)