### PR TITLE
fix: replace HTTPException with domain errors in sharing service (#645)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_uzJyCY"
+      "filename": ".merge_file_LumU1V"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -324,1458 +324,1864 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "7c40b15babc4ed6d48bb4cfd907cd1a3e83e6961",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "7c40b15babc4ed6d48bb4cfd907cd1a3e83e6961",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "92cbfd159c359a08de38e5958db271a80324e32a",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "92cbfd159c359a08de38e5958db271a80324e32a",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "00047bc6c4d527a8ca1c36c125377402cfe30eec",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "00047bc6c4d527a8ca1c36c125377402cfe30eec",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 1388
+        "line_number": 1377
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 1388
+        "line_number": 1377
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 1395
+        "line_number": 1391
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 1395
+        "line_number": 1391
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 1402
+        "line_number": 1405
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 1402
+        "line_number": 1405
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 1420
+        "line_number": 1419
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 1420
+        "line_number": 1419
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 1427
+        "line_number": 1433
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 1427
+        "line_number": 1433
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1434
+        "line_number": 1447
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1434
+        "line_number": 1447
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1443
+        "line_number": 1461
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1443
+        "line_number": 1461
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1452
+        "line_number": 1475
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1452
+        "line_number": 1475
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1459
+        "line_number": 1489
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1459
+        "line_number": 1489
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1466
+        "line_number": 1503
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1466
+        "line_number": 1503
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1491
+        "line_number": 1517
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1491
+        "line_number": 1517
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1498
+        "line_number": 1531
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1498
+        "line_number": 1531
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1507
+        "line_number": 1545
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1507
+        "line_number": 1545
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1516
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1516
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1523
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1523
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1532
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1532
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1541
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1541
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 1568
+        "line_number": 1573
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 1568
+        "line_number": 1573
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 1575
+        "line_number": 1587
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 1575
+        "line_number": 1587
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 1584
+        "line_number": 1601
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 1584
+        "line_number": 1601
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 1609
+        "line_number": 1615
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 1609
+        "line_number": 1615
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1629
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1629
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 1636
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 1636
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 1657
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 1657
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 1671
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 1671
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 1685
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 1685
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 1699
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 1699
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 1713
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 1713
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 1727
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 1727
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 1741
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 1741
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 1755
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 1755
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 1769
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 1769
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 1794
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 1794
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 1801
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 1801
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 1808
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 1808
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1826
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1826
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1833
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1833
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1840
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1840
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1849
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1849
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1858
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1858
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1865
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1865
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1872
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1872
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1897
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1897
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1904
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1904
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1913
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1913
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1922
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1922
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1929
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1929
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1938
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1938
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1947
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1947
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1965
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1965
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 1974
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 1974
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 1981
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 1981
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 1990
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 1990
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 2015
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 2015
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 2033
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 2033
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 2042
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 2042
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 2049
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 2049
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 1650
+        "line_number": 2056
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 1650
+        "line_number": 2056
       }
     ],
     "Makefile": [
@@ -2059,5 +2465,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T12:31:58Z"
+  "generated_at": "2026-05-15T12:32:25Z"
 }

--- a/src/wikimind/errors.py
+++ b/src/wikimind/errors.py
@@ -59,6 +59,13 @@ class PermissionDeniedError(WikiMindError):
     status_code: int = 403
 
 
+class GoneError(WikiMindError):
+    """Raised when a resource existed but is no longer available (e.g. expired link)."""
+
+    code: str = "gone"
+    status_code: int = 410
+
+
 class UpstreamError(WikiMindError):
     """Raised when an external upstream service fails."""
 

--- a/src/wikimind/services/sharing.py
+++ b/src/wikimind/services/sharing.py
@@ -10,12 +10,12 @@ import secrets
 from datetime import timedelta
 
 import structlog
