### PR TITLE
refactor: replace session.execute(select) with session.exec across codebase (#614)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_t2gF37"
+      "filename": ".merge_file_8Jl0K1"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -198,366 +198,772 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 159
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "c4630d05ac3ffd099fdb02373ca70ac9ac183930",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 159
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "7be9858e96bbb2b9b4632f4ec45518ade024e48d",
         "is_verified": false,
-        "line_number": 175
+        "line_number": 173
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "7be9858e96bbb2b9b4632f4ec45518ade024e48d",
         "is_verified": false,
-        "line_number": 175
+        "line_number": 173
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "be12c12cec3afb81bcc35bada5b46d2a7e190739",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "be12c12cec3afb81bcc35bada5b46d2a7e190739",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 187
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 200
+        "line_number": 201
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 200
+        "line_number": 201
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 215
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 215
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 214
+        "line_number": 229
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 214
+        "line_number": 229
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 223
+        "line_number": 243
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 223
+        "line_number": 243
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 232
+        "line_number": 257
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 232
+        "line_number": 257
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
-        "is_verified": false,
-        "line_number": 239
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
-        "is_verified": false,
-        "line_number": 239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
-        "is_verified": false,
-        "line_number": 246
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
-        "is_verified": false,
-        "line_number": 246
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 285
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 285
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 287
+        "line_number": 299
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 287
+        "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 313
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 313
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 303
+        "line_number": 327
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 303
+        "line_number": 327
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
-        "line_number": 312
+        "line_number": 341
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
-        "line_number": 312
+        "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 321
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 321
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
-        "is_verified": false,
-        "line_number": 339
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
-        "is_verified": false,
-        "line_number": 339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
-        "is_verified": false,
-        "line_number": 348
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
-        "is_verified": false,
-        "line_number": 348
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "is_verified": false,
+        "line_number": 369
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "is_verified": false,
+        "line_number": 369
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 383
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 383
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 397
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 397
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "is_verified": false,
+        "line_number": 411
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "is_verified": false,
+        "line_number": 411
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "is_verified": false,
+        "line_number": 425
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "is_verified": false,
+        "line_number": 425
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 453
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 453
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 467
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 467
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 481
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 481
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 495
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 495
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 509
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "da0276d781c1591180c42ecea255ea67fb353ccd",
+        "is_verified": false,
+        "line_number": 509
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 523
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 523
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 537
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 537
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 551
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 551
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 583
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 583
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 590
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 608
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 608
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 622
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 622
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 631
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 631
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 640
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 640
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 647
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 647
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 654
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 654
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 679
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 679
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 686
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 686
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 695
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 695
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 704
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 704
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 711
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 711
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 720
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 720
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 729
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 729
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 747
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 747
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 756
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 756
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 763
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 763
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 772
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 772
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
         "is_verified": false,
-        "line_number": 389
+        "line_number": 797
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
         "is_verified": false,
-        "line_number": 389
+        "line_number": 797
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
         "is_verified": false,
-        "line_number": 407
+        "line_number": 815
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
         "is_verified": false,
-        "line_number": 407
+        "line_number": 815
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
         "is_verified": false,
-        "line_number": 416
+        "line_number": 824
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
         "is_verified": false,
-        "line_number": 416
+        "line_number": 824
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
         "is_verified": false,
-        "line_number": 423
+        "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
         "is_verified": false,
-        "line_number": 423
+        "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 430
+        "line_number": 838
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 430
+        "line_number": 838
       }
     ],
     "Makefile": [
@@ -841,5 +1247,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T18:22:35Z"
+  "generated_at": "2026-05-15T18:22:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": ".merge_file_t2gF37"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -150,6 +150,414 @@
         "hashed_secret": "f25e7e3dd1539e107ca4c4705ebe293496c38e10",
         "is_verified": false,
         "line_number": 246
+      }
+    ],
+    ".secrets.baseline": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c332c15e76c22a7f7125d03261e4218a2005a6ba",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c332c15e76c22a7f7125d03261e4218a2005a6ba",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6116e7dbe0baf62ebaf5b48cfac17685433f6329",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6116e7dbe0baf62ebaf5b48cfac17685433f6329",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 278
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 278
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 287
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 287
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 303
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 303
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 312
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 312
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 339
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 339
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 348
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 348
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 355
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 355
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 364
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 364
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 407
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b88523b051593c11a9e4eda0dc1e87ae7afbd70c",
+        "is_verified": false,
+        "line_number": 407
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 423
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 423
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
+        "is_verified": false,
+        "line_number": 430
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
+        "is_verified": false,
+        "line_number": 430
       }
     ],
     "Makefile": [
@@ -433,5 +841,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T17:30:31Z"
+  "generated_at": "2026-05-15T18:22:35Z"
 }

