### PR TITLE
fix: patch CVE-2026-27135 — add libnghttp2-14 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
         curl \
         gosu \
         libmupdf-dev \
+        libnghttp2-14 \
         libsqlite3-0 \
     && pip install --upgrade pip setuptools wheel \
     && rm -rf /var/lib/apt/lists/* /root/.cache/pip


### PR DESCRIPTION
## Summary

- Trivy CVE scan fails on all PRs: `libnghttp2-14` has HIGH severity DoS via malformed HTTP/2 frames (CVE-2026-27135).
- The `python:3.11.12-slim` base image ships with `1.52.0-1+deb12u2`; fix is in `1.52.0-1+deb12u3`.
- The existing `apt-get upgrade -y` doesn't help because Docker layer caching preserves the old package version.
- Adding `libnghttp2-14` explicitly to `apt-get install` busts the cache and ensures the patched version.

Closes #686

## Test plan
- [ ] Docker build succeeds
- [ ] Trivy CVE scan passes (no HIGH/CRITICAL)
- [ ] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)