### PR TITLE
refactor(tests): centralize test session factories in conftest (#650)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_8HyYXd"
+      "filename": ".merge_file_DT2tEZ"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -408,2186 +408,2592 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
+        "hashed_secret": "c5f467c99e36222cc1f95f82517404119ce31885",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
+        "hashed_secret": "c5f467c99e36222cc1f95f82517404119ce31885",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
+        "hashed_secret": "e37fba695f2b14efeda533cff2806cc18ae3313f",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
+        "hashed_secret": "e37fba695f2b14efeda533cff2806cc18ae3313f",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
+        "hashed_secret": "0f3a4a52aeec95259de12d7db227c4d15ea7725b",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
+        "hashed_secret": "0f3a4a52aeec95259de12d7db227c4d15ea7725b",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
+        "hashed_secret": "53f7514fbd7ac2c3e8b1c689069c37fbe34fb3d9",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
+        "hashed_secret": "53f7514fbd7ac2c3e8b1c689069c37fbe34fb3d9",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
+        "hashed_secret": "8c6b4b5ed430b9906beff0c52c020075bda647d5",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
+        "hashed_secret": "8c6b4b5ed430b9906beff0c52c020075bda647d5",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
+        "hashed_secret": "66cdb5e4ce3f8245dba3113ace861d0e7bf438a9",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
+        "hashed_secret": "66cdb5e4ce3f8245dba3113ace861d0e7bf438a9",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
+        "hashed_secret": "a735be39964d403bd07168e327a666386e7e33e7",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
+        "hashed_secret": "a735be39964d403bd07168e327a666386e7e33e7",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
+        "hashed_secret": "203cbb7e849fa5d11c81f68cf42b35b578a0a779",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
+        "hashed_secret": "203cbb7e849fa5d11c81f68cf42b35b578a0a779",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
+        "hashed_secret": "d2b1443ccdc6283a94d57660d12daa4077e42b13",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
+        "hashed_secret": "d2b1443ccdc6283a94d57660d12daa4077e42b13",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
+        "hashed_secret": "fdad28bd396a9338c52af3bfe3452ec892e37e72",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
+        "hashed_secret": "fdad28bd396a9338c52af3bfe3452ec892e37e72",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
+        "hashed_secret": "9b2c316d0b145debe2ae588cba1ea948aefae887",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
+        "hashed_secret": "9b2c316d0b145debe2ae588cba1ea948aefae887",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
+        "hashed_secret": "ccc50db4d879b255c5653a2e430d2b1414175d7c",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
+        "hashed_secret": "ccc50db4d879b255c5653a2e430d2b1414175d7c",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
+        "hashed_secret": "537369f063e9b3660ac50eaef50f017c864aa4ce",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
+        "hashed_secret": "537369f063e9b3660ac50eaef50f017c864aa4ce",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
+        "hashed_secret": "ad63f7902fd9111de53b762eb8fbcec8b01a34c2",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
+        "hashed_secret": "ad63f7902fd9111de53b762eb8fbcec8b01a34c2",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
+        "hashed_secret": "712870abf505aba3208eac8cd1cd9c40ad47908f",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
+        "hashed_secret": "712870abf505aba3208eac8cd1cd9c40ad47908f",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
+        "hashed_secret": "30802b7ba42d7fa49b66268cb956347cfa251cad",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
+        "hashed_secret": "30802b7ba42d7fa49b66268cb956347cfa251cad",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
+        "hashed_secret": "9c37b5557d9fb759a608dd2ec89517abbbeb9146",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
+        "hashed_secret": "9c37b5557d9fb759a608dd2ec89517abbbeb9146",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
+        "hashed_secret": "0da08e0a2059c84a991a7662396ea854fa5ea558",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
+        "hashed_secret": "0da08e0a2059c84a991a7662396ea854fa5ea558",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
+        "hashed_secret": "e1a6a51e9a1dae0509914dc005641b24d6fcb093",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
+        "hashed_secret": "e1a6a51e9a1dae0509914dc005641b24d6fcb093",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
+        "hashed_secret": "a8c65a7d6ec3ab2b6b9371edb764b083d37b08bf",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
+        "hashed_secret": "a8c65a7d6ec3ab2b6b9371edb764b083d37b08bf",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
+        "hashed_secret": "a6b584f2d18a5724922ef5ce1547beb81ace8a81",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
+        "hashed_secret": "a6b584f2d18a5724922ef5ce1547beb81ace8a81",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
+        "hashed_secret": "8c6984b1e1e4fb41ba4ea4d3bdb3c89aaba3a0c1",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
+        "hashed_secret": "8c6984b1e1e4fb41ba4ea4d3bdb3c89aaba3a0c1",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1087ae5d0ff7d6972f1235b88109d645f0e85efd",
+        "hashed_secret": "3d41323f7517e406817145ca2b126577e06c9e2b",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1087ae5d0ff7d6972f1235b88109d645f0e85efd",
+        "hashed_secret": "3d41323f7517e406817145ca2b126577e06c9e2b",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
+        "hashed_secret": "992f451a59b652057939e981111bb6d30308b217",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
+        "hashed_secret": "992f451a59b652057939e981111bb6d30308b217",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
+        "hashed_secret": "310354ba6711ca3c2b93eddfa153aff98fd7ed72",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
+        "hashed_secret": "310354ba6711ca3c2b93eddfa153aff98fd7ed72",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
+        "hashed_secret": "b64e221cb90f07767291331e641fbb2dac4ee9ca",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
+        "hashed_secret": "b64e221cb90f07767291331e641fbb2dac4ee9ca",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
+        "hashed_secret": "157d6d412aecd18a03e8b132b341a505ed328dd5",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
+        "hashed_secret": "157d6d412aecd18a03e8b132b341a505ed328dd5",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
+        "hashed_secret": "760185e12a9c8f8a0fa66296739b4081252ddadf",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
+        "hashed_secret": "760185e12a9c8f8a0fa66296739b4081252ddadf",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
+        "hashed_secret": "4795878cc3e9d3502c45f40b00c3ff93d03f4557",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
+        "hashed_secret": "4795878cc3e9d3502c45f40b00c3ff93d03f4557",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
+        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
+        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
+        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
+        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
+        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
+        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
+        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
+        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
+        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
+        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
+        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
+        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
+        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
+        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
+        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
+        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
+        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
+        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
+        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
+        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
+        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
+        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
+        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
+        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
+        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
+        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
+        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
+        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
+        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
+        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
+        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
+        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
+        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
+        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
+        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
+        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
+        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
+        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
+        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
+        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
+        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
+        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
+        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
+        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
+        "hashed_secret": "1087ae5d0ff7d6972f1235b88109d645f0e85efd",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
+        "hashed_secret": "1087ae5d0ff7d6972f1235b88109d645f0e85efd",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 1377
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 1377
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 1391
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 1391
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 1405
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 1405
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 1419
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 1419
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 1433
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 1433
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
         "is_verified": false,
         "line_number": 1447
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "48f17df902b017f697a1c09d0dff1472a1d87fa8",
         "is_verified": false,
         "line_number": 1447
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 1461
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 1461
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 1475
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 1475
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 1489
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 1489
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 1503
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 1503
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 1517
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 1517
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 1531
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 1531
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 1545
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 1545
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 1573
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 1573
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 1601
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 1601
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 1615
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 1615
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 1629
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 1629
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 1657
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 1657
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 1671
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 1671
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 1685
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 1685
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 1699
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 1699
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 1727
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 1727
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 1741
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 1741
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 1755
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 1755
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 1769
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 1769
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 1783
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 1783
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 1797
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 1797
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 1811
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "5d25d941256d0cb04a3b2e7eb3ce99ed14f03174",
         "is_verified": false,
         "line_number": 1811
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 1825
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 1825
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 1839
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 1839
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 1853
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 1853
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 1867
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 1867
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 1881
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 1881
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 1895
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 1895
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 1909
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 1909
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 1923
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 1923
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 1937
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 1937
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 1951
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 1951
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 1965
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 1965
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 1979
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 1979
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 1993
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 1993
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 2007
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 2007
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 2021
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 2021
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 2035
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 2035
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 2049
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 2049
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 2063
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 2063
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 2077
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 2077
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 2091
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 2091
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 2105
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 2105
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 2119
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 2119
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 2133
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 2133
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 2147
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 2147
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 2161
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 2161
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 2175
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "dd357c15811cbefb90117c1ec49f95195e89c63a",
         "is_verified": false,
         "line_number": 2175
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 2200
+        "line_number": 2189
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 2200
+        "line_number": 2189
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 2207
+        "line_number": 2203
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 2207
+        "line_number": 2203
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 2214
+        "line_number": 2217
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 2214
+        "line_number": 2217
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 2232
+        "line_number": 2231
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 2232
+        "line_number": 2231
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 2239
+        "line_number": 2245
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 2239
+        "line_number": 2245
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 2246
+        "line_number": 2259
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 2246
+        "line_number": 2259
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 2255
+        "line_number": 2273
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 2255
+        "line_number": 2273
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 2264
+        "line_number": 2287
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 2264
+        "line_number": 2287
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 2271
+        "line_number": 2301
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 2271
+        "line_number": 2301
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 2278
+        "line_number": 2315
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 2278
+        "line_number": 2315
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 2303
+        "line_number": 2329
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 2303
+        "line_number": 2329
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 2310
+        "line_number": 2343
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 2310
+        "line_number": 2343
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 2319
+        "line_number": 2357
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 2319
+        "line_number": 2357
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 2328
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 2328
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 2335
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 2335
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 2344
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 2344
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 2353
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 2353
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 2371
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 2371
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 2380
+        "line_number": 2385
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
-        "line_number": 2380
+        "line_number": 2385
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 2387
+        "line_number": 2399
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
         "is_verified": false,
-        "line_number": 2387
+        "line_number": 2399
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 2396
+        "line_number": 2413
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
         "is_verified": false,
-        "line_number": 2396
+        "line_number": 2413
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 2421
+        "line_number": 2427
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
         "is_verified": false,
-        "line_number": 2421
+        "line_number": 2427
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 2439
+        "line_number": 2441
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
         "is_verified": false,
-        "line_number": 2439
+        "line_number": 2441
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 2448
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
-        "is_verified": false,
-        "line_number": 2448
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 2455
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
         "is_verified": false,
         "line_number": 2455
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 2469
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 2469
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 2483
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 2483
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 2497
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 2497
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 2511
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 2511
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 2525
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 2525
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 2539
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 2539
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 2553
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 2553
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 2567
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 2567
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 2581
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 2581
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 2606
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 2606
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 2613
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 2613
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 2620
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 2620
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 2638
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 2638
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 2645
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 2645
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 2652
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 2652
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 2661
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 2661
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 2670
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 2670
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 2677
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 2677
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 2684
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 2684
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 2709
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 2709
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 2716
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 2716
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 2725
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 2725
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 2734
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 2734
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 2741
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 2741
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 2750
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 2750
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 2759
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 2759
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 2777
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 2777
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 2786
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 2786
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 2793
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 2793
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 2802
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 2802
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 2827
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 2827
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 2845
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 2845
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 2854
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 2854
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 2861
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 2861
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 2462
+        "line_number": 2868
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 2462
+        "line_number": 2868
       }
     ],
     "Makefile": [
@@ -2871,5 +3277,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T15:44:36Z"
+  "generated_at": "2026-05-15T15:45:07Z"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,18 @@ async def async_engine() -> AsyncGenerator[AsyncEngine, None]:
 
 
 @pytest.fixture
+def session_factory(async_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """Reusable async session factory backed by the in-memory test engine.
+
+    Prefer this fixture whenever a test (or its helper) needs to open
+    multiple independent sessions against the same test database — e.g.
+    for seeding data before exercising a route, or for verifying state
+    after a service call.
+    """
+    return async_sessionmaker(async_engine, expire_on_commit=False)
+
+
+@pytest.fixture
 async def db_session(async_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
     """Async database session backed by in-memory SQLite."""
     factory = async_sessionmaker(async_engine, expire_on_commit=False)

--- a/tests/integration/test_sweep_integration.py
+++ b/tests/integration/test_sweep_integration.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.conftest import TEST_USER_ID
 from wikimind._datetime import utcnow_naive
@@ -55,7 +58,7 @@ async def _make_article(
 
 
 @pytest.mark.asyncio
-async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engine, tmp_path: Path) -> None:
+async def test_sweep_resolves_incrementally(db_session: AsyncSession, session_factory, tmp_path: Path) -> None:
     """Full sweep resolves brackets as target articles appear over time."""
     wiki = _wiki_root()
     # --- Setup: article B exists, article C does not yet exist ---
@@ -70,7 +73,7 @@ async def test_sweep_resolves_incrementally(db_session: AsyncSession, async_engi
     article_a = await _make_article(db_session, "AI Overview", "overview.md", slug="ai-overview")
 
     # Build a real session factory backed by the same in-memory engine
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
 
     # --- Phase 1: run sweep --- only Machine Learning should resolve ---
     with patch("wikimind.jobs.sweep.get_session_factory", return_value=factory):

--- a/tests/integration/test_typed_graph_filtering.py
+++ b/tests/integration/test_typed_graph_filtering.py
@@ -9,15 +9,14 @@ to just the contradiction edge.
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.models import Article, Backlink, RelationType
 
 
 @pytest.mark.asyncio
-async def test_graph_relation_type_contradicts_returns_only_contradictions(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+async def test_graph_relation_type_contradicts_returns_only_contradictions(client, session_factory) -> None:
+    factory = session_factory
     async with factory() as session:
         session.add(
             Article(

--- a/tests/unit/test_backlink_enforcer.py
+++ b/tests/unit/test_backlink_enforcer.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
 from tests.conftest import TEST_USER_ID
@@ -236,9 +235,8 @@ async def test_contradiction_detection_creates_typed_backlink(db_session, _isola
 
 
 @pytest.mark.asyncio
-async def test_resolve_contradiction_endpoint(client, async_engine):
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    async with factory() as session:
+async def test_resolve_contradiction_endpoint(client, session_factory):
+    async with session_factory() as session:
         session.add(Article(id="a1", slug="art-a", title="Art A", file_path="/tmp/a.md", user_id=TEST_USER_ID))
         session.add(Article(id="a2", slug="art-b", title="Art B", file_path="/tmp/b.md", user_id=TEST_USER_ID))
         session.add(
@@ -268,7 +266,7 @@ async def test_resolve_contradiction_endpoint(client, async_engine):
     data = response.json()
     assert data["resolved"] is True
     assert data["resolution"] == "source_a_wins"
-    async with factory() as session:
+    async with session_factory() as session:
         result = await session.execute(
             select(Backlink).where(Backlink.source_article_id == "a1", Backlink.target_article_id == "a2")
         )
@@ -284,9 +282,8 @@ async def test_resolve_contradiction_404(client):
 
 
 @pytest.mark.asyncio
-async def test_resolve_contradiction_422_invalid(client, async_engine):
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    async with factory() as session:
+async def test_resolve_contradiction_422_invalid(client, session_factory):
+    async with session_factory() as session:
         session.add(Article(id="a1", slug="art-a", title="Art A", file_path="/tmp/a.md", user_id=TEST_USER_ID))
         session.add(Article(id="a2", slug="art-b", title="Art B", file_path="/tmp/b.md", user_id=TEST_USER_ID))
         session.add(
@@ -304,9 +301,8 @@ async def test_resolve_contradiction_422_invalid(client, async_engine):
 
 
 @pytest.mark.asyncio
-async def test_graph_api_includes_relation_type(client, async_engine):
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    async with factory() as session:
+async def test_graph_api_includes_relation_type(client, session_factory):
+    async with session_factory() as session:
         session.add(Article(id="a1", slug="art-a", title="Art A", file_path="/tmp/a.md", user_id=ANONYMOUS_USER_ID))
         session.add(Article(id="a2", slug="art-b", title="Art B", file_path="/tmp/b.md", user_id=ANONYMOUS_USER_ID))
         session.add(

--- a/tests/unit/test_contradictions.py
+++ b/tests/unit/test_contradictions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from tests.conftest import TEST_USER_ID
 from wikimind.api.deps import ANONYMOUS_USER_ID
@@ -280,9 +279,8 @@ async def test_service_create_from_finding_different_claims_creates_separate(db_
 
 
 @pytest.mark.asyncio
-async def test_api_list_contradictions(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles_and_contradictions(factory)
+async def test_api_list_contradictions(client, session_factory) -> None:
+    await _seed_articles_and_contradictions(session_factory)
 
     response = await client.get("/api/wiki/contradictions")
     assert response.status_code == 200
@@ -291,9 +289,8 @@ async def test_api_list_contradictions(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_list_contradictions_filter_active(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles_and_contradictions(factory)
+async def test_api_list_contradictions_filter_active(client, session_factory) -> None:
+    await _seed_articles_and_contradictions(session_factory)
 
     response = await client.get("/api/wiki/contradictions", params={"status": "active"})
     assert response.status_code == 200
@@ -303,9 +300,8 @@ async def test_api_list_contradictions_filter_active(client, async_engine) -> No
 
 
 @pytest.mark.asyncio
-async def test_api_get_single_contradiction(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles_and_contradictions(factory)
+async def test_api_get_single_contradiction(client, session_factory) -> None:
+    await _seed_articles_and_contradictions(session_factory)
 
     response = await client.get("/api/wiki/contradictions/ctr1")
     assert response.status_code == 200
@@ -323,9 +319,8 @@ async def test_api_get_contradiction_not_found(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_resolve_contradiction(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles_and_contradictions(factory)
+async def test_api_resolve_contradiction(client, session_factory) -> None:
+    await _seed_articles_and_contradictions(session_factory)
 
     response = await client.patch(
         "/api/wiki/contradictions/ctr1",
@@ -339,9 +334,8 @@ async def test_api_resolve_contradiction(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_dismiss_contradiction(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles_and_contradictions(factory)
+async def test_api_dismiss_contradiction(client, session_factory) -> None:
+    await _seed_articles_and_contradictions(session_factory)
 
     response = await client.patch(
         "/api/wiki/contradictions/ctr1",
@@ -404,20 +398,18 @@ async def _seed_other_user_contradiction(factory) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_get_contradiction_cross_user_returns_404(client, async_engine) -> None:
+async def test_api_get_contradiction_cross_user_returns_404(client, session_factory) -> None:
     """GET another user's contradiction returns 404 — not leaked."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_other_user_contradiction(factory)
+    await _seed_other_user_contradiction(session_factory)
 
     response = await client.get("/api/wiki/contradictions/other-ctr1")
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_api_patch_contradiction_cross_user_returns_404(client, async_engine) -> None:
+async def test_api_patch_contradiction_cross_user_returns_404(client, session_factory) -> None:
     """PATCH another user's contradiction returns 404 — not modifiable."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_other_user_contradiction(factory)
+    await _seed_other_user_contradiction(session_factory)
 
     response = await client.patch(
         "/api/wiki/contradictions/other-ctr1",

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -8,7 +8,6 @@ import uuid
 from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
 from tests.conftest import TEST_USER_ID
@@ -28,12 +27,6 @@ def _wiki_root() -> Path:
     root = Path(settings.data_dir) / "wiki" / TEST_USER_ID
     root.mkdir(parents=True, exist_ok=True)
     return root
-
-
-@pytest.fixture
-def session_factory(async_engine):
-    """Override get_session to use the in-memory engine."""
-    return async_sessionmaker(async_engine, expire_on_commit=False)
 
 
 @pytest.fixture

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -10,22 +10,19 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.models import Job, JobStatus, JobType, Source, SourceType
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
-    from sqlalchemy.ext.asyncio import AsyncEngine
 
 OTHER_USER_ID = "other-user"
 
 
-async def _seed(async_engine: AsyncEngine, model):
+async def _seed(session_factory, model):
     """Insert a model instance and return it refreshed."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    async with factory() as session:
+    async with session_factory() as session:
         session.add(model)
         await session.commit()
         await session.refresh(model)
@@ -39,10 +36,10 @@ async def _seed(async_engine: AsyncEngine, model):
 
 class TestGetJobOwnership:
     @pytest.mark.asyncio
-    async def test_get_job_own_user(self, client: AsyncClient, async_engine: AsyncEngine):
+    async def test_get_job_own_user(self, client: AsyncClient, session_factory):
         """Owner can read their own job."""
         job = await _seed(
-            async_engine,
+            session_factory,
             Job(
                 id="job-owned",
                 user_id=ANONYMOUS_USER_ID,
@@ -57,10 +54,10 @@ class TestGetJobOwnership:
         assert data["id"] == "job-owned"
 
     @pytest.mark.asyncio
-    async def test_get_job_other_user_returns_none(self, client: AsyncClient, async_engine: AsyncEngine):
+    async def test_get_job_other_user_returns_none(self, client: AsyncClient, session_factory):
         """A job belonging to another user is invisible (returns None/null)."""
         await _seed(
-            async_engine,
+            session_factory,
             Job(
                 id="job-other",
                 user_id=OTHER_USER_ID,
@@ -80,10 +77,10 @@ class TestGetJobOwnership:
 
 class TestTriggerCompileOwnership:
     @pytest.mark.asyncio
-    async def test_trigger_compile_own_source(self, client: AsyncClient, async_engine: AsyncEngine):
+    async def test_trigger_compile_own_source(self, client: AsyncClient, session_factory):
         """Owner can trigger compile on their own source."""
         await _seed(
-            async_engine,
+            session_factory,
             Source(
                 id="src-owned",
                 source_type=SourceType.TEXT,
@@ -104,10 +101,10 @@ class TestTriggerCompileOwnership:
         assert data["status"] == "queued"
 
     @pytest.mark.asyncio
-    async def test_trigger_compile_other_user_returns_404(self, client: AsyncClient, async_engine: AsyncEngine):
+    async def test_trigger_compile_other_user_returns_404(self, client: AsyncClient, session_factory):
         """Triggering compile on another user's source returns 404."""
         await _seed(
-            async_engine,
+            session_factory,
             Source(
                 id="src-other",
                 source_type=SourceType.TEXT,

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -10,7 +10,6 @@ import pytest
 import structlog
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
 from tests.conftest import TEST_USER_ID
@@ -137,9 +136,8 @@ async def test_settings_test_llm_uses_provider_safe_token_budget(client) -> None
     assert seen["request"].max_tokens >= 16
 
 
-async def test_settings_get_cost(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    with patch("wikimind.api.routes.settings.get_session_factory", return_value=factory):
+async def test_settings_get_cost(client, session_factory) -> None:
+    with patch("wikimind.api.routes.settings.get_session_factory", return_value=session_factory):
         resp = await client.get("/api/settings/llm/cost")
     assert resp.status_code == 200
     assert "cost_this_month_usd" in resp.json()

--- a/tests/unit/test_remaining_routes.py
+++ b/tests/unit/test_remaining_routes.py
@@ -337,11 +337,8 @@ class TestWikiRoutesWithData:
     """Route tests that create data in the database via the same engine as the client."""
 
     @staticmethod
-    async def _seed_article(async_engine, **kwargs):
-        from sqlalchemy.ext.asyncio import async_sessionmaker
-
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def _seed_article(session_factory, **kwargs):
+        async with session_factory() as session:
             art = Article(**kwargs)
             session.add(art)
             await session.commit()
@@ -349,10 +346,10 @@ class TestWikiRoutesWithData:
             return art
 
     @pytest.mark.asyncio
-    async def test_recompile_existing_article(self, client: AsyncClient, async_engine):
+    async def test_recompile_existing_article(self, client: AsyncClient, session_factory):
         """Recompile route should create a job and schedule recompile."""
         art = await self._seed_article(
-            async_engine,
+            session_factory,
             slug="recompile-test",
             title="Recompile Test",
             file_path="wiki/recompile-test.md",
@@ -370,10 +367,10 @@ class TestWikiRoutesWithData:
         assert data["job_id"] is not None
 
     @pytest.mark.asyncio
-    async def test_refresh_existing_article(self, client: AsyncClient, async_engine):
+    async def test_refresh_existing_article(self, client: AsyncClient, session_factory):
         """Refresh route should mark article as still-current."""
         art = await self._seed_article(
-            async_engine,
+            session_factory,
             slug="refresh-test",
             title="Refresh Test",
             file_path="wiki/refresh-test.md",
@@ -387,10 +384,10 @@ class TestWikiRoutesWithData:
         assert data["status"] == "refreshed"
 
     @pytest.mark.asyncio
-    async def test_get_article_tags(self, client: AsyncClient, async_engine):
+    async def test_get_article_tags(self, client: AsyncClient, session_factory):
         """Get tags for an article."""
         art = await self._seed_article(
-            async_engine,
+            session_factory,
             slug="tagged-art",
             title="Tagged Art",
             file_path="wiki/tagged-art.md",
@@ -403,10 +400,10 @@ class TestWikiRoutesWithData:
         assert isinstance(resp.json(), list)
 
     @pytest.mark.asyncio
-    async def test_export_existing_article_pdf(self, client: AsyncClient, async_engine):
+    async def test_export_existing_article_pdf(self, client: AsyncClient, session_factory):
         """Export an existing article as PDF HTML."""
         art = await self._seed_article(
-            async_engine,
+            session_factory,
             slug="export-test",
             title="Export Test",
             file_path="wiki/export-test.md",

--- a/tests/unit/test_schema_models.py
+++ b/tests/unit/test_schema_models.py
@@ -1,12 +1,17 @@
 """Tests for schema overhaul Phase 1 — enums, tables, Pydantic models, and registry."""
 
+from __future__ import annotations
+
 import json
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import ValidationError
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.conftest import TEST_USER_ID
 from wikimind.engine.concept_kind_registry import (
@@ -327,59 +332,52 @@ class TestAnswerCompilationResult:
 
 
 class TestSeedBuiltinKinds:
-    async def test_creates_five_kinds(self, async_engine):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_creates_five_kinds(self, session_factory):
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
-        async with factory() as session:
+        async with session_factory() as session:
             result = await session.execute(select(ConceptKindDef))
             assert {k.name for k in result.scalars().all()} == {"topic", "person", "organization", "product", "paper"}
 
-    async def test_idempotent(self, async_engine):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_idempotent(self, session_factory):
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
-        async with factory() as session:
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
-        async with factory() as session:
+        async with session_factory() as session:
             assert len((await session.execute(select(ConceptKindDef))).scalars().all()) == 5
 
-    async def test_topic_has_correct_sections(self, async_engine):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_topic_has_correct_sections(self, session_factory):
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
-        async with factory() as session:
+        async with session_factory() as session:
             topic = (await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "topic"))).scalar_one()
             assert "overview" in json.loads(topic.required_sections)
 
-    async def test_person_has_correct_template_key(self, async_engine):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_person_has_correct_template_key(self, session_factory):
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
-        async with factory() as session:
+        async with session_factory() as session:
             person = (await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "person"))).scalar_one()
             assert person.prompt_template_key == "concept_synthesis_person"
 
 
 class TestValidateRegistryAgainstPrompts:
-    async def test_passes_with_valid_templates(self, async_engine):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_passes_with_valid_templates(self, session_factory):
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
-        async with factory() as session:
+        async with session_factory() as session:
             await validate_registry_against_prompts(session)
 
-    async def test_fails_with_missing_template(self, async_engine, monkeypatch):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_fails_with_missing_template(self, session_factory, monkeypatch):
+        async with session_factory() as session:
             await seed_builtin_kinds(session)
         modified = {k: v for k, v in PROMPT_TEMPLATES.items() if k != "concept_synthesis_topic"}
         monkeypatch.setattr("wikimind.engine.concept_kind_registry.PROMPT_TEMPLATES", modified)
-        async with factory() as session:
+        async with session_factory() as session:
             with pytest.raises(RegistryTemplateMismatchError, match="concept_synthesis_topic"):
                 await validate_registry_against_prompts(session)
 
-    async def test_passes_with_empty_registry(self, async_engine):
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-        async with factory() as session:
+    async def test_passes_with_empty_registry(self, session_factory):
+        async with session_factory() as session:
             await validate_registry_against_prompts(session)

--- a/tests/unit/test_snapshot_responses.py
+++ b/tests/unit/test_snapshot_responses.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from tests.conftest import TEST_USER_ID
 from tests.snapshot_utils import assert_matches_snapshot
@@ -72,10 +71,9 @@ async def test_articles_list_empty_snapshot(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_articles_list_populated_snapshot(client, async_engine) -> None:
+async def test_articles_list_populated_snapshot(client, session_factory) -> None:
     """GET /api/wiki/articles with one article must match the golden file."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    async with factory() as session:
+    async with session_factory() as session:
         session.add(
             Article(
                 id="snap-art-1",

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
 from tests.conftest import TEST_USER_ID
@@ -135,9 +134,9 @@ async def test_refresh_not_found_raises(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_refresh_endpoint(client, async_engine):
+async def test_refresh_endpoint(client, session_factory):
     """POST /wiki/articles/{slug}/refresh should return 200 with staleness."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
     old_time = utcnow_naive() - timedelta(days=300)
 
     async with factory() as session:
@@ -173,9 +172,9 @@ async def test_refresh_endpoint_not_found(client):
 
 
 @pytest.mark.asyncio
-async def test_list_articles_includes_staleness(client, async_engine):
+async def test_list_articles_includes_staleness(client, session_factory):
     """GET /wiki/articles should include staleness_score in each response."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
 
     async with factory() as session:
         session.add(

--- a/tests/unit/test_stub_and_wikilinks.py
+++ b/tests/unit/test_stub_and_wikilinks.py
@@ -6,7 +6,6 @@ import uuid
 from typing import TYPE_CHECKING
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel import select
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
@@ -16,7 +15,6 @@ from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
-    from sqlalchemy.ext.asyncio import AsyncEngine
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tests.conftest import TEST_USER_ID
@@ -297,10 +295,9 @@ async def test_post_stub_empty_title_rejected(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_wikilink_resolve_endpoint(client: AsyncClient, async_engine: AsyncEngine) -> None:
+async def test_wikilink_resolve_endpoint(client: AsyncClient, session_factory) -> None:
     """GET /wiki/wikilinks/resolve returns matching articles."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     response = await client.get("/api/wiki/wikilinks/resolve", params={"q": "learning"})
     assert response.status_code == 200
@@ -312,10 +309,9 @@ async def test_wikilink_resolve_endpoint(client: AsyncClient, async_engine: Asyn
 
 
 @pytest.mark.asyncio
-async def test_wikilink_resolve_shows_stub_flag(client: AsyncClient, async_engine: AsyncEngine) -> None:
+async def test_wikilink_resolve_shows_stub_flag(client: AsyncClient, session_factory) -> None:
     """Wikilink resolve response includes is_stub field."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     response = await client.get("/api/wiki/wikilinks/resolve", params={"q": "Deep"})
     assert response.status_code == 200
@@ -332,10 +328,9 @@ async def test_wikilink_resolve_empty_query_rejected(client: AsyncClient) -> Non
 
 
 @pytest.mark.asyncio
-async def test_article_list_includes_stub_flag(client: AsyncClient, async_engine: AsyncEngine) -> None:
+async def test_article_list_includes_stub_flag(client: AsyncClient, session_factory) -> None:
     """GET /wiki/articles returns is_stub in the response for each article."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     response = await client.get("/api/wiki/articles")
     assert response.status_code == 200

--- a/tests/unit/test_sweep_session.py
+++ b/tests/unit/test_sweep_session.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlmodel import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from tests.conftest import TEST_USER_ID
 from wikimind._datetime import utcnow_naive
@@ -82,7 +85,7 @@ async def test_sweep_creates_backlinks(db_session: AsyncSession, tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_sweep_handles_duplicate_backlinks(async_engine: AsyncEngine, tmp_path: Path) -> None:
+async def test_sweep_handles_duplicate_backlinks(session_factory, tmp_path: Path) -> None:
     """When a Backlink already exists, sweep uses merge() without SAWarning or error.
 
     Uses separate sessions (as production code does): one for setup, one
@@ -90,7 +93,7 @@ async def test_sweep_handles_duplicate_backlinks(async_engine: AsyncEngine, tmp_
     created the Backlink in a prior session.
     """
     wiki = _wiki_root()
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
 
     # Setup: create articles and a pre-existing backlink.
     async with factory() as setup_session:
@@ -146,7 +149,7 @@ class _CountingSessionFactory:
 
 @pytest.mark.asyncio
 async def test_sweep_wikilinks_uses_isolated_sessions(
-    async_engine: AsyncEngine,
+    session_factory,
     tmp_path: Path,
 ) -> None:
     """sweep_wikilinks(user_id="test-user") creates a separate session per article via get_session_factory().
@@ -155,7 +158,7 @@ async def test_sweep_wikilinks_uses_isolated_sessions(
     multiple sessions are created (one for the job + one per article).
     """
     wiki = _wiki_root()
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
 
     # Pre-populate: one article with an unresolved bracket, one target
     async with factory() as setup_session:

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.config import get_settings
@@ -84,9 +83,8 @@ async def _seed_article(factory) -> str:
 
 
 @pytest.mark.asyncio
-async def test_tag_article(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+async def test_tag_article(client, session_factory) -> None:
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "important"})
     tag_id = tag_resp.json()["id"]
@@ -102,10 +100,9 @@ async def test_tag_article(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_tag_article_idempotent(client, async_engine) -> None:
+async def test_tag_article_idempotent(client, session_factory) -> None:
     """Tagging the same article twice should not raise an error."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "star"})
     tag_id = tag_resp.json()["id"]
@@ -118,9 +115,8 @@ async def test_tag_article_idempotent(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_untag_article(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+async def test_untag_article(client, session_factory) -> None:
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "remove-me"})
     tag_id = tag_resp.json()["id"]
@@ -131,9 +127,8 @@ async def test_untag_article(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_untag_nonexistent_returns_404(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+async def test_untag_nonexistent_returns_404(client, session_factory) -> None:
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "nope"})
     tag_id = tag_resp.json()["id"]
@@ -143,9 +138,8 @@ async def test_untag_nonexistent_returns_404(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_article_tags(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+async def test_get_article_tags(client, session_factory) -> None:
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "alpha", "color": "#22c55e"})
     tag_id = tag_resp.json()["id"]
@@ -160,9 +154,8 @@ async def test_get_article_tags(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_articles_by_tag(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+async def test_get_articles_by_tag(client, session_factory) -> None:
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "special"})
     tag_id = tag_resp.json()["id"]
@@ -176,9 +169,9 @@ async def test_get_articles_by_tag(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_article_response_includes_tags(client, async_engine) -> None:
+async def test_article_response_includes_tags(client, session_factory) -> None:
     """Article detail should include tags in the response."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
 
     # Seed article with a file that can be read
     settings = get_settings()
@@ -210,10 +203,9 @@ async def test_article_response_includes_tags(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_tag_cascades_to_associations(client, async_engine) -> None:
+async def test_delete_tag_cascades_to_associations(client, session_factory) -> None:
     """Deleting a tag should remove all article-tag associations."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_article(factory)
+    await _seed_article(session_factory)
 
     tag_resp = await client.post("/api/tags", json={"name": "cascade-test"})
     tag_id = tag_resp.json()["id"]
@@ -289,9 +281,9 @@ async def test_execute_saved_search_empty(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_saved_search_with_tag_filter(client, async_engine) -> None:
+async def test_execute_saved_search_with_tag_filter(client, session_factory) -> None:
     """Executing a search with tag filter returns only tagged articles."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = session_factory
 
     async with factory() as session:
         session.add(

--- a/tests/unit/test_taxonomy.py
+++ b/tests/unit/test_taxonomy.py
@@ -93,16 +93,12 @@ class TestUpsertConcepts:
         concept = result.scalar_one()
         assert concept.description == "Machine Learning"
 
-    async def test_concurrent_upsert_no_integrity_error(self, async_engine):
+    async def test_concurrent_upsert_no_integrity_error(self, session_factory):
         """Two concurrent upserts for the same concept must not raise IntegrityError (#637)."""
-        from sqlalchemy.ext.asyncio import async_sessionmaker
-
         from wikimind.models import User
 
-        factory = async_sessionmaker(async_engine, expire_on_commit=False)
-
         # Seed test user
-        async with factory() as s:
+        async with session_factory() as s:
             s.add(
                 User(
                     id=TEST_USER_ID,
@@ -117,7 +113,7 @@ class TestUpsertConcepts:
         # Run two upserts concurrently — both target the same concept name.
         # Before the fix, the second would hit IntegrityError on the unique
         # constraint (user_id, name).
-        async with factory() as s1, factory() as s2:
+        async with session_factory() as s1, session_factory() as s2:
             c1 = await upsert_concepts(["Machine Learning"], s1, user_id=TEST_USER_ID)
             c2 = await upsert_concepts(["Machine Learning"], s2, user_id=TEST_USER_ID)
             assert len(c1) == 1

--- a/tests/unit/test_wiki_routes.py
+++ b/tests/unit/test_wiki_routes.py
@@ -6,7 +6,6 @@ Also covers the /wiki/articles/{id_or_slug}/relationships endpoint (issue #423).
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.models import Article, Backlink, RelationType
@@ -54,9 +53,8 @@ async def _seed_three_article_graph(factory) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_no_filters_returns_all_edges(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_no_filters_returns_all_edges(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph")
     assert response.status_code == 200
@@ -66,9 +64,8 @@ async def test_graph_no_filters_returns_all_edges(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_filter_by_relation_type(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_filter_by_relation_type(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"relation_type": "contradicts"})
     assert response.status_code == 200
@@ -81,9 +78,8 @@ async def test_graph_filter_by_relation_type(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_filter_by_from_article_id(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_filter_by_from_article_id(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"from_article": "a1"})
     assert response.status_code == 200
@@ -94,9 +90,8 @@ async def test_graph_filter_by_from_article_id(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_filter_by_from_article_slug(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_filter_by_from_article_slug(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"from_article": "art-a"})
     assert response.status_code == 200
@@ -105,9 +100,8 @@ async def test_graph_filter_by_from_article_slug(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_filter_by_to_article(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_filter_by_to_article(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"to_article": "a3"})
     assert response.status_code == 200
@@ -118,9 +112,8 @@ async def test_graph_filter_by_to_article(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_filters_compose_with_and(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_filters_compose_with_and(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     # from a1 AND relation_type contradicts → only a1->a3.
     response = await client.get(
@@ -137,9 +130,8 @@ async def test_graph_filters_compose_with_and(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_unknown_from_article_returns_empty(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_unknown_from_article_returns_empty(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"from_article": "no-such-thing"})
     assert response.status_code == 200
@@ -149,18 +141,16 @@ async def test_graph_unknown_from_article_returns_empty(client, async_engine) ->
 
 
 @pytest.mark.asyncio
-async def test_graph_invalid_relation_type_is_422(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_invalid_relation_type_is_422(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"relation_type": "bogus"})
     assert response.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_relationships_endpoint_groups_by_direction_and_type(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_relationships_endpoint_groups_by_direction_and_type(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/articles/a1/relationships")
     assert response.status_code == 200
@@ -182,9 +172,8 @@ async def test_relationships_endpoint_groups_by_direction_and_type(client, async
 
 
 @pytest.mark.asyncio
-async def test_relationships_endpoint_resolves_slug(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_relationships_endpoint_resolves_slug(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     # a3 has two incoming (a1 contradicts, a2 supersedes) and no outgoing.
     response = await client.get("/api/wiki/articles/art-c/relationships")
@@ -203,9 +192,8 @@ async def test_relationships_endpoint_404_when_missing(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_unknown_to_article_returns_empty(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_unknown_to_article_returns_empty(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"to_article": "no-such-thing"})
     assert response.status_code == 200
@@ -215,9 +203,8 @@ async def test_graph_unknown_to_article_returns_empty(client, async_engine) -> N
 
 
 @pytest.mark.asyncio
-async def test_graph_filter_by_to_article_slug(client, async_engine) -> None:
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_three_article_graph(factory)
+async def test_graph_filter_by_to_article_slug(client, session_factory) -> None:
+    await _seed_three_article_graph(session_factory)
 
     response = await client.get("/api/wiki/graph", params={"to_article": "art-c"})
     assert response.status_code == 200

--- a/tests/unit/test_wiki_routes_extra.py
+++ b/tests/unit/test_wiki_routes_extra.py
@@ -6,7 +6,6 @@ Covers issues #660 (recompile_article) and #663 (get_article_tags).
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from wikimind.api.deps import ANONYMOUS_USER_ID
 from wikimind.models import Article
@@ -44,10 +43,9 @@ async def _seed_articles(factory) -> None:
 
 
 @pytest.mark.asyncio
-async def test_recompile_own_article_succeeds(client, async_engine) -> None:
+async def test_recompile_own_article_succeeds(client, session_factory) -> None:
     """Recompiling own article should return 200 with scheduled status."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     resp = await client.post("/api/wiki/articles/own-art/recompile")
     assert resp.status_code == 200
@@ -57,10 +55,9 @@ async def test_recompile_own_article_succeeds(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_recompile_other_users_article_returns_404(client, async_engine) -> None:
+async def test_recompile_other_users_article_returns_404(client, session_factory) -> None:
     """Recompiling another user's article should return 404."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     resp = await client.post("/api/wiki/articles/other-art/recompile")
     assert resp.status_code == 404
@@ -79,10 +76,9 @@ async def test_recompile_nonexistent_article_returns_404(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_tags_own_article(client, async_engine) -> None:
+async def test_get_tags_own_article(client, session_factory) -> None:
     """Getting tags for own article should succeed (empty list when untagged)."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     resp = await client.get("/api/wiki/articles/own-art/tags")
     assert resp.status_code == 200
@@ -90,20 +86,18 @@ async def test_get_tags_own_article(client, async_engine) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_tags_other_users_article_returns_404(client, async_engine) -> None:
+async def test_get_tags_other_users_article_returns_404(client, session_factory) -> None:
     """Getting tags for another user's article should return 404."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     resp = await client.get("/api/wiki/articles/other-art/tags")
     assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_get_tags_own_article_with_tags(client, async_engine) -> None:
+async def test_get_tags_own_article_with_tags(client, session_factory) -> None:
     """Getting tags for own article that has tags should return them."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
-    await _seed_articles(factory)
+    await _seed_articles(session_factory)
 
     # Create a tag and apply it
     tag_resp = await client.post("/api/tags", json={"name": "important", "color": "#ef4444"})


### PR DESCRIPTION
## Summary
- **Problem:** 17+ test files each created their own `async_sessionmaker(async_engine, expire_on_commit=False)` instead of using a shared fixture
- **Fix:** Added `session_factory` fixture to `tests/conftest.py`, updated 17 test files to use it. Removed unused `async_sessionmaker` and `AsyncEngine` imports. Moved runtime-unnecessary imports to `TYPE_CHECKING` blocks
- **Kept specialized:** `test_search.py` and `test_faceted_search.py` (FTS5 engine), `test_postgres_integration.py` (real Postgres)

Closes #650

## Test plan
- [ ] All 1669 tests pass
- [ ] Lint/format clean
- [ ] No behavior change — just consolidated factory creation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to use a new session fixture pattern for improved test database session management across integration and unit tests.

* **Chores**
  * Updated secret detection baseline configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manavgup/wikimind/pull/724)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->