### PR TITLE
fix: deploy pipeline stability (Redis URL, urllib3/Trivy, secrets, release token, smoke E2E)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,21 +185,21 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       # 2️⃣  Stage secrets (--stage avoids double-restart before deploy)
+      # WIKIMIND_REDIS_URL is staged only from Fly Redis status above — do not pass
+      # GitHub secrets.WIKIMIND_REDIS_URL here (empty secret would overwrite the Fly URL).
       - name: 🔑  Stage secrets for staging
         run: |
           flyctl secrets set --stage --app wikimind-staging \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
-            WIKIMIND_REDIS_URL="${WIKIMIND_REDIS_URL}"
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
-          WIKIMIND_REDIS_URL: ${{ secrets.WIKIMIND_REDIS_URL }}
 
       # 3️⃣  Deploy sidecar + app
       - name: 🧠  Deploy docling-serve sidecar
@@ -220,7 +220,7 @@ jobs:
   smoke-test-staging:
     name: smoke-test staging
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     needs: deploy-staging
 
     steps:
@@ -313,9 +313,9 @@ jobs:
             -H "Authorization: Bearer $TOKEN" > /dev/null || { echo "::error::compile trigger failed for source $SOURCE_ID"; exit 1; }
           echo "PASS: compile triggered"
 
-          # Poll for completion (max 60s)
+          # Poll for completion (max 120s — cold LLM + ARQ can exceed 60s on staging)
           E2E_DONE=false
-          for i in $(seq 1 12); do
+          for i in $(seq 1 24); do
             sleep 5
             STATUS=$(curl -sf "$BASE/api/ingest/sources/$SOURCE_ID" \
               -H "Authorization: Bearer $TOKEN" | jq -r '.status // empty')
@@ -331,7 +331,7 @@ jobs:
             fi
           done
           if [ "$E2E_DONE" != "true" ]; then
-            echo "::error::E2E compile did not reach terminal status in 60s"
+            echo "::error::E2E compile did not reach terminal status in 120s"
             exit 1
           fi
 
@@ -412,21 +412,20 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      # WIKIMIND_REDIS_URL comes only from Fly Redis status above (same overwrite risk as staging).
       - name: 🔑  Stage secrets for production
         run: |
           flyctl secrets set --stage --app wikimind \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
-            WIKIMIND_REDIS_URL="${WIKIMIND_REDIS_URL}"
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
-          WIKIMIND_REDIS_URL: ${{ secrets.WIKIMIND_REDIS_URL }}
 
       - name: 🧠  Deploy docling-serve sidecar
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,7 +173,7 @@ jobs:
 
           # Redis (Upstash) — provisioned manually (flyctl redis create requires
           # interactive prompts). Verify it exists and stage the URL as a secret.
-          REDIS_URL=$(flyctl redis status wikimind-staging-redis --json 2>/dev/null | jq -r '.private_url // empty')
+          REDIS_URL=$(flyctl redis status wikimind-staging-redis 2>/dev/null | grep "Private URL" | awk -F'│' '{print $2}' | tr -d ' ')
           if [ -n "$REDIS_URL" ]; then
             flyctl secrets set --stage --app wikimind-staging WIKIMIND_REDIS_URL="$REDIS_URL"
             echo "Staging Redis URL staged"
@@ -401,7 +401,7 @@ jobs:
 
           # Redis (Upstash) — provisioned manually (flyctl redis create requires
           # interactive prompts). Verify it exists and stage the URL as a secret.
-          REDIS_URL=$(flyctl redis status wikimind-redis --json 2>/dev/null | jq -r '.private_url // empty')
+          REDIS_URL=$(flyctl redis status wikimind-redis 2>/dev/null | grep "Private URL" | awk -F'│' '{print $2}' | tr -d ' ')
           if [ -n "$REDIS_URL" ]; then
             flyctl secrets set --stage --app wikimind WIKIMIND_REDIS_URL="$REDIS_URL"
             echo "Production Redis URL staged"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@
 #   - determines version bump from conventional commits (feat/fix)
 #   - updates version in pyproject.toml, creates git tag + GitHub release
 #   - skips if no releasable commits since last tag
+#
+#   Branch protection: pushes to main from the default GITHUB_TOKEN are
+#   rejected when rules require pull requests. Set repository secret
+#   SEMANTIC_RELEASE_GITHUB_TOKEN to a PAT (contents:write, bypass if needed)
+#   or add a ruleset exception for GitHub Actions. The step below prefers
+#   the PAT when present and falls back to GITHUB_TOKEN.
 # ---------------------------------------------------------------
 
 name: Release
