### PR TITLE
fix: scope source dedup by user_id to prevent cross-tenant collision (#664)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_JoXhGU"
+      "filename": ".merge_file_IW62YS"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -240,730 +240,1136 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 201
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "a75a4b24d2fda5b9a72a5318cf59dd76c2a2b300",
         "is_verified": false,
         "line_number": 201
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "1d14a09fba713a551c5b40dd03988f6a1e8da3f7",
         "is_verified": false,
         "line_number": 215
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "1d14a09fba713a551c5b40dd03988f6a1e8da3f7",
         "is_verified": false,
         "line_number": 215
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "4071c9c253ba9e4638aebd3697fae2e3eaff0307",
         "is_verified": false,
         "line_number": 229
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "4071c9c253ba9e4638aebd3697fae2e3eaff0307",
         "is_verified": false,
         "line_number": 229
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 243
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 243
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 257
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 257
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 576
+        "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 576
+        "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 590
+        "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 590
+        "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 608
+        "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 608
+        "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 615
+        "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 615
+        "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 622
+        "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 622
+        "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 640
+        "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 640
+        "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 647
+        "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 647
+        "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 654
+        "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 654
+        "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 679
+        "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 679
+        "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 686
+        "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 686
+        "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 695
+        "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 695
+        "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 704
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 704
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 711
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 711
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 720
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 720
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 729
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 756
+        "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 756
+        "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 763
+        "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 763
+        "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 772
+        "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 772
+        "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 797
+        "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 797
+        "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 815
+        "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 815
+        "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 824
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 824
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 845
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 845
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 859
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 859
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 873
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 873
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 887
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 887
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 901
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 901
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 915
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 915
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 929
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 929
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 943
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 943
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 957
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 957
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 982
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 982
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 989
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 989
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 996
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 996
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1014
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1014
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1021
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1021
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1028
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1028
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1037
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1037
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1046
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1046
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1053
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1053
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1060
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1060
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1085
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1085
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1092
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1092
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1101
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1101
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1110
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1110
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1117
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1117
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1126
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1126
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1135
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1135
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1153
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1153
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 1162
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 1162
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 1169
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 1169
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 1178
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 1178
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 1203
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 1203
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 1221
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 1221
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 1230
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 1230
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 1237
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 1237
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 838
+        "line_number": 1244
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 838
+        "line_number": 1244
       }
     ],
     "Makefile": [
@@ -1247,5 +1653,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T12:31:09Z"
+  "generated_at": "2026-05-15T12:31:33Z"
 }

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -168,7 +168,7 @@ class PDFAdapter:
         # Dedup: hash the raw PDF bytes and short-circuit if we've already
         # ingested this exact file (issue #67). The hash is computed before
         # any LLM work or extraction so re-uploads are essentially free.
-        dedup = await _check_source_dedup(file_bytes, session, "PDF")
+        dedup = await _check_source_dedup(file_bytes, session, "PDF", user_id)
         if dedup is not None:
             return dedup
         content_hash = compute_hash(file_bytes)

--- a/src/wikimind/ingest/adapters/text.py
+++ b/src/wikimind/ingest/adapters/text.py
@@ -41,7 +41,7 @@ class TextAdapter:
         # Dedup: hash the UTF-8 bytes of the pasted content (issue #67).
         # Title differences do NOT contribute — re-pasting the same body
         # under a new title still hits the dedup.
-        dedup = await _check_source_dedup(content.encode("utf-8"), session, "text")
+        dedup = await _check_source_dedup(content.encode("utf-8"), session, "text", user_id)
         if dedup is not None:
             return dedup
         content_hash = compute_hash(content.encode("utf-8"))

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -52,7 +52,7 @@ class URLAdapter:
         # ingested this exact content (issue #67). We use the HTML bytes — not
         # the cleaned extraction — so the hash is stable across changes to the
         # trafilatura extraction pipeline.
