### PR TITLE
fix: remove falsy user_id guards to enforce unconditional isolation (#665)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_LumU1V"
+      "filename": ".merge_file_AaXrDX"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -366,1822 +366,2228 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
+        "hashed_secret": "84415f68346b5c497e553f0c5941288954483b9a",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
+        "hashed_secret": "84415f68346b5c497e553f0c5941288954483b9a",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
+        "hashed_secret": "7b23d9073c67c640fde4b3d29bf47187c5684367",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
+        "hashed_secret": "7b23d9073c67c640fde4b3d29bf47187c5684367",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
+        "hashed_secret": "05957e2b3bf2609c276332d713edccbac0f19287",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
+        "hashed_secret": "05957e2b3bf2609c276332d713edccbac0f19287",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
+        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
+        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
+        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
+        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
+        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
+        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
+        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
+        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
+        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
+        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
+        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
+        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
+        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
+        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
+        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
+        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
+        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
+        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
+        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
+        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
+        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
+        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
+        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
+        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
+        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
+        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
+        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
+        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
+        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
+        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
+        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
+        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
+        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
+        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
+        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
+        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
+        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
+        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
+        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
+        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
+        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
+        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
+        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
+        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
+        "hashed_secret": "1087ae5d0ff7d6972f1235b88109d645f0e85efd",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
+        "hashed_secret": "1087ae5d0ff7d6972f1235b88109d645f0e85efd",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 1377
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 1377
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 1391
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 1391
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 1405
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 1405
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 1419
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 1419
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 1433
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 1433
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 1447
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 1447
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 1461
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 1461
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 1475
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 1475
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 1489
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 1489
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 1503
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 1503
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 1517
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 1517
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 1531
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 1531
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 1545
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 1545
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 1573
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 1573
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 1601
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 1601
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 1615
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 1615
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 1629
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 1629
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 1657
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 1657
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 1671
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 1671
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 1685
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 1685
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 1699
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 1699
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 1727
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 1727
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 1741
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 1741
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 1755
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 1755
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 1769
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 1769
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 1794
+        "line_number": 1783
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 1794
+        "line_number": 1783
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 1801
+        "line_number": 1797
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 1801
+        "line_number": 1797
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 1808
+        "line_number": 1811
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 1808
+        "line_number": 1811
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 1826
+        "line_number": 1825
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 1826
+        "line_number": 1825
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 1833
+        "line_number": 1839
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 1833
+        "line_number": 1839
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1840
+        "line_number": 1853
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1840
+        "line_number": 1853
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1849
+        "line_number": 1867
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1849
+        "line_number": 1867
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1858
+        "line_number": 1881
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1858
+        "line_number": 1881
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1865
+        "line_number": 1895
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1865
+        "line_number": 1895
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1872
+        "line_number": 1909
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1872
+        "line_number": 1909
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1897
+        "line_number": 1923
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1897
+        "line_number": 1923
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1904
+        "line_number": 1937
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1904
+        "line_number": 1937
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1913
+        "line_number": 1951
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1913
+        "line_number": 1951
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1922
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1922
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1929
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1938
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1938
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1947
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1947
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1965
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1965
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 1974
+        "line_number": 1979
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 1974
+        "line_number": 1979
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 1981
+        "line_number": 1993
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 1981
+        "line_number": 1993
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 1990
+        "line_number": 2007
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 1990
+        "line_number": 2007
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 2015
+        "line_number": 2021
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 2015
+        "line_number": 2021
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 2033
+        "line_number": 2035
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 2033
+        "line_number": 2035
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 2042
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 2042
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 2049
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 2049
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 2063
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 2063
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 2077
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 2077
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 2091
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 2091
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 2105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 2105
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 2119
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 2119
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 2133
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 2133
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 2147
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 2147
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 2161
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 2161
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 2175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 2175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 2200
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 2200
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 2207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 2207
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 2214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 2214
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 2232
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 2232
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 2239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 2239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 2246
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 2246
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 2255
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 2255
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 2264
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 2264
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 2271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 2271
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 2278
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 2278
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 2303
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 2303
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 2310
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 2310
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 2319
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 2319
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 2328
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 2328
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 2335
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 2335
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 2344
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 2344
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 2353
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 2353
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 2371
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 2371
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 2380
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 2380
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 2387
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 2387
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 2396
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 2396
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 2421
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 2421
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 2439
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 2439
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 2448
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 2448
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 2455
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 2455
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 2056
+        "line_number": 2462
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 2056
+        "line_number": 2462
       }
     ],
     "Makefile": [
@@ -2465,5 +2871,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T12:32:25Z"
+  "generated_at": "2026-05-15T12:37:49Z"
 }