@@ -46,7 +52,9 @@ jobs:
 
       - name: Semantic Release — version + publish
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMANTIC_RELEASE_GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          export GH_TOKEN="${SEMANTIC_RELEASE_GITHUB_TOKEN:-$GITHUB_TOKEN}"
           semantic-release version
           semantic-release publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,56 +13,45 @@ dependencies = [
     # Web framework
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.6",
-    "python-multipart>=0.0.27",  # CVE-2026-42561 — DoS via unbounded multipart headers
-
+    "python-multipart>=0.0.27", # CVE-2026-42561 — DoS via unbounded multipart headers
     # Data validation
     "pydantic>=2.9.2",
     "pydantic-settings>=2.5.2",
-
     # Database
     "sqlmodel>=0.0.21",
     "aiosqlite>=0.20.0",
     "asyncpg>=0.30.0",
     "alembic>=1.14.0",
-    "mako>=1.3.12",  # CVE-2026-44307 — path traversal via backslash URI
-
+    "mako>=1.3.12", # CVE-2026-44307 — path traversal via backslash URI
     # Job queue + cross-replica pub/sub
     "arq>=0.26.1",
     "fakeredis>=2.26.0",
     "redis>=5.0.0",
-
     # LLM providers
     "anthropic>=0.40.0",
     "openai>=1.54.3",
     "google-genai>=1.0.0",
     "ollama>=0.3.3",
-
     # Document processing (docling is in [pdf] extra — see below)
     "defusedxml>=0.7.1",
-    "lxml>=6.1.0",  # CVE-2026-41066 — transitive dep, pinned to force safe version
+    "lxml>=6.1.0", # CVE-2026-41066 — transitive dep, pinned to force safe version
     "trafilatura>=1.12.2",
     "pymupdf>=1.24.13",
     "youtube-transcript-api>=0.6.3",
     "feedparser>=6.0.11",
-
     # Security / keychain
     "keyring>=25.4.1",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-
     # Sync
     "boto3>=1.35.49",
     "httpx>=0.27.2",
-
     # Production server
     "gunicorn>=22.0.0",
-
     # Monitoring
     "prometheus-fastapi-instrumentator>=7.0.0",
-
     # MCP (Model Context Protocol)
     "fastmcp>=3.0.2",
-
     # Utilities
     "python-slugify>=8.0.4",
     "python-dateutil>=2.9.0",
@@ -70,6 +59,7 @@ dependencies = [
     "pyyaml>=6.0",
     "structlog>=24.4.0",
     "click>=8.1.0",
+    "urllib3>=2.7.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -4998,11 +4998,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]
@@ -5286,6 +5286,7 @@ dependencies = [
     { name = "structlog" },
     { name = "toml" },
     { name = "trafilatura" },
+    { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "youtube-transcript-api" },
 ]
@@ -5415,6 +5416,7 @@ requires-dist = [
     { name = "trafilatura", specifier = ">=1.12.2" },
     { name = "types-pyyaml", marker = "extra == 'lint'", specifier = ">=6.0" },
     { name = "types-toml", marker = "extra == 'lint'", specifier = ">=0.10.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6" },
     { name = "vulture", marker = "extra == 'lint'", specifier = ">=2.11" },
     { name = "wikimind", extras = ["test", "lint"], marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

Deploy and CI stability: correct Fly Redis URL discovery, satisfy Trivy on the Docker image, avoid wiping Redis secrets during deploy, optional PAT for semantic-release on protected `main`, and more resilient staging smoke E2E.

## Commit 1 — `fix: parse flyctl redis status text output (no --json flag)`

**Problem:** `flyctl redis status` does not support `--json`. Piping its output to `jq` caused parse errors and failed the **Ensure staging/production app exists** steps before deploy.

**Change:** Parse the **Private URL** from the **text table** output of `flyctl redis status` (same pattern for `wikimind-staging-redis` and `wikimind-redis`).

**Files:** `.github/workflows/deploy.yml`

---

## Commit 2 — `fix: stabilize pipeline — urllib3, Redis secrets, release token, smoke E2E`

### 1. Docker / Trivy (GHCR publish unblock)

- **Pin `urllib3>=2.7.0`** in `pyproject.toml` and refresh `uv.lock`.
- Resolves Trivy **HIGH** findings on urllib3 **2.6.3** (**CVE-2026-44431**, **CVE-2026-44432**; fixed in **2.7.0**), which were failing the Docker workflow **CVE scan** job and blocking **publish** to GHCR.

### 2. Deploy — do not overwrite `WIKIMIND_REDIS_URL` from GitHub secrets

- After the infra step stages `WIKIMIND_REDIS_URL` from Fly CLI, the follow-up **Stage secrets** steps for **staging** and **production** **no longer** pass `WIKIMIND_REDIS_URL` from `secrets.WIKIMIND_REDIS_URL`.
- **Why:** An **empty** or unset GitHub secret would overwrite the Fly-derived URL in the same `--stage` batch, breaking Redis/ARQ at runtime.

### 3. Release — semantic-release vs branch protection

- **`release.yml`:** Prefer repository secret **`SEMANTIC_RELEASE_GITHUB_TOKEN`** when set: `export GH_TOKEN="${SEMANTIC_RELEASE_GITHUB_TOKEN:-$GITHUB_TOKEN}"` before `semantic-release version` / `publish`.
- **Why:** Default `GITHUB_TOKEN` cannot push to `main` when rules require pull requests. A fine-grained PAT (**Contents: Read and write** on this repo) stored as `SEMANTIC_RELEASE_GITHUB_TOKEN` allows the release job to push version bumps/tags when the token’s user is allowed to bypass or push to `main`.
- Header comments in the workflow document this.

### 4. Staging smoke — E2E compile window

- **E2E poll:** `12 × 5s` (60s) → **`24 × 5s` (120s)** for ingest→compile→terminal status (cold LLM + ARQ on staging).
- **Job timeout:** smoke-test staging **`5` → `12` minutes** so the job is not killed while polling.

**Files:** `pyproject.toml`, `uv.lock`, `.github/workflows/deploy.yml`, `.github/workflows/release.yml`

---

## Post-merge checklist

- [ ] Confirm **`SEMANTIC_RELEASE_GITHUB_TOKEN`** is set if you want **Release** to push to `main` under branch protection.
- [ ] After merge, confirm **Docker** (build + Trivy + **publish**) is green on `main`, then **Deploy** (workflow_run) can proceed.
