### PR TITLE
fix: store PDF extracted images in Postgres (#638)

### DIFF
--- a/alembic/versions/0014_add_source_image_table.py
+++ b/alembic/versions/0014_add_source_image_table.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
         op.create_table(
             "sourceimage",
             sa.Column("id", sa.String(), primary_key=True),
-            sa.Column("source_id", sa.String(), sa.ForeignKey("source.id"), nullable=False),
+            sa.Column("source_id", sa.String(), sa.ForeignKey("source.id", ondelete="CASCADE"), nullable=False),
             sa.Column("user_id", sa.String(), sa.ForeignKey("user.id"), nullable=False),
             sa.Column("filename", sa.String(), nullable=False),
             sa.Column("kind", sa.String(), nullable=False),

--- a/alembic/versions/0014_add_source_image_table.py
+++ b/alembic/versions/0014_add_source_image_table.py
@@ -1,0 +1,48 @@
+"""Add sourceimage table for DB-backed PDF image storage.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-05-14
+
+Store extracted PDF images in Postgres so the web machine can serve them
+without needing access to the worker machine's filesystem volume (issue #638).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0014"
+down_revision: str = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    if "sourceimage" not in inspector.get_table_names():
+        op.create_table(
+            "sourceimage",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("source_id", sa.String(), sa.ForeignKey("source.id"), nullable=False),
+            sa.Column("user_id", sa.String(), sa.ForeignKey("user.id"), nullable=False),
+            sa.Column("filename", sa.String(), nullable=False),
+            sa.Column("kind", sa.String(), nullable=False),
+            sa.Column("image_data", sa.LargeBinary(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+        )
+        op.create_index("ix_sourceimage_source_id", "sourceimage", ["source_id"])
+        op.create_index("ix_sourceimage_user_id", "sourceimage", ["user_id"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    if "sourceimage" in inspector.get_table_names():
+        op.drop_index("ix_sourceimage_user_id", table_name="sourceimage")
+        op.drop_index("ix_sourceimage_source_id", table_name="sourceimage")
+        op.drop_table("sourceimage")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -268,11 +268,9 @@ paths:
       description: 'List extracted images for a PDF source.
 
 
-        Returns a list of image entries with filename, kind (figure/table),
+        Reads from the ``source_image`` table first (DB-backed storage),
 
-        and label. The actual image bytes are served by the
-
-        ``/sources/{source_id}/images/{filename}`` endpoint.'
+        falling back to the filesystem for pre-migration sources.'
       operationId: list_source_images_api_ingest_sources__source_id__images_get
       parameters:
       - name: source_id
@@ -303,11 +301,9 @@ paths:
       description: 'Serve an extracted image file for a PDF source.
 
 
-        Verifies the source belongs to the authenticated user before serving
+        Reads from the ``source_image`` table first (DB-backed storage),
 
-        the image. Path traversal is prevented by resolving the path and
-
-        checking it stays within the expected directory.'
+        falling back to the filesystem for pre-migration sources.'
       operationId: get_source_image_api_ingest_sources__source_id__images__filename__get
       parameters:
       - name: source_id

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -3,13 +3,20 @@
 import mimetypes
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
 from wikimind.ingest.adapters.pdf import PDFAdapter
-from wikimind.models import IngestTextRequest, IngestURLRequest, Source, SourceContentResponse
+from wikimind.models import (
+    IngestTextRequest,
+    IngestURLRequest,
+    Source,
+    SourceContentResponse,
+    SourceImage,
+)
 from wikimind.services.ingest import IngestService, get_ingest_service
 from wikimind.storage import find_original_sibling, get_raw_storage
 
@@ -163,13 +170,29 @@ async def list_source_images(
 ):
     """List extracted images for a PDF source.
 
-    Returns a list of image entries with filename, kind (figure/table),
-    and label. The actual image bytes are served by the
-    ``/sources/{source_id}/images/{filename}`` endpoint.
+    Reads from the ``source_image`` table first (DB-backed storage),
+    falling back to the filesystem for pre-migration sources.
     """
-    # Verify source exists and belongs to user
     await service.get_source(source_id, session, user_id=user_id)
 
+    # DB-first: query source_image table
+    stmt = (
+        select(SourceImage.filename, SourceImage.kind)
+        .where(SourceImage.source_id == source_id, SourceImage.user_id == user_id)
+        .order_by(SourceImage.filename)
+    )
+    rows = (await session.exec(stmt)).all()
+    if rows:
+        entries = []
+        for filename, kind in rows:
+            stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+            parts = stem.rsplit("-", 1)
+            num = parts[1] if len(parts) == 2 and parts[1].isdigit() else stem
+            label = f"{'Table' if kind == 'table' else 'Figure'} {num}"
+            entries.append({"filename": filename, "kind": kind, "label": label})
+        return entries
+
+    # Filesystem fallback for pre-migration sources
     image_dir = PDFAdapter.get_image_dir(user_id, source_id)
     if not image_dir.is_dir():
         return []
@@ -180,7 +203,6 @@ async def list_source_images(
             continue
         stem = path.stem
         kind = "table" if stem.startswith("table-") else "figure"
-        # Extract the number from e.g. "picture-3" or "table-1"
         parts = stem.rsplit("-", 1)
         num = parts[1] if len(parts) == 2 and parts[1].isdigit() else stem
         label = f"{'Table' if kind == 'table' else 'Figure'} {num}"
@@ -202,26 +224,38 @@ async def get_source_image(
 ):
     """Serve an extracted image file for a PDF source.
 
-    Verifies the source belongs to the authenticated user before serving
-    the image. Path traversal is prevented by resolving the path and
-    checking it stays within the expected directory.
+    Reads from the ``source_image`` table first (DB-backed storage),
+    falling back to the filesystem for pre-migration sources.
     """
-    # Verify source exists and belongs to user
     await service.get_source(source_id, session, user_id=user_id)
 
+    content_type, _ = mimetypes.guess_type(filename)
+    if content_type is None:
+        content_type = "application/octet-stream"
+
+    # DB-first: query source_image table
+    stmt = select(SourceImage.image_data).where(
+        SourceImage.source_id == source_id,
+        SourceImage.user_id == user_id,
+        SourceImage.filename == filename,
+    )
+    row = (await session.exec(stmt)).first()
+    if row is not None:
+        return Response(
+            content=row,
+            media_type=content_type,
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+    # Filesystem fallback for pre-migration sources
     image_dir = PDFAdapter.get_image_dir(user_id, source_id)
     image_path = (image_dir / filename).resolve()
 
-    # Prevent path traversal
     if not image_path.is_relative_to(image_dir.resolve()):
         raise HTTPException(status_code=404, detail="Image not found")
 
     if not image_path.is_file():
         raise HTTPException(status_code=404, detail="Image not found")
-
-    content_type, _ = mimetypes.guess_type(image_path.name)
-    if content_type is None:
-        content_type = "application/octet-stream"
 
     return FileResponse(
         path=str(image_path),

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -10,13 +10,15 @@ extraction to ``~/.wikimind/raw/{source_id}.txt``, with ``Source.file_path``
 pointing at the latter.
 
 Image extraction (issue #378): embedded images are extracted from each page
-via fitz and saved to ``{data_dir}/images/{user_id}/{source_id}/``. The
-images are served by an authenticated API endpoint, not a static mount.
+via fitz and stored in Postgres (``source_image`` table) so both web and
+worker machines can access them without shared volumes (issue #638).
+Filesystem writes are kept as a cache but the DB is the source of truth.
 """
 
 from __future__ import annotations
 
 import base64
+import contextlib
 import re
 from datetime import date
 from pathlib import Path
@@ -253,20 +255,32 @@ class PDFAdapter:
             raise
 
         # Image extraction (issue #378): extract embedded images from the
-        # PDF and save them to a user-scoped directory. This runs after text
-        # extraction so failures don't block the rest of the pipeline.
+        # PDF and store them in Postgres (issue #638). Filesystem writes
+        # are kept as a best-effort cache.
         if settings.image_extraction_enabled:
             try:
-                image_count = self._extract_images(
+                from wikimind.models import SourceImage  # noqa: PLC0415
+
+                extracted = self._extract_images(
                     file_bytes,
                     source.id,
                     user_id,
                     max_images=settings.image_max_per_pdf,
                 )
+                for img_name, img_kind, img_bytes in extracted:
+                    session.add(
+                        SourceImage(
+                            source_id=source.id,
+                            user_id=user_id,
+                            filename=img_name,
+                            kind=img_kind,
+                            image_data=img_bytes,
+                        )
+                    )
                 log.info(
                     "PDF images extracted",
                     source_id=source.id,
-                    image_count=image_count,
+                    image_count=len(extracted),
                 )
             except Exception:
                 log.warning(
@@ -341,12 +355,13 @@ class PDFAdapter:
         source_id: str,
         user_id: str,
         max_images: int = 30,
-    ) -> int:
-        """Extract embedded images from a PDF and save as PNGs.
+    ) -> list[tuple[str, str, bytes]]:
+        """Extract embedded images from a PDF.
 
         Iterates over every page, extracting images via
-        ``page.get_images()`` and saving them to the user-scoped image
-        directory. Images smaller than 5KB are skipped (icons, bullets).
+        ``page.get_images()``. Images smaller than 5KB are skipped
+        (icons, bullets). Returns a list of (filename, kind, image_bytes)
+        tuples for the caller to persist.
 
         Args:
             file_bytes: Raw PDF binary contents.
@@ -355,28 +370,28 @@ class PDFAdapter:
             max_images: Maximum number of images to extract.
 
         Returns:
-            The number of images saved.
+            List of (filename, kind, image_bytes) tuples.
         """
+        # Also write to filesystem as a cache (best-effort)
         out_dir = PDFAdapter.get_image_dir(user_id, source_id)
         out_dir.mkdir(parents=True, exist_ok=True)
 
         doc = fitz.open(stream=file_bytes, filetype="pdf")
-        count = 0
+        results: list[tuple[str, str, bytes]] = []
         pic_idx = 0
         tbl_idx = 0
         seen_xrefs: set[int] = set()
 
         for page_num in range(doc.page_count):
-            if count >= max_images:
+            if len(results) >= max_images:
                 break
             page = doc[page_num]
             image_list = page.get_images(full=True)
 
             for img_info in image_list:
-                if count >= max_images:
+                if len(results) >= max_images:
                     break
                 xref = img_info[0]
-                # Skip duplicate xrefs (same image referenced on multiple pages)
                 if xref in seen_xrefs:
                     continue
                 seen_xrefs.add(xref)
@@ -386,27 +401,29 @@ class PDFAdapter:
                     continue
 
                 image_bytes = base_image["image"]
-                # Skip tiny images (icons, bullets, decorations)
                 if len(image_bytes) < 5000:
                     continue
 
                 ext = base_image.get("ext", "png")
-                # Determine whether this looks like a table or picture
-                # based on aspect ratio: wide+short images are likely tables.
                 width = base_image.get("width", 0)
                 height = base_image.get("height", 0)
                 if width > 0 and height > 0 and width / height > 2.5:
                     tbl_idx += 1
                     filename = f"table-{tbl_idx}.{ext}"
+                    kind = "table"
                 else:
                     pic_idx += 1
                     filename = f"picture-{pic_idx}.{ext}"
+                    kind = "figure"
 
-                (out_dir / filename).write_bytes(image_bytes)
-                count += 1
+                # Best-effort filesystem cache
+                with contextlib.suppress(OSError):
+                    (out_dir / filename).write_bytes(image_bytes)
+
+                results.append((filename, kind, image_bytes))
 
         doc.close()
-        return count
+        return results
 
     async def _extract_via_docling(self, raw_pdf_path: Path, source_id: str, user_id: str) -> tuple[str, int]:
         """Extract PDF text via docling-serve HTTP API.

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -37,7 +37,7 @@ from wikimind.ingest.utils import (
     compute_hash,
     estimate_tokens,
 )
-from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceType, TaskType
+from wikimind.models import IngestStatus, NormalizedDocument, Source, SourceImage, SourceType, TaskType
 from wikimind.storage import get_raw_storage
 
 if TYPE_CHECKING:
@@ -259,8 +259,6 @@ class PDFAdapter:
         # are kept as a best-effort cache.
         if settings.image_extraction_enabled:
             try:
-                from wikimind.models import SourceImage  # noqa: PLC0415
-
                 extracted = self._extract_images(
                     file_bytes,
                     source.id,

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -370,9 +370,10 @@ class PDFAdapter:
         Returns:
             List of (filename, kind, image_bytes) tuples.
         """
-        # Also write to filesystem as a cache (best-effort)
+        # Best-effort filesystem cache directory (non-fatal if unavailable)
         out_dir = PDFAdapter.get_image_dir(user_id, source_id)
-        out_dir.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(OSError):
+            out_dir.mkdir(parents=True, exist_ok=True)
 
         doc = fitz.open(stream=file_bytes, filetype="pdf")
         results: list[tuple[str, str, bytes]] = []

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -11,7 +11,7 @@ from enum import StrEnum
 from typing import Any, Literal, NamedTuple
 
 from pydantic import BaseModel, computed_field
-from sqlalchemy import Column, String, Text, UniqueConstraint
+from sqlalchemy import Column, LargeBinary, String, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
@@ -231,6 +231,22 @@ class Source(SQLModel, table=True):
         raw_storage = get_raw_storage(self.user_id)
         txt_path = raw_storage.resolve_path(self.file_path)
         return find_original_sibling(txt_path) is not None
+
+
+class SourceImage(SQLModel, table=True):
+    """Image extracted from a PDF source, stored in Postgres.
+
+    Replaces filesystem storage so web and worker machines can both
+    access extracted images without shared volumes (issue #638).
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    source_id: str = Field(foreign_key="source.id", index=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
+    filename: str  # e.g. "picture-1.png", "table-2.png"
+    kind: str  # "figure" or "table"
+    image_data: bytes = Field(sa_type=LargeBinary, exclude=True)
+    created_at: datetime = Field(default_factory=utcnow_naive)
 
 
 class Article(SQLModel, table=True):

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -11,7 +11,7 @@ from enum import StrEnum
 from typing import Any, Literal, NamedTuple
 
 from pydantic import BaseModel, computed_field
-from sqlalchemy import Column, LargeBinary, String, Text, UniqueConstraint
+from sqlalchemy import Column, ForeignKey, LargeBinary, String, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
@@ -241,7 +241,9 @@ class SourceImage(SQLModel, table=True):
     """
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
-    source_id: str = Field(foreign_key="source.id", index=True)
+    source_id: str = Field(
+        sa_column=Column(String, ForeignKey("source.id", ondelete="CASCADE"), index=True),
+    )
     user_id: str = Field(foreign_key="user.id", index=True)
     filename: str  # e.g. "picture-1.png", "table-2.png"
     kind: str  # "figure" or "table"

--- a/tests/unit/test_pdf_image_extraction.py
+++ b/tests/unit/test_pdf_image_extraction.py
@@ -122,17 +122,21 @@ class TestExtractImages:
         self,
         isolated_data_dir: Path,
     ) -> None:
-        """Images embedded in a PDF are extracted and saved as files."""
+        """Images embedded in a PDF are extracted and returned as tuples."""
         pdf_bytes = _build_pdf_with_images(["Page with images"], image_count=2)
         source_id = "src-img-001"
 
-        count = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=30)
+        results = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=30)
 
+        assert len(results) > 0
+        for filename, kind, image_bytes in results:
+            assert isinstance(filename, str)
+            assert kind in ("figure", "table")
+            assert len(image_bytes) > 0
+        # Filesystem cache should also exist
         image_dir = isolated_data_dir / "images" / TEST_USER_ID / source_id
         assert image_dir.exists()
-        assert count > 0
-        image_files = list(image_dir.iterdir())
-        assert len(image_files) == count
+        assert len(list(image_dir.iterdir())) == len(results)
 
     def test_respects_max_images_limit(
         self,
@@ -142,16 +146,15 @@ class TestExtractImages:
         pdf_bytes = _build_pdf_with_images(["Page with many images"], image_count=5)
         source_id = "src-img-002"
 
-        count = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=2)
+        results = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=2)
 
-        assert count <= 2
+        assert len(results) <= 2
 
     def test_skips_tiny_images(
         self,
         isolated_data_dir: Path,
     ) -> None:
         """Images smaller than 5KB (icons, bullets) are skipped."""
-        # Build PDF with a very small image (10x10 pixels -> tiny file)
         pdf_bytes = _build_pdf_with_images(
             ["Page with tiny image"],
             image_count=1,
@@ -160,16 +163,15 @@ class TestExtractImages:
         )
         source_id = "src-img-003"
 
-        count = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=30)
+        results = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=30)
 
-        # Tiny images should be filtered out
-        assert count == 0
+        assert len(results) == 0
 
-    def test_no_images_returns_zero(
+    def test_no_images_returns_empty(
         self,
         isolated_data_dir: Path,
     ) -> None:
-        """A text-only PDF produces zero extracted images."""
+        """A text-only PDF produces an empty list."""
         doc = fitz.open()
         page = doc.new_page()
         page.insert_text((72, 72), "Text only, no images")
@@ -178,9 +180,9 @@ class TestExtractImages:
 
         source_id = "src-img-004"
 
-        count = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=30)
+        results = PDFAdapter._extract_images(pdf_bytes, source_id, TEST_USER_ID, max_images=30)
 
-        assert count == 0
+        assert len(results) == 0
 
     def test_user_scoped_directory(
         self,
@@ -228,7 +230,7 @@ class TestIngestWithImageExtraction:
         isolated_data_dir: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """PDFAdapter.ingest extracts images when image_extraction_enabled=True."""
+        """PDFAdapter.ingest extracts images and stores them in the DB."""
         monkeypatch.setattr(
             ingest_service,
             "_convert_via_docling_serve",
@@ -241,10 +243,20 @@ class TestIngestWithImageExtraction:
 
         source, _doc = await adapter.ingest(pdf_bytes, "images.pdf", db_session, user_id=TEST_USER_ID)
 
+        # Images should be stored in the database
+        from sqlalchemy import select as sa_select
+
+        from wikimind.models import SourceImage
+
+        result = await db_session.execute(sa_select(SourceImage).where(SourceImage.source_id == source.id))
+        rows = result.scalars().all()
+        assert len(rows) > 0
+        assert rows[0].kind in ("figure", "table")
+        assert len(rows[0].image_data) > 0
+
+        # Filesystem cache should also exist
         image_dir = isolated_data_dir / "images" / TEST_USER_ID / source.id
         assert image_dir.exists()
-        image_files = list(image_dir.iterdir())
-        assert len(image_files) > 0
 
     async def test_ingest_succeeds_when_image_extraction_disabled(
         self,


### PR DESCRIPTION
## Summary

- PDF images extracted by the worker couldn't be served by the web machine (separate Fly.io volumes)
- Same volume-split pattern as #626 (source text), now fixed for images too
- Adds `sourceimage` table with BYTEA column, migration 0014
- DB-first reads with filesystem fallback for pre-migration sources

## Changes

| File | What |
|------|------|
| `models.py` | New `SourceImage` model |
| `alembic/versions/0014_...` | Migration: create `sourceimage` table |
| `ingest/adapters/pdf.py` | `_extract_images()` returns data, caller saves to DB |
| `api/routes/ingest.py` | `list_source_images` + `get_source_image` read DB first |
| `tests/unit/test_pdf_image_extraction.py` | Updated for new return type + DB assertions |

## Test plan

- [x] `make verify` passes (lint, format, typecheck, 1606 tests)
- [x] PDF image extraction unit tests updated and passing
- [x] Integration test verifies images stored in DB during ingest
- [x] Deploy to staging, upload a PDF, verify images downloadable

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)