### PR TITLE
fix: keep staging machine alive for smoke tests

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -33,7 +33,7 @@ primary_region = "ord"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [http_service.concurrency]
     type = "connections"


### PR DESCRIPTION
Sets min_machines_running=1 so staging doesn't auto-stop between smoke test requests.