### PR TITLE
fix(security): add path traversal guard to LocalFileStorage._resolve

### DIFF
--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -137,7 +137,10 @@ async def get_source_original(
         raise HTTPException(status_code=404, detail="No original document available")
 
     raw_storage = get_raw_storage(user_id)
-    txt_path = raw_storage.resolve_path(source.file_path)
+    try:
+        txt_path = raw_storage.resolve_path(source.file_path)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="No original document available") from None
     original = find_original_sibling(txt_path)
     if original is None:
         raise HTTPException(status_code=404, detail="No original document available")

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -656,7 +656,11 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
     cleaned = 0
     for article in concept_articles:
         wiki_storage = get_wiki_storage(article.user_id)
-        if await wiki_storage.exists(article.file_path):
+        try:
+            exists = await wiki_storage.exists(article.file_path)
+        except ValueError:
+            exists = False
+        if exists:
             continue
 
         # Remove backlinks referencing the orphaned article first.
@@ -678,7 +682,7 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
             "startup: removed orphaned concept page (file missing)",
             article_id=article.id,
             slug=article.slug,
-            path=str(wiki_storage.resolve_path(article.file_path)),
+            path=article.file_path,
         )
 
     if cleaned:

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -62,11 +62,14 @@ async def _sweep_single_article(
 
     uid = article.user_id
     wiki_storage = get_wiki_storage(uid)
-    if not await wiki_storage.exists(article.file_path):
+    try:
+        file_exists = await wiki_storage.exists(article.file_path)
+    except ValueError:
+        file_exists = False
+    if not file_exists:
         log.warning(
-            "sweep: file not found, skipping",
+            "sweep: file not found or invalid path, skipping",
             article_id=article.id,
-            path=str(wiki_storage.resolve_path(article.file_path)),
         )
         return False
 
@@ -161,7 +164,11 @@ async def _cleanup_orphaned_concept_pages(
     wiki_storage = get_wiki_storage(user_id)
     cleaned = 0
     for article in concept_articles:
-        if await wiki_storage.exists(article.file_path):
+        try:
+            exists = await wiki_storage.exists(article.file_path)
+        except ValueError:
+            exists = False
+        if exists:
             continue
 
         # Bulk-delete backlinks referencing the orphaned article to avoid

--- a/src/wikimind/models.py
+++ b/src/wikimind/models.py
@@ -229,7 +229,10 @@ class Source(SQLModel, table=True):
         from wikimind.storage import find_original_sibling, get_raw_storage  # noqa: PLC0415
 
         raw_storage = get_raw_storage(self.user_id)
-        txt_path = raw_storage.resolve_path(self.file_path)
+        try:
+            txt_path = raw_storage.resolve_path(self.file_path)
+        except ValueError:
+            return False
         return find_original_sibling(txt_path) is not None
 
 

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -329,17 +329,18 @@ class IngestService:
         """
         raw_storage = get_raw_storage(source.user_id)
         if source.file_path:
-            resolved = raw_storage.resolve_path(source.file_path)
-            with suppress(OSError):
+            with suppress(OSError, ValueError):
+                resolved = raw_storage.resolve_path(source.file_path)
                 resolved.unlink(missing_ok=True)
 
         # Use the storage root to find sibling files
-        raw_dir = raw_storage.resolve_path("")
-        if not raw_dir.is_dir():
-            return
-        for sibling in raw_dir.glob(f"{source.id}.*"):
-            with suppress(OSError):
-                sibling.unlink(missing_ok=True)
+        with suppress(ValueError):
+            raw_dir = raw_storage.resolve_path("")
+            if not raw_dir.is_dir():
+                return
+            for sibling in raw_dir.glob(f"{source.id}.*"):
+                with suppress(OSError):
+                    sibling.unlink(missing_ok=True)
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -256,15 +256,9 @@ class IngestService:
         if content is None and source.file_path:
             raw_storage = get_raw_storage(user_id)
 
-            # Defense-in-depth: ensure the resolved path stays under the storage root.
-            resolved = raw_storage.resolve_path(source.file_path).resolve()
-            if not resolved.is_relative_to(raw_storage.resolve_path("").resolve()):
-                msg = "Source content file not found"
-                raise NotFoundError(msg)
-
             try:
                 content = await raw_storage.read(source.file_path)
-            except OSError as exc:
+            except (OSError, ValueError) as exc:
                 msg = "Source content file not found"
                 raise NotFoundError(msg) from exc
 

--- a/src/wikimind/storage.py
+++ b/src/wikimind/storage.py
@@ -67,7 +67,11 @@ class LocalFileStorage:
         self.root = root
 
     def _resolve(self, relative_path: str) -> Path:
-        return self.root / relative_path
+        resolved = (self.root / relative_path).resolve()
+        if not resolved.is_relative_to(self.root.resolve()):
+            msg = f"Path traversal detected: {relative_path!r}"
+            raise ValueError(msg)
+        return resolved
 
     def resolve_path(self, relative_path: str) -> Path:
         """Resolve a relative path to an absolute filesystem path.
@@ -170,7 +174,7 @@ async def read_article_content(file_path: str, user_id: str) -> str:
     try:
         storage = get_wiki_storage(user_id)
         return await storage.read(file_path)
-    except OSError:
+    except (OSError, ValueError):
         return ""
 
 

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -64,15 +64,20 @@ async def test_ask_with_file_back_creates_article_end_to_end(
     """
     # Seed an article so _retrieve_context returns a non-empty list and the
     # agent takes the _query_llm branch (not the empty-context shortcut).
-    article_md = tmp_path / "knowledge.md"
-    article_md.write_text(
+    from pathlib import Path as _Path
+
+    from wikimind.config import get_settings as _gs
+
+    wiki_dir = _Path(_gs().data_dir) / "wiki" / ANONYMOUS_USER_ID
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    (wiki_dir / "knowledge.md").write_text(
         "# Knowledge\n\nThe wikimind project answers questions from sources.",
         encoding="utf-8",
     )
     seed = Article(
         slug="knowledge",
         title="Knowledge",
-        file_path=str(article_md),
+        file_path="knowledge.md",
         summary="seed article",
         user_id=ANONYMOUS_USER_ID,
     )
@@ -269,10 +274,9 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
         agent = QAAgent()
 
     # Seed a fixture article on disk so retrieval has something real to find
-    wiki_dir = data_dir / "wiki"
+    wiki_dir = data_dir / "wiki" / ANONYMOUS_USER_ID
     wiki_dir.mkdir(parents=True, exist_ok=True)
-    fixture_path = wiki_dir / "fixture-source.md"
-    fixture_path.write_text(
+    (wiki_dir / "fixture-source.md").write_text(
         "# Fixture Source\n\nThe Karpathy loop is the core mechanism of WikiMind."
         " It compounds explorations into the wiki.\n",
         encoding="utf-8",
@@ -282,7 +286,7 @@ async def test_filed_back_conversation_is_retrievable_by_next_query(
             id="art-fixture",
             slug="fixture-source",
             title="Fixture Source",
-            file_path=str(fixture_path),
+            file_path="fixture-source.md",
             summary="A fixture article for the loop closure test.",
             created_at=utcnow_naive(),
             updated_at=utcnow_naive(),

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -15,6 +15,7 @@ Article so retrieval has something to find, and runs the full
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
@@ -64,11 +65,9 @@ async def test_ask_with_file_back_creates_article_end_to_end(
     """
     # Seed an article so _retrieve_context returns a non-empty list and the
     # agent takes the _query_llm branch (not the empty-context shortcut).
-    from pathlib import Path as _Path
-
     from wikimind.config import get_settings as _gs
 
-    wiki_dir = _Path(_gs().data_dir) / "wiki" / ANONYMOUS_USER_ID
+    wiki_dir = Path(_gs().data_dir) / "wiki" / ANONYMOUS_USER_ID
     wiki_dir.mkdir(parents=True, exist_ok=True)
     (wiki_dir / "knowledge.md").write_text(
         "# Knowledge\n\nThe wikimind project answers questions from sources.",

--- a/tests/integration/test_sweep_integration.py
+++ b/tests/integration/test_sweep_integration.py
@@ -10,20 +10,26 @@ Scenario:
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
+from tests.conftest import TEST_USER_ID
 from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
 from wikimind.jobs.sweep import sweep_wikilinks
 from wikimind.models import Article, Backlink, ConfidenceLevel, Job, JobStatus, JobType
 
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
+
+def _wiki_root() -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 async def _make_article(
@@ -51,17 +57,17 @@ async def _make_article(
 @pytest.mark.asyncio
 async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engine, tmp_path: Path) -> None:
     """Full sweep resolves brackets as target articles appear over time."""
+    wiki = _wiki_root()
     # --- Setup: article B exists, article C does not yet exist ---
-    article_b = await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"), slug="machine-learning")
+    article_b = await _make_article(db_session, "Machine Learning", "ml.md", slug="machine-learning")
 
     # Article A has brackets for both B and C (C does not exist yet)
-    a_md = tmp_path / "overview.md"
-    a_md.write_text(
+    (wiki / "overview.md").write_text(
         "# AI Overview\n\n"
         "See [[Machine Learning]] for the basics.\n\n"
         "Also check [[Deep Learning]] for advanced topics.\n"
     )
-    article_a = await _make_article(db_session, "AI Overview", str(a_md), slug="ai-overview")
+    article_a = await _make_article(db_session, "AI Overview", "overview.md", slug="ai-overview")
 
     # Build a real session factory backed by the same in-memory engine
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
@@ -71,7 +77,7 @@ async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engi
         await sweep_wikilinks({}, user_id=TEST_USER_ID)
 
     # Assert: Machine Learning bracket resolved
-    content_after_phase1 = a_md.read_text()
+    content_after_phase1 = (wiki / "overview.md").read_text()
     assert f"[Machine Learning](/wiki/{article_b.id})" in content_after_phase1
     assert "[[Machine Learning]]" not in content_after_phase1
 
@@ -100,7 +106,7 @@ async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engi
             id=str(uuid.uuid4()),
             slug="deep-learning",
             title="Deep Learning",
-            file_path=str(tmp_path / "dl.md"),
+            file_path="dl.md",
             confidence=ConfidenceLevel.SOURCED,
             created_at=utcnow_naive(),
             user_id=TEST_USER_ID,
@@ -113,7 +119,7 @@ async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engi
         await sweep_wikilinks({}, user_id=TEST_USER_ID)
 
     # Assert: Deep Learning bracket now resolved
-    content_after_phase2 = a_md.read_text()
+    content_after_phase2 = (wiki / "overview.md").read_text()
     assert f"[Deep Learning](/wiki/{article_c.id})" in content_after_phase2
     assert "[[Deep Learning]]" not in content_after_phase2
 
@@ -135,4 +141,4 @@ async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engi
         await sweep_wikilinks({}, user_id=TEST_USER_ID)
 
     # Content unchanged
-    assert a_md.read_text() == content_after_phase2
+    assert (wiki / "overview.md").read_text() == content_after_phase2

--- a/tests/unit/test_backlink_enforcer.py
+++ b/tests/unit/test_backlink_enforcer.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
+from tests.conftest import TEST_USER_ID
+from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.config import get_settings
 from wikimind.engine.backlink_enforcer import enforce_backlinks, ensure_bidirectional
 from wikimind.engine.linter.contradictions import detect_contradictions
@@ -23,10 +25,13 @@ from wikimind.models import (
     RelationType,
 )
 
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
-from wikimind.api.deps import ANONYMOUS_USER_ID
+
+def _wiki_root() -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 def _make_article(
@@ -39,7 +44,8 @@ def _make_article(
     page_type: PageType = PageType.SOURCE,
     claims: list[str] | None = None,
 ) -> Article:
-    file_path = tmp_path / f"{slug}.md"
+    wiki = _wiki_root()
+    file_path = wiki / f"{slug}.md"
     body_lines = [f"# {title}", ""]
     if claims:
         body_lines.append("## Key Claims")
@@ -52,7 +58,7 @@ def _make_article(
         id=article_id,
         slug=slug,
         title=title,
-        file_path=str(file_path),
+        file_path=f"{slug}.md",
         concept_ids=json.dumps(concept_ids) if concept_ids else None,
         page_type=page_type,
         user_id=TEST_USER_ID,

--- a/tests/unit/test_concept_recompilation.py
+++ b/tests/unit/test_concept_recompilation.py
@@ -9,13 +9,14 @@ Verifies that:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from slugify import slugify
 
+from tests.conftest import TEST_USER_ID
 from wikimind.engine.compiler import Compiler
 from wikimind.engine.concept_compiler import ConceptCompiler
 from wikimind.models import (
@@ -31,10 +32,6 @@ from wikimind.models import (
     Source,
 )
 from wikimind.services.taxonomy import _concept_source_set_changed, maybe_trigger_concept_pages
-
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
 
 
 def _fake_concept_resp(name: str = "Test") -> str:
@@ -66,14 +63,15 @@ async def _seed_kind(session, name: str = "topic") -> ConceptKindDef:
 
 
 async def _mk_source_article(session, tmp_path: Path, slug: str, title: str, concepts: list[str]) -> Article:
-    d = tmp_path / "wiki" / "test"
-    d.mkdir(parents=True, exist_ok=True)
-    fp = d / f"{slug}.md"
-    fp.write_text(f"# {title}\nSummary text.", encoding="utf-8")
+    from wikimind.config import get_settings as _gs
+
+    wiki = Path(_gs().data_dir) / "wiki" / TEST_USER_ID
+    wiki.mkdir(parents=True, exist_ok=True)
+    (wiki / f"{slug}.md").write_text(f"# {title}\nSummary text.", encoding="utf-8")
     a = Article(
         slug=slug,
         title=title,
-        file_path=str(fp),
+        file_path=f"{slug}.md",
         summary="Sum.",
         concept_ids=json.dumps(concepts),
         page_type=PageType.SOURCE,
@@ -106,8 +104,10 @@ def _mock_router(name: str = "ML") -> MagicMock:
 
 
 def _settings(tmp_path: Path, min_sources: int = 2) -> SimpleNamespace:
+    from wikimind.config import get_settings as _gs
+
     return SimpleNamespace(
-        data_dir=str(tmp_path),
+        data_dir=_gs().data_dir,
         taxonomy=SimpleNamespace(concept_page_min_sources=min_sources),
         compiler=SimpleNamespace(max_tokens=8192, source_text_max_chars=60000, concept_source_max_chars=5000),
     )
@@ -223,6 +223,12 @@ class TestReplaceArticleTriggersConceptPages:
 
     async def test_replace_calls_maybe_trigger(self, db_session, tmp_path):
         """Verify that _upsert_article invokes maybe_trigger_concept_pages when replacing."""
+        from wikimind.config import get_settings as _gs
+
+        settings = _gs()
+        wiki = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+        wiki.mkdir(parents=True, exist_ok=True)
+
         # Create a source.
         source = Source(
             title="Test Source",
@@ -236,14 +242,11 @@ class TestReplaceArticleTriggersConceptPages:
         await db_session.refresh(source)
 
         # Create an existing article for this source.
-        d = tmp_path / "wiki" / "test"
-        d.mkdir(parents=True, exist_ok=True)
-        fp = d / "test-article.md"
-        fp.write_text("# Test\nOld content.", encoding="utf-8")
+        (wiki / "test-article.md").write_text("# Test\nOld content.", encoding="utf-8")
         existing = Article(
             slug="test-article",
             title="Test Article",
-            file_path=str(fp),
+            file_path="test-article.md",
             summary="Old summary.",
             source_ids=json.dumps([source.id]),
             concept_ids=json.dumps(["ml"]),

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import contextlib
 import json
 import uuid
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
+from tests.conftest import TEST_USER_ID
+from wikimind.config import get_settings
 from wikimind.database import (
     _cleanup_orphan_concept_rows,
     _repair_json_array,
@@ -19,9 +21,13 @@ from wikimind.database import (
 )
 from wikimind.models import Article, Backlink, ConfidenceLevel, PageType, Source, SourceType
 
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
+
+def _wiki_root() -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 @pytest.fixture
@@ -195,11 +201,12 @@ class TestRepairMalformedJsonArraysMigration:
 class TestCleanupOrphanConceptRows:
     async def test_deletes_concept_article_with_missing_file(self, db_session, tmp_path: Path):
         """Concept article whose .md file doesn't exist on disk is deleted."""
+        _wiki_root()
         article = Article(
             id=str(uuid.uuid4()),
             slug="concept-stale-topic",
             title="Stale Topic",
-            file_path=str(tmp_path / "concept-stale-topic" / "concept-stale-topic.md"),
+            file_path="concept-stale-topic/concept-stale-topic.md",
             page_type=PageType.CONCEPT,
             user_id=TEST_USER_ID,
         )
@@ -213,16 +220,16 @@ class TestCleanupOrphanConceptRows:
 
     async def test_keeps_concept_article_with_existing_file(self, db_session, tmp_path: Path):
         """Concept article whose .md file exists on disk is preserved."""
-        md_dir = tmp_path / "concept-active-topic"
-        md_dir.mkdir(parents=True)
-        md_file = md_dir / "concept-active-topic.md"
-        md_file.write_text("# Active Topic\n")
+        wiki = _wiki_root()
+        md_dir = wiki / "concept-active-topic"
+        md_dir.mkdir(parents=True, exist_ok=True)
+        (md_dir / "concept-active-topic.md").write_text("# Active Topic\n")
 
         article = Article(
             id=str(uuid.uuid4()),
             slug="concept-active-topic",
             title="Active Topic",
-            file_path=str(md_file),
+            file_path="concept-active-topic/concept-active-topic.md",
             page_type=PageType.CONCEPT,
             user_id=TEST_USER_ID,
         )
@@ -236,11 +243,12 @@ class TestCleanupOrphanConceptRows:
 
     async def test_leaves_source_articles_untouched(self, db_session, tmp_path: Path):
         """Source articles with missing files are NOT cleaned up (only concepts)."""
+        _wiki_root()
         article = Article(
             id=str(uuid.uuid4()),
             slug="some-source",
             title="Some Source",
-            file_path=str(tmp_path / "missing-source.md"),
+            file_path="missing-source.md",
             page_type=PageType.SOURCE,
             user_id=TEST_USER_ID,
         )
@@ -254,22 +262,22 @@ class TestCleanupOrphanConceptRows:
 
     async def test_deletes_associated_backlinks(self, db_session, tmp_path: Path):
         """Backlinks referencing an orphaned concept article are also deleted."""
+        wiki = _wiki_root()
         orphan = Article(
             id=str(uuid.uuid4()),
             slug="concept-orphan",
             title="Orphan Concept",
-            file_path=str(tmp_path / "concept-orphan" / "concept-orphan.md"),
+            file_path="concept-orphan/concept-orphan.md",
             page_type=PageType.CONCEPT,
             user_id=TEST_USER_ID,
         )
         # A surviving article that links to the orphan
-        md_file = tmp_path / "surviving.md"
-        md_file.write_text("# Surviving\n")
+        (wiki / "surviving.md").write_text("# Surviving\n")
         survivor = Article(
             id=str(uuid.uuid4()),
             slug="surviving-article",
             title="Surviving Article",
-            file_path=str(md_file),
+            file_path="surviving.md",
             page_type=PageType.SOURCE,
             user_id=TEST_USER_ID,
         )

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -421,8 +421,9 @@ class TestServiceSkipsEnqueueOnDedupHit:
         # content we are about to ingest, so the adapter dedup hit path fires.
         body = "already compiled body"
         digest = compute_hash(body.encode("utf-8"))
-        text_path = isolated_data_dir / "raw" / "seed.txt"
-        text_path.write_text(body, encoding="utf-8")
+        raw_dir = isolated_data_dir / "raw" / TEST_USER_ID
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "seed.txt").write_text(body, encoding="utf-8")
 
         existing = Source(
             source_type=SourceType.TEXT,
@@ -430,7 +431,7 @@ class TestServiceSkipsEnqueueOnDedupHit:
             content_hash=digest,
             status=IngestStatus.COMPILED,
             compiled_at=utcnow_naive(),
-            file_path=str(text_path),
+            file_path="seed.txt",
             user_id=TEST_USER_ID,
         )
         db_session.add(existing)

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -120,13 +121,16 @@ class TestGracefulDegradation:
     @pytest.mark.asyncio
     async def test_wiki_search_works_without_search_extras(self, db_session, tmp_path):
         """WikiService.search falls back to keyword-only when extras are missing."""
-        fp = tmp_path / "test.md"
-        fp.write_text("# Deep Learning\n\nNeural network architectures.", encoding="utf-8")
+        from wikimind.config import get_settings as _gs
+
+        wiki = Path(_gs().data_dir) / "wiki" / TEST_USER_ID
+        wiki.mkdir(parents=True, exist_ok=True)
+        (wiki / "test.md").write_text("# Deep Learning\n\nNeural network architectures.", encoding="utf-8")
 
         article = Article(
             slug="deep-learning",
             title="Deep Learning",
-            file_path=str(fp),
+            file_path="test.md",
             summary="About deep learning.",
             user_id=TEST_USER_ID,
         )

--- a/tests/unit/test_enforcer_integration.py
+++ b/tests/unit/test_enforcer_integration.py
@@ -3,19 +3,25 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlmodel import select
 
+from tests.conftest import TEST_USER_ID
+from wikimind.config import get_settings
 from wikimind.engine.linter.runner import run_lint
 from wikimind.models import Article, Backlink, LintReportStatus, PageType, RelationType, StructuralFinding
 from wikimind.services.linter import LinterService
 
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
+
+def _wiki_root() -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 def _make_article(
@@ -28,7 +34,8 @@ def _make_article(
     page_type: PageType = PageType.SOURCE,
     claims: list[str] | None = None,
 ) -> Article:
-    file_path = tmp_path / f"{slug}.md"
+    wiki = _wiki_root()
+    file_path = wiki / f"{slug}.md"
     body_lines = [f"# {title}", ""]
     if claims:
         body_lines.append("## Key Claims")
@@ -41,7 +48,7 @@ def _make_article(
         id=article_id,
         slug=slug,
         title=title,
-        file_path=str(file_path),
+        file_path=f"{slug}.md",
         concept_ids=json.dumps(concept_ids) if concept_ids else None,
         page_type=page_type,
         user_id=TEST_USER_ID,

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -2,22 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.conftest import TEST_USER_ID
+from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.models import (
     Article,
     CompletionResponse,
     Provider,
 )
 from wikimind.services.export import ExportService, _inline_format, _markdown_to_html
-
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
-from wikimind.api.deps import ANONYMOUS_USER_ID
 
 # ---------------------------------------------------------------------------
 # Unit tests — ExportService (no DB, no LLM)
@@ -173,11 +170,9 @@ class TestExportServiceSlides:
 
 async def _seed_article(db_session, tmp_path: Path) -> Article:
     """Create an article on disk and in the database."""
-    from pathlib import Path as _Path
-
     from wikimind.config import get_settings as _gs
 
-    wiki_dir = _Path(_gs().data_dir) / "wiki" / ANONYMOUS_USER_ID
+    wiki_dir = Path(_gs().data_dir) / "wiki" / ANONYMOUS_USER_ID
     wiki_dir.mkdir(parents=True, exist_ok=True)
     (wiki_dir / "test-export.md").write_text(
         "# Test Export Article\n\n"

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -173,10 +173,13 @@ class TestExportServiceSlides:
 
 async def _seed_article(db_session, tmp_path: Path) -> Article:
     """Create an article on disk and in the database."""
-    wiki_dir = tmp_path / "wikimind" / "wiki"
+    from pathlib import Path as _Path
+
+    from wikimind.config import get_settings as _gs
+
+    wiki_dir = _Path(_gs().data_dir) / "wiki" / ANONYMOUS_USER_ID
     wiki_dir.mkdir(parents=True, exist_ok=True)
-    md_path = wiki_dir / "test-export.md"
-    md_path.write_text(
+    (wiki_dir / "test-export.md").write_text(
         "# Test Export Article\n\n"
         "This article covers AI agents and their architecture.\n\n"
         "## Key Points\n\n"
@@ -188,7 +191,7 @@ async def _seed_article(db_session, tmp_path: Path) -> Article:
     article = Article(
         slug="test-export",
         title="Test Export Article",
-        file_path=str(md_path),
+        file_path="test-export.md",
         summary="An article about AI agents.",
         user_id=ANONYMOUS_USER_ID,
     )

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3,14 +3,37 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.conftest import TEST_USER_ID
+from wikimind.config import get_settings
 from wikimind.jobs import background as bg_mod
 from wikimind.jobs import worker as worker_mod
 from wikimind.jobs.background import BackgroundCompiler, get_background_compiler
-from wikimind.jobs.worker import _recompile_from_source, compile_source, get_redis_settings, lint_wiki
-from wikimind.models import Article, IngestStatus, LintReport, LintReportStatus, PageType, Source, SourceType
+from wikimind.jobs.worker import (
+    _recompile_from_source,
+    compile_source,
+    get_redis_settings,
+    lint_wiki,
+)
+from wikimind.models import (
+    Article,
+    IngestStatus,
+    LintReport,
+    LintReportStatus,
+    PageType,
+    Source,
+    SourceType,
+)
+
+
+def _raw_root() -> Path:
+    """Return the raw storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "raw" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 async def test_background_compiler_dev_mode_compile() -> None:
@@ -229,12 +252,12 @@ async def test_compile_source_compiler_returns_none(db_session, tmp_path) -> Non
 
 async def test_compile_source_sets_processing_on_start(db_session, tmp_path) -> None:
     """When compile_source starts, source.status must be PROCESSING and error_message cleared."""
-    text_file = tmp_path / "src.txt"
-    text_file.write_text("hello world", encoding="utf-8")
+    raw = _raw_root()
+    (raw / "src.txt").write_text("hello world", encoding="utf-8")
     src = Source(
         source_type=SourceType.TEXT,
         title="t",
-        file_path=str(text_file),
+        file_path="src.txt",
         status=IngestStatus.FAILED,
         error_message="previous error",
         user_id=TEST_USER_ID,
@@ -264,12 +287,12 @@ async def test_compile_source_sets_processing_on_start(db_session, tmp_path) -> 
 
 async def test_compile_source_clears_error_on_retry(db_session, tmp_path) -> None:
     """A previously-failed source should have error_message=None while compiling."""
-    text_file = tmp_path / "src.txt"
-    text_file.write_text("content", encoding="utf-8")
+    raw = _raw_root()
+    (raw / "src.txt").write_text("content", encoding="utf-8")
     src = Source(
         source_type=SourceType.TEXT,
         title="retry-me",
-        file_path=str(text_file),
+        file_path="src.txt",
         status=IngestStatus.FAILED,
         error_message="old boom",
         user_id=TEST_USER_ID,
@@ -306,12 +329,12 @@ async def test_compile_source_clears_error_on_retry(db_session, tmp_path) -> Non
 
 async def test_compile_source_failure_after_retry_sets_failed(db_session, tmp_path) -> None:
     """On failure the source must revert to FAILED with a new error_message."""
-    text_file = tmp_path / "src.txt"
-    text_file.write_text("content", encoding="utf-8")
+    raw = _raw_root()
+    (raw / "src.txt").write_text("content", encoding="utf-8")
     src = Source(
         source_type=SourceType.TEXT,
         title="fail-again",
-        file_path=str(text_file),
+        file_path="src.txt",
         status=IngestStatus.FAILED,
         error_message="old error",
         user_id=TEST_USER_ID,
@@ -371,12 +394,12 @@ async def test_lint_wiki_failure(db_session, tmp_path) -> None:
 
 async def test_recompile_from_source_calls_save_article_in_place(db_session, tmp_path) -> None:
     """_recompile_from_source must call save_article_in_place with the existing article."""
-    text_file = tmp_path / "src.txt"
-    text_file.write_text("hello world", encoding="utf-8")
+    raw = _raw_root()
+    (raw / "src.txt").write_text("hello world", encoding="utf-8")
     src = Source(
         source_type=SourceType.TEXT,
         title="t",
-        file_path=str(text_file),
+        file_path="src.txt",
         status=IngestStatus.COMPILED,
         user_id=TEST_USER_ID,
     )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -216,8 +217,6 @@ async def test_ingest_service_get_source_ok(db_session) -> None:
 
 
 async def test_ingest_service_delete_source(db_session, tmp_path, monkeypatch) -> None:
-    from pathlib import Path
-
     from wikimind.config import get_settings as _gs
 
     svc = IngestService()

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -216,14 +216,17 @@ async def test_ingest_service_get_source_ok(db_session) -> None:
 
 
 async def test_ingest_service_delete_source(db_session, tmp_path, monkeypatch) -> None:
+    from pathlib import Path
+
+    from wikimind.config import get_settings as _gs
+
     svc = IngestService()
-    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path))
-    raw = tmp_path / "raw"
-    raw.mkdir()
-    s = Source(source_type=SourceType.PDF, title="t", file_path=str(raw / "x.txt"), user_id=TEST_USER_ID)
+    raw = Path(_gs().data_dir) / "raw" / TEST_USER_ID
+    raw.mkdir(parents=True, exist_ok=True)
+    s = Source(source_type=SourceType.PDF, title="t", file_path="placeholder.txt", user_id=TEST_USER_ID)
     (raw / f"{s.id}.txt").write_text("content")
     (raw / f"{s.id}.pdf").write_bytes(b"x")
-    s.file_path = str(raw / f"{s.id}.txt")
+    s.file_path = f"{s.id}.txt"
     db_session.add(s)
     await db_session.commit()
     result = await svc.delete_source(s.id, db_session, user_id=TEST_USER_ID)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -98,6 +98,49 @@ async def test_read_missing_raises(storage):
 
 
 # ---------------------------------------------------------------------------
+# Path traversal guard tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_normal_relative_path(tmp_path):
+    """Normal relative paths resolve correctly within root."""
+    storage = LocalFileStorage(root=tmp_path)
+    result = storage._resolve("articles/foo.md")
+    assert result == (tmp_path / "articles" / "foo.md").resolve()
+    assert result.is_relative_to(tmp_path.resolve())
+
+
+def test_resolve_rejects_parent_traversal(tmp_path):
+    """Paths containing ../ that escape root are rejected."""
+    storage = LocalFileStorage(root=tmp_path)
+    with pytest.raises(ValueError, match="Path traversal detected"):
+        storage._resolve("../secret.txt")
+
+
+def test_resolve_rejects_deep_traversal(tmp_path):
+    """Deep traversal like ../../etc/passwd is rejected."""
+    storage = LocalFileStorage(root=tmp_path)
+    with pytest.raises(ValueError, match="Path traversal detected"):
+        storage._resolve("../../etc/passwd")
+
+
+def test_resolve_rejects_absolute_path_escaping_root(tmp_path):
+    """Absolute paths that escape root are rejected."""
+    storage = LocalFileStorage(root=tmp_path)
+    with pytest.raises(ValueError, match="Path traversal detected"):
+        storage._resolve("/etc/passwd")
+
+
+def test_resolve_allows_traversal_back_into_root(tmp_path):
+    """Paths that use ../ but resolve back inside root are allowed."""
+    storage = LocalFileStorage(root=tmp_path)
+    # subdir/../other/file.md resolves to tmp_path/other/file.md (still under root)
+    result = storage._resolve("subdir/../other/file.md")
+    assert result == (tmp_path / "other" / "file.md").resolve()
+    assert result.is_relative_to(tmp_path.resolve())
+
+
+# ---------------------------------------------------------------------------
 # Protocol and factory tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -3,20 +3,28 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from sqlmodel import select
 
+from tests.conftest import TEST_USER_ID
 from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
 from wikimind.jobs.sweep import _sweep_single_article
 from wikimind.models import Article, Backlink, ConfidenceLevel
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from sqlmodel.ext.asyncio.session import AsyncSession
-from tests.conftest import TEST_USER_ID
+
+
+def _wiki_root(tmp_path: Path) -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 async def _make_article(
@@ -44,16 +52,16 @@ async def _make_article(
 @pytest.mark.asyncio
 async def test_resolves_bracket_and_creates_backlink(db_session: AsyncSession, tmp_path: Path) -> None:
     """An article with [[Existing Title]] -> file rewritten + Backlink row created."""
-    target = await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"))
+    wiki = _wiki_root(tmp_path)
+    target = await _make_article(db_session, "Machine Learning", "ml.md")
 
-    md_path = tmp_path / "source.md"
-    md_path.write_text("Some text about [[Machine Learning]] in the body.\n")
-    source = await _make_article(db_session, "AI Overview", str(md_path), slug="ai-overview")
+    (wiki / "source.md").write_text("Some text about [[Machine Learning]] in the body.\n")
+    source = await _make_article(db_session, "AI Overview", "source.md", slug="ai-overview")
 
     changed = await _sweep_single_article(source.id, db_session)
 
     assert changed is True
-    content = md_path.read_text()
+    content = (wiki / "source.md").read_text()
     assert f"[Machine Learning](/wiki/{target.id})" in content
     assert "[[Machine Learning]]" not in content
 
@@ -70,28 +78,28 @@ async def test_resolves_bracket_and_creates_backlink(db_session: AsyncSession, t
 @pytest.mark.asyncio
 async def test_no_brackets_no_write(db_session: AsyncSession, tmp_path: Path) -> None:
     """An article with no [[brackets]] -> NOT rewritten (idempotency)."""
-    md_path = tmp_path / "clean.md"
+    wiki = _wiki_root(tmp_path)
     original = "This article has no brackets at all.\n"
-    md_path.write_text(original)
-    article = await _make_article(db_session, "Clean Article", str(md_path))
+    (wiki / "clean.md").write_text(original)
+    article = await _make_article(db_session, "Clean Article", "clean.md")
 
     changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
-    assert md_path.read_text() == original
+    assert (wiki / "clean.md").read_text() == original
 
 
 @pytest.mark.asyncio
 async def test_unknown_bracket_stays(db_session: AsyncSession, tmp_path: Path) -> None:
     """An article with [[Unknown Title]] -> bracket stays, no Backlink row."""
-    md_path = tmp_path / "unknown.md"
-    md_path.write_text("See also [[Nonexistent Topic]] for more.\n")
-    article = await _make_article(db_session, "Some Article", str(md_path))
+    wiki = _wiki_root(tmp_path)
+    (wiki / "unknown.md").write_text("See also [[Nonexistent Topic]] for more.\n")
+    article = await _make_article(db_session, "Some Article", "unknown.md")
 
     changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
-    content = md_path.read_text()
+    content = (wiki / "unknown.md").read_text()
     assert "[[Nonexistent Topic]]" in content
 
     result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
@@ -101,25 +109,25 @@ async def test_unknown_bracket_stays(db_session: AsyncSession, tmp_path: Path) -
 @pytest.mark.asyncio
 async def test_already_resolved_link_not_rewritten(db_session: AsyncSession, tmp_path: Path) -> None:
     """An article with [Title](/wiki/{id}) from a fresh compile -> NOT rewritten."""
-    target = await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"))
-    md_path = tmp_path / "resolved.md"
+    wiki = _wiki_root(tmp_path)
+    target = await _make_article(db_session, "Machine Learning", "ml.md")
     original = f"Read about [Machine Learning](/wiki/{target.id}) here.\n"
-    md_path.write_text(original)
-    article = await _make_article(db_session, "Resolved Article", str(md_path))
+    (wiki / "resolved.md").write_text(original)
+    article = await _make_article(db_session, "Resolved Article", "resolved.md")
 
     changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
-    assert md_path.read_text() == original
+    assert (wiki / "resolved.md").read_text() == original
 
 
 @pytest.mark.asyncio
 async def test_idempotent_rerun_after_sweep(db_session: AsyncSession, tmp_path: Path) -> None:
     """Re-running the sweep after a previous sweep -> no changes."""
-    await _make_article(db_session, "Machine Learning", str(tmp_path / "ml.md"))
-    md_path = tmp_path / "source.md"
-    md_path.write_text("Text about [[Machine Learning]] here.\n")
-    source = await _make_article(db_session, "AI Overview", str(md_path), slug="ai-overview")
+    wiki = _wiki_root(tmp_path)
+    await _make_article(db_session, "Machine Learning", "ml.md")
+    (wiki / "source.md").write_text("Text about [[Machine Learning]] here.\n")
+    source = await _make_article(db_session, "AI Overview", "source.md", slug="ai-overview")
 
     # First run: should make changes
     changed1 = await _sweep_single_article(source.id, db_session)
@@ -133,15 +141,15 @@ async def test_idempotent_rerun_after_sweep(db_session: AsyncSession, tmp_path: 
 @pytest.mark.asyncio
 async def test_multiple_brackets_partial_resolution(db_session: AsyncSession, tmp_path: Path) -> None:
     """Multiple brackets: some resolve, some stay. Only resolved ones are replaced."""
-    target = await _make_article(db_session, "React", str(tmp_path / "react.md"))
-    md_path = tmp_path / "multi.md"
-    md_path.write_text("Uses [[React]] and [[Unknown Framework]] for UI.\n")
-    source = await _make_article(db_session, "Frontend Guide", str(md_path))
+    wiki = _wiki_root(tmp_path)
+    target = await _make_article(db_session, "React", "react.md")
+    (wiki / "multi.md").write_text("Uses [[React]] and [[Unknown Framework]] for UI.\n")
+    source = await _make_article(db_session, "Frontend Guide", "multi.md")
 
     changed = await _sweep_single_article(source.id, db_session)
 
     assert changed is True
-    content = md_path.read_text()
+    content = (wiki / "multi.md").read_text()
     assert f"[React](/wiki/{target.id})" in content
     assert "[[Unknown Framework]]" in content
 
@@ -149,21 +157,22 @@ async def test_multiple_brackets_partial_resolution(db_session: AsyncSession, tm
 @pytest.mark.asyncio
 async def test_self_link_excluded(db_session: AsyncSession, tmp_path: Path) -> None:
     """A bracket matching the article's own title is not resolved (no self-link)."""
-    md_path = tmp_path / "self.md"
-    md_path.write_text("This article about [[Self Referencing]] itself.\n")
-    article = await _make_article(db_session, "Self Referencing", str(md_path), slug="self-referencing")
+    wiki = _wiki_root(tmp_path)
+    (wiki / "self.md").write_text("This article about [[Self Referencing]] itself.\n")
+    article = await _make_article(db_session, "Self Referencing", "self.md", slug="self-referencing")
 
     changed = await _sweep_single_article(article.id, db_session)
 
     assert changed is False
-    content = md_path.read_text()
+    content = (wiki / "self.md").read_text()
     assert "[[Self Referencing]]" in content
 
 
 @pytest.mark.asyncio
 async def test_missing_file_handled_gracefully(db_session: AsyncSession, tmp_path: Path) -> None:
     """Article whose file_path doesn't exist -> skip gracefully."""
-    article = await _make_article(db_session, "Missing File", str(tmp_path / "does-not-exist.md"))
+    _wiki_root(tmp_path)
+    article = await _make_article(db_session, "Missing File", "does-not-exist.md")
 
     changed = await _sweep_single_article(article.id, db_session)
     assert changed is False

--- a/tests/unit/test_sweep_session.py
+++ b/tests/unit/test_sweep_session.py
@@ -11,20 +11,26 @@ Verifies that:
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlmodel import select
 
+from tests.conftest import TEST_USER_ID
 from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
 from wikimind.jobs.sweep import _sweep_single_article, sweep_wikilinks
 from wikimind.models import Article, Backlink, ConfidenceLevel
 
-if TYPE_CHECKING:
-    from pathlib import Path
-from tests.conftest import TEST_USER_ID
+
+def _wiki_root() -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 async def _make_article(
@@ -52,16 +58,16 @@ async def _make_article(
 @pytest.mark.asyncio
 async def test_sweep_creates_backlinks(db_session: AsyncSession, tmp_path: Path) -> None:
     """Sweep resolves [[brackets]] and creates corresponding Backlink rows."""
-    target = await _make_article(db_session, "Quantum Computing", str(tmp_path / "qc.md"))
+    wiki = _wiki_root()
+    target = await _make_article(db_session, "Quantum Computing", "qc.md")
 
-    md_path = tmp_path / "source.md"
-    md_path.write_text("Research on [[Quantum Computing]] is advancing.\n")
-    source = await _make_article(db_session, "Physics Overview", str(md_path))
+    (wiki / "source.md").write_text("Research on [[Quantum Computing]] is advancing.\n")
+    source = await _make_article(db_session, "Physics Overview", "source.md")
 
     changed = await _sweep_single_article(source.id, db_session)
 
     assert changed is True
-    content = md_path.read_text()
+    content = (wiki / "source.md").read_text()
     assert f"[Quantum Computing](/wiki/{target.id})" in content
 
     result = await db_session.execute(
@@ -83,15 +89,15 @@ async def test_sweep_handles_duplicate_backlinks(async_engine: AsyncEngine, tmp_
     for the sweep. This mirrors the real scenario where the compiler
     created the Backlink in a prior session.
     """
+    wiki = _wiki_root()
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
 
     # Setup: create articles and a pre-existing backlink.
     async with factory() as setup_session:
-        target = await _make_article(setup_session, "Machine Learning", str(tmp_path / "ml.md"))
+        target = await _make_article(setup_session, "Machine Learning", "ml.md")
 
-        md_path = tmp_path / "source.md"
-        md_path.write_text("Exploring [[Machine Learning]] techniques.\n")
-        source = await _make_article(setup_session, "AI Guide", str(md_path))
+        (wiki / "source.md").write_text("Exploring [[Machine Learning]] techniques.\n")
+        source = await _make_article(setup_session, "AI Guide", "source.md")
 
         # Pre-create the backlink (simulates prior compilation)
         existing_bl = Backlink(
@@ -111,7 +117,7 @@ async def test_sweep_handles_duplicate_backlinks(async_engine: AsyncEngine, tmp_
         changed = await _sweep_single_article(source_id, sweep_session)
 
     assert changed is True
-    content = md_path.read_text()
+    content = (wiki / "source.md").read_text()
     assert f"[Machine Learning](/wiki/{target_id})" in content
 
     # Verify exactly one backlink row exists (not two).
@@ -148,6 +154,7 @@ async def test_sweep_wikilinks_uses_isolated_sessions(
     We mock get_session_factory to return a counting wrapper, then verify
     multiple sessions are created (one for the job + one per article).
     """
+    wiki = _wiki_root()
     factory = async_sessionmaker(async_engine, expire_on_commit=False)
 
     # Pre-populate: one article with an unresolved bracket, one target
@@ -156,18 +163,17 @@ async def test_sweep_wikilinks_uses_isolated_sessions(
             id=str(uuid.uuid4()),
             slug="deep-learning",
             title="Deep Learning",
-            file_path=str(tmp_path / "dl.md"),
+            file_path="dl.md",
             confidence=ConfidenceLevel.SOURCED,
             created_at=utcnow_naive(),
             user_id=TEST_USER_ID,
         )
-        md_path = tmp_path / "intro.md"
-        md_path.write_text("Introduction to [[Deep Learning]] methods.\n")
+        (wiki / "intro.md").write_text("Introduction to [[Deep Learning]] methods.\n")
         source = Article(
             id=str(uuid.uuid4()),
             slug="intro-ai",
             title="Intro to AI",
-            file_path=str(md_path),
+            file_path="intro.md",
             confidence=ConfidenceLevel.SOURCED,
             created_at=utcnow_naive(),
             user_id=TEST_USER_ID,

--- a/tests/unit/test_wiki_service.py
+++ b/tests/unit/test_wiki_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from tests.conftest import TEST_USER_ID
+from wikimind.config import get_settings
 from wikimind.errors import NotFoundError
 from wikimind.models import (
     Article,
@@ -21,10 +22,18 @@ from wikimind.models import (
 from wikimind.services.wiki import WikiService
 
 
+def _wiki_root() -> Path:
+    """Return the wiki storage root for TEST_USER_ID and ensure it exists."""
+    settings = get_settings()
+    root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
 async def _seed_article_with_sources(db_session, tmp_path: Path) -> tuple[Article, list[Source]]:
     """Create one article on disk and two persisted sources it references."""
-    file_path = tmp_path / "test-article.md"
-    file_path.write_text("# Test Article\n\nSome content about Langflow.", encoding="utf-8")
+    wiki = _wiki_root()
+    (wiki / "test-article.md").write_text("# Test Article\n\nSome content about Langflow.", encoding="utf-8")
 
     pdf_source = Source(
         source_type=SourceType.PDF,
@@ -45,7 +54,7 @@ async def _seed_article_with_sources(db_session, tmp_path: Path) -> tuple[Articl
     article = Article(
         slug="ibm-agentic-ai-labs",
         title="IBM Agentic AI Labs",
-        file_path=str(file_path),
+        file_path="test-article.md",
         summary="Summary about IBM Agentic AI Labs.",
         source_ids=json.dumps([pdf_source.id, url_source.id]),
         user_id=TEST_USER_ID,
@@ -108,12 +117,12 @@ class TestArticleProvenance:
 
     async def test_get_article_handles_missing_sources_gracefully(self, db_session, tmp_path):
         """An article that references a deleted source still returns successfully."""
-        file_path = tmp_path / "orphan.md"
-        file_path.write_text("# Orphan", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "orphan.md").write_text("# Orphan", encoding="utf-8")
         article = Article(
             slug="orphan-article",
             title="Orphan Article",
-            file_path=str(file_path),
+            file_path="orphan.md",
             source_ids=json.dumps(["does-not-exist-uuid"]),
             user_id=TEST_USER_ID,
         )
@@ -128,12 +137,12 @@ class TestArticleProvenance:
 
     async def test_get_article_handles_missing_source_ids_field(self, db_session, tmp_path):
         """An article with no source_ids JSON returns an empty sources list."""
-        file_path = tmp_path / "no-sources.md"
-        file_path.write_text("# No sources", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "no-sources.md").write_text("# No sources", encoding="utf-8")
         article = Article(
             slug="no-source-article",
             title="No Source Article",
-            file_path=str(file_path),
+            file_path="no-sources.md",
             source_ids=None,
             user_id=TEST_USER_ID,
         )
@@ -147,12 +156,12 @@ class TestArticleProvenance:
 
     async def test_get_article_by_id_returns_article(self, db_session, tmp_path):
         """Fetching an article by its UUID id returns it."""
-        file_path = tmp_path / "my-article.md"
-        file_path.write_text("# My Article", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "my-article.md").write_text("# My Article", encoding="utf-8")
         article = Article(
             slug="my-article",
             title="My Article",
-            file_path=str(file_path),
+            file_path="my-article.md",
             user_id=TEST_USER_ID,
         )
         db_session.add(article)
@@ -167,12 +176,12 @@ class TestArticleProvenance:
 
     async def test_get_article_by_slug_still_works(self, db_session, tmp_path):
         """Backward compat: slug lookup continues to work after the ID-first rewrite."""
-        file_path = tmp_path / "legacy.md"
-        file_path.write_text("# Legacy Bookmark", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "legacy.md").write_text("# Legacy Bookmark", encoding="utf-8")
         article = Article(
             slug="legacy-bookmark",
             title="Legacy Bookmark",
-            file_path=str(file_path),
+            file_path="legacy.md",
             user_id=TEST_USER_ID,
         )
         db_session.add(article)
@@ -189,17 +198,15 @@ class TestArticleProvenance:
 class TestBacklinkEntries:
     async def test_get_article_returns_backlink_entries_with_title_and_slug(self, db_session, tmp_path):
         """backlinks_in and backlinks_out are BacklinkEntry objects with id, title, slug."""
+        wiki = _wiki_root()
         # Create three articles: A links to B, C links to B
-        fp_a = tmp_path / "article-a.md"
-        fp_a.write_text("# Article A", encoding="utf-8")
-        fp_b = tmp_path / "article-b.md"
-        fp_b.write_text("# Article B", encoding="utf-8")
-        fp_c = tmp_path / "article-c.md"
-        fp_c.write_text("# Article C", encoding="utf-8")
+        (wiki / "article-a.md").write_text("# Article A", encoding="utf-8")
+        (wiki / "article-b.md").write_text("# Article B", encoding="utf-8")
+        (wiki / "article-c.md").write_text("# Article C", encoding="utf-8")
 
-        article_a = Article(slug="article-a", title="Article A", file_path=str(fp_a), user_id=TEST_USER_ID)
-        article_b = Article(slug="article-b", title="Article B", file_path=str(fp_b), user_id=TEST_USER_ID)
-        article_c = Article(slug="article-c", title="Article C", file_path=str(fp_c), user_id=TEST_USER_ID)
+        article_a = Article(slug="article-a", title="Article A", file_path="article-a.md", user_id=TEST_USER_ID)
+        article_b = Article(slug="article-b", title="Article B", file_path="article-b.md", user_id=TEST_USER_ID)
+        article_c = Article(slug="article-c", title="Article C", file_path="article-c.md", user_id=TEST_USER_ID)
         db_session.add_all([article_a, article_b, article_c])
         await db_session.flush()
 
@@ -231,10 +238,10 @@ class TestBacklinkEntries:
 
     async def test_get_article_skips_deleted_backlink_targets(self, db_session, tmp_path):
         """Backlinks referencing a deleted article are silently dropped."""
-        fp = tmp_path / "survivor.md"
-        fp.write_text("# Survivor", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "survivor.md").write_text("# Survivor", encoding="utf-8")
 
-        article = Article(slug="survivor", title="Survivor", file_path=str(fp), user_id=TEST_USER_ID)
+        article = Article(slug="survivor", title="Survivor", file_path="survivor.md", user_id=TEST_USER_ID)
         db_session.add(article)
         await db_session.flush()
 
@@ -253,10 +260,10 @@ class TestBacklinkEntries:
 
     async def test_get_article_empty_backlinks(self, db_session, tmp_path):
         """An article with no backlinks returns empty BacklinkEntry lists."""
-        fp = tmp_path / "lonely.md"
-        fp.write_text("# Lonely", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "lonely.md").write_text("# Lonely", encoding="utf-8")
 
-        article = Article(slug="lonely", title="Lonely", file_path=str(fp), user_id=TEST_USER_ID)
+        article = Article(slug="lonely", title="Lonely", file_path="lonely.md", user_id=TEST_USER_ID)
         db_session.add(article)
         await db_session.commit()
 
@@ -271,13 +278,13 @@ class TestBacklinkEntries:
 class TestConceptPopulation:
     async def test_get_article_populates_concepts_from_concept_ids(self, db_session, tmp_path):
         """ArticleResponse.concepts is populated from Article.concept_ids JSON."""
-        fp = tmp_path / "ml-article.md"
-        fp.write_text("# ML Article", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "ml-article.md").write_text("# ML Article", encoding="utf-8")
 
         article = Article(
             slug="ml-article",
             title="ML Article",
-            file_path=str(fp),
+            file_path="ml-article.md",
             concept_ids=json.dumps(["Machine Learning", "Deep Learning"]),
             user_id=TEST_USER_ID,
         )
@@ -291,13 +298,13 @@ class TestConceptPopulation:
 
     async def test_get_article_returns_empty_concepts_when_none(self, db_session, tmp_path):
         """ArticleResponse.concepts is [] when concept_ids is None."""
-        fp = tmp_path / "no-concepts.md"
-        fp.write_text("# No Concepts", encoding="utf-8")
+        wiki = _wiki_root()
+        (wiki / "no-concepts.md").write_text("# No Concepts", encoding="utf-8")
 
         article = Article(
             slug="no-concepts",
             title="No Concepts",
-            file_path=str(fp),
+            file_path="no-concepts.md",
             concept_ids=None,
             user_id=TEST_USER_ID,
         )


### PR DESCRIPTION
## Summary

- `LocalFileStorage._resolve` did a bare `root / relative_path` join with no bounds check. Paths containing `../` could escape the storage root.
- Added `is_relative_to` guard that resolves the path and rejects anything outside root with `ValueError`.
- Fixed 48 tests across 15 files that stored absolute paths in `Article.file_path` / `Source.file_path` — these tests relied on the vulnerability. Updated to use relative paths with files under the storage root, matching production behavior.
- 5 new tests: normal paths, parent traversal, deep traversal, absolute escape, and traversal-back-into-root edge case.

Closes #659

## Test plan
- [ ] `make verify` passes
- [ ] `../` paths raise `ValueError`
- [ ] `../../etc/passwd` raises `ValueError`
- [ ] Normal relative paths work
- [ ] Paths that traverse out then back in (e.g., `subdir/../other/file.md`) are allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)