-        dedup = await _check_source_dedup(html.encode("utf-8"), session, "URL")
+        dedup = await _check_source_dedup(html.encode("utf-8"), session, "URL", user_id)
         if dedup is not None:
             return dedup
         content_hash = compute_hash(html.encode("utf-8"))

--- a/src/wikimind/ingest/adapters/youtube.py
+++ b/src/wikimind/ingest/adapters/youtube.py
@@ -58,7 +58,7 @@ class YouTubeAdapter:
         # are stable for a given video so the hash is effectively a video-id
         # alias, but hashing the actual content also catches the (rare) case
         # where the same transcript appears under multiple URLs.
-        dedup = await _check_source_dedup(transcript_text.encode("utf-8"), session, "YouTube")
+        dedup = await _check_source_dedup(transcript_text.encode("utf-8"), session, "YouTube", user_id)
         if dedup is not None:
             return dedup
         content_hash = compute_hash(transcript_text.encode("utf-8"))

--- a/src/wikimind/ingest/utils.py
+++ b/src/wikimind/ingest/utils.py
@@ -342,17 +342,20 @@ def compute_hash(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-async def find_source_by_hash(session: AsyncSession, content_hash: str) -> Source | None:
-    """Look up an existing :class:`Source` by its content hash.
+async def find_source_by_hash(session: AsyncSession, content_hash: str, user_id: str) -> Source | None:
+    """Look up an existing :class:`Source` by its content hash within a user's scope.
 
     Args:
         session: Async database session.
         content_hash: SHA-256 hex digest produced by :func:`compute_hash`.
+        user_id: Owner whose sources to search — prevents cross-tenant dedup.
 
     Returns:
         The matching `Source`, or ``None`` if no source has this hash.
     """
-    result = await session.execute(select(Source).where(Source.content_hash == content_hash))
+    result = await session.execute(
+        select(Source).where(Source.content_hash == content_hash).where(Source.user_id == user_id)
+    )
     return result.scalar_one_or_none()
 
 
@@ -360,10 +363,11 @@ async def _check_source_dedup(
     payload: bytes,
     session: AsyncSession,
     source_type: str,
+    user_id: str,
 ) -> tuple[Source, NormalizedDocument] | None:
     """Return existing (source, doc) if content was already ingested, else None."""
     content_hash = compute_hash(payload)
-    existing = await find_source_by_hash(session, content_hash)
+    existing = await find_source_by_hash(session, content_hash, user_id)
     if existing is not None:
         if existing.file_path:
             log.info(

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -112,7 +112,7 @@ class TestFindSourceByHash:
     """`find_source_by_hash` returns None when nothing matches."""
 
     async def test_returns_none_when_no_match(self, db_session) -> None:
-        result = await find_source_by_hash(db_session, "deadbeef" * 8)
+        result = await find_source_by_hash(db_session, "deadbeef" * 8, TEST_USER_ID)
         assert result is None
 
     async def test_returns_source_when_present(self, db_session) -> None:
@@ -127,7 +127,7 @@ class TestFindSourceByHash:
         db_session.add(source)
         await db_session.commit()
 
-        found = await find_source_by_hash(db_session, digest)
+        found = await find_source_by_hash(db_session, digest, TEST_USER_ID)
         assert found is not None
         assert found.id == source.id
 


### PR DESCRIPTION
## Summary
- **Problem:** `find_source_by_hash` queried `Source` only by `content_hash` without `user_id` filter — two users ingesting the same content would collide, leaking the first user's source to the second
- **Fix:** Added `user_id: str` parameter to `find_source_by_hash()` and `_check_source_dedup()`, updated all 4 ingest adapters (url, pdf, youtube, text) to pass `user_id`
- **Tests:** Updated dedup test calls to pass `TEST_USER_ID`

Closes #664

## Test plan
- [ ] `make verify` passes
- [ ] Dedup lookups are scoped per user
- [ ] Two users ingesting identical content get separate Source rows

🤖 Generated with [Claude Code](https://claude.ai/claude-code)