### PR TITLE
fix(security): reject empty jwt_secret_key when auth is enabled

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -295,14 +295,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 485
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 497
+        "line_number": 510
       }
     ],
     "src/wikimind/engine/providers/openai.py": [
@@ -355,6 +355,15 @@
         "hashed_secret": "9cea46b39bd44a1ef9f3e71bfe9e45c24d3300f6",
         "is_verified": false,
         "line_number": 210
+      }
+    ],
+    "tests/unit/test_config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config.py",
+        "hashed_secret": "e6dbc31dd1db7a3197c7b3c5cef52af60e4936d3",
+        "is_verified": false,
+        "line_number": 282
       }
     ],
     "tests/unit/test_db_compat.py": [
@@ -424,5 +433,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-12T19:01:45Z"
+  "generated_at": "2026-05-14T19:15:59Z"
 }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -274,10 +274,7 @@ class AuthConfig(BaseModel):
         real secret.
         """
         if self.enabled and not self.jwt_secret_key:
-            msg = (
-                "jwt_secret_key must not be empty when auth is enabled — "
-                "set WIKIMIND_AUTH__JWT_SECRET_KEY"
-            )
+            msg = "jwt_secret_key must not be empty when auth is enabled — set WIKIMIND_AUTH__JWT_SECRET_KEY"
             raise ValueError(msg)
         return self
 

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -274,10 +274,11 @@ class AuthConfig(BaseModel):
         real secret.
         """
         if self.enabled and not self.jwt_secret_key:
-            raise ValueError(
+            msg = (
                 "jwt_secret_key must not be empty when auth is enabled — "
                 "set WIKIMIND_AUTH__JWT_SECRET_KEY"
             )
+            raise ValueError(msg)
         return self
 
 

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -265,6 +265,21 @@ class AuthConfig(BaseModel):
     magic_link_ttl_seconds: int = 600  # 10 minutes
     magic_link_token_length: int = 32  # bytes for secrets.token_urlsafe
 
+    @model_validator(mode="after")
+    def _reject_empty_secret_when_enabled(self) -> AuthConfig:
+        """Prevent auth bypass via empty HMAC secret.
+
+        PyJWT accepts an empty string as a valid HMAC key, so an attacker
+        could forge tokens if the operator enables auth without setting a
+        real secret.
+        """
+        if self.enabled and not self.jwt_secret_key:
+            raise ValueError(
+                "jwt_secret_key must not be empty when auth is enabled — "
+                "set WIKIMIND_AUTH__JWT_SECRET_KEY"
+            )
+        return self
+
 
 # Mapping from provider name → (Settings field for SecretStr key, raw env var name).
 # Used by both `get_api_key` and the auto-enable validator below.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,8 +2,9 @@
 
 import keyring
 import pytest
+from pydantic import ValidationError
 
-from wikimind.config import Settings, _reconcile_providers, get_settings
+from wikimind.config import AuthConfig, Settings, _reconcile_providers, get_settings
 
 
 @pytest.fixture(autouse=True)
@@ -265,3 +266,24 @@ class TestDatabaseUrlRewrite:
     def test_sqlite_default_when_no_env(self):
         s = Settings()
         assert "sqlite+aiosqlite" in s.database_url
+
+
+class TestAuthConfigJwtSecret:
+    """AuthConfig must reject empty jwt_secret_key when auth is enabled (#656)."""
+
+    def test_rejects_empty_secret_when_enabled(self):
+        """An empty secret with auth enabled is an auth bypass — must fail."""
+        with pytest.raises(ValidationError, match="jwt_secret_key must not be empty"):
+            AuthConfig(enabled=True, jwt_secret_key="")
+
+    def test_accepts_real_secret_when_enabled(self):
+        """A non-empty secret with auth enabled is valid."""
+        cfg = AuthConfig(enabled=True, jwt_secret_key="real-secret")
+        assert cfg.jwt_secret_key == "real-secret"
+        assert cfg.enabled is True
+
+    def test_allows_empty_secret_when_disabled(self):
+        """Auth disabled + empty secret is fine — no tokens are verified."""
+        cfg = AuthConfig(enabled=False, jwt_secret_key="")
+        assert cfg.enabled is False
+        assert cfg.jwt_secret_key == ""


### PR DESCRIPTION
## Summary

- `AuthConfig.jwt_secret_key` defaults to `""`. PyJWT accepts tokens signed with an empty HMAC secret, allowing auth bypass when `enabled=True` without setting the secret.
- Added `model_validator` on `AuthConfig` that raises at startup when `enabled=True` and `jwt_secret_key` is falsy.
- 3 new tests covering enabled+empty (rejects), enabled+real (accepts), disabled+empty (accepts).

Closes #656

## Test plan
- [ ] `make verify` passes
- [ ] App refuses to start with `WIKIMIND_AUTH__ENABLED=true` and no `WIKIMIND_AUTH__JWT_SECRET_KEY`
- [ ] App starts normally with auth disabled or with a real secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)