### PR TITLE
fix: store source content in Postgres for multi-machine compatibility

### DIFF
--- a/alembic/versions/0013_add_source_clean_text.py
+++ b/alembic/versions/0013_add_source_clean_text.py
@@ -1,0 +1,43 @@
+"""Add clean_text column to source table.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-05-12
+
+Store source content in Postgres so the worker can read it without needing
+access to the web machine's filesystem volume (issue #626).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0013"
+down_revision: str = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _column_exists(conn: sa.engine.Connection, table: str, column: str) -> bool:
+    inspector = sa_inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _column_exists(conn, "source", "clean_text"):
+        op.add_column("source", sa.Column("clean_text", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    is_sqlite = conn.dialect.name == "sqlite"
+    if _column_exists(conn, "source", "clean_text"):
+        if is_sqlite:
+            with op.batch_alter_table("source") as batch_op:
+                batch_op.drop_column("clean_text")
+        else:
+            op.drop_column("source", "clean_text")

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -239,6 +239,7 @@ class PDFAdapter:
         try:
             await raw_storage.write(f"{source.id}.txt", clean_text)
             source.file_path = f"{source.id}.txt"
+            source.clean_text = clean_text
         except Exception as exc:
             log.error(
                 "File write failed after source commit — marking as failed",

--- a/src/wikimind/ingest/adapters/text.py
+++ b/src/wikimind/ingest/adapters/text.py
@@ -65,6 +65,7 @@ class TextAdapter:
             raw_storage = get_raw_storage(user_id)
             await raw_storage.write(f"{source.id}.txt", content)
             source.file_path = f"{source.id}.txt"
+            source.clean_text = content
         except Exception as exc:
             log.error(
                 "File write failed after source commit — marking as failed",

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -96,6 +96,7 @@ class URLAdapter:
             await raw_storage.write(f"{source.id}.html", html)
             await raw_storage.write(f"{source.id}.txt", downloaded)
             source.file_path = f"{source.id}.txt"
+            source.clean_text = downloaded
         except Exception as exc:
             log.error(
                 "File write failed after source commit — marking as failed",

--- a/src/wikimind/ingest/adapters/youtube.py
+++ b/src/wikimind/ingest/adapters/youtube.py
@@ -82,6 +82,7 @@ class YouTubeAdapter:
             raw_storage = get_raw_storage(user_id)
             await raw_storage.write(f"{source.id}.txt", transcript_text)
             source.file_path = f"{source.id}.txt"
+            source.clean_text = transcript_text
         except Exception as exc:
             log.error(
                 "File write failed after source commit — marking as failed",

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -320,15 +320,18 @@ async def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     (``tuple[Source, NormalizedDocument]``) stays consistent whether the
     source is new or replayed from the cache.
 
+    Reads from ``source.clean_text`` (Postgres) first, falling back to
+    the raw ``.txt`` file on disk for backward compatibility.
+
     Args:
-        source: A persisted Source whose ``file_path`` points at the
-            cached cleaned text on disk.
+        source: A persisted Source with ``clean_text`` set or a non-null
+            ``file_path`` pointing at the cached text on disk.
 
     Returns:
-        A NormalizedDocument loaded from the cached `.txt` file.
+        A NormalizedDocument built from the source content.
 
     Raises:
-        ValueError: If the source has no `file_path` set.
+        ValueError: If neither ``clean_text`` nor ``file_path`` provides content.
     """
     clean_text = source.clean_text
     if clean_text is None and source.file_path:

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -330,11 +330,13 @@ async def reconstruct_normalized_doc(source: Source) -> NormalizedDocument:
     Raises:
         ValueError: If the source has no `file_path` set.
     """
-    if not source.file_path:
-        msg = f"Source {source.id} has no file_path; cannot reconstruct NormalizedDocument"
+    clean_text = source.clean_text
+    if clean_text is None and source.file_path:
+        raw_storage = get_raw_storage(source.user_id)
+        clean_text = await raw_storage.read(source.file_path)
+    if clean_text is None:
+        msg = f"No content available for source {source.id}"
         raise ValueError(msg)
-    raw_storage = get_raw_storage(source.user_id)
-    clean_text = await raw_storage.read(source.file_path)
     return NormalizedDocument(
         raw_source_id=source.id,
         clean_text=clean_text,

--- a/src/wikimind/jobs/background.py
+++ b/src/wikimind/jobs/background.py
@@ -78,8 +78,9 @@ class BackgroundCompiler:
             user_id: Owner — scopes to this user's data.
             doc: Pre-built NormalizedDocument from the ingest adapter. Passed
                 to the in-process worker to avoid re-reading and re-chunking
-                the source file. Ignored in the ARQ (Redis) path because
-                Pydantic models are not ARQ-serializable.
+                the source file. Not passed in the ARQ (Redis) path — the
+                worker reads clean_text from the Source table instead of
+                needing the in-memory document.
 
         Returns:
             A placeholder job ID string.

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -78,12 +78,13 @@ async def _build_normalized_doc(source: Source) -> NormalizedDocument:
     Raises:
         ValueError: If the source has no ``file_path``.
     """
