### PR TITLE
fix: remove interactive flyctl redis create from deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,18 +171,15 @@ jobs:
             fi
           }
 
-          # Redis (Upstash) — staging-specific instance
-          if ! flyctl redis status wikimind-staging-redis 2>/dev/null; then
-            echo "Creating staging Redis instance..."
-            flyctl redis create --name wikimind-staging-redis --region ord --disable-eviction --no-replicas -o personal
-            # Get the private URL and set as secret
-            REDIS_URL=$(flyctl redis status wikimind-staging-redis --json 2>/dev/null | jq -r '.private_url // empty')
-            if [ -n "$REDIS_URL" ]; then
-              flyctl secrets set --stage --app wikimind-staging WIKIMIND_REDIS_URL="$REDIS_URL"
-              echo "Staging Redis provisioned and secret staged"
-            else
-              echo "::warning::Staging Redis created but could not retrieve URL — set WIKIMIND_REDIS_URL manually"
-            fi
+          # Redis (Upstash) — provisioned manually (flyctl redis create requires
+          # interactive prompts). Verify it exists and stage the URL as a secret.
+          REDIS_URL=$(flyctl redis status wikimind-staging-redis --json 2>/dev/null | jq -r '.private_url // empty')
+          if [ -n "$REDIS_URL" ]; then
+            flyctl secrets set --stage --app wikimind-staging WIKIMIND_REDIS_URL="$REDIS_URL"
+            echo "Staging Redis URL staged"
+          else
+            echo "::error::wikimind-staging-redis not found — provision manually: flyctl redis create --name wikimind-staging-redis --region ord"
+            exit 1
           fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -402,17 +399,15 @@ jobs:
             fi
           }
 
-          # Redis (Upstash) — production-specific instance
-          if ! flyctl redis status wikimind-redis 2>/dev/null; then
-            echo "Creating production Redis instance..."
-            flyctl redis create --name wikimind-redis --region ord --disable-eviction --no-replicas -o personal
-          fi
+          # Redis (Upstash) — provisioned manually (flyctl redis create requires
+          # interactive prompts). Verify it exists and stage the URL as a secret.
           REDIS_URL=$(flyctl redis status wikimind-redis --json 2>/dev/null | jq -r '.private_url // empty')
           if [ -n "$REDIS_URL" ]; then
             flyctl secrets set --stage --app wikimind WIKIMIND_REDIS_URL="$REDIS_URL"
-            echo "Production Redis secret staged"
+            echo "Production Redis URL staged"
           else
-            echo "::warning::Could not retrieve production Redis URL — set WIKIMIND_REDIS_URL manually"
+            echo "::error::wikimind-redis not found — provision manually: flyctl redis create --name wikimind-redis --region ord"
+            exit 1
           fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/src/wikimind/api/routes/health.py
+++ b/src/wikimind/api/routes/health.py
@@ -24,6 +24,7 @@ from wikimind.models import IngestStatus, Source
 router = APIRouter()
 log = structlog.get_logger()
 
+
 # Alembic head revision — derived from the migration files at import time
 # so it never goes stale when new migrations are added.
 def _get_alembic_head() -> str:

--- a/src/wikimind/api/routes/health.py
+++ b/src/wikimind/api/routes/health.py
@@ -29,8 +29,8 @@ log = structlog.get_logger()
 def _get_alembic_head() -> str:
     """Read the latest revision from alembic's script directory."""
     try:
-        from alembic.config import Config
-        from alembic.script import ScriptDirectory
+        from alembic.config import Config  # noqa: PLC0415
+        from alembic.script import ScriptDirectory  # noqa: PLC0415
 
         cfg = Config("alembic.ini")
         script = ScriptDirectory.from_config(cfg)


### PR DESCRIPTION
## Summary
- Remove `flyctl redis create` (can't run non-interactively)
- Keep `flyctl redis status` to read URL and stage secret on each deploy
- Fail hard with clear error if Redis instance doesn't exist

Redis is a one-time manual provision: `flyctl redis create --name wikimind-redis --region ord`

## Test plan
- [ ] Deploy succeeds when Redis exists (reads URL, stages secret)
- [ ] Deploy fails with clear error message when Redis is missing