### PR TITLE
feat: add make dev-parity target for production-topology local dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ make typecheck     # Run mypy
 make test          # Run pytest
 make coverage      # Run tests with coverage
 make verify        # Run all quality checks (lint + format + typecheck + test)
+make dev-parity    # Run dev server against production-parity stack (PgBouncer + Redis)
+make test-parity   # Run tests against production-parity stack
 ```
 
 ## Coding Standards

--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,37 @@ docker-down: ## Stop and remove the dev stack
 	docker compose down --remove-orphans
 	docker compose rm -f 2>/dev/null || true
 
+##@ 🔄 PRODUCTION PARITY
+
+PARITY_DB := postgresql+asyncpg://wikimind:wikimind@localhost:5434/wikimind
+PARITY_REDIS := redis://localhost:6380
+
+.PHONY: parity-up
+parity-up: ## Start production-parity stack (Postgres + PgBouncer + Redis)
+	$(COMPOSE_CMD) -f docker-compose.parity.yml up -d
+	@echo "Production-parity stack running:"
+	@echo "  Postgres (via PgBouncer): localhost:5434"
+	@echo "  Redis: localhost:6380"
+
+.PHONY: parity-down
+parity-down: ## Stop production-parity stack
+	$(COMPOSE_CMD) -f docker-compose.parity.yml down
+
+.PHONY: dev-parity
+dev-parity: check-venv parity-up ## Run dev server against production-parity stack (PgBouncer + Redis)
+	WIKIMIND_DATABASE_URL=$(PARITY_DB) \
+	WIKIMIND_REDIS_URL=$(PARITY_REDIS) \
+	$(BIN)/python -m alembic upgrade head
+	WIKIMIND_DATABASE_URL=$(PARITY_DB) \
+	WIKIMIND_REDIS_URL=$(PARITY_REDIS) \
+	$(BIN)/honcho start -f Procfile.dev
+
+.PHONY: test-parity
+test-parity: parity-up ## Run tests against production-parity stack
+	WIKIMIND_DATABASE_URL=$(PARITY_DB) \
+	WIKIMIND_REDIS_URL=$(PARITY_REDIS) \
+	$(BIN)/pytest $(ARGS)
+
 ##@ 🚀 DEPLOY
 
 .PHONY: deploy-up

--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ dev-parity: check-venv parity-up ## Run dev server against production-parity sta
 .PHONY: test-parity
 test-parity: parity-up ## Run tests against production-parity stack
 	WIKIMIND_DATABASE_URL=$(PARITY_DB) \
+	WIKIMIND_TEST_POSTGRES_URL=$(PARITY_DB) \
 	WIKIMIND_REDIS_URL=$(PARITY_REDIS) \
 	$(BIN)/pytest $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,8 @@ PARITY_REDIS := redis://localhost:6380
 
 .PHONY: parity-up
 parity-up: ## Start production-parity stack (Postgres + PgBouncer + Redis)
-	$(COMPOSE_CMD) -f docker-compose.parity.yml up -d
+	@docker info >/dev/null 2>&1 || (echo "❌  Docker is not running" && exit 1)
+	$(COMPOSE_CMD) -f docker-compose.parity.yml up -d --wait
 	@echo "Production-parity stack running:"
 	@echo "  Postgres (via PgBouncer): localhost:5434"
 	@echo "  Redis: localhost:6380"
@@ -379,6 +380,10 @@ parity-up: ## Start production-parity stack (Postgres + PgBouncer + Redis)
 .PHONY: parity-down
 parity-down: ## Stop production-parity stack
 	$(COMPOSE_CMD) -f docker-compose.parity.yml down
+
+.PHONY: parity-reset
+parity-reset: ## Stop production-parity stack and wipe all data
+	$(COMPOSE_CMD) -f docker-compose.parity.yml down -v
 
 .PHONY: dev-parity
 dev-parity: check-venv parity-up ## Run dev server against production-parity stack (PgBouncer + Redis)

--- a/README.md
+++ b/README.md
@@ -353,6 +353,16 @@ WIKIMIND_LLM__DEFAULT_PROVIDER=openai_compatible
 | `make docker-logs` | Tail logs from all dev stack services |
 | `make docker-down` | Stop and remove the dev stack |
 
+### 🔄 PRODUCTION PARITY
+
+| Target | Description |
+|--------|-------------|
+| `make parity-up` | Start production-parity stack (Postgres + PgBouncer + Redis) |
+| `make parity-down` | Stop production-parity stack |
+| `make parity-reset` | Stop production-parity stack and wipe all data |
+| `make dev-parity` | Run dev server against production-parity stack (PgBouncer + Redis) |
+| `make test-parity` | Run tests against production-parity stack |
+
 ### 🚀 DEPLOY
 
 | Target | Description |

--- a/docker-compose.parity.yml
+++ b/docker-compose.parity.yml
@@ -1,0 +1,44 @@
+# Production-parity stack: Postgres behind PgBouncer + Redis
+# Replicates the topology of Fly.io / Kubernetes production.
+#
+# Usage:
+#   make parity-up       # start the stack
+#   make dev-parity      # run the app against it
+#   make test-parity     # run tests against it
+#   make parity-down     # stop the stack
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: wikimind
+      POSTGRES_PASSWORD: wikimind
+      POSTGRES_DB: wikimind
+    volumes:
+      - parity-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U wikimind"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    environment:
+      DATABASE_URL: postgres://wikimind:wikimind@postgres:5432/wikimind
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: 100
+      DEFAULT_POOL_SIZE: 20
+    ports:
+      - "5434:5432"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6380:6379"
+
+volumes:
+  parity-pgdata:

--- a/docker-compose.parity.yml
+++ b/docker-compose.parity.yml
@@ -1,18 +1,19 @@
 # Production-parity stack: Postgres behind PgBouncer + Redis
-# Replicates the topology of Fly.io / Kubernetes production.
+# Replicates production topology (PgBouncer transaction pooling + Redis).
 #
 # Usage:
 #   make parity-up       # start the stack
 #   make dev-parity      # run the app against it
 #   make test-parity     # run tests against it
 #   make parity-down     # stop the stack
+#   make parity-reset    # stop + wipe all data
 
 services:
   postgres:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: wikimind
-      POSTGRES_PASSWORD: wikimind
+      POSTGRES_PASSWORD: wikimind # pragma: allowlist secret
       POSTGRES_DB: wikimind
     volumes:
       - parity-pgdata:/var/lib/postgresql/data
@@ -25,7 +26,7 @@ services:
   pgbouncer:
     image: edoburu/pgbouncer:latest
     environment:
-      DATABASE_URL: postgres://wikimind:wikimind@postgres:5432/wikimind
+      DATABASE_URL: postgres://wikimind:wikimind@postgres:5432/wikimind # pragma: allowlist secret
       POOL_MODE: transaction
       MAX_CLIENT_CONN: 100
       DEFAULT_POOL_SIZE: 20
@@ -34,11 +35,21 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -p 5432"]
+      interval: 3s
+      timeout: 2s
+      retries: 5
 
   redis:
     image: redis:7-alpine
     ports:
       - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
 
 volumes:
   parity-pgdata:

--- a/docker-compose.parity.yml
+++ b/docker-compose.parity.yml
@@ -30,6 +30,7 @@ services:
       POOL_MODE: transaction
       MAX_CLIENT_CONN: 100
       DEFAULT_POOL_SIZE: 20
+      AUTH_TYPE: scram-sha-256
     ports:
       - "5434:5432"
     depends_on:


### PR DESCRIPTION
## Summary

Adds a production-parity local dev stack so developers can catch PgBouncer, Redis, and multi-process issues before they hit production.

- **`docker-compose.parity.yml`**: Postgres 16 behind PgBouncer (transaction pooling, port 5434) + Redis 7 (port 6380)
- **`make parity-up`** / **`make parity-down`**: Start/stop the parity stack
- **`make dev-parity`**: Run the app against PgBouncer + Redis (runs Alembic migrations first)
- **`make test-parity`**: Run tests through PgBouncer

Platform-agnostic naming (not "fly-parity") per #628 — this topology applies to Fly.io, Kubernetes, or any production setup with a connection pooler.

## What this catches locally

| Production bug | How parity stack catches it |
|---------------|---------------------------|
| `InvalidCachedStatementError` (#622) | PgBouncer transaction pooling reassigns backends |
| Connection drops during LLM calls (#617) | PgBouncer idle timeout kills connections |
| Schema drift (#624) | Alembic runs against real Postgres, not SQLite |

## Test plan

- [x] `docker compose -f docker-compose.parity.yml config --quiet` validates
- [x] `make parity-up` starts all 3 services
- [x] `make dev-parity` runs the app with Alembic + PgBouncer
- [x] `make parity-down` stops cleanly
- [x] Existing `make dev` unchanged (SQLite default)

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)