### PR TITLE
fix: Docker + CI hardening (#596, #599, #600)

### DIFF
--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -195,6 +195,42 @@ jobs:
           echo "Migration state is at head"
 
       # -----------------------------------------------------------
+      # 5b. Downgrade test: head -> N-1 -> head (round-trip)
+      # -----------------------------------------------------------
+      - name: "Downgrade test: head → N-1 → head"
+        run: |
+          set -euo pipefail
+
+          HEAD=$(uv run alembic heads 2>/dev/null | grep -oP '^\w+')
+          PREV=$(uv run alembic history 2>/dev/null | grep -oP '^\w+' | head -2 | tail -1)
+          echo "HEAD=$HEAD  PREV=$PREV"
+
+          if [ "$HEAD" = "$PREV" ] || [ -z "$PREV" ]; then
+            echo "Only one migration — skipping downgrade test"
+            exit 0
+          fi
+
+          echo "Downgrading from $HEAD to $PREV..."
+          uv run alembic downgrade "$PREV"
+
+          CURRENT=$(uv run alembic current 2>/dev/null | grep -oP '^\w+')
+          if [ "$CURRENT" != "$PREV" ]; then
+            echo "::error::Downgrade failed: expected $PREV, got $CURRENT"
+            exit 1
+          fi
+          echo "Downgrade successful"
+
+          echo "Re-upgrading to head..."
+          uv run alembic upgrade head
+
+          CURRENT=$(uv run alembic current 2>/dev/null | grep -oP '^\w+')
+          if [ "$CURRENT" != "$HEAD" ]; then
+            echo "::error::Re-upgrade failed: expected $HEAD, got $CURRENT"
+            exit 1
+          fi
+          echo "Round-trip downgrade test passed"
+
+      # -----------------------------------------------------------
       # 6. Upgrade-path test: N-1 -> seed data -> head (no data loss)
       # -----------------------------------------------------------
       - name: Create second database for upgrade-path test

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,79 @@
+# ===============================================================
+# External Uptime Monitor
+# ===============================================================
+#
+# Pings production and staging health endpoints from GitHub Actions
+# (outside Fly.io network) every 15 minutes. Creates an issue on
+# 3 consecutive failures.
+
+name: Uptime Monitor
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  check-health:
+    name: health check
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Check production health
+        id: prod
+        continue-on-error: true
+        run: |
+          status=$(curl -sf --max-time 10 https://wikimind.fly.dev/health \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" \
+            2>/dev/null || echo "unreachable")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" != "ok" ]; then
+            echo "::warning::Production health: $status"
+          fi
+
+      - name: Check staging health
+        id: staging
+        continue-on-error: true
+        run: |
+          status=$(curl -sf --max-time 10 https://wikimind-staging.fly.dev/health \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" \
+            2>/dev/null || echo "unreachable")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" != "ok" ]; then
+            echo "::warning::Staging health: $status"
+          fi
+
+      - name: Alert on production failure
+        if: steps.prod.outputs.status != 'ok'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            // Check for existing open uptime issue to avoid duplicates
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'uptime-alert',
+              state: 'open',
+              per_page: 1,
+            });
+            if (issues.data.length > 0) {
+              // Add a comment to existing issue instead of creating new one
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body: `Production still unhealthy: ${{ steps.prod.outputs.status }} at ${new Date().toISOString()}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: '🚨 Production health check failed',
+                body: `Production health endpoint returned: ${{ steps.prod.outputs.status }}\n\nTime: ${new Date().toISOString()}\nCheck: https://wikimind.fly.dev/health`,
+                labels: ['bug', 'uptime-alert'],
+              });
+            }

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -4,7 +4,7 @@
 #
 # Pings production and staging health endpoints from GitHub Actions
 # (outside Fly.io network) every 15 minutes. Creates an issue on
-# 3 consecutive failures.
+# failure.
 
 name: Uptime Monitor
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": ".merge_file_MB2khG"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -149,7 +149,303 @@
         "filename": ".github/workflows/migration-replay.yml",
         "hashed_secret": "f25e7e3dd1539e107ca4c4705ebe293496c38e10",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 237
+      }
+    ],
+    ".secrets.baseline": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c332c15e76c22a7f7125d03261e4218a2005a6ba",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c332c15e76c22a7f7125d03261e4218a2005a6ba",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6116e7dbe0baf62ebaf5b48cfac17685433f6329",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6116e7dbe0baf62ebaf5b48cfac17685433f6329",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 248
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 248
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 257
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 257
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 284
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 284
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 350
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 350
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
+        "is_verified": false,
+        "line_number": 357
       }
     ],
     "Makefile": [
@@ -360,5 +656,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-12T01:22:55Z"
+  "generated_at": "2026-05-12T02:34:54Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@
 #   prod   — slim runtime with only production dependencies
 
 # ---------------------------------------------------------------------------
-ARG PYTHON_VERSION=3.11
+# Pin to specific Python version to prevent upstream breakage.
+# Update deliberately via PR, not silently via :latest.
+ARG PYTHON_VERSION=3.11.12
 FROM python:${PYTHON_VERSION}-slim AS base
 
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- Pin Python base image to 3.11.12 to prevent silent upstream breakage
- Add Alembic downgrade round-trip test (head → N-1 → head) to CI
- Add external uptime monitor that pings health endpoints every 15 minutes from outside Fly.io

## Changes
- `Dockerfile` — pin PYTHON_VERSION to 3.11.12
- `.github/workflows/migration-replay.yml` — add downgrade test step
- `.github/workflows/uptime.yml` — new workflow for external monitoring

## Test plan
- [ ] YAML validates
- [ ] Dockerfile builds with pinned version
- [ ] Downgrade test passes in migration replay CI
- [ ] Uptime workflow can be triggered manually

Closes #596, closes #599, closes #600