### PR TITLE
fix: add --yes to flyctl deploy for non-interactive CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -237,7 +237,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🚀  Deploy to staging
-        run: flyctl deploy --config fly.staging.toml --image ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }} --remote-only
+        run: flyctl deploy --config fly.staging.toml --image ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }} --remote-only --yes
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -436,7 +436,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🚀  Deploy to production
-        run: flyctl deploy --image ghcr.io/${{ github.repository }}:${{ needs.deploy-staging.outputs.image_tag }} --remote-only
+        run: flyctl deploy --image ghcr.io/${{ github.repository }}:${{ needs.deploy-staging.outputs.image_tag }} --remote-only --yes
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## Problem

Production deploy fails with:
```
Warning! machine 17812531f59238 [worker] has a volume mounted but app config does not specify a volume.
Error: yes flag must be specified when not running interactively
```

A worker machine was manually created with a volume (workaround for #626). `flyctl deploy` detects the mismatch and prompts for confirmation, which fails in CI.

## Fix

Add `--yes` to all `flyctl deploy` commands in the deploy workflow.

## Follow-up

The rogue worker machine with the volume should be destroyed and recreated without a volume (now that #626 stores content in Postgres, workers don't need volumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)