### PR TITLE
fix(security): add URL scheme and host validation to prevent SSRF

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5095,6 +5095,8 @@ components:
       properties:
         url:
           type: string
+          minLength: 1
+          format: uri
           title: Url
         auto_compile:
           type: boolean
@@ -5104,7 +5106,10 @@ components:
       required:
       - url
       title: IngestURLRequest
-      description: Request to ingest a URL.
+      description: 'Request to ingest a URL.
+
+
+        Only ``http`` and ``https`` schemes are accepted (enforced by ``AnyHttpUrl``).'
     Job:
       properties:
         id:

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -31,7 +31,7 @@ async def ingest_url(
     user_id: str = Depends(get_current_user_id),
 ):
     """Ingest a web URL or YouTube video."""
-    return await service.ingest_url(request.url, session, auto_compile=request.auto_compile, user_id=user_id)
+    return await service.ingest_url(str(request.url), session, auto_compile=request.auto_compile, user_id=user_id)
 
 
 @router.post("/pdf", response_model=Source)

--- a/src/wikimind/ingest/adapters/rss.py
+++ b/src/wikimind/ingest/adapters/rss.py
@@ -15,6 +15,7 @@ import structlog
 
 from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
+from wikimind.ingest.utils import validate_url_host
 from wikimind.models import (
     CaptureKind,
     CaptureSource,
@@ -137,6 +138,7 @@ class RssAdapter:
         max_entries = settings.capture.rss_max_entries_per_poll
 
         try:
+            validate_url_host(feed.feed_url)
             async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
                 response = await client.get(
                     feed.feed_url,
@@ -144,7 +146,7 @@ class RssAdapter:
                 )
                 response.raise_for_status()
                 xml_text = response.text
-        except (httpx.HTTPError, OSError) as e:
+        except (httpx.HTTPError, OSError, ValueError) as e:
             log.warning(
                 "RSS fetch failed",
                 feed_id=feed.id,

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -22,6 +22,7 @@ from wikimind.ingest.adapters.pdf import PDFAdapter
 from wikimind.ingest.adapters.text import TextAdapter
 from wikimind.ingest.adapters.url import URLAdapter
 from wikimind.ingest.adapters.youtube import YouTubeAdapter
+from wikimind.ingest.utils import is_youtube_url, validate_url_host
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -58,7 +59,10 @@ class IngestService:
            ``application/pdf``) -> download bytes, delegate to PDFAdapter
         3. Everything else -> URLAdapter (trafilatura HTML extraction)
         """
-        if "youtube.com" in url or "youtu.be" in url:
+        # SSRF protection: reject URLs that resolve to private/loopback
+        validate_url_host(url)
+
+        if is_youtube_url(url):
             return await self.youtube_adapter.ingest(url, session, user_id=user_id)
 
         if self._looks_like_pdf_url(url):
@@ -205,5 +209,7 @@ __all__ = [
     "compute_hash",
     "estimate_tokens",
     "find_source_by_hash",
+    "is_youtube_url",
     "reconstruct_normalized_doc",
+    "validate_url_host",
 ]

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -30,21 +30,21 @@ log = structlog.get_logger()
 # SSRF protection: URL host validation (issue #657)
 # ---------------------------------------------------------------------------
 
-# IPv4 and IPv6 private/reserved networks that MUST be blocked.
-_BLOCKED_NETWORKS = [
-    ipaddress.ip_network("127.0.0.0/8"),  # loopback
-    ipaddress.ip_network("10.0.0.0/8"),  # RFC 1918
-    ipaddress.ip_network("172.16.0.0/12"),  # RFC 1918
-    ipaddress.ip_network("192.168.0.0/16"),  # RFC 1918
-    ipaddress.ip_network("169.254.0.0/16"),  # link-local
-    ipaddress.ip_network("::1/128"),  # IPv6 loopback
-    ipaddress.ip_network("fc00::/7"),  # IPv6 unique-local
-    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
-]
-
 
 def validate_url_host(url: str) -> None:
     """Resolve the URL's hostname and reject private/loopback addresses.
+
+    Uses Python stdlib ``ipaddress.is_global`` instead of a hardcoded
+    CIDR blocklist.  This automatically covers all RFC-mandated
+    non-routable ranges for both IPv4 and IPv6, including carrier-grade
+    NAT (100.64.0.0/10).  Multicast addresses are blocked separately
+    since ``is_global`` returns ``True`` for some multicast ranges.
+
+    IPv4-mapped IPv6 addresses (e.g. ``::ffff:127.0.0.1``) are unwrapped
+    before the check so they cannot bypass the filter.
+
+    Note: This validates the initial URL only. DNS rebinding and HTTP redirects
+    to internal addresses are not yet mitigated (requires transport-level hooks).
 
     Raises:
         ValueError: If the hostname resolves to a private, loopback, or
@@ -64,10 +64,12 @@ def validate_url_host(url: str) -> None:
 
     for _family, _type, _proto, _canonname, sockaddr in addr_infos:
         ip = ipaddress.ip_address(sockaddr[0])
-        for network in _BLOCKED_NETWORKS:
-            if ip in network:
-                msg = f"URL host {hostname!r} resolves to private/reserved address {ip} (blocked)"
-                raise ValueError(msg)
+        # Unwrap IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1 -> 127.0.0.1)
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
+        if not ip.is_global or ip.is_multicast:
+            msg = f"URL host {hostname!r} resolves to blocked address {ip}"
+            raise ValueError(msg)
 
 
 def is_youtube_url(url: str) -> bool:

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -1,14 +1,18 @@
 """Shared utilities for the ingest subsystem.
 
-Content-hash deduplication helpers, token estimation, and text chunking
-functions used by all adapters and the orchestrating IngestService.
+Content-hash deduplication helpers, token estimation, text chunking,
+and URL security validation functions used by all adapters and the
+orchestrating IngestService.
 """
 
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import re
+import socket
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 import structlog
 from sqlmodel import select
@@ -20,6 +24,67 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# SSRF protection: URL host validation (issue #657)
+# ---------------------------------------------------------------------------
+
+# IPv4 and IPv6 private/reserved networks that MUST be blocked.
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),  # loopback
+    ipaddress.ip_network("10.0.0.0/8"),  # RFC 1918
+    ipaddress.ip_network("172.16.0.0/12"),  # RFC 1918
+    ipaddress.ip_network("192.168.0.0/16"),  # RFC 1918
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local
+    ipaddress.ip_network("::1/128"),  # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),  # IPv6 unique-local
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+]
+
+
+def validate_url_host(url: str) -> None:
+    """Resolve the URL's hostname and reject private/loopback addresses.
+
+    Raises:
+        ValueError: If the hostname resolves to a private, loopback, or
+            link-local address, or if the hostname cannot be resolved.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        msg = f"URL has no hostname: {url}"
+        raise ValueError(msg)
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        msg = f"Cannot resolve hostname {hostname!r}: {exc}"
+        raise ValueError(msg) from exc
+
+    for _family, _type, _proto, _canonname, sockaddr in addr_infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        for network in _BLOCKED_NETWORKS:
+            if ip in network:
+                msg = f"URL host {hostname!r} resolves to private/reserved address {ip} (blocked)"
+                raise ValueError(msg)
+
+
+def is_youtube_url(url: str) -> bool:
+    """Return True if *url* is a genuine YouTube video URL.
+
+    Uses ``urllib.parse.urlparse`` to check the hostname, preventing
+    bypass via path-based tricks like ``http://evil.com/youtube.com/``.
+    """
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+    return hostname in {
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+    }
 
 
 def estimate_tokens(text: str) -> int:

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -10,7 +10,7 @@ from datetime import date, datetime
 from enum import StrEnum
 from typing import Any, Literal, NamedTuple
 
-from pydantic import BaseModel, computed_field
+from pydantic import AnyHttpUrl, BaseModel, computed_field
 from sqlalchemy import Column, ForeignKey, LargeBinary, String, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -1164,9 +1164,12 @@ class ResolveContradictionRequest(BaseModel):
 
 
 class IngestURLRequest(BaseModel):
-    """Request to ingest a URL."""
+    """Request to ingest a URL.
 