--- a/src/wikimind/api/routes/export.py
+++ b/src/wikimind/api/routes/export.py
@@ -28,15 +28,11 @@ async def _resolve_article(
     user_id: str,
 ) -> Article:
     """Look up an article by ID or slug, raising 404 if not found."""
-    id_stmt = select(Article).where(Article.id == id_or_slug)
-    if user_id:
-        id_stmt = id_stmt.where(Article.user_id == user_id)
+    id_stmt = select(Article).where(Article.id == id_or_slug, Article.user_id == user_id)
     result = await session.execute(id_stmt)
     article = result.scalar_one_or_none()
     if article is None:
-        slug_stmt = select(Article).where(Article.slug == id_or_slug)
-        if user_id:
-            slug_stmt = slug_stmt.where(Article.user_id == user_id)
+        slug_stmt = select(Article).where(Article.slug == id_or_slug, Article.user_id == user_id)
         result = await session.execute(slug_stmt)
         article = result.scalar_one_or_none()
     if not article:

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -543,9 +543,9 @@ async def get_llm_cost_breakdown(
     settings = get_settings()
 
     async with get_session_factory()() as session:
-        total_stmt = select(func.sum(CostLog.cost_usd)).where(CostLog.created_at >= start_of_month)
-        if user_id:
-            total_stmt = total_stmt.where(CostLog.user_id == user_id)
+        total_stmt = select(func.sum(CostLog.cost_usd)).where(
+            CostLog.created_at >= start_of_month, CostLog.user_id == user_id
+        )
         total_result = await session.execute(total_stmt)
         total = total_result.scalar() or 0.0
 
@@ -555,11 +555,9 @@ async def get_llm_cost_breakdown(
                 func.sum(CostLog.cost_usd),
                 func.count(),
             )
-            .where(CostLog.created_at >= start_of_month)
+            .where(CostLog.created_at >= start_of_month, CostLog.user_id == user_id)
             .group_by(CostLog.provider)
         )
-        if user_id:
-            provider_stmt = provider_stmt.where(CostLog.user_id == user_id)
         provider_result = await session.execute(provider_stmt)
         provider_rows = provider_result.all()
 
@@ -569,11 +567,9 @@ async def get_llm_cost_breakdown(
                 func.sum(CostLog.cost_usd),
                 func.count(),
             )
-            .where(CostLog.created_at >= start_of_month)
+            .where(CostLog.created_at >= start_of_month, CostLog.user_id == user_id)
             .group_by(CostLog.task_type)
         )
-        if user_id:
-            task_stmt = task_stmt.where(CostLog.user_id == user_id)
         task_result = await session.execute(task_stmt)
         task_rows = task_result.all()
 
@@ -614,9 +610,9 @@ async def get_llm_cost(
     start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)
 
     async with get_session_factory()() as session:
