### PR TITLE
fix: add Redis connectivity and queue depth to /health/deep (#587)

### DIFF
--- a/src/wikimind/api/routes/health.py
+++ b/src/wikimind/api/routes/health.py
@@ -1,8 +1,9 @@
 """Deep health check endpoint for production monitoring.
 
 Checks database connectivity, Alembic migration version, LLM provider
-availability, and stuck source processing jobs. Returns a structured JSON
-response with per-check status and overall system health.
+availability, stuck source processing jobs, Redis connectivity, and ARQ
+queue depth. Returns a structured JSON response with per-check status
+and overall system health.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter
+from redis.asyncio import Redis
 from sqlalchemy import text as sa_text
 from sqlmodel import select
 
@@ -117,6 +119,43 @@ async def _check_stuck_sources() -> dict[str, Any]:
         return {"status": "error", "count": -1, "error": str(exc)}
 
 
+async def _check_redis() -> dict[str, Any]:
+    """Verify Redis connectivity via PING when redis_url is configured."""
+    settings = get_settings()
+    if settings.redis_url is None:
+        return {"status": "ok", "mode": "in_process"}
+
+    start = time.monotonic()
+    r = Redis.from_url(settings.redis_url, socket_connect_timeout=3)
+    try:
+        await r.ping()
+        latency_ms = round((time.monotonic() - start) * 1000)
+        return {"status": "ok", "mode": "arq", "latency_ms": latency_ms}
+    except Exception as exc:
+        log.warning("health: redis check failed", error=str(exc))
+        return {"status": "error", "mode": "arq", "error": str(exc)}
+    finally:
+        await r.aclose()
+
+
+async def _check_queue_depth() -> dict[str, Any]:
+    """Check the ARQ pending job queue depth."""
+    settings = get_settings()
+    if settings.redis_url is None:
+        return {"status": "ok", "pending_jobs": 0}
+
+    r = Redis.from_url(settings.redis_url, socket_connect_timeout=3)
+    try:
+        depth = await r.zcard("arq:queue")
+        status = "ok" if depth < 100 else "warning"
+        return {"status": status, "pending_jobs": depth}
+    except Exception as exc:
+        log.warning("health: queue depth check failed", error=str(exc))
+        return {"status": "error", "error": str(exc)}
+    finally:
+        await r.aclose()
+
+
 def _overall_status(checks: dict[str, dict[str, Any]]) -> str:
     """Derive overall status from individual check results.
 
@@ -141,6 +180,8 @@ async def deep_health_check() -> dict[str, Any]:
     checks["migrations"] = await _check_migrations()
     checks["llm_provider"] = _check_llm_provider()
     checks["stuck_sources"] = await _check_stuck_sources()
+    checks["redis"] = await _check_redis()
+    checks["queue"] = await _check_queue_depth()
 
     return {
         "status": _overall_status(checks),

--- a/src/wikimind/api/routes/health.py
+++ b/src/wikimind/api/routes/health.py
@@ -126,7 +126,7 @@ async def _check_redis() -> dict[str, Any]:
         return {"status": "ok", "mode": "in_process"}
 
     start = time.monotonic()
-    r = Redis.from_url(settings.redis_url, socket_connect_timeout=3)
+    r = Redis.from_url(settings.redis_url, socket_connect_timeout=3, socket_timeout=3)
     try:
         await r.ping()
         latency_ms = round((time.monotonic() - start) * 1000)
@@ -144,7 +144,7 @@ async def _check_queue_depth() -> dict[str, Any]:
     if settings.redis_url is None:
         return {"status": "ok", "pending_jobs": 0}
 
-    r = Redis.from_url(settings.redis_url, socket_connect_timeout=3)
+    r = Redis.from_url(settings.redis_url, socket_connect_timeout=3, socket_timeout=3)
     try:
         depth = await r.zcard("arq:queue")
         status = "ok" if depth < 100 else "warning"


### PR DESCRIPTION
## Summary
- `/health/deep` reported background mode based solely on whether `redis_url` was configured, not whether Redis was actually reachable or the ARQ worker was processing jobs. This made it impossible to detect Redis outages or queue backlogs from the health endpoint.

## Changes
- `src/wikimind/api/routes/health.py`: Added `_check_redis()` that PINGs Redis with a 3-second connect timeout and reports latency, and `_check_queue_depth()` that reads the `arq:queue` sorted-set length and warns when backlog exceeds 100 jobs. Both gracefully degrade to `in_process`/0 when no `redis_url` is configured. Both checks are wired into `deep_health_check()` alongside the existing database, migrations, LLM provider, and stuck-sources checks.

## Test plan
- [x] `ruff format` and `ruff check` pass with no issues
- [x] All 16 existing health tests pass (`pytest -k health`)
- [x] Full test suite passes (1606 passed, 4 skipped)
- [ ] Manual verification on staging: `curl /health/deep` returns `redis` and `queue` check results

Closes #587