### PR TITLE
fix: add user_id checks to recompile_article and get_article_tags

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_GAcnTs"
+      "filename": ".merge_file_VNCZed"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -282,1094 +282,1500 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 243
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 243
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "809d6b631f8d62e2cb81e389888335073ab8f5d2",
         "is_verified": false,
         "line_number": 257
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "809d6b631f8d62e2cb81e389888335073ab8f5d2",
         "is_verified": false,
         "line_number": 257
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "19179043706fc62ad1fceda1a6f236e9b0b11216",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "19179043706fc62ad1fceda1a6f236e9b0b11216",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 982
+        "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 982
+        "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 989
+        "line_number": 985
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 989
+        "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 996
+        "line_number": 999
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 996
+        "line_number": 999
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 1014
+        "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 1014
+        "line_number": 1013
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 1021
+        "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 1021
+        "line_number": 1027
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1028
+        "line_number": 1041
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1028
+        "line_number": 1041
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1037
+        "line_number": 1055
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1037
+        "line_number": 1055
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1046
+        "line_number": 1069
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1046
+        "line_number": 1069
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1053
+        "line_number": 1083
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1053
+        "line_number": 1083
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1060
+        "line_number": 1097
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1060
+        "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1085
+        "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1085
+        "line_number": 1111
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1092
+        "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1092
+        "line_number": 1125
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1101
+        "line_number": 1139
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1101
+        "line_number": 1139
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1110
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1110
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1117
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1117
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1126
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1126
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1135
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1135
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 1162
+        "line_number": 1167
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 1162
+        "line_number": 1167
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 1169
+        "line_number": 1181
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 1169
+        "line_number": 1181
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 1178
+        "line_number": 1195
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 1178
+        "line_number": 1195
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 1203
+        "line_number": 1209
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 1203
+        "line_number": 1209
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 1221
+        "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 1221
+        "line_number": 1223
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 1230
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 1230
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 1251
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 1251
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 1265
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 1265
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 1279
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 1279
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 1293
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 1293
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 1307
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 1307
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 1321
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 1321
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 1335
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 1335
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 1349
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 1349
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 1363
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 1363
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 1388
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 1388
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 1395
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 1395
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 1402
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 1402
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1420
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1420
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1427
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1427
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1434
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1434
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1443
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1443
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1452
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1452
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1459
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1459
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1466
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1466
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1491
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1491
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1498
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1498
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1507
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1507
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1516
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1516
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1523
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1523
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1532
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1532
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1541
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1541
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1559
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1559
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 1568
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 1568
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 1575
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 1575
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 1584
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 1584
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 1609
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 1609
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 1627
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 1627
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 1636
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 1636
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 1643
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 1643
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 1244
+        "line_number": 1650
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 1244
+        "line_number": 1650
       }
     ],
     "Makefile": [
@@ -1653,5 +2059,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T02:13:59Z"
+  "generated_at": "2026-05-15T02:14:35Z"
 }

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -554,7 +554,8 @@ async def recompile_article(
             detail=f"mode must be one of {sorted(_VALID_RECOMPILE_MODES)} or null",
         )
 
-    article = await session.get(Article, article_id)
+    result = await session.execute(select(Article).where(Article.id == article_id, Article.user_id == user_id))
+    article = result.scalar_one_or_none()
     if article is None:
         raise HTTPException(status_code=404, detail="Article not found")
 
@@ -647,7 +648,7 @@ async def get_article_tags(
     article_id: str,
     session: AsyncSession = Depends(get_session),
     tag_service: TagService = Depends(get_tag_service),
-    _user_id: str = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),
 ):
     """Get all tags applied to an article."""
-    return await tag_service.get_tags_for_article(session, article_id=article_id)
+    return await tag_service.get_tags_for_article(session, article_id=article_id, user_id=user_id)

--- a/src/wikimind/services/tags.py
+++ b/src/wikimind/services/tags.py
@@ -192,16 +192,24 @@ class TagService:
         self,
         session: AsyncSession,
         article_id: str,
+        user_id: str | None = None,
     ) -> list[TagResponse]:
         """Return all tags applied to an article.
 
         Args:
             session: Async database session.
             article_id: Article to look up.
+            user_id: If provided, verify the article belongs to this user.
 
         Returns:
             List of TagResponse records.
+
+        Raises:
+            NotFoundError: If user_id is given and the article does not belong
+                to that user.
         """