--- a/src/wikimind/api/deps.py
+++ b/src/wikimind/api/deps.py
@@ -54,8 +54,8 @@ async def require_admin(
 
     from wikimind.models import User  # noqa: PLC0415 — deferred to avoid circular import
 
-    result = await session.execute(select(User).where(User.id == user_id))
-    user = result.scalar_one_or_none()
+    result = await session.exec(select(User).where(User.id == user_id))
+    user = result.one_or_none()
     if user is None or not user.is_admin:
         raise HTTPException(
             status_code=403,

--- a/src/wikimind/api/routes/jobs.py
+++ b/src/wikimind/api/routes/jobs.py
@@ -50,8 +50,8 @@ async def trigger_compile(
     user_id: str = Depends(get_current_user_id),
 ):
     """Trigger compilation for a source."""
-    result = await session.execute(select(Source).where(Source.id == source_id, Source.user_id == user_id))
-    source = result.scalar_one_or_none()
+    result = await session.exec(select(Source).where(Source.id == source_id, Source.user_id == user_id))
+    source = result.one_or_none()
     if not source:
         raise HTTPException(status_code=404, detail="Source not found")
     if not source.file_path:

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -168,8 +168,8 @@ async def apply_runtime_llm_preferences() -> None:
     """Apply persisted LLM runtime preferences to the in-memory settings singleton."""
     settings = get_settings()
     async with get_session_factory()() as session:
-        result = await session.execute(select(UserPreference))
-        for pref in result.scalars().all():
+        result = await session.exec(select(UserPreference))
+        for pref in result.all():
             if pref.key == "llm.default_provider":
                 settings.llm.default_provider = pref.value
             elif pref.key == "llm.monthly_budget_usd":
@@ -654,8 +654,8 @@ async def get_onboarding_status(
         return OnboardingStatusResponse(completed=True, step=int(step_val) if step_val else 5)
 
     # Implicit completion: existing articles for THIS user mean they know the app.
-    result = await session.execute(select(Article.id).where(Article.user_id == user_id).limit(1))
-    if result.scalar_one_or_none() is not None:
+    result = await session.exec(select(Article.id).where(Article.user_id == user_id).limit(1))
+    if result.one_or_none() is not None:
         return OnboardingStatusResponse(completed=True, step=5)
 
     step_val = await _get_preference(step_key)

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -554,8 +554,8 @@ async def recompile_article(
             detail=f"mode must be one of {sorted(_VALID_RECOMPILE_MODES)} or null",
         )
 
-    result = await session.execute(select(Article).where(Article.id == article_id, Article.user_id == user_id))
-    article = result.scalar_one_or_none()
+    result = await session.exec(select(Article).where(Article.id == article_id, Article.user_id == user_id))
+    article = result.one_or_none()
     if article is None:
         raise HTTPException(status_code=404, detail="Article not found")
 

--- a/src/wikimind/cli/create_token.py
+++ b/src/wikimind/cli/create_token.py
@@ -48,8 +48,8 @@ async def _lookup_user_by_email(email: str) -> tuple[str, str | None]:
 
     factory = get_session_factory()
     async with factory() as session:
-        result = await session.execute(select(User).where(User.email == email))
-        user = result.scalar_one_or_none()
+        result = await session.exec(select(User).where(User.email == email))
+        user = result.one_or_none()
 
     if user is None:
         print(f"ERROR: No user found with email '{email}'.", file=sys.stderr)

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -648,8 +648,8 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
     from wikimind.models import Article, Backlink, PageType  # noqa: PLC0415
     from wikimind.storage import get_wiki_storage  # noqa: PLC0415
 
-    result = await session.execute(select(Article).where(Article.page_type == PageType.CONCEPT))
-    concept_articles = list(result.scalars().all())
+    result = await session.exec(select(Article).where(Article.page_type == PageType.CONCEPT))
+    concept_articles = list(result.all())
 
     cleaned = 0
     for article in concept_articles:
@@ -665,12 +665,12 @@ async def _cleanup_orphan_concept_rows(session: AsyncSession) -> None:
         await session.execute(
             sa_delete(Backlink).where(
                 sa_or(
-                    Backlink.source_article_id == article.id,
-                    Backlink.target_article_id == article.id,
+                    Backlink.source_article_id == article.id,  # type: ignore[arg-type]
+                    Backlink.target_article_id == article.id,  # type: ignore[arg-type]
                 )
             )
         )
-        await session.execute(sa_delete(Article).where(Article.id == article.id))
+        await session.execute(sa_delete(Article).where(Article.id == article.id))  # type: ignore[arg-type]
 
         from wikimind.services.search import remove_article as fts_remove_article  # noqa: PLC0415
 
@@ -700,15 +700,15 @@ async def _migrate_to_relative_paths(session: AsyncSession) -> None:
     raw_prefix = str(Path(settings.data_dir) / "raw") + "/"
 
     # Migrate Article.file_path (wiki-relative)
-    result = await session.execute(select(Article).where(Article.file_path.startswith("/")))
-    for article in result.scalars().all():
+    result = await session.exec(select(Article).where(Article.file_path.startswith("/")))
+    for article in result.all():
         if article.file_path.startswith(wiki_prefix):
             article.file_path = article.file_path[len(wiki_prefix) :]
             session.add(article)
 
     # Migrate Source.file_path (raw-relative)
-    result = await session.execute(select(Source).where(Source.file_path.startswith("/")))  # type: ignore[union-attr]
-    for source in result.scalars().all():
+    result = await session.exec(select(Source).where(Source.file_path.startswith("/")))  # type: ignore[union-attr,arg-type]
+    for source in result.all():
         if source.file_path and source.file_path.startswith(raw_prefix):
             source.file_path = source.file_path[len(raw_prefix) :]
             session.add(source)

--- a/src/wikimind/engine/backlink_enforcer.py
+++ b/src/wikimind/engine/backlink_enforcer.py
@@ -24,7 +24,7 @@ from sqlmodel import select
 from wikimind.models import Article, ArticleConcept, Backlink, RelationType
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -106,8 +106,8 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> EnforcerR
     result = EnforcerResult()
 
     # Load the article
-    query_result = await session.execute(select(Article).where(Article.id == article_id))
-    article = query_result.scalars().first()
+    query_result = await session.exec(select(Article).where(Article.id == article_id))
+    article = query_result.first()
     if article is None:
         msg = f"Article {article_id} not found"
         result.warnings.append(msg)
@@ -115,8 +115,8 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> EnforcerR
 
     # ---- Check 1: source pages need >= 1 concept ----
     if article.page_type == "source":
-        ac_result = await session.execute(select(ArticleConcept).where(ArticleConcept.article_id == article_id))
-        concept_ids: list[str] = [ac.concept_name for ac in ac_result.scalars().all()]
+        ac_result = await session.exec(select(ArticleConcept).where(ArticleConcept.article_id == article_id))
+        concept_ids: list[str] = [ac.concept_name for ac in ac_result.all()]
         # Fallback to JSON column for pre-migration data
         if not concept_ids and article.concept_ids:
             with contextlib.suppress(TypeError, ValueError):
@@ -135,13 +135,13 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> EnforcerR
 
     # ---- Check 2: concept pages need >= 2 synthesizes links ----
     if article.page_type == "concept":
-        synth_result = await session.execute(
+        synth_result = await session.exec(
             select(Backlink).where(
                 Backlink.source_article_id == article_id,
                 Backlink.relation_type == RelationType.SYNTHESIZES,
             )
         )
-        synth_count = len(list(synth_result.scalars().all()))
+        synth_count = len(list(synth_result.all()))
         if synth_count < 2:
             msg = f"Concept page '{article.title}' has {synth_count} synthesizes links (need >= 2)"
             result.warnings.append(msg)
@@ -155,11 +155,11 @@ async def enforce_backlinks(article_id: str, session: AsyncSession) -> EnforcerR
             )
 
     # ---- Check 3: bidirectional enforcement for symmetric types ----
-    out_result = await session.execute(select(Backlink).where(Backlink.source_article_id == article_id))
-    outbound = list(out_result.scalars().all())
+    out_result = await session.exec(select(Backlink).where(Backlink.source_article_id == article_id))
+    outbound = list(out_result.all())
 
-    in_result = await session.execute(select(Backlink).where(Backlink.target_article_id == article_id))
-    inbound = list(in_result.scalars().all())
+    in_result = await session.exec(select(Backlink).where(Backlink.target_article_id == article_id))
+    inbound = list(in_result.all())
 
     all_links = outbound + inbound
     for bl in all_links:

--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -61,7 +61,7 @@ from wikimind.storage import get_wiki_storage
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -339,7 +339,7 @@ class Compiler:
             f"\n\nUSER GUIDANCE — weight the article toward these priorities:\n<guidance>{safe_guidance}</guidance>"
         )
 
-        existing_concepts = [c.name for c in (await session.execute(select(Concept))).scalars().all()]
+        existing_concepts = [c.name for c in (await session.exec(select(Concept))).all()]
         if existing_concepts:
             user_prompt += "\n\nExisting concepts in this wiki (REUSE these before inventing new ones):\n" + ", ".join(
                 sorted(existing_concepts)
@@ -402,7 +402,7 @@ class Compiler:
 
         # Concept ID registry injection: prevents concept fragmentation by
         # telling the LLM which concepts already exist (issue #143, Phase 2).
-        existing_concepts = [c.name for c in (await session.execute(select(Concept))).scalars().all()]
+        existing_concepts = [c.name for c in (await session.exec(select(Concept))).all()]
         if existing_concepts:
             user_prompt += "\n\nExisting concepts in this wiki (REUSE these before inventing new ones):\n" + ", ".join(
                 sorted(existing_concepts)
@@ -781,17 +781,17 @@ Compile this into a wiki article following the JSON schema exactly."""
         session: AsyncSession,
     ) -> None:
         """Delete backlinks, claims, and join-table rows for an article before re-populating."""
-        old_bl = await session.execute(select(Backlink).where(Backlink.source_article_id == article_id))
-        for row in old_bl.scalars().all():
+        old_bl = await session.exec(select(Backlink).where(Backlink.source_article_id == article_id))
+        for row in old_bl.all():
             await session.delete(row)
-        old_claims = await session.execute(select(CompiledClaim).where(CompiledClaim.article_id == article_id))
-        for claim in old_claims.scalars().all():
+        old_claims = await session.exec(select(CompiledClaim).where(CompiledClaim.article_id == article_id))
+        for claim in old_claims.all():
             await session.delete(claim)
-        old_ac = await session.execute(select(ArticleConcept).where(ArticleConcept.article_id == article_id))
-        for ac in old_ac.scalars().all():
+        old_ac = await session.exec(select(ArticleConcept).where(ArticleConcept.article_id == article_id))
+        for ac in old_ac.all():
             await session.delete(ac)
-        old_as = await session.execute(select(ArticleSource).where(ArticleSource.article_id == article_id))
-        for a_s in old_as.scalars().all():
+        old_as = await session.exec(select(ArticleSource).where(ArticleSource.article_id == article_id))
+        for a_s in old_as.all():
             await session.delete(a_s)
 
     async def _post_save_side_effects(
@@ -896,7 +896,7 @@ Compile this into a wiki article following the JSON schema exactly."""
         candidate = base
         suffix = 2
         for _ in range(max_attempts):
-            existing = (await session.execute(select(Article).where(Article.slug == candidate))).scalars().first()
+            existing = (await session.exec(select(Article).where(Article.slug == candidate))).first()
             if existing is None:
                 return candidate
             candidate = f"{base}-{suffix}"

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -31,7 +31,7 @@ from wikimind.services.search import index_article as fts_index_article
 from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -240,8 +240,8 @@ class ConceptCompiler:
         return await self._save_concept_page(compilation, concept, source_articles, session)
 
     async def _load_kind_def(self, kind_name: str, session: AsyncSession) -> ConceptKindDef | None:
-        result = await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == kind_name))
-        return result.scalar_one_or_none()
+        result = await session.exec(select(ConceptKindDef).where(ConceptKindDef.name == kind_name))
+        return result.one_or_none()
 
     async def _save_concept_page(
         self,
@@ -268,20 +268,20 @@ class ConceptCompiler:
             existing.page_type = PageType.CONCEPT
             existing.user_id = concept.user_id
             session.add(existing)
-            old_links = await session.execute(
+            old_links = await session.exec(
                 select(Backlink).where(
                     Backlink.source_article_id == existing.id,
                     Backlink.relation_type == RelationType.SYNTHESIZES,
                 )
             )
-            for bl in old_links.scalars().all():
+            for bl in old_links.all():
                 await session.delete(bl)
             # Refresh join tables
-            old_ac = await session.execute(select(ArticleConcept).where(ArticleConcept.article_id == existing.id))
-            for ac in old_ac.scalars().all():
+            old_ac = await session.exec(select(ArticleConcept).where(ArticleConcept.article_id == existing.id))
+            for ac in old_ac.all():
                 await session.delete(ac)
-            old_as = await session.execute(select(ArticleSource).where(ArticleSource.article_id == existing.id))
-            for a_s in old_as.scalars().all():
+            old_as = await session.exec(select(ArticleSource).where(ArticleSource.article_id == existing.id))
+            for a_s in old_as.all():
                 await session.delete(a_s)
             await session.commit()
             await session.refresh(existing)

--- a/src/wikimind/engine/concept_kind_registry.py
+++ b/src/wikimind/engine/concept_kind_registry.py
@@ -2,8 +2,8 @@
 
 import json
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.models import ConceptKindDef
 
@@ -60,8 +60,8 @@ async def seed_builtin_kinds(session: AsyncSession) -> None:
     """Idempotently create the five built-in ConceptKindDef rows."""
     for kind_data in _BUILTIN_KINDS:
         name = kind_data["name"]
-        result = await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == name))
-        existing = result.scalar_one_or_none()
+        result = await session.exec(select(ConceptKindDef).where(ConceptKindDef.name == name))
+        existing = result.one_or_none()
         if existing is None:
             kind = ConceptKindDef(**kind_data)
             session.add(kind)
@@ -74,8 +74,8 @@ class RegistryTemplateMismatchError(Exception):
 
 async def validate_registry_against_prompts(session: AsyncSession) -> None:
     """Check that every ConceptKindDef prompt_template_key exists in PROMPT_TEMPLATES."""
-    result = await session.execute(select(ConceptKindDef))
-    kinds = result.scalars().all()
+    result = await session.exec(select(ConceptKindDef))
+    kinds = result.all()
     missing: list[str] = [
         f"{kind.name} -> {kind.prompt_template_key}"
         for kind in kinds

--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -45,7 +45,7 @@ from wikimind.models import (
 from wikimind.services.contradiction import get_contradiction_service
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 

--- a/src/wikimind/engine/synthesis_compiler.py
+++ b/src/wikimind/engine/synthesis_compiler.py
@@ -34,7 +34,7 @@ from wikimind.services.search import index_article as fts_index_article
 from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -383,7 +383,7 @@ provider: {provider_str}
         candidate = base
         suffix = 2
         while True:
-            existing = (await session.execute(select(Article).where(Article.slug == candidate))).scalars().first()
+            existing = (await session.exec(select(Article).where(Article.slug == candidate))).first()
             if existing is None:
                 return candidate
             candidate = f"{base}-{suffix}"

--- a/src/wikimind/jobs/sweep.py
+++ b/src/wikimind/jobs/sweep.py
@@ -28,7 +28,7 @@ from wikimind.services.search import remove_article as fts_remove_article
 from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -176,14 +176,12 @@ async def _cleanup_orphaned_concept_pages(
         await session.execute(
             sa_delete(Backlink).where(
                 or_(
-                    Backlink.source_article_id == article.id,  # type: ignore[arg-type]
-                    Backlink.target_article_id == article.id,  # type: ignore[arg-type]
+                    Backlink.source_article_id == article.id,
+                    Backlink.target_article_id == article.id,
                 )
             )
         )
-        await session.execute(
-            sa_delete(Article).where(Article.id == article.id)  # type: ignore[arg-type]
-        )
+        await session.execute(sa_delete(Article).where(Article.id == article.id))
         await fts_remove_article(session, article.id)
         cleaned += 1
         log.warning(

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -342,8 +342,8 @@ async def lint_wiki(_ctx, user_id: str):
 
 async def _get_article_source_ids(article: Article, session) -> list[str]:
     """Fetch source IDs from join table with JSON column fallback."""
-    result = await session.execute(select(ArticleSource.source_id).where(ArticleSource.article_id == article.id))
-    ids = [row[0] for row in result.all()]
+    result = await session.exec(select(ArticleSource.source_id).where(ArticleSource.article_id == article.id))
+    ids = list(result.all())
     if not ids:
         ids = json.loads(article.source_ids) if article.source_ids else []
     return ids
@@ -351,8 +351,8 @@ async def _get_article_source_ids(article: Article, session) -> list[str]:
 
 async def _get_article_concept_names(article: Article, session) -> list[str]:
     """Fetch concept names from join table with JSON column fallback."""
-    result = await session.execute(select(ArticleConcept.concept_name).where(ArticleConcept.article_id == article.id))
-    names = [row[0] for row in result.all()]
+    result = await session.exec(select(ArticleConcept.concept_name).where(ArticleConcept.article_id == article.id))
+    names = list(result.all())
     if not names:
         names = json.loads(article.concept_ids) if article.concept_ids else []
     return names
@@ -409,8 +409,8 @@ async def _recompile_from_concept(article: Article, session, user_id: str) -> No
         raise ValueError(msg)
 
     concept_name = concept_names[0]
-    result = await session.execute(select(Concept).where(Concept.name == concept_name))
-    concept = result.scalars().first()
+    result = await session.exec(select(Concept).where(Concept.name == concept_name))
+    concept = result.first()
     if not concept:
         msg = "Concept not found"
         raise ValueError(msg)

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -136,8 +136,8 @@ async def _reset_stuck_sources() -> None:
     source still in PROCESSING was interrupted.
     """
     async with get_session_factory()() as session:
-        result = await session.execute(select(Source).where(Source.status == IngestStatus.PROCESSING))
-        stuck = list(result.scalars().all())
+        result = await session.exec(select(Source).where(Source.status == IngestStatus.PROCESSING))
+        stuck = list(result.all())
         for source in stuck:
             source.status = IngestStatus.FAILED
             source.error_message = "Compilation interrupted — retry when ready"

--- a/src/wikimind/services/api_keys.py
+++ b/src/wikimind/services/api_keys.py
@@ -189,8 +189,8 @@ async def list_user_api_keys(
     Returns:
         List of UserApiKey records (encrypted_key is NOT decrypted).
     """
-    result = await session.execute(select(UserApiKey).where(UserApiKey.user_id == user_id))
-    return list(result.scalars().all())
+    result = await session.exec(select(UserApiKey).where(UserApiKey.user_id == user_id))
+    return list(result.all())
 
 
 async def delete_user_api_key(

--- a/src/wikimind/services/crystallization.py
+++ b/src/wikimind/services/crystallization.py
@@ -163,8 +163,8 @@ async def _check_already_crystallized(
         conversation_id=conversation.id,
         article_id=existing.id,
     )
-    turn_result = await session.execute(select(Query).where(Query.conversation_id == conversation.id))
-    turn_count = len(list(turn_result.scalars().all()))
+    turn_result = await session.exec(select(Query).where(Query.conversation_id == conversation.id))
+    turn_count = len(list(turn_result.all()))
     return CrystallizeResponse(
         article_id=existing.id,
         article_slug=existing.slug,

--- a/src/wikimind/services/query.py
+++ b/src/wikimind/services/query.py
@@ -137,17 +137,17 @@ async def _build_citations(query: Query, session: AsyncSession, user_id: str) ->
         if article is None:
             continue
         # Query join table for source IDs
-        as_result = await session.execute(select(ArticleSource.source_id).where(ArticleSource.article_id == article.id))
-        source_ids = [row[0] for row in as_result.all()]
+        as_result = await session.exec(select(ArticleSource.source_id).where(ArticleSource.article_id == article.id))
+        source_ids = list(as_result.all())
         # Fallback to JSON column for pre-migration data
         if not source_ids:
             source_ids = _parse_source_ids(article.source_ids)
         sources: list[Source] = []
         if source_ids:
-            src_result = await session.execute(
+            src_result = await session.exec(
                 select(Source).where(Source.id.in_(source_ids)),  # type: ignore[attr-defined]
             )
-            by_id = {s.id: s for s in src_result.scalars().all()}
+            by_id = {s.id: s for s in src_result.all()}
             sources = [by_id[sid] for sid in source_ids if sid in by_id]
         if article.last_reinforced_at is None:
             effective = article.confidence_score

--- a/src/wikimind/services/saved_searches.py
+++ b/src/wikimind/services/saved_searches.py
@@ -155,24 +155,24 @@ class SavedSearchService:
 
         # Apply tag filter — articles must have ALL specified tags
         if tag_names:
-            tag_result = await session.execute(
+            tag_result = await session.exec(
                 select(Tag.id).where(
                     Tag.user_id == user_id,
                     Tag.name.in_(tag_names),  # type: ignore[attr-defined]
                 )
             )
-            tag_ids = [row[0] for row in tag_result.all()]
+            tag_ids = list(tag_result.all())
             for tid in tag_ids:
-                at_result = await session.execute(select(ArticleTag.article_id).where(ArticleTag.tag_id == tid))
-                tagged_ids = {row[0] for row in at_result.all()}
+                at_result = await session.exec(select(ArticleTag.article_id).where(ArticleTag.tag_id == tid))
+                tagged_ids = set(at_result.all())
                 candidate_ids &= tagged_ids
 
         # Apply concept filter — articles must have ALL specified concepts
         for concept_name in concept_names:
-            ac_result = await session.execute(
+            ac_result = await session.exec(
                 select(ArticleConcept.article_id).where(ArticleConcept.concept_name == concept_name)
             )
-            concept_ids = {row[0] for row in ac_result.all()}
+            concept_ids = set(ac_result.all())
             candidate_ids &= concept_ids
 
         return response, list(candidate_ids)

--- a/src/wikimind/services/search.py
+++ b/src/wikimind/services/search.py
@@ -42,7 +42,7 @@ from wikimind.storage import get_wiki_storage
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -103,8 +103,8 @@ async def rebuild_fts_index(session: AsyncSession) -> int:
     """
     url = get_settings().database_url
 
-    result = await session.execute(select(Article))
-    articles = list(result.scalars().all())
+    result = await session.exec(select(Article))
+    articles = list(result.all())
 
     if not articles:
         return 0
@@ -282,8 +282,8 @@ async def _search_sqlite(
     # Map FTS rowids back to article IDs: fetch only the user's article IDs
     # (lightweight — no ORM hydration), compute their rowid hashes, and
     # select only the ones that matched the FTS query.
-    id_result = await session.execute(select(Article.id).where(Article.user_id == user_id))
-    user_article_ids = [row[0] for row in id_result.all()]
+    id_result = await session.exec(select(Article.id).where(Article.user_id == user_id))
+    user_article_ids = list(id_result.all())
 
     matched_ids: list[str] = []
     id_to_rowid: dict[str, int] = {}

--- a/src/wikimind/services/sharing.py
+++ b/src/wikimind/services/sharing.py
@@ -183,8 +183,8 @@ class SharingService:
             NotFoundError: If link is revoked, invalid, or article missing.
             GoneError: If link has expired.
         """
-        result = await session.execute(select(ShareLink).where(ShareLink.token == token))
-        link = result.scalar_one_or_none()
+        result = await session.exec(select(ShareLink).where(ShareLink.token == token))
+        link = result.one_or_none()
 
         if link is None or link.revoked:
             msg = "Share link not found"

--- a/src/wikimind/services/tags.py
+++ b/src/wikimind/services/tags.py
@@ -95,8 +95,8 @@ class TagService:
         """
         tag = await self._get_tag(session, tag_id, user_id)
         # Remove all article-tag associations first
-        result = await session.execute(select(ArticleTag).where(ArticleTag.tag_id == tag.id))
-        for at in result.scalars().all():
+        result = await session.exec(select(ArticleTag).where(ArticleTag.tag_id == tag.id))
+        for at in result.all():
             await session.delete(at)
         await session.delete(tag)
 
@@ -185,8 +185,8 @@ class TagService:
             NotFoundError: If the tag does not exist for this user.
         """
         await self._get_tag(session, tag_id, user_id)
-        result = await session.execute(select(ArticleTag.article_id).where(ArticleTag.tag_id == tag_id))
-        return [row[0] for row in result.all()]
+        result = await session.exec(select(ArticleTag.article_id).where(ArticleTag.tag_id == tag_id))
+        return list(result.all())
 
     async def get_tags_for_article(
         self,
@@ -254,8 +254,8 @@ class TagService:
         user_id: str,
     ) -> Tag:
         """Look up a tag by ID, scoped to the user."""
-        result = await session.execute(select(Tag).where(Tag.id == tag_id, Tag.user_id == user_id))
-        tag = result.scalar_one_or_none()
+        result = await session.exec(select(Tag).where(Tag.id == tag_id, Tag.user_id == user_id))
+        tag = result.one_or_none()
         if tag is None:
             msg = "Tag not found"
             raise NotFoundError(msg)
@@ -268,8 +268,8 @@ class TagService:
         user_id: str,
     ) -> Article:
         """Look up an article by ID, scoped to the user."""
-        result = await session.execute(select(Article).where(Article.id == article_id, Article.user_id == user_id))
-        article = result.scalar_one_or_none()
+        result = await session.exec(select(Article).where(Article.id == article_id, Article.user_id == user_id))
+        article = result.one_or_none()
         if article is None:
             msg = "Article not found"
             raise NotFoundError(msg)

--- a/src/wikimind/services/taxonomy.py
+++ b/src/wikimind/services/taxonomy.py
@@ -31,7 +31,7 @@ from wikimind.models import (
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -196,19 +196,19 @@ async def _concept_source_set_changed(concept: Concept, session: AsyncSession, u
 
     # Look up existing concept page.
     slug = f"concept-{slugify(concept.name)}"
-    existing_result = await session.execute(
+    existing_result = await session.exec(
         select(Article).where(
             Article.slug == slug,
             Article.page_type == PageType.CONCEPT,
             Article.user_id == user_id,
         )
     )
-    existing = existing_result.scalar_one_or_none()
+    existing = existing_result.one_or_none()
     if existing is None:
         return True
 
-    prev_result = await session.execute(select(ArticleSource.source_id).where(ArticleSource.article_id == existing.id))
-    previous_ids = sorted(row[0] for row in prev_result.all())
+    prev_result = await session.exec(select(ArticleSource.source_id).where(ArticleSource.article_id == existing.id))
+    previous_ids = sorted(prev_result.all())
 
     # Fallback to JSON if join table is empty (pre-migration data)
     if not previous_ids:

--- a/src/wikimind/services/user.py
+++ b/src/wikimind/services/user.py
@@ -153,14 +153,14 @@ class UserService:
             name = user_info.name or user_info.login
             avatar_url = user_info.avatar_url
 
-        result = await session.execute(
+        result = await session.exec(
             select(User).where(User.auth_provider == provider, User.auth_provider_id == provider_id)
         )
-        user = result.scalar_one_or_none()
+        user = result.one_or_none()
 
         if not user and email:
-            result = await session.execute(select(User).where(User.email == email))
-            user = result.scalar_one_or_none()
+            result = await session.exec(select(User).where(User.email == email))
+            user = result.one_or_none()
 
         if user:
             user.name = name
@@ -341,8 +341,8 @@ class UserService:
         Returns:
             The existing or newly created User record.
         """
-        result = await session.execute(select(User).where(User.email == email))
-        user = result.scalar_one_or_none()
+        result = await session.exec(select(User).where(User.email == email))
+        user = result.one_or_none()
         if user:
             return user
 
@@ -381,16 +381,9 @@ class UserService:
             raise NotFoundError(msg)
 
         # Collect IDs for join-table / child-table cleanup
-        article_ids = [
-            row[0] for row in (await session.execute(select(Article.id).where(Article.user_id == user_id))).all()
-        ]
-        report_ids = [
-            row[0] for row in (await session.execute(select(LintReport.id).where(LintReport.user_id == user_id))).all()
-        ]
-        conv_ids = [
-            row[0]
-            for row in (await session.execute(select(Conversation.id).where(Conversation.user_id == user_id))).all()
-        ]
+        article_ids = list((await session.exec(select(Article.id).where(Article.user_id == user_id))).all())
+        report_ids = list((await session.exec(select(LintReport.id).where(LintReport.user_id == user_id))).all())
+        conv_ids = list((await session.exec(select(Conversation.id).where(Conversation.user_id == user_id))).all())
 
         # 1. Delete child rows that reference articles
         if article_ids:

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -143,8 +143,8 @@ async def _fetch_sources(session: AsyncSession, source_ids: list[str]) -> list[S
     """
     if not source_ids:
         return []
-    result = await session.execute(select(Source).where(Source.id.in_(source_ids)))  # type: ignore[attr-defined]
-    by_id = {s.id: s for s in result.scalars().all()}
+    result = await session.exec(select(Source).where(Source.id.in_(source_ids)))  # type: ignore[attr-defined]
+    by_id = {s.id: s for s in result.all()}
     return [by_id[sid] for sid in source_ids if sid in by_id]
 
 
@@ -153,14 +153,14 @@ async def _fetch_source_ids_from_join(session: AsyncSession, article_id: str) ->
 
     Falls back to parsing the legacy JSON column if no join rows exist.
     """
-    result = await session.execute(select(ArticleSource.source_id).where(ArticleSource.article_id == article_id))
-    ids = [row[0] for row in result.all()]
+    result = await session.exec(select(ArticleSource.source_id).where(ArticleSource.article_id == article_id))
+    ids = list(result.all())
     if ids:
         return ids
     # Fallback: read from legacy JSON column
-    art_result = await session.execute(select(Article.source_ids).where(Article.id == article_id))
-    row = art_result.first()
-    return _parse_source_ids(row[0] if row else None)
+    art_result = await session.exec(select(Article.source_ids).where(Article.id == article_id))
+    val = art_result.first()
+    return _parse_source_ids(val)
 
 
 async def _fetch_concept_names_from_join(session: AsyncSession, article_id: str) -> list[str]:
@@ -168,14 +168,14 @@ async def _fetch_concept_names_from_join(session: AsyncSession, article_id: str)
 
     Falls back to parsing the legacy JSON column if no join rows exist.
     """
-    result = await session.execute(select(ArticleConcept.concept_name).where(ArticleConcept.article_id == article_id))
-    names = [row[0] for row in result.all()]
+    result = await session.exec(select(ArticleConcept.concept_name).where(ArticleConcept.article_id == article_id))
+    names = list(result.all())
     if names:
         return names
     # Fallback: read from legacy JSON column
-    art_result = await session.execute(select(Article.concept_ids).where(Article.id == article_id))
-    row = art_result.first()
-    return _parse_source_ids(row[0] if row else None)
+    art_result = await session.exec(select(Article.concept_ids).where(Article.id == article_id))
+    val = art_result.first()
+    return _parse_source_ids(val)
 
 
 async def _fetch_concepts_for_articles(
@@ -835,8 +835,8 @@ class WikiService:
         if not ranked_ids:
             return []
 
-        result = await session.execute(select(Article).where(Article.id.in_(ranked_ids)))  # type: ignore[attr-defined]
-        articles_by_id = {a.id: a for a in result.scalars().all()}
+        result = await session.exec(select(Article).where(Article.id.in_(ranked_ids)))  # type: ignore[attr-defined]
+        articles_by_id = {a.id: a for a in result.all()}
         ordered = [articles_by_id[aid] for aid in ranked_ids if aid in articles_by_id]
 
         return [await _build_article_summary(a, session) for a in ordered]

--- a/src/wikimind/services/wiki_export.py
+++ b/src/wikimind/services/wiki_export.py
@@ -87,8 +87,8 @@ class WikiExportService:
         Returns:
             Tuple of (zip bytes buffer, suggested filename, article count).
         """
-        result = await session.execute(select(Article).where(Article.user_id == user_id).order_by(Article.title))
-        articles = list(result.scalars().all())
+        result = await session.exec(select(Article).where(Article.user_id == user_id).order_by(Article.title))
+        articles = list(result.all())
 
         # Pre-load concepts for all articles
         concepts_map: dict[str, list[str]] = {}

--- a/src/wikimind/services/wiki_index.py
+++ b/src/wikimind/services/wiki_index.py
@@ -20,7 +20,7 @@ from wikimind.models import Article, ArticleConcept, Backlink, Concept, PageType
 from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 log = structlog.get_logger()
 
@@ -92,12 +92,12 @@ async def _group_articles_by_concept(
     Returns:
         GroupedArticles with by_concept mapping and uncategorized list.
     """
-    concepts_result = await session.execute(select(Concept))
-    concept_map: dict[str, str] = {c.id: c.name for c in concepts_result.scalars().all()}
+    concepts_result = await session.exec(select(Concept))
+    concept_map: dict[str, str] = {c.id: c.name for c in concepts_result.all()}
 
-    ac_result = await session.execute(select(ArticleConcept))
+    ac_result = await session.exec(select(ArticleConcept))
     article_concept_map: dict[str, list[str]] = defaultdict(list)
-    for ac in ac_result.scalars().all():
+    for ac in ac_result.all():
         article_concept_map[ac.article_id].append(ac.concept_name)
 
     concept_articles: dict[str, list[Article]] = defaultdict(list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,9 @@ import keyring
 import pytest
 from httpx import ASGITransport, AsyncClient
 from keyring.backend import KeyringBackend
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.config import get_settings
 from wikimind.database import get_session
@@ -139,13 +140,13 @@ def session_factory(async_engine: AsyncEngine) -> async_sessionmaker[AsyncSessio
     for seeding data before exercising a route, or for verifying state
     after a service call.
     """
-    return async_sessionmaker(async_engine, expire_on_commit=False)
+    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.fixture
 async def db_session(async_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
     """Async database session backed by in-memory SQLite."""
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
     async with factory() as session:
         yield session
         # Explicitly close the session connection before the event loop ends,
@@ -163,7 +164,7 @@ async def client(async_engine: AsyncEngine) -> AsyncGenerator[AsyncClient, None]
     engine so that route handlers that call ``get_session_factory()`` directly
     (rather than through FastAPI's DI) also use the hermetic test DB.
     """
-    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     async def _override_session() -> AsyncGenerator[AsyncSession, None]:
         async with factory() as session:

--- a/tests/integration/test_multiuser_isolation.py
+++ b/tests/integration/test_multiuser_isolation.py
@@ -372,11 +372,11 @@ class TestConceptIsolation:
         await upsert_concepts(["Python", "Rust"], db_session, user_id=USER_ALICE)
         await upsert_concepts(["Go", "Java"], db_session, user_id=USER_BOB)
 
-        alice_result = await db_session.execute(select(Concept).where(Concept.user_id == USER_ALICE))
-        alice_names = {c.name for c in alice_result.scalars().all()}
+        alice_result = await db_session.exec(select(Concept).where(Concept.user_id == USER_ALICE))
+        alice_names = {c.name for c in alice_result.all()}
 
-        bob_result = await db_session.execute(select(Concept).where(Concept.user_id == USER_BOB))
-        bob_names = {c.name for c in bob_result.scalars().all()}
+        bob_result = await db_session.exec(select(Concept).where(Concept.user_id == USER_BOB))
+        bob_names = {c.name for c in bob_result.all()}
 
         assert "python" in alice_names
         assert "rust" in alice_names

--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -10,8 +10,9 @@ import json
 import os
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tests.conftest import TEST_USER_ID
 from wikimind.database import _backfill_concepts_from_articles
@@ -47,7 +48,7 @@ async def pg_session(pg_engine) -> AsyncSession:
     Postgres' foreign-key constraints (SQLite tests get away without this
     because FKs are off by default in SQLite).
     """
-    factory = async_sessionmaker(pg_engine, expire_on_commit=False)
+    factory = async_sessionmaker(pg_engine, class_=AsyncSession, expire_on_commit=False)
     async with factory() as session:
         session.add(
             User(
@@ -69,8 +70,8 @@ class TestPostgresBasicOperations:
         pg_session.add(source)
         await pg_session.commit()
 
-        result = await pg_session.execute(select(Source).where(Source.id == source.id))
-        loaded = result.scalar_one()
+        result = await pg_session.exec(select(Source).where(Source.id == source.id))
+        loaded = result.one()
         assert loaded.source_url == "https://example.com"
 
     async def test_json_column_round_trip(self, pg_session):
@@ -88,8 +89,8 @@ class TestPostgresBasicOperations:
         pg_session.add(article)
         await pg_session.commit()
 
-        result = await pg_session.execute(select(Article).where(Article.slug == "pg-json-test"))
-        loaded = result.scalar_one()
+        result = await pg_session.exec(select(Article).where(Article.slug == "pg-json-test"))
+        loaded = result.one()
         assert loaded.concept_ids is not None
 
     async def test_query_with_json_fields(self, pg_session):
@@ -104,8 +105,8 @@ class TestPostgresBasicOperations:
         pg_session.add(q)
         await pg_session.commit()
 
-        result = await pg_session.execute(select(Query).where(Query.id == q.id))
-        loaded = result.scalar_one()
+        result = await pg_session.exec(select(Query).where(Query.id == q.id))
+        loaded = result.one()
         assert loaded.question == "What is AI?"
 
 

--- a/tests/integration/test_qa_loop_integration.py
+++ b/tests/integration/test_qa_loop_integration.py
@@ -155,7 +155,7 @@ async def test_ask_with_file_back_creates_article_end_to_end(
     assert filed.confidence is None
 
     # Sanity: the Query row is queryable end-to-end via the session.
-    fetched = (await db_session.execute(select(Query).where(Query.id == query.id))).scalar_one()
+    fetched = (await db_session.exec(select(Query).where(Query.id == query.id))).one()
     assert fetched.filed_article_id == filed.id
 
 

--- a/tests/integration/test_sweep_integration.py
+++ b/tests/integration/test_sweep_integration.py
@@ -89,17 +89,17 @@ async def test_sweep_resolves_incrementally(db_session: AsyncSession, session_fa
 
     # Assert: Backlink A -> B exists (use a fresh session from factory to see committed data)
     async with factory() as check_session:
-        bl_result = await check_session.execute(
+        bl_result = await check_session.exec(
             select(Backlink).where(
                 Backlink.source_article_id == article_a.id,
                 Backlink.target_article_id == article_b.id,
             )
         )
-        assert bl_result.scalar_one_or_none() is not None
+        assert bl_result.one_or_none() is not None
 
         # Assert: Job row was created
-        job_result = await check_session.execute(select(Job).where(Job.job_type == JobType.SWEEP_WIKILINKS))
-        jobs = list(job_result.scalars().all())
+        job_result = await check_session.exec(select(Job).where(Job.job_type == JobType.SWEEP_WIKILINKS))
+        jobs = list(job_result.all())
         assert len(jobs) >= 1
         assert jobs[0].status == JobStatus.COMPLETE
 

--- a/tests/integration/test_wikilink_resolution_integration.py
+++ b/tests/integration/test_wikilink_resolution_integration.py
@@ -86,8 +86,8 @@ async def test_wikilink_resolution_end_to_end(
     article = await compiler.save_article(result, source, db_session)
 
     # 3. Backlink row exists
-    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    backlinks = list(bl_result.scalars().all())
+    bl_result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.all())
     assert len(backlinks) == 1
     assert backlinks[0].target_article_id == target.id
 

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -398,8 +398,8 @@ class TestRssAdapterPoll:
         assert new_count == 2
 
         # Verify captures created
-        result = await db_session.execute(select(CaptureSource).where(CaptureSource.user_id == TEST_USER_ID))
-        captures = list(result.scalars().all())
+        result = await db_session.exec(select(CaptureSource).where(CaptureSource.user_id == TEST_USER_ID))
+        captures = list(result.all())
         assert len(captures) == 2
         assert all(c.kind == CaptureKind.RSS for c in captures)
 

--- a/tests/unit/test_concept_layer_schema.py
+++ b/tests/unit/test_concept_layer_schema.py
@@ -123,8 +123,8 @@ async def test_compiled_claim_create_and_read(db_session) -> None:
     db_session.add(claim)
     await db_session.commit()
 
-    result = await db_session.execute(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
-    rows = list(result.scalars().all())
+    result = await db_session.exec(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
+    rows = list(result.all())
     assert len(rows) == 1
     assert rows[0].text == "Redis is single-threaded"
     assert json.loads(rows[0].subjects) == ["Redis", "single-threaded execution"]
@@ -168,8 +168,8 @@ async def test_concept_cluster_create_and_read(db_session) -> None:
     db_session.add(cluster)
     await db_session.commit()
 
-    result = await db_session.execute(select(ConceptCluster).where(ConceptCluster.user_id == TEST_USER_ID))
-    rows = list(result.scalars().all())
+    result = await db_session.exec(select(ConceptCluster).where(ConceptCluster.user_id == TEST_USER_ID))
+    rows = list(result.all())
     assert len(rows) == 1
     assert rows[0].canonical_text == "Redis"
     assert rows[0].status == ClusterStatus.CANDIDATE
@@ -271,8 +271,8 @@ async def test_claim_concept_join(db_session) -> None:
     db_session.add(join_row)
     await db_session.commit()
 
-    result = await db_session.execute(select(ClaimConcept).where(ClaimConcept.claim_id == claim.id))
-    rows = list(result.scalars().all())
+    result = await db_session.exec(select(ClaimConcept).where(ClaimConcept.claim_id == claim.id))
+    rows = list(result.all())
     assert len(rows) == 1
     assert rows[0].concept_id == cluster.id
     assert rows[0].role == ClaimConceptRole.SUBJECT
@@ -355,8 +355,8 @@ async def test_save_article_persists_compiled_claims(db_session, tmp_path) -> No
 
     article = await compiler.save_article(result, source, db_session)
 
-    claim_result = await db_session.execute(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
-    claim_rows = list(claim_result.scalars().all())
+    claim_result = await db_session.exec(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
+    claim_rows = list(claim_result.all())
     assert len(claim_rows) == 2
 
     texts = {r.text for r in claim_rows}
@@ -397,8 +397,8 @@ async def test_recompile_clears_old_claims(db_session, tmp_path) -> None:
         article_body="Body text. " * 50,
     )
     article = await compiler.save_article(result1, source, db_session)
-    claim_result = await db_session.execute(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
-    assert len(list(claim_result.scalars().all())) == 2
+    claim_result = await db_session.exec(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
+    assert len(list(claim_result.all())) == 2
 
     # Second compile with 1 claim (replacing)
     result2 = CompilationResult(
@@ -414,8 +414,8 @@ async def test_recompile_clears_old_claims(db_session, tmp_path) -> None:
     )
     await compiler.save_article(result2, source, db_session)
 
-    claim_result = await db_session.execute(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
-    claims = list(claim_result.scalars().all())
+    claim_result = await db_session.exec(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
+    claims = list(claim_result.all())
     assert len(claims) == 1
     assert claims[0].text == "Claim C"
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -52,8 +52,8 @@ class TestSessionLifecycle:
 
         # Verify the row was persisted
         async with session_factory() as verify_session:
-            result = await verify_session.execute(select(Source).where(Source.id == source_id))
-            persisted = result.scalar_one_or_none()
+            result = await verify_session.exec(select(Source).where(Source.id == source_id))
+            persisted = result.one_or_none()
             assert persisted is not None
             assert persisted.source_url == "https://example.com"
 
@@ -72,8 +72,8 @@ class TestSessionLifecycle:
 
         # Verify the row was NOT persisted
         async with session_factory() as verify_session:
-            result = await verify_session.execute(select(Source).where(Source.id == source_id))
-            persisted = result.scalar_one_or_none()
+            result = await verify_session.exec(select(Source).where(Source.id == source_id))
+            persisted = result.one_or_none()
             assert persisted is None
 
 
@@ -129,8 +129,8 @@ class TestRepairMalformedJsonArraysMigration:
         await _repair_malformed_json_arrays(async_engine)
 
         db_session.expire_all()
-        result = await db_session.execute(select(Article).where(Article.id == article_id))
-        fixed = result.scalar_one()
+        result = await db_session.exec(select(Article).where(Article.id == article_id))
+        fixed = result.one()
         parsed = json.loads(fixed.concept_ids)
         assert parsed == ["data deduplication", "data management", "storage optimization"]
 
@@ -155,8 +155,8 @@ class TestRepairMalformedJsonArraysMigration:
         await _repair_malformed_json_arrays(async_engine)
 
         db_session.expire_all()
-        result = await db_session.execute(select(Article).where(Article.id == article_id))
-        fixed = result.scalar_one()
+        result = await db_session.exec(select(Article).where(Article.id == article_id))
+        fixed = result.one()
         assert fixed.concept_ids == valid_concepts
         assert fixed.source_ids == valid_sources
 
@@ -180,8 +180,8 @@ class TestRepairMalformedJsonArraysMigration:
         await _repair_malformed_json_arrays(async_engine)
 
         db_session.expire_all()
-        result = await db_session.execute(select(Article).where(Article.id == article_id))
-        fixed = result.scalar_one()
+        result = await db_session.exec(select(Article).where(Article.id == article_id))
+        fixed = result.one()
         parsed = json.loads(fixed.source_ids)
         assert parsed == ["id1", "id2", "id3"]
 
@@ -208,8 +208,8 @@ class TestCleanupOrphanConceptRows:
 
         await _cleanup_orphan_concept_rows(db_session)
 
-        result = await db_session.execute(select(Article).where(Article.id == article.id))
-        assert result.scalar_one_or_none() is None
+        result = await db_session.exec(select(Article).where(Article.id == article.id))
+        assert result.one_or_none() is None
 
     async def test_keeps_concept_article_with_existing_file(self, db_session, tmp_path: Path):
         """Concept article whose .md file exists on disk is preserved."""
@@ -231,8 +231,8 @@ class TestCleanupOrphanConceptRows:
 
         await _cleanup_orphan_concept_rows(db_session)
 
-        result = await db_session.execute(select(Article).where(Article.id == article.id))
-        assert result.scalar_one_or_none() is not None
+        result = await db_session.exec(select(Article).where(Article.id == article.id))
+        assert result.one_or_none() is not None
 
     async def test_leaves_source_articles_untouched(self, db_session, tmp_path: Path):
         """Source articles with missing files are NOT cleaned up (only concepts)."""
@@ -250,8 +250,8 @@ class TestCleanupOrphanConceptRows:
 
         await _cleanup_orphan_concept_rows(db_session)
 
-        result = await db_session.execute(select(Article).where(Article.id == article.id))
-        assert result.scalar_one_or_none() is not None
+        result = await db_session.exec(select(Article).where(Article.id == article.id))
+        assert result.one_or_none() is not None
 
     async def test_deletes_associated_backlinks(self, db_session, tmp_path: Path):
         """Backlinks referencing an orphaned concept article are also deleted."""
@@ -289,21 +289,21 @@ class TestCleanupOrphanConceptRows:
         await _cleanup_orphan_concept_rows(db_session)
 
         # Orphan article gone
-        result = await db_session.execute(select(Article).where(Article.id == orphan.id))
-        assert result.scalar_one_or_none() is None
+        result = await db_session.exec(select(Article).where(Article.id == orphan.id))
+        assert result.one_or_none() is None
 
         # Backlink also gone
-        result = await db_session.execute(
+        result = await db_session.exec(
             select(Backlink).where(
                 Backlink.source_article_id == survivor.id,
                 Backlink.target_article_id == orphan.id,
             )
         )
-        assert result.scalar_one_or_none() is None
+        assert result.one_or_none() is None
 
         # Survivor remains
-        result = await db_session.execute(select(Article).where(Article.id == survivor.id))
-        assert result.scalar_one_or_none() is not None
+        result = await db_session.exec(select(Article).where(Article.id == survivor.id))
+        assert result.one_or_none() is not None
 
     async def test_idempotent_no_orphans(self, db_session, tmp_path: Path):
         """Running with zero concept articles is a no-op."""

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -340,8 +340,8 @@ class TestCompilerSaveArticle:
         assert second.provider == Provider.ANTHROPIC
 
         # Only one article in DB
-        result = await db_session.execute(select(Article))
-        assert len(result.scalars().all()) == 1
+        result = await db_session.exec(select(Article))
+        assert len(result.all()) == 1
 
     async def test_different_provider_stacks_as_separate_article(
         self,
@@ -370,8 +370,8 @@ class TestCompilerSaveArticle:
         assert anthropic_article.provider == Provider.ANTHROPIC
         assert openai_article.provider == Provider.OPENAI
 
-        result = await db_session.execute(select(Article))
-        assert len(result.scalars().all()) == 2
+        result = await db_session.exec(select(Article))
+        assert len(result.all()) == 2
 
     async def test_no_tracked_provider_falls_back_to_create(
         self,

--- a/tests/unit/test_enforcer_integration.py
+++ b/tests/unit/test_enforcer_integration.py
@@ -79,8 +79,8 @@ async def test_lint_run_includes_structural_findings(db_session, _isolated_data_
     assert report.status == LintReportStatus.COMPLETE
     assert report.structural_count >= 1
     assert report.checked_articles == 1
-    result = await db_session.execute(select(StructuralFinding).where(StructuralFinding.report_id == report.id))
-    findings = list(result.scalars().all())
+    result = await db_session.exec(select(StructuralFinding).where(StructuralFinding.report_id == report.id))
+    findings = list(result.all())
     assert len(findings) >= 1
     assert any(f.violation_type == "source_no_concepts" for f in findings)
 

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -414,8 +414,8 @@ async def test_save_creates_backlink_rows_for_resolved_candidates(db_session, tm
     )
     article = await compiler.save_article(result, source, db_session)
 
-    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    backlinks = list(bl_result.scalars().all())
+    bl_result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.all())
     assert len(backlinks) == 1
     assert backlinks[0].target_article_id == target.id
     assert backlinks[0].context == "Existing Article"
@@ -473,8 +473,8 @@ async def test_save_dedupes_candidates_resolving_to_same_target(db_session, tmp_
     result = _result_with_backlinks("New Article", backlink_suggestions=["React", "react"])
     article = await compiler.save_article(result, source, db_session)
 
-    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    backlinks = list(bl_result.scalars().all())
+    bl_result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.all())
     assert len(backlinks) == 1
 
 
@@ -484,8 +484,8 @@ async def test_save_skips_backlinks_when_no_candidates(db_session, tmp_path) -> 
     result = _result_with_backlinks("Solo Article", backlink_suggestions=[])
     article = await compiler.save_article(result, source, db_session)
 
-    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    assert list(bl_result.scalars().all()) == []
+    bl_result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    assert list(bl_result.all()) == []
 
 
 # ---------------------------------------------------------------------------
@@ -500,8 +500,8 @@ async def test_save_article_creates_concept_rows(db_session, tmp_path) -> None:
     result = _result(concepts=["Machine Learning", "Deep Learning"])
     await compiler.save_article(result, source, db_session)
 
-    concept_result = await db_session.execute(select(Concept))
-    concepts = {c.name for c in concept_result.scalars().all()}
+    concept_result = await db_session.exec(select(Concept))
+    concepts = {c.name for c in concept_result.all()}
     assert "machine-learning" in concepts
     assert "deep-learning" in concepts
 
@@ -513,8 +513,8 @@ async def test_save_article_updates_concept_article_counts(db_session, tmp_path)
     result = _result(concepts=["ML"])
     await compiler.save_article(result, source, db_session)
 
-    concept_result = await db_session.execute(select(Concept).where(Concept.name == "ml"))
-    concept = concept_result.scalar_one()
+    concept_result = await db_session.exec(select(Concept).where(Concept.name == "ml"))
+    concept = concept_result.one()
     assert concept.article_count == 1
 
 
@@ -532,8 +532,8 @@ async def test_replace_article_upserts_new_concepts(db_session, tmp_path) -> Non
     result2 = _result(concepts=["beta", "gamma"])
     await compiler.save_article(result2, source, db_session)
 
-    concept_result = await db_session.execute(select(Concept))
-    names = {c.name for c in concept_result.scalars().all()}
+    concept_result = await db_session.exec(select(Concept))
+    names = {c.name for c in concept_result.all()}
     assert "alpha" in names
     assert "beta" in names
     assert "gamma" in names
@@ -566,7 +566,7 @@ async def test_save_article_in_place_updates_existing_row(db_session, tmp_path) 
     assert replaced.slug == original_slug
 
     # Confirm only one article exists in the DB.
-    all_articles = (await db_session.execute(select(Article))).scalars().all()
+    all_articles = (await db_session.exec(select(Article))).all()
     assert len(all_articles) == 1
 
 

--- a/tests/unit/test_faceted_search.py
+++ b/tests/unit/test_faceted_search.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tests.conftest import TEST_USER_ID
 from wikimind.models import (
@@ -23,9 +22,6 @@ from wikimind.services.search import (
     create_fts_table,
     index_article,
 )
-
-if TYPE_CHECKING:
-    from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 @pytest.fixture
@@ -44,7 +40,7 @@ async def fts_engine() -> AsyncEngine:
 @pytest.fixture
 async def fts_session(fts_engine: AsyncEngine) -> AsyncSession:
     """Session backed by the FTS-enabled in-memory engine."""
-    factory = async_sessionmaker(fts_engine, expire_on_commit=False)
+    factory = async_sessionmaker(fts_engine, class_=AsyncSession, expire_on_commit=False)
     async with factory() as session:
         yield session
 

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -385,8 +385,8 @@ async def test_backfill_creates_conversation_for_legacy_query(tmp_path, monkeypa
     # Idempotency: a second init_db is a no-op (migration already recorded)
     await init_db()
     async with factory() as session:
-        rows_result = await session.execute(select(Conversation).where(Conversation.id == result.conversation_id))
-        rows = list(rows_result.scalars().all())
+        rows_result = await session.exec(select(Conversation).where(Conversation.id == result.conversation_id))
+        rows = list(rows_result.all())
         assert len(rows) == 1, "backfill is not idempotent — it duplicated the conversation row"
 
     await close_db()

--- a/tests/unit/test_phase2_compiler.py
+++ b/tests/unit/test_phase2_compiler.py
@@ -236,8 +236,8 @@ async def test_relation_type_persisted(db_session, tmp_path):
     compiler._last_typed_suggestions = {"existing article": "extends"}
     source = await _make_source(db_session)
     article = await compiler.save_article(_result(backlink_suggestions=["Existing Article"]), source, db_session)
-    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    backlinks = list(bl_result.scalars().all())
+    bl_result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.all())
     assert len(backlinks) == 1
     assert backlinks[0].relation_type == RelationType.EXTENDS
 
@@ -257,8 +257,8 @@ async def test_default_relation_type_references(db_session, tmp_path):
     compiler._last_typed_suggestions = {}
     source = await _make_source(db_session)
     article = await compiler.save_article(_result(backlink_suggestions=["Target Article"]), source, db_session)
-    bl_result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    backlinks = list(bl_result.scalars().all())
+    bl_result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    backlinks = list(bl_result.all())
     assert len(backlinks) == 1
     assert backlinks[0].relation_type == RelationType.REFERENCES
 

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -494,8 +494,8 @@ class TestFileBackSelection:
         article_id = result.article.id
 
         # Refresh the selected queries
-        res = await db_session.execute(select(Query).where(Query.conversation_id == "conv-sel-1"))
-        queries = {q.turn_index: q for q in res.scalars().all()}
+        res = await db_session.exec(select(Query).where(Query.conversation_id == "conv-sel-1"))
+        queries = {q.turn_index: q for q in res.all()}
 
         assert queries[0].filed_back is True
         assert queries[0].filed_article_id == article_id

--- a/tests/unit/test_schema_models.py
+++ b/tests/unit/test_schema_models.py
@@ -89,15 +89,15 @@ class TestConceptKindDef:
         )
         db_session.add(kind)
         await db_session.commit()
-        result = await db_session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "test-kind"))
-        assert result.scalar_one().prompt_template_key == "test_key"
+        result = await db_session.exec(select(ConceptKindDef).where(ConceptKindDef.name == "test-kind"))
+        assert result.one().prompt_template_key == "test_key"
 
     async def test_primary_key_is_name(self, db_session: AsyncSession):
         kind = ConceptKindDef(name="unique-kind", prompt_template_key="k", required_sections="[]", linter_rules="[]")
         db_session.add(kind)
         await db_session.commit()
-        result = await db_session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "unique-kind"))
-        assert result.scalar_one() is not None
+        result = await db_session.exec(select(ConceptKindDef).where(ConceptKindDef.name == "unique-kind"))
+        assert result.one() is not None
 
 
 class TestArticlePageType:
@@ -121,8 +121,8 @@ class TestArticlePageType:
         )
         db_session.add(article)
         await db_session.commit()
-        result = await db_session.execute(select(Article).where(Article.slug == "answer-page"))
-        assert result.scalar_one().page_type == PageType.ANSWER
+        result = await db_session.exec(select(Article).where(Article.slug == "answer-page"))
+        assert result.one().page_type == PageType.ANSWER
 
 
 class TestBacklinkRelationType:
@@ -196,8 +196,8 @@ class TestConceptKind:
         concept = Concept(name="openai", concept_kind="organization", user_id=TEST_USER_ID)
         db_session.add(concept)
         await db_session.commit()
-        result = await db_session.execute(select(Concept).where(Concept.name == "openai"))
-        assert result.scalar_one().concept_kind == "organization"
+        result = await db_session.exec(select(Concept).where(Concept.name == "openai"))
+        assert result.one().concept_kind == "organization"
 
 
 class TestSourceFrontmatter:
@@ -336,8 +336,8 @@ class TestSeedBuiltinKinds:
         async with session_factory() as session:
             await seed_builtin_kinds(session)
         async with session_factory() as session:
-            result = await session.execute(select(ConceptKindDef))
-            assert {k.name for k in result.scalars().all()} == {"topic", "person", "organization", "product", "paper"}
+            result = await session.exec(select(ConceptKindDef))
+            assert {k.name for k in result.all()} == {"topic", "person", "organization", "product", "paper"}
 
     async def test_idempotent(self, session_factory):
         async with session_factory() as session:
@@ -345,20 +345,20 @@ class TestSeedBuiltinKinds:
         async with session_factory() as session:
             await seed_builtin_kinds(session)
         async with session_factory() as session:
-            assert len((await session.execute(select(ConceptKindDef))).scalars().all()) == 5
+            assert len((await session.exec(select(ConceptKindDef))).all()) == 5
 
     async def test_topic_has_correct_sections(self, session_factory):
         async with session_factory() as session:
             await seed_builtin_kinds(session)
         async with session_factory() as session:
-            topic = (await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "topic"))).scalar_one()
+            topic = (await session.exec(select(ConceptKindDef).where(ConceptKindDef.name == "topic"))).one()
             assert "overview" in json.loads(topic.required_sections)
 
     async def test_person_has_correct_template_key(self, session_factory):
         async with session_factory() as session:
             await seed_builtin_kinds(session)
         async with session_factory() as session:
-            person = (await session.execute(select(ConceptKindDef).where(ConceptKindDef.name == "person"))).scalar_one()
+            person = (await session.exec(select(ConceptKindDef).where(ConceptKindDef.name == "person"))).one()
             assert person.prompt_template_key == "concept_synthesis_person"
 
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tests.conftest import TEST_USER_ID
 from wikimind.models import Article, SearchResponse, SearchResult, User
@@ -22,9 +21,6 @@ from wikimind.services.search import (
     remove_article,
     search_articles,
 )
-
-if TYPE_CHECKING:
-    from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 @pytest.fixture
@@ -43,7 +39,7 @@ async def fts_engine() -> AsyncEngine:
 @pytest.fixture
 async def fts_session(fts_engine: AsyncEngine) -> AsyncSession:
     """Session backed by the FTS-enabled in-memory engine."""
-    factory = async_sessionmaker(fts_engine, expire_on_commit=False)
+    factory = async_sessionmaker(fts_engine, class_=AsyncSession, expire_on_commit=False)
     async with factory() as session:
         yield session
 

--- a/tests/unit/test_sharing.py
+++ b/tests/unit/test_sharing.py
@@ -117,8 +117,8 @@ class TestSharingServiceUnit:
         await db_session.commit()
 
         # Verify it's revoked
-        result = await db_session.execute(select(ShareLink).where(ShareLink.id == created.id))
-        link = result.scalar_one()
+        result = await db_session.exec(select(ShareLink).where(ShareLink.id == created.id))
+        link = result.one()
         assert link.revoked is True
 
     @pytest.mark.asyncio

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -111,8 +111,8 @@ async def test_refresh_creates_reinforcement_event(db_session: AsyncSession):
     assert updated.last_reinforced_at > old_time
 
     # Verify a ReinforcementEvent was created
-    result = await db_session.execute(select(ReinforcementEvent).where(ReinforcementEvent.article_id == article.id))
-    events = list(result.scalars().all())
+    result = await db_session.exec(select(ReinforcementEvent).where(ReinforcementEvent.article_id == article.id))
+    events = list(result.all())
     assert len(events) == 1
     assert events[0].event_type == "manual_refresh"
     assert events[0].user_id == TEST_USER_ID

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -102,8 +102,8 @@ async def test_unknown_bracket_stays(db_session: AsyncSession, tmp_path: Path) -
     content = (wiki / "unknown.md").read_text()
     assert "[[Nonexistent Topic]]" in content
 
-    result = await db_session.execute(select(Backlink).where(Backlink.source_article_id == article.id))
-    assert result.scalar_one_or_none() is None
+    result = await db_session.exec(select(Backlink).where(Backlink.source_article_id == article.id))
+    assert result.one_or_none() is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_taxonomy.py
+++ b/tests/unit/test_taxonomy.py
@@ -89,8 +89,8 @@ class TestUpsertConcepts:
         await upsert_concepts(["Machine Learning"], db_session, user_id=TEST_USER_ID)
         # Second call with different casing should not overwrite description
         await upsert_concepts(["machine learning"], db_session, user_id=TEST_USER_ID)
-        result = await db_session.execute(select(Concept).where(Concept.name == "machine-learning"))
-        concept = result.scalar_one()
+        result = await db_session.exec(select(Concept).where(Concept.name == "machine-learning"))
+        concept = result.one()
         assert concept.description == "Machine Learning"
 
     async def test_concurrent_upsert_no_integrity_error(self, session_factory):
@@ -162,8 +162,8 @@ class TestUpdateArticleCounts:
 
         await update_article_counts(db_session, user_id=TEST_USER_ID)
 
-        result = await db_session.execute(select(Concept))
-        concepts = {c.name: c.article_count for c in result.scalars().all()}
+        result = await db_session.exec(select(Concept))
+        concepts = {c.name: c.article_count for c in result.all()}
         assert concepts["ml"] == 2
         assert concepts["nlp"] == 1
 
@@ -172,8 +172,8 @@ class TestUpdateArticleCounts:
         await upsert_concepts(["orphan-concept"], db_session, user_id=TEST_USER_ID)
 
         # Manually set a stale count
-        result = await db_session.execute(select(Concept).where(Concept.name == "orphan-concept"))
-        concept = result.scalar_one()
+        result = await db_session.exec(select(Concept).where(Concept.name == "orphan-concept"))
+        concept = result.one()
         concept.article_count = 5
         db_session.add(concept)
         await db_session.commit()
@@ -287,8 +287,8 @@ class TestRebuildTaxonomy:
         ):
             await rebuild_taxonomy(db_session, user_id=TEST_USER_ID)
 
-        result = await db_session.execute(select(Concept))
-        concepts = {c.name: c for c in result.scalars().all()}
+        result = await db_session.exec(select(Concept))
+        concepts = {c.name: c for c in result.all()}
         assert concepts["ml"].parent_id is None
         assert concepts["deep-learning"].parent_id == concepts["ml"].id
         assert concepts["nlp"].parent_id == concepts["ml"].id
@@ -322,8 +322,8 @@ class TestRebuildTaxonomy:
         ):
             await rebuild_taxonomy(db_session, user_id=TEST_USER_ID)
 
-        result = await db_session.execute(select(Concept))
-        for concept in result.scalars().all():
+        result = await db_session.exec(select(Concept))
+        for concept in result.all():
             assert concept.parent_id is None
 
     async def test_rebuild_skips_empty_concepts(self, db_session):
@@ -368,6 +368,6 @@ class TestRebuildTaxonomy:
         ):
             await rebuild_taxonomy(db_session, user_id=TEST_USER_ID)
 
-        result = await db_session.execute(select(Concept))
-        for concept in result.scalars().all():
+        result = await db_session.exec(select(Concept))
+        for concept in result.all():
             assert concept.parent_id is None

--- a/tests/unit/test_user_scoping.py
+++ b/tests/unit/test_user_scoping.py
@@ -108,8 +108,8 @@ class TestUpdateArticleCountsUserScoping:
         # Update counts for alice only
         await update_article_counts(db_session, user_id="alice")
 
-        result = await db_session.execute(select(Concept).where(Concept.user_id == "alice"))
-        alice_concept = result.scalar_one()
+        result = await db_session.exec(select(Concept).where(Concept.user_id == "alice"))
+        alice_concept = result.one()
         assert alice_concept.article_count == 1
 
 
@@ -147,8 +147,8 @@ class TestRebuildTaxonomyUserScoping:
             await rebuild_taxonomy(db_session, user_id="alice")
 
         # Bob's concept should be untouched
-        bob_result = await db_session.execute(select(Concept).where(Concept.user_id == "bob"))
-        bob_concept = bob_result.scalar_one()
+        bob_result = await db_session.exec(select(Concept).where(Concept.user_id == "bob"))
+        bob_concept = bob_result.one()
         assert bob_concept.parent_id is None
         assert bob_concept.name == "biology"
 
@@ -324,8 +324,8 @@ class TestFileBackSelectionPathScoping:
         article_info = result.article
 
         # Verify the article stores a relative path and resolves under wiki/alice/
-        art_result = await db_session.execute(select(Article).where(Article.id == article_info.id))
-        article = art_result.scalar_one()
+        art_result = await db_session.exec(select(Article).where(Article.id == article_info.id))
+        article = art_result.one()
         assert article.file_path.startswith("qa-answers/")
         resolved = get_wiki_storage("alice").root / article.file_path
         assert "/alice/" in str(resolved)


### PR DESCRIPTION
## Summary
- **Problem:** 263 occurrences of deprecated `session.execute(select(...))` with manual `.scalars().all()` / `.scalar_one_or_none()` unwrapping
- **Fix:** Replaced with `session.exec(select(...))` which returns typed results directly (`.all()`, `.one_or_none()`, `.first()`)
- **Scope:** 27 source files + 22 test files (51 total)
- **Kept as execute():** `insert()`, `update()`, `delete()`, `text()`, `func.count()` calls (not compatible with exec)

Closes #614

## Test plan
- [x] 1632 unit tests pass
- [x] mypy: 0 errors across 115 source files
- [x] ruff lint + format clean
- [x] No behavior change — same queries, typed returns

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized async database query handling across the app and tests to use a consistent SQLModel async session API for result retrieval. No user-facing behavior, APIs, or data models changed; core features, error responses, and workflows remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manavgup/wikimind/pull/731)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->