-        cost_stmt = select(func.sum(CostLog.cost_usd)).where(CostLog.created_at >= start_of_month)
-        if user_id:
-            cost_stmt = cost_stmt.where(CostLog.user_id == user_id)
+        cost_stmt = select(func.sum(CostLog.cost_usd)).where(
+            CostLog.created_at >= start_of_month, CostLog.user_id == user_id
+        )
         result = await session.execute(cost_stmt)
         total = result.scalar() or 0.0
 

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -140,9 +140,7 @@ async def _score_wiki_worthiness(
 
     dedup_collision = False
     if candidate_slug:
-        stmt = select(Article).where(Article.slug == candidate_slug)
-        if user_id:
-            stmt = stmt.where(Article.user_id == user_id)
+        stmt = select(Article).where(Article.slug == candidate_slug, Article.user_id == user_id)
         existing = await db_session.execute(stmt)
         dedup_collision = existing.scalar_one_or_none() is not None
 
@@ -635,9 +633,7 @@ conversation context contradicts the wiki, prefer the wiki."""
         # Extract key terms from question (simple approach for Phase 1)
         terms = [t for t in question.lower().split() if len(t) > 3]
 
-        ctx_stmt = select(Article)
-        if user_id:
-            ctx_stmt = ctx_stmt.where(Article.user_id == user_id)
+        ctx_stmt = select(Article).where(Article.user_id == user_id)
         result = await session.execute(ctx_stmt)
         all_articles = result.scalars().all()
 

--- a/src/wikimind/services/admin.py
+++ b/src/wikimind/services/admin.py
@@ -364,9 +364,8 @@ class AdminService:
             Source.status == IngestStatus.PROCESSING,
             Source.file_path.is_(None),  # type: ignore[union-attr]
             Source.ingested_at < cutoff,
+            Source.user_id == user_id,
         )
-        if user_id:
-            stmt = stmt.where(Source.user_id == user_id)
         result = await session.execute(stmt)
         return [
             ZombieSource(

--- a/src/wikimind/services/compiler.py
+++ b/src/wikimind/services/compiler.py
@@ -34,9 +34,7 @@ class CompilerService:
         Returns:
             List of Job records ordered by queue time descending.
         """
-        query = select(Job).order_by(Job.queued_at.desc()).limit(limit)  # type: ignore[attr-defined]
-        if user_id:
-            query = query.where(Job.user_id == user_id)
+        query = select(Job).where(Job.user_id == user_id).order_by(Job.queued_at.desc()).limit(limit)  # type: ignore[attr-defined]
         if status:
             query = query.where(Job.status == status)
         result = await session.execute(query)

--- a/src/wikimind/services/embedding.py
+++ b/src/wikimind/services/embedding.py
@@ -249,14 +249,12 @@ class EmbeddingService:
             return []
 
         query_embedding = self._encode([query])
-        n_results = limit if user_id else min(limit, self._collection.count())
         query_kwargs: dict[str, Any] = {
             "query_embeddings": query_embedding,
-            "n_results": n_results,
+            "n_results": limit,
             "include": ["documents", "metadatas", "distances"],
+            "where": {"user_id": user_id},
         }
-        if user_id:
-            query_kwargs["where"] = {"user_id": user_id}
         results = self._collection.query(**query_kwargs)
 
         search_results: list[SemanticSearchResult] = []

--- a/src/wikimind/services/ingest.py
+++ b/src/wikimind/services/ingest.py
@@ -195,9 +195,7 @@ class IngestService:
         Returns:
             List of Source records.
         """
-        query = select(Source).offset(offset).limit(limit)
-        if user_id:
-            query = query.where(Source.user_id == user_id)
+        query = select(Source).where(Source.user_id == user_id).offset(offset).limit(limit)
         if status:
             query = query.where(Source.status == status)
         result = await session.execute(query)

--- a/src/wikimind/services/linter.py
+++ b/src/wikimind/services/linter.py
@@ -59,11 +59,10 @@ class LinterService:
         """
         stmt = (
             select(LintReport)
+            .where(LintReport.user_id == user_id)
             .order_by(LintReport.generated_at.desc())  # type: ignore[attr-defined]
             .limit(limit)
         )
-        if user_id:
-            stmt = stmt.where(LintReport.user_id == user_id)
         result = await session.execute(stmt)
         return list(result.scalars().all())
 
@@ -175,11 +174,10 @@ class LinterService:
         """
         latest_stmt = (
             select(LintReport)
+            .where(LintReport.user_id == user_id)
             .order_by(LintReport.generated_at.desc())  # type: ignore[attr-defined]
             .limit(1)
         )
-        if user_id:
-            latest_stmt = latest_stmt.where(LintReport.user_id == user_id)
         result = await session.execute(latest_stmt)
         report = result.scalars().first()
         if not report:

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -127,9 +127,7 @@ async def _build_citations(query: Query, session: AsyncSession, user_id: str) ->
     if not titles:
         return []
 
-    stmt = select(Article).where(Article.title.in_(titles))  # type: ignore[attr-defined]
-    if user_id:
-        stmt = stmt.where(Article.user_id == user_id)
+    stmt = select(Article).where(Article.title.in_(titles), Article.user_id == user_id)  # type: ignore[attr-defined]
     article_result = await session.execute(stmt)
     articles_by_title = {a.title: a for a in article_result.scalars().all()}
 
@@ -341,9 +339,7 @@ class QueryService:
         Returns:
             List of Query records.
         """
-        stmt = select(Query).order_by(Query.created_at.desc()).limit(limit)  # type: ignore[attr-defined]
-        if user_id:
-            stmt = stmt.where(Query.user_id == user_id)
+        stmt = select(Query).where(Query.user_id == user_id).order_by(Query.created_at.desc()).limit(limit)  # type: ignore[attr-defined]
         result = await session.execute(stmt)
         return list(result.scalars().all())
 
@@ -367,11 +363,10 @@ class QueryService:
         """
         conv_stmt = (
             select(Conversation)
+            .where(Conversation.user_id == user_id)
             .order_by(Conversation.updated_at.desc())  # type: ignore[attr-defined]
             .limit(limit)
         )
-        if user_id:
-            conv_stmt = conv_stmt.where(Conversation.user_id == user_id)
         result = await session.execute(conv_stmt)
         conversations = list(result.scalars().all())
 

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -161,10 +161,8 @@ async def update_article_counts(
     ac_stmt = (
         select(ArticleConcept)
         .join(Article, ArticleConcept.article_id == Article.id)  # type: ignore[arg-type]
-        .where(Article.page_type == PageType.SOURCE)
+        .where(Article.page_type == PageType.SOURCE, Article.user_id == user_id)
     )
-    if user_id:
-        ac_stmt = ac_stmt.where(Article.user_id == user_id)
     ac_result = await session.execute(ac_stmt)
     for ac in ac_result.scalars().all():
         normalized = slugify(ac.concept_name)
@@ -172,9 +170,7 @@ async def update_article_counts(
             counts[normalized] = counts.get(normalized, 0) + 1
 
     # Apply counts to all concepts (scoped by user_id)
-    concept_stmt = select(Concept)
-    if user_id:
-        concept_stmt = concept_stmt.where(Concept.user_id == user_id)
+    concept_stmt = select(Concept).where(Concept.user_id == user_id)
     concepts_result = await session.execute(concept_stmt)
     for concept in concepts_result.scalars().all():
         concept.article_count = counts.get(concept.name, 0)
@@ -242,9 +238,7 @@ async def maybe_trigger_concept_pages(
     """
     settings = get_settings()
     min_sources = settings.taxonomy.concept_page_min_sources
-    stmt = select(Concept).where(Concept.article_count >= min_sources)
-    if user_id:
-        stmt = stmt.where(Concept.user_id == user_id)
+    stmt = select(Concept).where(Concept.article_count >= min_sources, Concept.user_id == user_id)
     result = await session.execute(stmt)  # AsyncSession, not SQLModel Session
     eligible = list(result.scalars().all())
     if not eligible:
@@ -286,10 +280,9 @@ async def maybe_trigger_taxonomy_rebuild(
     threshold = settings.taxonomy.rebuild_threshold
 
     stmt = select(Concept).where(
-        Concept.parent_id.is_(None)  # type: ignore[union-attr]
+        Concept.parent_id.is_(None),  # type: ignore[union-attr]
+        Concept.user_id == user_id,
     )
-    if user_id:
-        stmt = stmt.where(Concept.user_id == user_id)
     result = await session.execute(stmt)
     unparented = list(result.scalars().all())
 
@@ -315,9 +308,7 @@ async def rebuild_taxonomy(
     settings = get_settings()
     max_depth = settings.taxonomy.max_hierarchy_depth
 
-    concept_stmt = select(Concept)
-    if user_id:
-        concept_stmt = concept_stmt.where(Concept.user_id == user_id)
+    concept_stmt = select(Concept).where(Concept.user_id == user_id)
     result = await session.execute(concept_stmt)
     all_concepts = list(result.scalars().all())
 

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -339,9 +339,7 @@ class WikiService:
         # Short-circuit: if article_ids filter is an empty list, return early
         if article_ids is not None and len(article_ids) == 0:
             return []
-        query = select(Article).offset(offset).limit(limit)
-        if user_id:
-            query = query.where(Article.user_id == user_id)
+        query = select(Article).where(Article.user_id == user_id).offset(offset).limit(limit)
         if article_ids is not None:
             query = query.where(
                 Article.id.in_(article_ids)  # type: ignore[attr-defined]
@@ -385,16 +383,12 @@ class WikiService:
             NotFoundError: If no article matches either lookup.
         """
         # Try ID first
-        id_stmt = select(Article).where(Article.id == id_or_slug)
-        if user_id:
-            id_stmt = id_stmt.where(Article.user_id == user_id)
+        id_stmt = select(Article).where(Article.id == id_or_slug, Article.user_id == user_id)
         result = await session.execute(id_stmt)
         article = result.scalar_one_or_none()
         if article is None:
             # Fall back to slug
-            slug_stmt = select(Article).where(Article.slug == id_or_slug)
-            if user_id:
-                slug_stmt = slug_stmt.where(Article.user_id == user_id)
+            slug_stmt = select(Article).where(Article.slug == id_or_slug, Article.user_id == user_id)
             result = await session.execute(slug_stmt)
             article = result.scalar_one_or_none()
         if not article:
@@ -531,15 +525,11 @@ class WikiService:
         """
         if not id_or_slug:
             return None
-        id_stmt = select(Article.id).where(Article.id == id_or_slug)
-        if user_id:
-            id_stmt = id_stmt.where(Article.user_id == user_id)
+        id_stmt = select(Article.id).where(Article.id == id_or_slug, Article.user_id == user_id)
         row = (await session.execute(id_stmt)).first()
         if row is not None:
             return row[0]
-        slug_stmt = select(Article.id).where(Article.slug == id_or_slug)
-        if user_id:
-            slug_stmt = slug_stmt.where(Article.user_id == user_id)
+        slug_stmt = select(Article.id).where(Article.slug == id_or_slug, Article.user_id == user_id)
         row = (await session.execute(slug_stmt)).first()
         return row[0] if row is not None else None
 
@@ -608,9 +598,7 @@ class WikiService:
                 return GraphResponse(nodes=[], edges=[])
 
         # Push every filter into a single SQL query against Backlink.
-        bl_stmt = select(Backlink)
-        if user_id:
-            bl_stmt = bl_stmt.where(Backlink.user_id == user_id)
+        bl_stmt = select(Backlink).where(Backlink.user_id == user_id)
         if relation_type is not None:
             bl_stmt = bl_stmt.where(Backlink.relation_type == relation_type.value)
         if from_id is not None:
@@ -622,9 +610,7 @@ class WikiService:
 
         # Articles for node list — full set per user scope so the graph
         # remains visually consistent across edge filters.
-        graph_stmt = select(Article)
-        if user_id:
-            graph_stmt = graph_stmt.where(Article.user_id == user_id)
+        graph_stmt = select(Article).where(Article.user_id == user_id)
         articles_result = await session.execute(graph_stmt)
         articles = articles_result.scalars().all()
 
@@ -701,10 +687,8 @@ class WikiService:
                 Backlink.resolution,
             )
             .join(Article, Article.id == Backlink.target_article_id)
-            .where(Backlink.source_article_id == article_id)
+            .where(Backlink.source_article_id == article_id, Article.user_id == user_id)
         )
-        if user_id:
-            out_stmt = out_stmt.where(Article.user_id == user_id)
         out_rows = (await session.execute(out_stmt)).all()
 
         # Incoming: this article is the target. Join source Article for metadata.
@@ -718,10 +702,8 @@ class WikiService:
                 Backlink.resolution,
             )
             .join(Article, Article.id == Backlink.source_article_id)
-            .where(Backlink.target_article_id == article_id)
+            .where(Backlink.target_article_id == article_id, Article.user_id == user_id)
         )