-    if not source.file_path:
-        msg = "No cleaned text file path for source"
+    content = source.clean_text
+    if content is None and source.file_path:
+        raw_storage = get_raw_storage(source.user_id)
+        content = await raw_storage.read(source.file_path)
+    if content is None:
+        msg = f"No content available for source {source.id}"
         raise ValueError(msg)
-
-    raw_storage = get_raw_storage(source.user_id)
-    content = await raw_storage.read(source.file_path)
 
     return NormalizedDocument(
         raw_source_id=source.id,

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -63,20 +63,21 @@ log = structlog.get_logger()
 
 
 async def _build_normalized_doc(source: Source) -> NormalizedDocument:
-    """Read a source's cleaned text file and build a NormalizedDocument.
+    """Build a NormalizedDocument from a source's content.
 
-    Used as fallback when no pre-built document is passed (ARQ path or
-    recompilation). Every ingest adapter writes a cleaned ``.txt`` and
-    stores its path on the Source record (see issue #59).
+    Reads from ``source.clean_text`` (Postgres) first.  Falls back to
+    the raw ``.txt`` file on disk when ``clean_text`` is ``None``
+    (backward compat with sources ingested before migration 0013).
 
     Args:
-        source: The source record with a non-null ``file_path``.
+        source: The source record.  Must have ``clean_text`` set or a
+            non-null ``file_path`` pointing at the cached text on disk.
 
     Returns:
         A NormalizedDocument ready for compilation.
 
     Raises:
-        ValueError: If the source has no ``file_path``.
+        ValueError: If neither ``clean_text`` nor ``file_path`` provides content.
     """
     content = source.clean_text
     if content is None and source.file_path:

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -11,7 +11,7 @@ from enum import StrEnum
 from typing import Any, Literal, NamedTuple
 
 from pydantic import BaseModel, computed_field
-from sqlalchemy import Column, String, UniqueConstraint
+from sqlalchemy import Column, String, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
@@ -210,6 +210,7 @@ class Source(SQLModel, table=True):
     token_count: int | None = None
     error_message: str | None = None
     file_path: str | None = None  # Path in raw/ directory
+    clean_text: str | None = Field(default=None, sa_type=Text)  # DB-backed source content
     # SHA-256 hex digest of the raw payload (issue #67). Used by the ingest
     # layer to detect duplicates: re-ingesting the same content returns the
     # existing source instead of creating a second row.

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -210,7 +210,9 @@ class Source(SQLModel, table=True):
     token_count: int | None = None
     error_message: str | None = None
     file_path: str | None = None  # Path in raw/ directory
-    clean_text: str | None = Field(default=None, sa_type=Text)  # DB-backed source content
+    clean_text: str | None = Field(
+        default=None, sa_type=Text, exclude=True,
+    )  # DB-backed source content; excluded from API responses
     # SHA-256 hex digest of the raw payload (issue #67). Used by the ingest
     # layer to detect duplicates: re-ingesting the same content returns the
     # existing source instead of creating a second row.

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -211,7 +211,9 @@ class Source(SQLModel, table=True):
     error_message: str | None = None
     file_path: str | None = None  # Path in raw/ directory
     clean_text: str | None = Field(
-        default=None, sa_type=Text, exclude=True,
+        default=None,
+        sa_type=Text,
+        exclude=True,
     )  # DB-backed source content; excluded from API responses
     # SHA-256 hex digest of the raw payload (issue #67). Used by the ingest
     # layer to detect duplicates: re-ingesting the same content returns the

--- a/src/wikimind/services/draft.py
+++ b/src/wikimind/services/draft.py
@@ -169,11 +169,13 @@ class DraftService:
         if guidance:
             draft.user_guidance = guidance
             # Re-read the source and compile with guidance
-            raw_storage = get_raw_storage(user_id)
-            if not source.file_path:
+            content = source.clean_text
+            if content is None and source.file_path:
+                raw_storage = get_raw_storage(user_id)
+                content = await raw_storage.read(source.file_path)
+            if content is None:
                 msg = "Source has no content file"
                 raise NotFoundError(msg)
-            content = await raw_storage.read(source.file_path)
             from wikimind.ingest.service import (  # noqa: PLC0415
                 chunk_text,
                 estimate_tokens,

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -251,23 +251,26 @@ class IngestService:
                 or has no stored file.
         """
         source = await self.get_source(source_id, session, user_id=user_id)
-        if not source.file_path:
+
+        content = source.clean_text
+        if content is None and source.file_path:
+            raw_storage = get_raw_storage(user_id)
+
+            # Defense-in-depth: ensure the resolved path stays under the storage root.
+            resolved = raw_storage.resolve_path(source.file_path).resolve()
+            if not resolved.is_relative_to(raw_storage.resolve_path("").resolve()):
+                msg = "Source content file not found"
+                raise NotFoundError(msg)
+
+            try:
+                content = await raw_storage.read(source.file_path)
+            except OSError as exc:
+                msg = "Source content file not found"
+                raise NotFoundError(msg) from exc
+
+        if content is None:
             msg = "Source has no stored content"
             raise NotFoundError(msg)
-
-        raw_storage = get_raw_storage(user_id)
-
-        # Defense-in-depth: ensure the resolved path stays under the storage root.
-        resolved = raw_storage.resolve_path(source.file_path).resolve()
-        if not resolved.is_relative_to(raw_storage.resolve_path("").resolve()):
-            msg = "Source content file not found"
-            raise NotFoundError(msg)
-
-        try:
-            content = await raw_storage.read(source.file_path)
-        except OSError as exc:
-            msg = "Source content file not found"
-            raise NotFoundError(msg) from exc
 
         truncated = False
         max_chars = get_settings().compiler.source_text_max_chars

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -270,7 +270,7 @@ class TestReconstructNormalizedDoc:
 
     async def test_raises_when_file_path_missing(self) -> None:
         source = Source(source_type=SourceType.TEXT, title="x", file_path=None, user_id=TEST_USER_ID)
-        with pytest.raises(ValueError, match="no file_path"):
+        with pytest.raises(ValueError, match="No content available"):
             await reconstruct_normalized_doc(source)
 
 


### PR DESCRIPTION
## Problem

Web and worker machines on Fly.io have separate volumes. When a source is ingested on the web machine, the raw `.txt` file is written to the web's volume. The ARQ worker on a separate machine can't read it:

```
[Errno 2] No such file or directory: '/home/wikimind/.wikimind/raw/.../source.txt'
```

**Every compilation fails on production.** This also blocks Kubernetes migration (pods are stateless).

## Fix

Store source content in Postgres alongside the filesystem write. The worker reads from DB first, falls back to disk.

### Changes (11 files, 1 new):

**Model**: Added `clean_text: str | None` column to `Source` (with `sa_type=Text`)

**Ingest adapters** (4 files): Each sets `source.clean_text = content` alongside the existing file write:
- `text.py`, `url.py`, `pdf.py`, `youtube.py`

**Read paths** (4 files): DB-first with disk fallback:
```python
content = source.clean_text
if content is None and source.file_path:
    raw_storage = get_raw_storage(source.user_id)
    content = await raw_storage.read(source.file_path)
```
- `worker.py` — `_build_normalized_doc()`
- `ingest/utils.py` — `reconstruct_normalized_doc()`
- `services/draft.py` — draft approval
- `services/ingest.py` — `get_source_content()`

**Migration**: `0013_add_source_clean_text.py` — idempotent, adds `clean_text TEXT` to source table

**Comment fix**: `background.py` — removed wrong claim that "Pydantic models are not ARQ-serializable"

## Test plan

- [ ] CI passes (lint, typecheck, 1606 tests)
- [ ] Migration-replay CI passes (including schema-drift check)
- [ ] Deploy to staging, ingest text, verify compilation succeeds (worker reads from DB)
- [ ] Existing sources with `clean_text=NULL` fall back to disk read

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)