### PR TITLE
fix: Fly config hardening (#594, #597)

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -26,7 +26,6 @@ primary_region = "ord"
   WIKIMIND_SERVER__HOST = "0.0.0.0"
   WIKIMIND_SERVER__PORT = "7842"
   WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
-  WEB_CONCURRENCY = "4"
 
 [http_service]
   internal_port = 7842

--- a/fly.toml
+++ b/fly.toml
@@ -19,17 +19,13 @@ primary_region = "ord"
   WIKIMIND_SERVER__PORT = "7842"
   WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
   WIKIMIND_AUTH__PUBLIC_URL = "https://wikimind.fly.dev"
-  # Gunicorn workers — 4 ensures at least one worker can respond to health
-  # checks while others are still initializing (DB init, migrations).
-  # Fewer workers caused deploy timeouts (health check fails within 5 min).
-  WEB_CONCURRENCY = "4"
 
 [http_service]
   internal_port = 7842
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["web"]
 
   [http_service.concurrency]


### PR DESCRIPTION
## Summary
- Production `min_machines_running = 0` allows scale-to-zero, but cold-start (Gunicorn + DB init + migrations) can exceed the 60s health-check grace period, causing deploy timeouts and user-facing downtime
- `WEB_CONCURRENCY = "4"` hardcoded in both `fly.toml` and `fly.staging.toml` forces 4 Gunicorn workers on a 1-CPU shared machine, causing CPU thrashing; `gunicorn.conf.py` already auto-tunes workers via `min(2*CPU+1, 4)`, so the env var override is unnecessary and harmful

## Changes
- `fly.toml`: removed `WEB_CONCURRENCY = "4"` env var and its explanatory comment block (lines 22-25); changed `min_machines_running` from `0` to `1`
- `fly.staging.toml`: removed `WEB_CONCURRENCY = "4"` env var (line 29)

## Test plan
- [ ] Verify `fly.toml` no longer contains `WEB_CONCURRENCY` and has `min_machines_running = 1`
- [ ] Verify `fly.staging.toml` no longer contains `WEB_CONCURRENCY`
- [ ] Deploy to staging and confirm Gunicorn auto-selects worker count (check logs for `[INFO] Booting worker with pid`)
- [ ] Verify staging machine stays running (does not scale to zero) after idle period
- [ ] Deploy to production and confirm no health-check timeout on cold start

Closes #594, closes #597