+        if user_id is not None:
+            await self._get_article(session, article_id, user_id)
         result = await session.execute(
             select(Tag)
             .join(ArticleTag, ArticleTag.tag_id == Tag.id)  # type: ignore[arg-type]

--- a/tests/unit/test_article_edit.py
+++ b/tests/unit/test_article_edit.py
@@ -14,8 +14,6 @@ if TYPE_CHECKING:
     from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-from tests.conftest import TEST_USER_ID
-
 # When auth is disabled (as in tests), get_current_user_id returns ANONYMOUS_USER_ID.
 # Tests that go through the HTTP client must create articles with this user_id
 # so the service-layer user_id filter finds them.
@@ -221,7 +219,7 @@ async def test_recompile_blocked_by_manual_edit(
         title="Edited Article",
         file_path="/tmp/edited.md",
         page_type=PageType.SOURCE,
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
         manually_edited=True,
     )
     db_session.add(article)
@@ -239,7 +237,7 @@ async def test_recompile_force_overrides_manual_edit(
     db_session: AsyncSession,
 ) -> None:
     """POST recompile with force=true clears manually_edited and proceeds."""
-    src = Source(source_type=SourceType.TEXT, title="src", user_id=TEST_USER_ID)
+    src = Source(source_type=SourceType.TEXT, title="src", user_id=_CLIENT_USER_ID)
     db_session.add(src)
     await db_session.commit()
 
@@ -249,7 +247,7 @@ async def test_recompile_force_overrides_manual_edit(
         file_path="/tmp/force.md",
         page_type=PageType.SOURCE,
         source_ids=json.dumps([src.id]),
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
         manually_edited=True,
     )
     db_session.add(article)
@@ -276,7 +274,7 @@ async def test_recompile_unedited_article_no_force_needed(
     db_session: AsyncSession,
 ) -> None:
     """POST recompile on a non-edited article works without force."""
-    src = Source(source_type=SourceType.TEXT, title="src", user_id=TEST_USER_ID)
+    src = Source(source_type=SourceType.TEXT, title="src", user_id=_CLIENT_USER_ID)
     db_session.add(src)
     await db_session.commit()
 
@@ -286,7 +284,7 @@ async def test_recompile_unedited_article_no_force_needed(
         file_path="/tmp/unedited.md",
         page_type=PageType.SOURCE,
         source_ids=json.dumps([src.id]),
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
         manually_edited=False,
     )
     db_session.add(article)

--- a/tests/unit/test_recompile.py
+++ b/tests/unit/test_recompile.py
@@ -7,17 +7,20 @@ import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.models import Article, PageType, Source, SourceType
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
-from tests.conftest import TEST_USER_ID
+
+# When auth is disabled (as in tests), get_current_user_id returns ANONYMOUS_USER_ID.
+_CLIENT_USER_ID = ANONYMOUS_USER_ID
 
 
 async def test_recompile_source_article(client: AsyncClient, db_session: AsyncSession) -> None:
     """POST recompile for a source-type article returns 200 + scheduled."""
-    src = Source(source_type=SourceType.TEXT, title="src", user_id=TEST_USER_ID)
+    src = Source(source_type=SourceType.TEXT, title="src", user_id=_CLIENT_USER_ID)
     db_session.add(src)
     await db_session.commit()
 
@@ -27,7 +30,7 @@ async def test_recompile_source_article(client: AsyncClient, db_session: AsyncSe
         file_path="/tmp/test.md",
         page_type=PageType.SOURCE,
         source_ids=json.dumps([src.id]),
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
     )
     db_session.add(article)
     await db_session.commit()
@@ -59,7 +62,7 @@ async def test_recompile_concept_article(client: AsyncClient, db_session: AsyncS
         file_path="/tmp/concept.md",
         page_type=PageType.CONCEPT,
         concept_ids=json.dumps(["concept-1"]),
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
     )
     db_session.add(article)
     await db_session.commit()
@@ -84,7 +87,7 @@ async def test_recompile_explicit_mode(client: AsyncClient, db_session: AsyncSes
         file_path="/tmp/explicit.md",
         page_type=PageType.CONCEPT,
         source_ids=json.dumps(["src-1"]),
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
     )
     db_session.add(article)
     await db_session.commit()
@@ -109,7 +112,7 @@ async def test_recompile_invalid_mode(client: AsyncClient, db_session: AsyncSess
         title="Test Invalid Mode",
         file_path="/tmp/invalid.md",
         page_type=PageType.SOURCE,
-        user_id=TEST_USER_ID,
+        user_id=_CLIENT_USER_ID,
     )
     db_session.add(article)
     await db_session.commit()

--- a/tests/unit/test_wiki_routes_extra.py
+++ b/tests/unit/test_wiki_routes_extra.py
@@ -1,1 +1,117 @@
-"""Placeholder."""
+"""Tests for user_id ownership checks on recompile_article and get_article_tags.
+
+Covers issues #660 (recompile_article) and #663 (get_article_tags).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from wikimind.api.deps import ANONYMOUS_USER_ID
+from wikimind.models import Article
+
+OTHER_USER_ID = "other-user"
+
+
+async def _seed_articles(factory) -> None:
+    """Create one article per user."""
+    async with factory() as session:
+        session.add(
+            Article(
+                id="own-art",
+                slug="own-article",
+                title="Own Article",
+                file_path="/tmp/own.md",
+                user_id=ANONYMOUS_USER_ID,
+            )
+        )
+        session.add(
+            Article(
+                id="other-art",
+                slug="other-article",
+                title="Other Article",
+                file_path="/tmp/other.md",
+                user_id=OTHER_USER_ID,
+            )
+        )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# recompile_article — user_id ownership (#660)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recompile_own_article_succeeds(client, async_engine) -> None:
+    """Recompiling own article should return 200 with scheduled status."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    resp = await client.post("/api/wiki/articles/own-art/recompile")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "scheduled"
+    assert "job_id" in data
+
+
+@pytest.mark.asyncio
+async def test_recompile_other_users_article_returns_404(client, async_engine) -> None:
+    """Recompiling another user's article should return 404."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    resp = await client.post("/api/wiki/articles/other-art/recompile")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_recompile_nonexistent_article_returns_404(client) -> None:
+    """Recompiling a nonexistent article should return 404."""
+    resp = await client.post("/api/wiki/articles/does-not-exist/recompile")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# get_article_tags — user_id ownership (#663)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_tags_own_article(client, async_engine) -> None:
+    """Getting tags for own article should succeed (empty list when untagged)."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    resp = await client.get("/api/wiki/articles/own-art/tags")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_tags_other_users_article_returns_404(client, async_engine) -> None:
+    """Getting tags for another user's article should return 404."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    resp = await client.get("/api/wiki/articles/other-art/tags")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_tags_own_article_with_tags(client, async_engine) -> None:
+    """Getting tags for own article that has tags should return them."""
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    await _seed_articles(factory)
+
+    # Create a tag and apply it
+    tag_resp = await client.post("/api/tags", json={"name": "important", "color": "#ef4444"})
+    tag_id = tag_resp.json()["id"]
+    await client.post("/api/wiki/articles/own-art/tags", json={"tag_id": tag_id})
+
+    resp = await client.get("/api/wiki/articles/own-art/tags")
+    assert resp.status_code == 200
+    tags = resp.json()
+    assert len(tags) == 1
+    assert tags[0]["name"] == "important"


### PR DESCRIPTION
## Summary

- **recompile_article (#660):** Replaced `session.get(Article, article_id)` with user-scoped query. Users can no longer trigger LLM recompilation on other users' articles.
- **get_article_tags (#663):** Forwarded `user_id` to `TagService.get_tags_for_article()` which now verifies article ownership before returning tags. Prevents cross-user tag disclosure.
- 6 new tests + 2 existing tests fixed (were using wrong user ID).

Closes #660, closes #663

## Test plan
- [ ] `make verify` passes
- [ ] `POST /wiki/articles/{id}/recompile` returns 404 for another user's article
- [ ] `GET /wiki/articles/{id}/tags` returns 404 for another user's article

🤖 Generated with [Claude Code](https://claude.com/claude-code)