### PR TITLE
fix: disable asyncpg statement cache for PgBouncer compatibility

### DIFF
--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -73,6 +73,12 @@ def _create_engine_from_url(url: str):
         return create_async_engine(url, echo=False, connect_args={"check_same_thread": False})
     if is_postgres(url):
         url, connect_args = _parse_ssl(url)
+        # Disable asyncpg's prepared-statement cache.  Fly.io Postgres
+        # uses PgBouncer in transaction-pooling mode, which can reassign
+        # backend connections between requests.  Cached statements from
+        # one backend are invalid on another, causing
+        # InvalidCachedStatementError.
+        connect_args["statement_cache_size"] = 0
         return create_async_engine(
             url,
             echo=False,


### PR DESCRIPTION
## Summary

- Fly.io Postgres uses PgBouncer in transaction-pooling mode, which reassigns backend connections between requests
- asyncpg caches prepared statements per-connection; when the backend changes, the cache is stale
- This causes `InvalidCachedStatementError` on production, making all authenticated API queries return 500
- Fix: set `statement_cache_size=0` in asyncpg connect args

## Evidence

From production logs:
```
asyncpg.exceptions.InvalidCachedStatementError
```

All authenticated endpoints returned 500 after deploy, while unauthenticated health checks worked fine.

## Test plan

- [ ] CI passes
- [ ] Deploy to staging, verify `/api/wiki/articles` returns 200 (not 500)
- [ ] Deploy to production, verify same

🤖 Generated with [Claude Code](https://claude.com/claude-code)