-        if user_id:
-            in_stmt = in_stmt.where(Article.user_id == user_id)
         in_rows = (await session.execute(in_stmt)).all()
 
         outgoing: dict[str, list[RelationshipEdge]] = {}
@@ -878,9 +860,7 @@ class WikiService:
         Returns:
             Mapping of article_id to normalised keyword score.
         """
-        kw_stmt = select(Article)
-        if user_id:
-            kw_stmt = kw_stmt.where(Article.user_id == user_id)
+        kw_stmt = select(Article).where(Article.user_id == user_id)
         result = await session.execute(kw_stmt)
         all_articles = result.scalars().all()
 
@@ -918,9 +898,7 @@ class WikiService:
         Returns:
             List of Concept records.
         """
-        query = select(Concept)
-        if user_id:
-            query = query.where(Concept.user_id == user_id)
+        query = select(Concept).where(Concept.user_id == user_id)
         if not include_empty:
             query = query.where(Concept.article_count > 0)
         result = await session.execute(query)
@@ -945,9 +923,7 @@ class WikiService:
         Raises:
             NotFoundError: If concept not found.
         """
-        query = select(Concept).where(Concept.name == name)
-        if user_id:
-            query = query.where(Concept.user_id == user_id)
+        query = select(Concept).where(Concept.name == name, Concept.user_id == user_id)
         result = await session.execute(query)
         concept = result.scalar_one_or_none()
         if not concept:
@@ -1018,9 +994,7 @@ class WikiService:
             content = await storage.read(health_relative)
             return WikiHealthReport(**json.loads(content))
 
-        article_stmt = select(Article)
-        if user_id:
-            article_stmt = article_stmt.where(Article.user_id == user_id)
+        article_stmt = select(Article).where(Article.user_id == user_id)
         articles_result = await session.execute(article_stmt)
         articles = articles_result.scalars().all()
 

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -198,9 +198,7 @@ async def regenerate_index_md(
     """
     wiki_storage = get_wiki_storage(user_id)
 
