### PR TITLE
fix: move migrations to Fly release command with advisory lock (#586)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,14 +11,8 @@ if [ "$(id -u)" = "0" ]; then
     exec gosu wikimind "$0" "$@"
 fi
 
-# Run Alembic migrations when using PostgreSQL — but only for the web process.
-# The ARQ worker should not race the web process for migrations.
-_db_url="${WIKIMIND_DATABASE_URL:-${DATABASE_URL:-}}"
-if [[ "$_db_url" == postgres* ]] && [[ "${1:-}" != *"arq"* ]]; then
-    echo "Running Alembic migrations..."
-    .venv/bin/python -m alembic upgrade head
-    echo "Migrations complete."
-fi
+# Alembic migrations run via Fly.io release_command (see fly.toml [deploy] section).
+# This ensures migrations execute exactly once per deploy, before any process starts.
 
 # Gunicorn crashes on empty WEB_CONCURRENCY (int("") fails at import time).
 # Unset it so gunicorn falls through to gunicorn.conf.py auto-tuning.

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -48,6 +48,7 @@ primary_region = "ord"
 
 [deploy]
   strategy = "rolling"
+  release_command = ".venv/bin/python -m alembic upgrade head"
 
 [mounts]
   source = "wikimind_staging_data"

--- a/fly.toml
+++ b/fly.toml
@@ -44,6 +44,7 @@ primary_region = "ord"
 
 [deploy]
   strategy = "rolling"
+  release_command = ".venv/bin/python -m alembic upgrade head"
 
 [mounts]
   source = "wikimind_data"

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -202,6 +202,19 @@ async def _ensure_anonymous_user(engine) -> None:
             log.info("created anonymous user for no-auth mode")
 
 
+async def _run_versioned_migrations(engine, versioned_migrations, session_migrations) -> None:
+    """Execute versioned data migrations, skipping already-applied ones."""
+    for version, migration_fn in versioned_migrations:
+        if await _migration_applied(engine, version):
+            continue
+        if version in session_migrations:
+            async with get_session_factory()() as session:
+                await session_migrations[version](session)
+        else:
+            await migration_fn(engine)  # type: ignore[operator]
+        await _record_migration(engine, version)
+
+
 async def init_db():
     """Create all tables and run idempotent data migrations.
 
@@ -247,7 +260,8 @@ async def init_db():
                 )
                 await rebuild_fts_index(fts_session)
 
-    # Versioned data migrations — each runs at most once
+    # Versioned data migrations — each runs at most once.
+    # On Postgres, use an advisory lock to serialize concurrent workers.
     _versioned_migrations: list[tuple[str, object]] = [
         ("0001_backfill_conversations", _backfill_conversation_for_legacy_queries),
         ("0002_repair_json_arrays", _repair_malformed_json_arrays),
@@ -263,15 +277,16 @@ async def init_db():
         "0006_cleanup_orphan_concepts": _cleanup_orphan_concept_rows,
     }
 
-    for version, migration_fn in _versioned_migrations:
-        if await _migration_applied(engine, version):
-            continue
-        if version in _session_migrations:
-            async with get_session_factory()() as session:
-                await _session_migrations[version](session)
-        else:
-            await migration_fn(engine)  # type: ignore[operator]
-        await _record_migration(engine, version)
+    settings = get_settings()
+    if is_postgres(settings.database_url):
+        async with engine.begin() as lock_conn:
+            await lock_conn.execute(sa_text("SELECT pg_advisory_lock(737069)"))
+            try:
+                await _run_versioned_migrations(engine, _versioned_migrations, _session_migrations)
+            finally:
+                await lock_conn.execute(sa_text("SELECT pg_advisory_unlock(737069)"))
+    else:
+        await _run_versioned_migrations(engine, _versioned_migrations, _session_migrations)
 
 
 async def _backfill_conversation_for_legacy_queries(engine) -> None:

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -211,7 +211,7 @@ async def _run_versioned_migrations(engine, versioned_migrations, session_migrat
             async with get_session_factory()() as session:
                 await session_migrations[version](session)
         else:
-            await migration_fn(engine)  # type: ignore[operator]
+            await migration_fn(engine)
         await _record_migration(engine, version)
 
 


### PR DESCRIPTION
## Summary
- Every Gunicorn worker ran Alembic migrations on startup, creating race conditions with concurrent workers
- Move Alembic schema migrations to Fly.io release_command (runs once before any process starts)
- Wrap data migrations in Postgres advisory lock to serialize concurrent init_db() calls
- Remove Alembic from docker/entrypoint.sh

## Changes
- `fly.toml` — add release_command for Alembic
- `fly.staging.toml` — same
- `docker/entrypoint.sh` — remove Alembic migration block
- `src/wikimind/database.py` — add advisory lock around versioned data migrations

## Test plan
- [ ] All unit tests pass
- [ ] Ruff lint/format clean
- [ ] Release command runs Alembic before app starts
- [ ] Data migrations serialize via advisory lock on Postgres
- [ ] SQLite path (local dev) unchanged

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)