### PR TITLE
fix(ci): scope auto-rebase concurrency to prevent cross-PR cancellation

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -15,8 +15,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Scopes the auto-rebase concurrency group from `${{ github.workflow }}` to `${{ github.workflow }}-${{ github.ref }}` (consistent with all other CI workflows)
- Sets `cancel-in-progress: false` so rebase runs complete fully without cancelling required CI checks on open PRs

## Problem

When multiple commits land on `main` in quick succession, the auto-rebase workflow's `cancel-in-progress: true` cancels the in-flight run. That run may have already force-pushed to PR branches (triggering their required CI). The restarted run pushes again, causing the PR branch CI workflows to cancel the already-running required checks — making them appear as failed/cancelled.

## Test plan

- [x] YAML validates (`python -c "import yaml; yaml.safe_load(...)"`)
- [ ] Merge two PRs in quick succession and verify both get rebased without CI cancellation

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)