-from fastapi import HTTPException
 from sqlalchemy import desc
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
+from wikimind.errors import GoneError, NotFoundError
 from wikimind.models import (
     Article,
     PublicArticleResponse,
@@ -54,11 +54,12 @@ class SharingService:
             The created share link response.
 
         Raises:
-            HTTPException: If article not found or not owned by user.
+            NotFoundError: If article not found or not owned by user.
         """
         article = await session.get(Article, article_id)
         if article is None or article.user_id != user_id:
-            raise HTTPException(status_code=404, detail="Article not found")
+            msg = "Article not found"
+            raise NotFoundError(msg)
 
         token = secrets.token_urlsafe(SHARE_TOKEN_BYTES)
         now = utcnow_naive()
@@ -101,11 +102,12 @@ class SharingService:
             user_id: Owner of the share link.
 
         Raises:
-            HTTPException: If link not found or not owned by user.
+            NotFoundError: If link not found or not owned by user.
         """
         link = await session.get(ShareLink, link_id)
         if link is None or link.user_id != user_id:
-            raise HTTPException(status_code=404, detail="Share link not found")
+            msg = "Share link not found"
+            raise NotFoundError(msg)
 
         link.revoked = True
         session.add(link)
@@ -176,21 +178,25 @@ class SharingService:
             Public article response with HTML content.
 
         Raises:
-            HTTPException: 404 if revoked/invalid, 410 if expired.
+            NotFoundError: If link is revoked, invalid, or article missing.
+            GoneError: If link has expired.
         """
         result = await session.execute(select(ShareLink).where(ShareLink.token == token))
         link = result.scalar_one_or_none()
 
         if link is None or link.revoked:
-            raise HTTPException(status_code=404, detail="Share link not found")
+            msg = "Share link not found"
+            raise NotFoundError(msg)
 
         now = utcnow_naive()
         if link.expires_at and link.expires_at < now:
-            raise HTTPException(status_code=410, detail="Share link has expired")
+            msg = "Share link has expired"
+            raise GoneError(msg)
 
         article = await session.get(Article, link.article_id)
         if article is None:
-            raise HTTPException(status_code=404, detail="Article not found")
+            msg = "Article not found"
+            raise NotFoundError(msg)
 
         # Update view count
         link.view_count += 1

--- a/tests/unit/test_sharing.py
+++ b/tests/unit/test_sharing.py
@@ -9,10 +9,10 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
 from sqlmodel import select
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
+from wikimind.errors import NotFoundError
 from wikimind.models import Article, ShareLink
 from wikimind.services.sharing import SharingService
 
@@ -94,7 +94,7 @@ class TestSharingServiceUnit:
     async def test_create_share_link_article_not_found(self, db_session):
         service = SharingService()
 
-        with pytest.raises(HTTPException, match="Article not found"):
+        with pytest.raises(NotFoundError, match="Article not found"):
             await service.create_share_link(
                 db_session,
                 article_id="nonexistent",
@@ -174,17 +174,15 @@ class TestSharingServiceUnit:
         await service.revoke_share_link(db_session, created.id, ANONYMOUS_USER_ID)
         await db_session.commit()
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await service.get_public_article(db_session, created.token)
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_get_public_article_invalid_token(self, db_session):
         service = SharingService()
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundError):
             await service.get_public_article(db_session, "bogus-token")
-        assert exc_info.value.status_code == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Problem:** `services/sharing.py` was the only service raising `HTTPException` directly (5 occurrences), violating the layer boundary where services should raise domain errors
- **Fix:** Replaced all 5 `HTTPException` raises with `NotFoundError` (4) and new `GoneError` (1, for expired share links). Removed FastAPI import from service layer
- **Tests:** Updated 3 test assertions to expect domain errors instead of `HTTPException`

Closes #645

## Test plan
- [ ] `make verify` passes (all 20 sharing tests pass)
- [ ] 404 responses still returned for missing shares (middleware maps `NotFoundError`)
- [ ] 410 response still returned for expired shares (middleware maps `GoneError`)
- [ ] No `HTTPException` imports remain in `services/sharing.py`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)