-    article_stmt = select(Article)
-    if user_id:
-        article_stmt = article_stmt.where(Article.user_id == user_id)
+    article_stmt = select(Article).where(Article.user_id == user_id)
     articles_result = await session.execute(article_stmt)
     articles: list[Article] = list(articles_result.scalars().all())
 
@@ -224,20 +222,16 @@ async def _fetch_health_data(
     user_id: str,
 ) -> HealthData:
     """Fetch articles and backlinks for the health page, scoped by user_id."""
-    article_stmt = select(Article)
-    if user_id:
-        article_stmt = article_stmt.where(Article.user_id == user_id)
+    article_stmt = select(Article).where(Article.user_id == user_id)
     articles_result = await session.execute(article_stmt)
     articles: list[Article] = list(articles_result.scalars().all())
 
     # Filter backlinks to only those between this user's articles
     article_ids = {a.id for a in articles}
-    backlink_stmt = select(Backlink)
-    if user_id:
-        backlink_stmt = backlink_stmt.where(
-            Backlink.source_article_id.in_(article_ids),  # type: ignore[attr-defined]
-            Backlink.target_article_id.in_(article_ids),  # type: ignore[attr-defined]
-        )
+    backlink_stmt = select(Backlink).where(
+        Backlink.source_article_id.in_(article_ids),  # type: ignore[attr-defined]
+        Backlink.target_article_id.in_(article_ids),  # type: ignore[attr-defined]
+    )
     backlinks_result = await session.execute(backlink_stmt)
     backlinks: list[Backlink] = list(backlinks_result.scalars().all())
 

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -724,8 +724,8 @@ class TestBuildCitationsOwnership:
         citations_b = await _build_citations(query, db_session, user_id="user-b")
         assert citations_b == []
 