-    url: str
+    Only ``http`` and ``https`` schemes are accepted (enforced by ``AnyHttpUrl``).
+    """
+
+    url: AnyHttpUrl
     auto_compile: bool = True
 
 

--- a/tests/unit/test_ingest_service.py
+++ b/tests/unit/test_ingest_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from tests.conftest import TEST_USER_ID
 from wikimind.ingest import service as svc_mod
@@ -24,8 +25,8 @@ from wikimind.ingest.adapters.text import TextAdapter
 from wikimind.ingest.adapters.url import URLAdapter
 from wikimind.ingest.adapters.youtube import YouTubeAdapter
 from wikimind.ingest.service import IngestService
-from wikimind.ingest.utils import chunk_text, estimate_tokens
-from wikimind.models import IngestStatus, Source, SourceType
+from wikimind.ingest.utils import chunk_text, estimate_tokens, is_youtube_url, validate_url_host
+from wikimind.models import IngestStatus, IngestURLRequest, Source, SourceType
 
 
 def test_estimate_tokens() -> None:
@@ -553,3 +554,99 @@ async def test_pdf_adapter_filename_fallback(db_session, monkeypatch) -> None:
         adapter = PDFAdapter()
         source, _ = await adapter.ingest(b"%PDF-1.4...", "report.pdf", db_session, user_id=TEST_USER_ID)
     assert source.title == "report"
+
+
+# ---------------------------------------------------------------------------
+# SSRF protection tests (issue #657)
+# ---------------------------------------------------------------------------
+
+
+class TestIngestURLRequestSchemeValidation:
+    """IngestURLRequest.url rejects non-HTTP(S) schemes via AnyHttpUrl."""
+
+    def test_http_url_accepted(self) -> None:
+        req = IngestURLRequest(url="http://example.com/page")
+        assert str(req.url) == "http://example.com/page"
+
+    def test_https_url_accepted(self) -> None:
+        req = IngestURLRequest(url="https://example.com/page")
+        assert str(req.url) == "https://example.com/page"
+
+    def test_file_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            IngestURLRequest(url="file:///etc/passwd")
+
+    def test_ftp_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            IngestURLRequest(url="ftp://internal.host/data")
+
+    def test_gopher_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            IngestURLRequest(url="gopher://internal.host/data")
+
+    def test_bare_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            IngestURLRequest(url="not-a-url")
+
+
+class TestValidateUrlHost:
+    """validate_url_host() rejects private and loopback resolved addresses."""
+
+    def test_localhost_rejected(self) -> None:
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_url_host("http://localhost/secret")
+
+    def test_loopback_ip_rejected(self) -> None:
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_url_host("http://127.0.0.1/secret")
+
+    def test_link_local_rejected(self) -> None:
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_url_host("http://169.254.169.254/latest/meta-data/")
+
+    def test_private_10_rejected(self) -> None:
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_url_host("http://10.0.0.1/internal")
+
+    def test_private_192_168_rejected(self) -> None:
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_url_host("http://192.168.1.1/admin")
+
+    def test_private_172_16_rejected(self) -> None:
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_url_host("http://172.16.0.1/internal")
+
+    def test_public_url_passes(self) -> None:
+        # Should not raise — example.com resolves to a public address
+        validate_url_host("http://example.com")
+
+    def test_no_hostname_rejected(self) -> None:
+        with pytest.raises(ValueError, match="no hostname"):
+            validate_url_host("http://")
+
+    def test_unresolvable_host_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Cannot resolve"):
+            validate_url_host("http://this-host-definitely-does-not-exist.invalid/x")
+
+
+class TestIsYoutubeUrl:
+    """is_youtube_url() uses hostname comparison, not string-contains."""
+
+    def test_standard_youtube(self) -> None:
+        assert is_youtube_url("https://www.youtube.com/watch?v=abc") is True
+
+    def test_short_youtube(self) -> None:
+        assert is_youtube_url("https://youtu.be/abc") is True
+
+    def test_mobile_youtube(self) -> None:
+        assert is_youtube_url("https://m.youtube.com/watch?v=abc") is True
+
+    def test_youtube_in_path_not_matched(self) -> None:
+        """URL with youtube.com in the *path* (not host) must NOT match."""
+        assert is_youtube_url("http://evil.com/youtube.com/watch?v=x") is False
+
+    def test_youtube_as_subdomain_not_matched(self) -> None:
+        assert is_youtube_url("http://youtube.com.evil.com/watch?v=x") is False
+
+    def test_plain_url_not_matched(self) -> None:
+        assert is_youtube_url("https://example.com/article") is False

--- a/tests/unit/test_ingest_service.py
+++ b/tests/unit/test_ingest_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -593,28 +594,67 @@ class TestValidateUrlHost:
     """validate_url_host() rejects private and loopback resolved addresses."""
 
     def test_localhost_rejected(self) -> None:
-        with pytest.raises(ValueError, match="private/reserved"):
+        with pytest.raises(ValueError, match="blocked address"):
             validate_url_host("http://localhost/secret")
 
     def test_loopback_ip_rejected(self) -> None:
-        with pytest.raises(ValueError, match="private/reserved"):
+        with pytest.raises(ValueError, match="blocked address"):
             validate_url_host("http://127.0.0.1/secret")
 
     def test_link_local_rejected(self) -> None:
-        with pytest.raises(ValueError, match="private/reserved"):
+        with pytest.raises(ValueError, match="blocked address"):
             validate_url_host("http://169.254.169.254/latest/meta-data/")
 
     def test_private_10_rejected(self) -> None:
-        with pytest.raises(ValueError, match="private/reserved"):
+        with pytest.raises(ValueError, match="blocked address"):
             validate_url_host("http://10.0.0.1/internal")
 
     def test_private_192_168_rejected(self) -> None:
-        with pytest.raises(ValueError, match="private/reserved"):
+        with pytest.raises(ValueError, match="blocked address"):
             validate_url_host("http://192.168.1.1/admin")
 
     def test_private_172_16_rejected(self) -> None:
-        with pytest.raises(ValueError, match="private/reserved"):
+        with pytest.raises(ValueError, match="blocked address"):
             validate_url_host("http://172.16.0.1/internal")
+
+    def test_ipv4_mapped_ipv6_rejected(self) -> None:
+        """IPv4-mapped IPv6 addresses like ::ffff:127.0.0.1 must be blocked."""
+        with (
+            patch(
+                "wikimind.ingest.utils.socket.getaddrinfo",
+                return_value=[
+                    (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:127.0.0.1", 0, 0, 0)),
+                ],
+            ),
+            pytest.raises(ValueError, match="blocked address"),
+        ):
+            validate_url_host("http://evil.com/secret")
+
+    def test_carrier_grade_nat_rejected(self) -> None:
+        """100.64.0.0/10 (carrier-grade NAT, RFC 6598) must be blocked."""
+        with (
+            patch(
+                "wikimind.ingest.utils.socket.getaddrinfo",
+                return_value=[
+                    (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("100.64.0.1", 0)),
+                ],
+            ),
+            pytest.raises(ValueError, match="blocked address"),
+        ):
+            validate_url_host("http://carrier-nat.example.com")
+
+    def test_zero_address_rejected(self) -> None:
+        """0.0.0.0 must be blocked."""
+        with (
+            patch(
+                "wikimind.ingest.utils.socket.getaddrinfo",
+                return_value=[
+                    (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("0.0.0.0", 0)),
+                ],
+            ),
+            pytest.raises(ValueError, match="blocked address"),
+        ):
+            validate_url_host("http://zero.example.com")
 
     def test_public_url_passes(self) -> None:
         # Should not raise — example.com resolves to a public address


### PR DESCRIPTION
## Summary

- Ingest URL input had no scheme or host validation — `file://`, loopback, and private CIDRs passed directly to `httpx.get()`.
- Changed `IngestURLRequest.url` from bare `str` to `AnyHttpUrl` (enforces http/https scheme).
- Added `validate_url_host()` that resolves hostname and checks against private/loopback CIDR blocklist before any HTTP fetch.
- Fixed YouTube URL detection: replaced bypassable `"youtube.com" in url` string check with proper `urlparse` host comparison.
- 21 new tests covering scheme rejection, host validation, and YouTube detection.

Closes #657

## Test plan
- [ ] `make verify` passes
- [ ] `file://`, `ftp://` URLs rejected at validation layer
- [ ] `http://localhost`, `http://127.0.0.1`, `http://169.254.169.254` rejected
- [ ] Normal `http://example.com` URLs accepted
- [ ] YouTube detection not bypassable with `http://evil.com/youtube.com/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)