### PR TITLE
fix: isolate staging Docling sidecar from production (#585)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,8 @@
 #   ────────────────────┼────────────────────┼──────────────────────────
 #   wikimind-staging    │ fly.staging.toml   │ Pre-prod gate
 #   wikimind            │ fly.toml           │ Production
-#   wikimind-docling    │ fly.docling.toml   │ PDF sidecar (production)
+#   wikimind-docling         │ fly.docling.toml   │ PDF sidecar (production)
+#   wikimind-staging-docling │ fly.docling.toml   │ PDF sidecar (staging)
 #   wikimind-staging-db │ (Postgres cluster) │ Staging database
 #   wikimind-db         │ (Postgres cluster) │ Production database
 #   wikimind-staging-redis │ (Upstash Redis)  │ Staging queue
@@ -204,10 +205,10 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
       # 3️⃣  Deploy sidecar + app
-      - name: 🧠  Deploy docling-serve sidecar
+      - name: 🧠  Deploy staging docling-serve sidecar
         run: |
-          flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
-          flyctl deploy --config fly.docling.toml --remote-only
+          flyctl status --app wikimind-staging-docling 2>/dev/null || flyctl apps create wikimind-staging-docling --org personal
+          flyctl deploy --config fly.docling.toml --app wikimind-staging-docling --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -25,7 +25,9 @@ primary_region = "ord"
 [env]
   WIKIMIND_SERVER__HOST = "0.0.0.0"
   WIKIMIND_SERVER__PORT = "7842"
-  WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
+  # Staging uses its own Docling sidecar (wikimind-staging-docling) to avoid
+  # affecting production during smoke tests.
+  WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-staging-docling.internal:5001"
 
 [http_service]
   internal_port = 7842


### PR DESCRIPTION
## Summary
- Staging and production shared the same `wikimind-docling` Fly app for PDF extraction
- Staging smoke tests could affect production Docling availability
- Create separate `wikimind-staging-docling` app for staging environment

## Changes
- `fly.staging.toml` — point DOCLING_SERVE_URL to staging-specific sidecar
- `.github/workflows/deploy.yml` — deploy staging Docling as separate app

## Test plan
- [ ] YAML validates
- [ ] Staging deploy creates/uses wikimind-staging-docling
- [ ] Production continues using wikimind-docling unchanged

Closes #585