-    async def test_build_citations_no_filter_when_user_id_none(self, db_session, tmp_path):
-        """_build_citations returns all matching articles when user_id is None."""
+    async def test_build_citations_enforces_user_id_filter(self, db_session, tmp_path):
+        """_build_citations always filters by user_id, even when empty string."""
         file_path = tmp_path / "any-article.md"
         file_path.write_text("# Any", encoding="utf-8")
 
@@ -751,5 +751,6 @@ class TestBuildCitationsOwnership:
         db_session.add(query)
         await db_session.commit()
 
-        citations = await _build_citations(query, db_session, user_id=None)
-        assert len(citations) == 1
+        # Empty string must not bypass isolation — should return no results
+        citations = await _build_citations(query, db_session, user_id="")
+        assert citations == []


### PR DESCRIPTION
## Summary
- **Problem:** 38 instances of `if user_id:` guards on `.where()` clauses meant an empty string `""` would skip isolation filters, leaking data across tenants
- **Fix:** Removed all 38 conditional guards across 12 source files, making `user_id` filtering unconditional on all database queries
- **Kept:** 4 legitimate guards (middleware logging, file path scoping, explicit `str | None` signatures)
- **Tests:** Updated test to verify empty strings are properly filtered

Files: `services/wiki.py` (14), `services/taxonomy.py` (5), `api/routes/settings.py` (4), `services/query.py` (3), `services/wiki_index.py` (3), `api/routes/export.py` (2), `engine/qa_agent.py` (2), `services/linter.py` (2), and 4 more

Closes #665

## Test plan
- [ ] `make verify` passes (1640 tests, 87.92% coverage)
- [ ] All database queries unconditionally filter by `user_id`
- [ ] Empty string `user_id` no longer bypasses isolation
- [ ] Legitimate non-DB guards preserved

🤖 Generated with [Claude Code](https://claude.ai/claude-code)