### PR TITLE
fix: use plain redis:// for Upstash Fly private endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,7 +190,7 @@ jobs:
           if [ "$REDIS_CHECK" -gt 0 ]; then
             echo "Redis URL secret exists"
           else
-            echo "::error::WIKIMIND_REDIS_URL not set — run: fly secrets set WIKIMIND_REDIS_URL='rediss://...' --app wikimind-staging"
+            echo "::error::WIKIMIND_REDIS_URL not set — run: fly secrets set WIKIMIND_REDIS_URL='redis://...' --app wikimind-staging"
             exit 1
           fi
         env:
@@ -415,7 +415,7 @@ jobs:
           if [ "$REDIS_CHECK" -gt 0 ]; then
             echo "Redis URL secret exists"
           else
-            echo "::error::WIKIMIND_REDIS_URL not set — run: fly secrets set WIKIMIND_REDIS_URL='rediss://...' --app wikimind"
+            echo "::error::WIKIMIND_REDIS_URL not set — run: fly secrets set WIKIMIND_REDIS_URL='redis://...' --app wikimind"
             exit 1
           fi
         env:

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -366,20 +366,11 @@ class Settings(BaseSettings):
         # Redis URL: fall back to unprefixed REDIS_URL
         if not self.redis_url:
             self.redis_url = os.environ.get("REDIS_URL") or None
-        # Upstash requires TLS even on the Fly private network. The private
-        # URL from `flyctl redis status` uses redis:// but the server expects
-        # TLS. Auto-upgrade to rediss:// when the hostname is *.upstash.io.
-        if self.redis_url and self.redis_url.startswith("redis://"):
-            host = (urlparse(self.redis_url).hostname or "").lower()
-            if host == "upstash.io" or host.endswith(".upstash.io"):
-                self.redis_url = self.redis_url.replace("redis://", "rediss://", 1)
-        # Upstash private certs are not publicly verifiable. Skip certificate
-        # verification for rediss:// URLs on *.upstash.io to avoid SSL errors.
-        if self.redis_url and self.redis_url.startswith("rediss://"):
-            host = (urlparse(self.redis_url).hostname or "").lower()
-            if (host == "upstash.io" or host.endswith(".upstash.io")) and "ssl_cert_reqs" not in self.redis_url:
-                sep = "&" if "?" in self.redis_url else "?"
-                self.redis_url += f"{sep}ssl_cert_reqs=none"
+        # Upstash Fly Redis private endpoint uses plain redis:// (no TLS).
+        # Do NOT auto-upgrade to rediss:// — confirmed via manual testing
+        # that the private endpoint rejects TLS handshakes.
+        # If using a public Upstash endpoint, set WIKIMIND_REDIS_URL to
+        # rediss:// explicitly.
         return self
 
     @property


### PR DESCRIPTION
## Summary

Staging deploys have been blocked because `/health/deep` reports Redis as unhealthy. After manual testing from inside the Fly VM, confirmed:

- `redis://` (plain) → **PING: True** 
- `rediss://` (TLS) → **SSL: WRONG_VERSION_NUMBER**

The Upstash Fly private endpoint does NOT support TLS. Fly's private network (6PN/WireGuard) handles encryption at the network layer.

## Root cause

PR #583 added a TLS auto-upgrade in `config.py` that converted `redis://` to `rediss://` for `*.upstash.io` hostnames. This was based on the incorrect assumption that Upstash requires TLS on the private endpoint. It doesn't.

## Changes

- `src/wikimind/config.py` — remove TLS auto-upgrade and `ssl_cert_reqs` logic for Upstash URLs
- `.github/workflows/deploy.yml` — fix error message hints to say `redis://` not `rediss://`
- Staging `WIKIMIND_REDIS_URL` secret set back to `redis://`

## Test plan

- [x] Manual test inside Fly VM: `redis.Redis.from_url('redis://...').ping()` → True
- [ ] `/health/deep` returns `redis.status == "ok"`
- [ ] Staging smoke tests pass (E2E compile via ARQ/Redis)