### PR TITLE
feat(inbox): add source detail view with pipeline artifacts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_JwqwAU"
+      "filename": ".merge_file_ZHWle4"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -492,2802 +492,3194 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7b5df53aa2078ca24ca557bf2c4782f26fdacea7",
+        "hashed_secret": "ea2f48f438990a988a53c85e98971cacd2cf309e",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7b5df53aa2078ca24ca557bf2c4782f26fdacea7",
+        "hashed_secret": "ea2f48f438990a988a53c85e98971cacd2cf309e",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2d85b4f2a9be825a9d2cbb243992eafd51c195c6",
+        "hashed_secret": "994dceb1656935a7c2802f102d6c4d11acb2d705",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2d85b4f2a9be825a9d2cbb243992eafd51c195c6",
+        "hashed_secret": "994dceb1656935a7c2802f102d6c4d11acb2d705",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3c537d81713e8892259be82ff52694f10c76428d",
+        "hashed_secret": "ade5c91f992bc1638881bde43b33509ad1fd9f1a",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3c537d81713e8892259be82ff52694f10c76428d",
+        "hashed_secret": "ade5c91f992bc1638881bde43b33509ad1fd9f1a",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29ea15875d62e83d513d8abed93c6612bcda4c6a",
+        "hashed_secret": "958c7a8dd85e24aacc40b6e5e1d417b7a2aa86d0",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29ea15875d62e83d513d8abed93c6612bcda4c6a",
+        "hashed_secret": "958c7a8dd85e24aacc40b6e5e1d417b7a2aa86d0",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cd0c7dff88fd88034c52518017c288420d717739",
+        "hashed_secret": "07fbafea803834f720725c808a56173d8dba9015",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cd0c7dff88fd88034c52518017c288420d717739",
+        "hashed_secret": "07fbafea803834f720725c808a56173d8dba9015",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "df6cc8287947973c44462f9bd82f600b7d8ae838",
+        "hashed_secret": "ca535d9fb91196956c7ba7529f7e9b41be52855f",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "df6cc8287947973c44462f9bd82f600b7d8ae838",
+        "hashed_secret": "ca535d9fb91196956c7ba7529f7e9b41be52855f",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "900fb2ceac4724eae9b0adc7a235a08b9ad53270",
+        "hashed_secret": "a8b2c0268343d9119fef4896f07631885668056a",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "900fb2ceac4724eae9b0adc7a235a08b9ad53270",
+        "hashed_secret": "a8b2c0268343d9119fef4896f07631885668056a",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d0bfae70db00dc1cce45a531034574e26c7040a",
+        "hashed_secret": "5aa45f0197a5185daa5ecddf5263f63465454d6c",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d0bfae70db00dc1cce45a531034574e26c7040a",
+        "hashed_secret": "5aa45f0197a5185daa5ecddf5263f63465454d6c",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e189702094319f59862a96a4723a54dee67a9f23",
+        "hashed_secret": "cdb7383b71d48b7c662c1d378f754351ebabcd00",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e189702094319f59862a96a4723a54dee67a9f23",
+        "hashed_secret": "cdb7383b71d48b7c662c1d378f754351ebabcd00",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32c84ad17c4d17b415b6bac6df7e3a98c9a90842",
+        "hashed_secret": "5bb5a48d9a73301d4a3e291c9e3597b8e25e36a0",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32c84ad17c4d17b415b6bac6df7e3a98c9a90842",
+        "hashed_secret": "5bb5a48d9a73301d4a3e291c9e3597b8e25e36a0",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4848ed4e5f026a2b84963c139d26b318d9e8ac4a",
+        "hashed_secret": "1343d460464edee59719ed02125eae3307d9493a",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4848ed4e5f026a2b84963c139d26b318d9e8ac4a",
+        "hashed_secret": "1343d460464edee59719ed02125eae3307d9493a",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "92a2c914d8f560e05f720368c38e5fdcf3065bb4",
+        "hashed_secret": "a01d3fad0bc1df1527f2004cea958a9f698e9db4",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "92a2c914d8f560e05f720368c38e5fdcf3065bb4",
+        "hashed_secret": "a01d3fad0bc1df1527f2004cea958a9f698e9db4",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e0e02a3de654269fc3d6b3174e33aaf9e1a68820",
+        "hashed_secret": "f4f067c79b390b72c5453739e3f8767262dd852d",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e0e02a3de654269fc3d6b3174e33aaf9e1a68820",
+        "hashed_secret": "f4f067c79b390b72c5453739e3f8767262dd852d",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c94cda4059bd37662d4a488c4b05db925dcba7c4",
+        "hashed_secret": "7cb6f0ec9f309902d1e5366efec769c369d317bf",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c94cda4059bd37662d4a488c4b05db925dcba7c4",
+        "hashed_secret": "7cb6f0ec9f309902d1e5366efec769c369d317bf",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6e1d52158ee832b581b5ac79772e157f6f1cedf6",
+        "hashed_secret": "e991288705097c672cb1b8632da534696d75d906",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6e1d52158ee832b581b5ac79772e157f6f1cedf6",
+        "hashed_secret": "e991288705097c672cb1b8632da534696d75d906",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fbf3a03ae6de818f2ace0d24dca8c39cd92858d9",
+        "hashed_secret": "a8c72a6b01f9715346cac0273f830092e344cd2c",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fbf3a03ae6de818f2ace0d24dca8c39cd92858d9",
+        "hashed_secret": "a8c72a6b01f9715346cac0273f830092e344cd2c",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4764a5e024ad1d3bdbfe829fadf18ec5b3023092",
+        "hashed_secret": "3bf3384ca8c7bb0f58f9e5efa40548c570e550f0",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4764a5e024ad1d3bdbfe829fadf18ec5b3023092",
+        "hashed_secret": "3bf3384ca8c7bb0f58f9e5efa40548c570e550f0",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7ded6ec0f15b934cf2985199a62fc8bc6c75e7d9",
+        "hashed_secret": "718d489401547381da132e1740cc460086de8c7b",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7ded6ec0f15b934cf2985199a62fc8bc6c75e7d9",
+        "hashed_secret": "718d489401547381da132e1740cc460086de8c7b",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "919e1f437b3a08f2a6d0e32fb15167d715eb4c9a",
+        "hashed_secret": "b75ee7a4e7258503dd53b38ede8d1bf4591a9dbc",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "919e1f437b3a08f2a6d0e32fb15167d715eb4c9a",
+        "hashed_secret": "b75ee7a4e7258503dd53b38ede8d1bf4591a9dbc",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9b1341c9d716a358bebf2fd44ab0357d1138d080",
+        "hashed_secret": "124a7342b22b906995ab73784993169d95f90aef",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9b1341c9d716a358bebf2fd44ab0357d1138d080",
+        "hashed_secret": "124a7342b22b906995ab73784993169d95f90aef",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6a09a913db6c6830586cd8aa9dee9439992b24ba",
+        "hashed_secret": "8abcfbe6993352cd7b2ccdf8550748975ffc8eee",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6a09a913db6c6830586cd8aa9dee9439992b24ba",
+        "hashed_secret": "8abcfbe6993352cd7b2ccdf8550748975ffc8eee",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32d96f5f4bd4b3d48007889345796e720d964fda",
+        "hashed_secret": "bb00024df4c75c0db35cb83d23144fcaf81ed5de",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32d96f5f4bd4b3d48007889345796e720d964fda",
+        "hashed_secret": "bb00024df4c75c0db35cb83d23144fcaf81ed5de",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b1da38ca066f4599e6578eca246c7c3eb37f6451",
+        "hashed_secret": "56287cc292af6d58427aa2bf812d393d7e1c3ed0",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b1da38ca066f4599e6578eca246c7c3eb37f6451",
+        "hashed_secret": "56287cc292af6d58427aa2bf812d393d7e1c3ed0",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d63889fe2dbf1ba4bac1534bbfee081072fe8877",
+        "hashed_secret": "1901088d633076f65a9526a8063d7a3a75a2453e",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d63889fe2dbf1ba4bac1534bbfee081072fe8877",
+        "hashed_secret": "1901088d633076f65a9526a8063d7a3a75a2453e",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bc081d7bd9fbcbdcebd7196f3c58792dfbcebf1b",
+        "hashed_secret": "fc7d0784a28b14ac88d65f2c78eb213185501ba0",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bc081d7bd9fbcbdcebd7196f3c58792dfbcebf1b",
+        "hashed_secret": "fc7d0784a28b14ac88d65f2c78eb213185501ba0",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "53f7514fbd7ac2c3e8b1c689069c37fbe34fb3d9",
+        "hashed_secret": "d59dc6d1c9dc4553363dd63ce17f610df0784903",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "53f7514fbd7ac2c3e8b1c689069c37fbe34fb3d9",
+        "hashed_secret": "d59dc6d1c9dc4553363dd63ce17f610df0784903",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8c6b4b5ed430b9906beff0c52c020075bda647d5",
+        "hashed_secret": "d6aa66f6a592400a0f90c5f653548151b12f1129",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8c6b4b5ed430b9906beff0c52c020075bda647d5",
+        "hashed_secret": "d6aa66f6a592400a0f90c5f653548151b12f1129",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66cdb5e4ce3f8245dba3113ace861d0e7bf438a9",
+        "hashed_secret": "133c941577ae7dc8a4e409ee85aa91e25521a74e",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66cdb5e4ce3f8245dba3113ace861d0e7bf438a9",
+        "hashed_secret": "133c941577ae7dc8a4e409ee85aa91e25521a74e",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a735be39964d403bd07168e327a666386e7e33e7",
+        "hashed_secret": "7b5df53aa2078ca24ca557bf2c4782f26fdacea7",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a735be39964d403bd07168e327a666386e7e33e7",
+        "hashed_secret": "7b5df53aa2078ca24ca557bf2c4782f26fdacea7",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "203cbb7e849fa5d11c81f68cf42b35b578a0a779",
+        "hashed_secret": "2d85b4f2a9be825a9d2cbb243992eafd51c195c6",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "203cbb7e849fa5d11c81f68cf42b35b578a0a779",
+        "hashed_secret": "2d85b4f2a9be825a9d2cbb243992eafd51c195c6",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d2b1443ccdc6283a94d57660d12daa4077e42b13",
+        "hashed_secret": "3c537d81713e8892259be82ff52694f10c76428d",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d2b1443ccdc6283a94d57660d12daa4077e42b13",
+        "hashed_secret": "3c537d81713e8892259be82ff52694f10c76428d",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdad28bd396a9338c52af3bfe3452ec892e37e72",
+        "hashed_secret": "29ea15875d62e83d513d8abed93c6612bcda4c6a",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdad28bd396a9338c52af3bfe3452ec892e37e72",
+        "hashed_secret": "29ea15875d62e83d513d8abed93c6612bcda4c6a",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9b2c316d0b145debe2ae588cba1ea948aefae887",
+        "hashed_secret": "cd0c7dff88fd88034c52518017c288420d717739",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9b2c316d0b145debe2ae588cba1ea948aefae887",
+        "hashed_secret": "cd0c7dff88fd88034c52518017c288420d717739",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ccc50db4d879b255c5653a2e430d2b1414175d7c",
+        "hashed_secret": "df6cc8287947973c44462f9bd82f600b7d8ae838",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ccc50db4d879b255c5653a2e430d2b1414175d7c",
+        "hashed_secret": "df6cc8287947973c44462f9bd82f600b7d8ae838",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "537369f063e9b3660ac50eaef50f017c864aa4ce",
+        "hashed_secret": "900fb2ceac4724eae9b0adc7a235a08b9ad53270",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "537369f063e9b3660ac50eaef50f017c864aa4ce",
+        "hashed_secret": "900fb2ceac4724eae9b0adc7a235a08b9ad53270",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad63f7902fd9111de53b762eb8fbcec8b01a34c2",
+        "hashed_secret": "4d0bfae70db00dc1cce45a531034574e26c7040a",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad63f7902fd9111de53b762eb8fbcec8b01a34c2",
+        "hashed_secret": "4d0bfae70db00dc1cce45a531034574e26c7040a",
         "is_verified": false,
         "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "712870abf505aba3208eac8cd1cd9c40ad47908f",
+        "hashed_secret": "e189702094319f59862a96a4723a54dee67a9f23",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "712870abf505aba3208eac8cd1cd9c40ad47908f",
+        "hashed_secret": "e189702094319f59862a96a4723a54dee67a9f23",
         "is_verified": false,
         "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30802b7ba42d7fa49b66268cb956347cfa251cad",
+        "hashed_secret": "32c84ad17c4d17b415b6bac6df7e3a98c9a90842",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30802b7ba42d7fa49b66268cb956347cfa251cad",
+        "hashed_secret": "32c84ad17c4d17b415b6bac6df7e3a98c9a90842",
         "is_verified": false,
         "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9c37b5557d9fb759a608dd2ec89517abbbeb9146",
+        "hashed_secret": "4848ed4e5f026a2b84963c139d26b318d9e8ac4a",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9c37b5557d9fb759a608dd2ec89517abbbeb9146",
+        "hashed_secret": "4848ed4e5f026a2b84963c139d26b318d9e8ac4a",
         "is_verified": false,
         "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0da08e0a2059c84a991a7662396ea854fa5ea558",
+        "hashed_secret": "92a2c914d8f560e05f720368c38e5fdcf3065bb4",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0da08e0a2059c84a991a7662396ea854fa5ea558",
+        "hashed_secret": "92a2c914d8f560e05f720368c38e5fdcf3065bb4",
         "is_verified": false,
         "line_number": 999
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e1a6a51e9a1dae0509914dc005641b24d6fcb093",
+        "hashed_secret": "e0e02a3de654269fc3d6b3174e33aaf9e1a68820",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e1a6a51e9a1dae0509914dc005641b24d6fcb093",
+        "hashed_secret": "e0e02a3de654269fc3d6b3174e33aaf9e1a68820",
         "is_verified": false,
         "line_number": 1013
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a8c65a7d6ec3ab2b6b9371edb764b083d37b08bf",
+        "hashed_secret": "c94cda4059bd37662d4a488c4b05db925dcba7c4",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a8c65a7d6ec3ab2b6b9371edb764b083d37b08bf",
+        "hashed_secret": "c94cda4059bd37662d4a488c4b05db925dcba7c4",
         "is_verified": false,
         "line_number": 1027
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a6b584f2d18a5724922ef5ce1547beb81ace8a81",
+        "hashed_secret": "6e1d52158ee832b581b5ac79772e157f6f1cedf6",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a6b584f2d18a5724922ef5ce1547beb81ace8a81",
+        "hashed_secret": "6e1d52158ee832b581b5ac79772e157f6f1cedf6",
         "is_verified": false,
         "line_number": 1041
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8c6984b1e1e4fb41ba4ea4d3bdb3c89aaba3a0c1",
+        "hashed_secret": "fbf3a03ae6de818f2ace0d24dca8c39cd92858d9",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8c6984b1e1e4fb41ba4ea4d3bdb3c89aaba3a0c1",
+        "hashed_secret": "fbf3a03ae6de818f2ace0d24dca8c39cd92858d9",
         "is_verified": false,
         "line_number": 1055
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3d41323f7517e406817145ca2b126577e06c9e2b",
+        "hashed_secret": "4764a5e024ad1d3bdbfe829fadf18ec5b3023092",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3d41323f7517e406817145ca2b126577e06c9e2b",
+        "hashed_secret": "4764a5e024ad1d3bdbfe829fadf18ec5b3023092",
         "is_verified": false,
         "line_number": 1069
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "992f451a59b652057939e981111bb6d30308b217",
+        "hashed_secret": "7ded6ec0f15b934cf2985199a62fc8bc6c75e7d9",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "992f451a59b652057939e981111bb6d30308b217",
+        "hashed_secret": "7ded6ec0f15b934cf2985199a62fc8bc6c75e7d9",
         "is_verified": false,
         "line_number": 1083
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "310354ba6711ca3c2b93eddfa153aff98fd7ed72",
+        "hashed_secret": "919e1f437b3a08f2a6d0e32fb15167d715eb4c9a",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "310354ba6711ca3c2b93eddfa153aff98fd7ed72",
+        "hashed_secret": "919e1f437b3a08f2a6d0e32fb15167d715eb4c9a",
         "is_verified": false,
         "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "157d6d412aecd18a03e8b132b341a505ed328dd5",
+        "hashed_secret": "9b1341c9d716a358bebf2fd44ab0357d1138d080",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "157d6d412aecd18a03e8b132b341a505ed328dd5",
+        "hashed_secret": "9b1341c9d716a358bebf2fd44ab0357d1138d080",
         "is_verified": false,
         "line_number": 1111
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "760185e12a9c8f8a0fa66296739b4081252ddadf",
+        "hashed_secret": "6a09a913db6c6830586cd8aa9dee9439992b24ba",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "760185e12a9c8f8a0fa66296739b4081252ddadf",
+        "hashed_secret": "6a09a913db6c6830586cd8aa9dee9439992b24ba",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4795878cc3e9d3502c45f40b00c3ff93d03f4557",
+        "hashed_secret": "32d96f5f4bd4b3d48007889345796e720d964fda",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4795878cc3e9d3502c45f40b00c3ff93d03f4557",
+        "hashed_secret": "32d96f5f4bd4b3d48007889345796e720d964fda",
         "is_verified": false,
         "line_number": 1139
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
+        "hashed_secret": "b1da38ca066f4599e6578eca246c7c3eb37f6451",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
+        "hashed_secret": "b1da38ca066f4599e6578eca246c7c3eb37f6451",
         "is_verified": false,
         "line_number": 1153
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
+        "hashed_secret": "d63889fe2dbf1ba4bac1534bbfee081072fe8877",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
+        "hashed_secret": "d63889fe2dbf1ba4bac1534bbfee081072fe8877",
         "is_verified": false,
         "line_number": 1167
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
+        "hashed_secret": "bc081d7bd9fbcbdcebd7196f3c58792dfbcebf1b",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
+        "hashed_secret": "bc081d7bd9fbcbdcebd7196f3c58792dfbcebf1b",
         "is_verified": false,
         "line_number": 1181
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
+        "hashed_secret": "53f7514fbd7ac2c3e8b1c689069c37fbe34fb3d9",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
+        "hashed_secret": "53f7514fbd7ac2c3e8b1c689069c37fbe34fb3d9",
         "is_verified": false,
         "line_number": 1195
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
+        "hashed_secret": "8c6b4b5ed430b9906beff0c52c020075bda647d5",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
+        "hashed_secret": "8c6b4b5ed430b9906beff0c52c020075bda647d5",
         "is_verified": false,
         "line_number": 1209
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
+        "hashed_secret": "66cdb5e4ce3f8245dba3113ace861d0e7bf438a9",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
+        "hashed_secret": "66cdb5e4ce3f8245dba3113ace861d0e7bf438a9",
         "is_verified": false,
         "line_number": 1223
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
+        "hashed_secret": "a735be39964d403bd07168e327a666386e7e33e7",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
+        "hashed_secret": "a735be39964d403bd07168e327a666386e7e33e7",
         "is_verified": false,
         "line_number": 1237
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
+        "hashed_secret": "203cbb7e849fa5d11c81f68cf42b35b578a0a779",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
+        "hashed_secret": "203cbb7e849fa5d11c81f68cf42b35b578a0a779",
         "is_verified": false,
         "line_number": 1251
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
+        "hashed_secret": "d2b1443ccdc6283a94d57660d12daa4077e42b13",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
+        "hashed_secret": "d2b1443ccdc6283a94d57660d12daa4077e42b13",
         "is_verified": false,
         "line_number": 1265
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
+        "hashed_secret": "fdad28bd396a9338c52af3bfe3452ec892e37e72",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
+        "hashed_secret": "fdad28bd396a9338c52af3bfe3452ec892e37e72",
         "is_verified": false,
         "line_number": 1279
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
+        "hashed_secret": "9b2c316d0b145debe2ae588cba1ea948aefae887",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
+        "hashed_secret": "9b2c316d0b145debe2ae588cba1ea948aefae887",
         "is_verified": false,
         "line_number": 1293
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
+        "hashed_secret": "ccc50db4d879b255c5653a2e430d2b1414175d7c",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
+        "hashed_secret": "ccc50db4d879b255c5653a2e430d2b1414175d7c",
         "is_verified": false,
         "line_number": 1307
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
+        "hashed_secret": "537369f063e9b3660ac50eaef50f017c864aa4ce",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
+        "hashed_secret": "537369f063e9b3660ac50eaef50f017c864aa4ce",
         "is_verified": false,
         "line_number": 1321
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
+        "hashed_secret": "ad63f7902fd9111de53b762eb8fbcec8b01a34c2",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
+        "hashed_secret": "ad63f7902fd9111de53b762eb8fbcec8b01a34c2",
         "is_verified": false,
         "line_number": 1335
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
+        "hashed_secret": "712870abf505aba3208eac8cd1cd9c40ad47908f",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
+        "hashed_secret": "712870abf505aba3208eac8cd1cd9c40ad47908f",
         "is_verified": false,
         "line_number": 1349
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
+        "hashed_secret": "30802b7ba42d7fa49b66268cb956347cfa251cad",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
+        "hashed_secret": "30802b7ba42d7fa49b66268cb956347cfa251cad",
         "is_verified": false,
         "line_number": 1363
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
+        "hashed_secret": "9c37b5557d9fb759a608dd2ec89517abbbeb9146",
         "is_verified": false,
         "line_number": 1377
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
+        "hashed_secret": "9c37b5557d9fb759a608dd2ec89517abbbeb9146",
         "is_verified": false,
         "line_number": 1377
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
+        "hashed_secret": "0da08e0a2059c84a991a7662396ea854fa5ea558",
         "is_verified": false,
         "line_number": 1391
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
+        "hashed_secret": "0da08e0a2059c84a991a7662396ea854fa5ea558",
         "is_verified": false,
         "line_number": 1391
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
+        "hashed_secret": "e1a6a51e9a1dae0509914dc005641b24d6fcb093",
         "is_verified": false,
         "line_number": 1405
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
+        "hashed_secret": "e1a6a51e9a1dae0509914dc005641b24d6fcb093",
         "is_verified": false,
         "line_number": 1405
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
+        "hashed_secret": "a8c65a7d6ec3ab2b6b9371edb764b083d37b08bf",
         "is_verified": false,
         "line_number": 1419
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
+        "hashed_secret": "a8c65a7d6ec3ab2b6b9371edb764b083d37b08bf",
         "is_verified": false,
         "line_number": 1419
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
+        "hashed_secret": "a6b584f2d18a5724922ef5ce1547beb81ace8a81",
         "is_verified": false,
         "line_number": 1433
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
+        "hashed_secret": "a6b584f2d18a5724922ef5ce1547beb81ace8a81",
         "is_verified": false,
         "line_number": 1433
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
+        "hashed_secret": "8c6984b1e1e4fb41ba4ea4d3bdb3c89aaba3a0c1",
         "is_verified": false,
         "line_number": 1447
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
+        "hashed_secret": "8c6984b1e1e4fb41ba4ea4d3bdb3c89aaba3a0c1",
         "is_verified": false,
         "line_number": 1447
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
+        "hashed_secret": "3d41323f7517e406817145ca2b126577e06c9e2b",
         "is_verified": false,
         "line_number": 1461
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
+        "hashed_secret": "3d41323f7517e406817145ca2b126577e06c9e2b",
         "is_verified": false,
         "line_number": 1461
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
+        "hashed_secret": "992f451a59b652057939e981111bb6d30308b217",
         "is_verified": false,
         "line_number": 1475
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
+        "hashed_secret": "992f451a59b652057939e981111bb6d30308b217",
         "is_verified": false,
         "line_number": 1475
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
+        "hashed_secret": "310354ba6711ca3c2b93eddfa153aff98fd7ed72",
         "is_verified": false,
         "line_number": 1489
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
+        "hashed_secret": "310354ba6711ca3c2b93eddfa153aff98fd7ed72",
         "is_verified": false,
         "line_number": 1489
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
+        "hashed_secret": "157d6d412aecd18a03e8b132b341a505ed328dd5",
         "is_verified": false,
         "line_number": 1503
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
+        "hashed_secret": "157d6d412aecd18a03e8b132b341a505ed328dd5",
         "is_verified": false,
         "line_number": 1503
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
+        "hashed_secret": "760185e12a9c8f8a0fa66296739b4081252ddadf",
         "is_verified": false,
         "line_number": 1517
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
+        "hashed_secret": "760185e12a9c8f8a0fa66296739b4081252ddadf",
         "is_verified": false,
         "line_number": 1517
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
+        "hashed_secret": "4795878cc3e9d3502c45f40b00c3ff93d03f4557",
         "is_verified": false,
         "line_number": 1531
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
+        "hashed_secret": "4795878cc3e9d3502c45f40b00c3ff93d03f4557",
         "is_verified": false,
         "line_number": 1531
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
+        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
         "is_verified": false,
         "line_number": 1545
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
+        "hashed_secret": "84d311fc036303c117f1b3d1f337a68790f959a9",
         "is_verified": false,
         "line_number": 1545
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
+        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
+        "hashed_secret": "5c0dcddc7fbece06a4a13e64b3a4366a7b03a816",
         "is_verified": false,
         "line_number": 1559
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
+        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
         "is_verified": false,
         "line_number": 1573
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
+        "hashed_secret": "212ea874aec571594ae1e06f45351fdfe908e3dd",
         "is_verified": false,
         "line_number": 1573
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
+        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
+        "hashed_secret": "2168fe51f9a2c60391596cb343a982a393675dc5",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
+        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
         "is_verified": false,
         "line_number": 1601
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
+        "hashed_secret": "dd83f657551b3ff47c8be3d661d10de388448141",
         "is_verified": false,
         "line_number": 1601
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
+        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
         "is_verified": false,
         "line_number": 1615
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
+        "hashed_secret": "870246cb453aa2cc917888e65cb7ed4741138876",
         "is_verified": false,
         "line_number": 1615
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
+        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
         "is_verified": false,
         "line_number": 1629
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
+        "hashed_secret": "53a70242614b4487cb7ea632e56e0bda1c1e8470",
         "is_verified": false,
         "line_number": 1629
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
+        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
+        "hashed_secret": "9c34259d39ab516fb427b2a769c6649713c32ca4",
         "is_verified": false,
         "line_number": 1643
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
+        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
         "is_verified": false,
         "line_number": 1657
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
+        "hashed_secret": "756c218b0881eb462fddc1b141b409e4c4732d69",
         "is_verified": false,
         "line_number": 1657
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
+        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
         "is_verified": false,
         "line_number": 1671
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
+        "hashed_secret": "4c8c6ead157717bd671410b8890ba0b121f77627",
         "is_verified": false,
         "line_number": 1671
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
+        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
         "is_verified": false,
         "line_number": 1685
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
+        "hashed_secret": "6f4cc0166f5af59fbecd5874bf0e4305cc738734",
         "is_verified": false,
         "line_number": 1685
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
+        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
         "is_verified": false,
         "line_number": 1699
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
+        "hashed_secret": "192fae5809b75c18bc098edb23e9d553877849f3",
         "is_verified": false,
         "line_number": 1699
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
+        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
+        "hashed_secret": "b2091821ec940ee62aec3753efc16682a92e6b02",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
+        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
         "is_verified": false,
         "line_number": 1727
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
+        "hashed_secret": "b92eaf8bc8c5dbb1a5679292b87ecb9898049a38",
         "is_verified": false,
         "line_number": 1727
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
+        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
         "is_verified": false,
         "line_number": 1741
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
+        "hashed_secret": "91c7042cffff0cc4fb5a0a21efb296eeec375840",
         "is_verified": false,
         "line_number": 1741
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
+        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
         "is_verified": false,
         "line_number": 1755
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
+        "hashed_secret": "10f69794c4becfe75a349742baf73a7bce043ba9",
         "is_verified": false,
         "line_number": 1755
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
+        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
         "is_verified": false,
         "line_number": 1769
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
+        "hashed_secret": "f5b9c32a6957dcfc66db1a0bf1521355f06890dc",
         "is_verified": false,
         "line_number": 1769
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
+        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
         "is_verified": false,
         "line_number": 1783
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
+        "hashed_secret": "6d11bf3afb5abfd52231d697dd02c3dcba76bf54",
         "is_verified": false,
         "line_number": 1783
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
+        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
         "is_verified": false,
         "line_number": 1797
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
+        "hashed_secret": "cd1b2cbff827fdb438ac71e2565db9facd79b389",
         "is_verified": false,
         "line_number": 1797
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
+        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
         "is_verified": false,
         "line_number": 1811
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
+        "hashed_secret": "748e887c4a2e8dbdb215df52890ad4b0673c87a6",
         "is_verified": false,
         "line_number": 1811
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
+        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
         "is_verified": false,
         "line_number": 1825
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
+        "hashed_secret": "763f3c128fa188659bf22cf18f56d8f9ac91de0b",
         "is_verified": false,
         "line_number": 1825
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
+        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
         "is_verified": false,
         "line_number": 1839
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
+        "hashed_secret": "1de1c1324ae3940c1e7617665200b512da1d0900",
         "is_verified": false,
         "line_number": 1839
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
         "is_verified": false,
         "line_number": 1853
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
+        "hashed_secret": "d844ad48e31c4b06b96e101249e9283e228cffd9",
         "is_verified": false,
         "line_number": 1853
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
         "is_verified": false,
         "line_number": 1867
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
+        "hashed_secret": "d8bc0c481752461445d58daa7d20a13a175b12da",
         "is_verified": false,
         "line_number": 1867
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
         "is_verified": false,
         "line_number": 1881
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
+        "hashed_secret": "49c89eae383e6490e682f5ace74a6d7c43fe94ec",
         "is_verified": false,
         "line_number": 1881
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 1895
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
+        "hashed_secret": "252d89c4eb2a748ea2a0ee025df9a69de2c75bef",
         "is_verified": false,
         "line_number": 1895
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 1909
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
+        "hashed_secret": "66c7fa75fd7cb1323c030ff584acfd476ffbfe04",
         "is_verified": false,
         "line_number": 1909
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 1923
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
+        "hashed_secret": "814fb8800085c00d80ba67f75bf21292ca5f2003",
         "is_verified": false,
         "line_number": 1923
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 1937
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
+        "hashed_secret": "543655637bc1acc9e9163cb7ac4f64f7ac187336",
         "is_verified": false,
         "line_number": 1937
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 1951
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
+        "hashed_secret": "a116a37a525335c2bc9a1dbc72f0b825bd44630e",
         "is_verified": false,
         "line_number": 1951
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 1965
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
+        "hashed_secret": "962a37d93aaa0c9e39265406a4d39d0f6758e2a5",
         "is_verified": false,
         "line_number": 1965
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 1979
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
+        "hashed_secret": "842f6d33b41169bee5326d2c58b56c05944bb227",
         "is_verified": false,
         "line_number": 1979
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 1993
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
+        "hashed_secret": "29c99a3293c09fd288350b23955f52ca5a9029c7",
         "is_verified": false,
         "line_number": 1993
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 2007
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
+        "hashed_secret": "d14e193e1ebc7e9cdfd6a9afccc817981273bec1",
         "is_verified": false,
         "line_number": 2007
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 2021
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
+        "hashed_secret": "f5d5a990a1273c934e15325d3afa5692dcaa8cf8",
         "is_verified": false,
         "line_number": 2021
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 2035
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
+        "hashed_secret": "f0327e26c7d2927c0c56c8cd1bd7c9b38fa8701d",
         "is_verified": false,
         "line_number": 2035
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 2049
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
+        "hashed_secret": "2ddac237156870decb1afcbde6c3648f856d5bcf",
         "is_verified": false,
         "line_number": 2049
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 2063
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
+        "hashed_secret": "ae6dd450f055c3c3db231589d222a303bd04b25e",
         "is_verified": false,
         "line_number": 2063
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 2077
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
+        "hashed_secret": "0e29120dc058bce7e28c5e1f0546cd539669a0bf",
         "is_verified": false,
         "line_number": 2077
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 2091
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
+        "hashed_secret": "ad203be2320b1adece96c46e0b48ef8a9e04de11",
         "is_verified": false,
         "line_number": 2091
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 2105
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
+        "hashed_secret": "d37c09d0cb8f69eabed05d9a20b1f3d026404042",
         "is_verified": false,
         "line_number": 2105
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 2119
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
+        "hashed_secret": "4e61e0f5d2284eff79c08c079a45090aef62ebd0",
         "is_verified": false,
         "line_number": 2119
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 2133
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
+        "hashed_secret": "1bf8296a931c8bc22fb4278e8982fafaee1713a5",
         "is_verified": false,
         "line_number": 2133
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 2147
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
+        "hashed_secret": "342747d13c116379bcbc69d6fff8df47017abf36",
         "is_verified": false,
         "line_number": 2147
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 2161
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
+        "hashed_secret": "86c69dbef03d98830d82eb2f76ee736de6d5ca95",
         "is_verified": false,
         "line_number": 2161
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 2175
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
+        "hashed_secret": "372d180bfcacd828ea7661ec75a41a74c5427b40",
         "is_verified": false,
         "line_number": 2175
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 2189
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
+        "hashed_secret": "3698616b2a66aa10c8851f59d2729acd588c7d2a",
         "is_verified": false,
         "line_number": 2189
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 2203
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "30ee40fb0dbeeb01388e4c6995490350ede8870f",
         "is_verified": false,
         "line_number": 2203
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 2217
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "8d5832efb88e133e2dbe1d55dfb49f7b63eb39ce",
         "is_verified": false,
         "line_number": 2217
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 2231
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "af4387a834fb3136c6bd813c3d11e7b92816ec3d",
         "is_verified": false,
         "line_number": 2231
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 2245
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 2245
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 2259
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 2259
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 2273
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 2273
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 2287
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 2287
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 2301
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 2301
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 2315
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 2315
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 2329
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 2329
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 2343
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 2343
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 2357
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 2357
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 2371
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 2371
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 2385
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 2385
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 2399
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 2399
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 2413
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 2413
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 2427
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 2427
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 2441
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 2441
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 2455
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 2455
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 2469
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 2469
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 2483
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 2483
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 2497
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 2497
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 2511
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 2511
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 2525
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 2525
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 2539
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 2539
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 2553
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 2553
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 2567
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 2567
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 2581
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 2581
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 2595
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 2595
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 2609
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 2609
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 2623
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 2623
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 2637
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 2637
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 2651
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 2651
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 2665
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 2665
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 2679
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 2679
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 2693
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 2693
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 2707
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 2707
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 2721
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 2721
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 2735
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 2735
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 2749
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 2749
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 2763
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 2763
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 2777
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 2777
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 2791
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 2791
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 2805
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 2805
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 2819
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 2819
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 2833
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 2833
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 2847
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 2847
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 2861
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 2861
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 2875
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 2875
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 2889
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 2889
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 2914
+        "line_number": 2903
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 2914
+        "line_number": 2903
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 2921
+        "line_number": 2917
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 2921
+        "line_number": 2917
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 2928
+        "line_number": 2931
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 2928
+        "line_number": 2931
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 2946
+        "line_number": 2945
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 2946
+        "line_number": 2945
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 2953
+        "line_number": 2959
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 2953
+        "line_number": 2959
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 2960
+        "line_number": 2973
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 2960
+        "line_number": 2973
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 2969
+        "line_number": 2987
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 2969
+        "line_number": 2987
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 2978
+        "line_number": 3001
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 2978
+        "line_number": 3001
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 2985
+        "line_number": 3015
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 2985
+        "line_number": 3015
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 2992
+        "line_number": 3029
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 2992
+        "line_number": 3029
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 3017
+        "line_number": 3043
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 3017
+        "line_number": 3043
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 3024
+        "line_number": 3057
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 3024
+        "line_number": 3057
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 3033
+        "line_number": 3071
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 3033
+        "line_number": 3071
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 3042
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 3042
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 3049
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 3049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 3058
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 3058
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 3067
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 3067
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 3085
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 3085
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 3099
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 3099
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "is_verified": false,
+        "line_number": 3113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "is_verified": false,
+        "line_number": 3113
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 3127
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 3127
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 3141
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 3141
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "is_verified": false,
+        "line_number": 3155
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "is_verified": false,
+        "line_number": 3155
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "is_verified": false,
+        "line_number": 3169
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "is_verified": false,
+        "line_number": 3169
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 3183
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 3183
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 3197
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 3197
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 3211
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 3211
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 3225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 3225
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 3239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 3239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 3253
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 3253
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 3267
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 3267
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 3281
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 3281
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 3306
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 3306
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 3313
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 3313
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 3320
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 3320
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 3338
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 3338
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 3345
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 3345
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 3352
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 3352
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 3361
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 3361
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 3370
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 3370
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 3377
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 3377
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 3384
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 3384
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 3409
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 3409
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 3416
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 3416
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 3425
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 3425
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 3434
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 3434
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 3441
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 3441
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 3450
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 3450
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 3459
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 3459
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 3477
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 3477
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
         "is_verified": false,
-        "line_number": 3094
+        "line_number": 3486
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
         "is_verified": false,
-        "line_number": 3094
+        "line_number": 3486
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
         "is_verified": false,
-        "line_number": 3101
+        "line_number": 3493
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
         "is_verified": false,
-        "line_number": 3101
+        "line_number": 3493
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
         "is_verified": false,
-        "line_number": 3110
+        "line_number": 3502
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
         "is_verified": false,
-        "line_number": 3110
+        "line_number": 3502
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
         "is_verified": false,
-        "line_number": 3135
+        "line_number": 3527
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
         "is_verified": false,
-        "line_number": 3135
+        "line_number": 3527
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
         "is_verified": false,
-        "line_number": 3153
+        "line_number": 3545
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
         "is_verified": false,
-        "line_number": 3153
+        "line_number": 3545
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
         "is_verified": false,
-        "line_number": 3160
+        "line_number": 3552
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
         "is_verified": false,
-        "line_number": 3160
+        "line_number": 3552
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 3167
+        "line_number": 3559
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 3167
+        "line_number": 3559
       }
     ],
     "Makefile": [
@@ -3562,5 +3954,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-16T13:51:44Z"
+  "generated_at": "2026-05-16T13:52:04Z"
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,6 +44,9 @@ const AdminDashboard = lazy(() =>
 const OnboardingWizard = lazy(() =>
   import("./components/onboarding/OnboardingWizard").then((m) => ({ default: m.OnboardingWizard }))
 );
+const SourceDetailView = lazy(() =>
+  import("./components/inbox/SourceDetailView").then((m) => ({ default: m.SourceDetailView }))
+);
 
 function AuthenticatedApp() {
   const navigate = useNavigate();
@@ -64,6 +67,7 @@ function AuthenticatedApp() {
         ) : (
           <Routes>
             <Route path="/inbox" element={<InboxView />} />
+            <Route path="/sources/:id" element={<SourceDetailView />} />
             <Route path="/ask" element={<AskView />} />
             <Route path="/ask/:conversationId" element={<AskView />} />
             <Route path="/wiki" element={<WikiExplorerView />} />

--- a/apps/web/src/api/sources.ts
+++ b/apps/web/src/api/sources.ts
@@ -8,6 +8,7 @@ import type {
   RejectDraftResponse,
   Source,
   SourceContentResponse,
+  SourceDetailResponse,
   TriggerCompileResponse,
 } from "../types/api";
 
@@ -23,6 +24,12 @@ export function listSources(params: ListSourcesParams = {}): Promise<Source[]> {
 
 export function getSource(sourceId: string): Promise<Source> {
   return apiFetch<Source>(`/api/ingest/sources/${encodeURIComponent(sourceId)}`);
+}
+
+export function getSourceDetail(sourceId: string): Promise<SourceDetailResponse> {
+  return apiFetch<SourceDetailResponse>(
+    `/api/ingest/sources/${encodeURIComponent(sourceId)}/detail`,
+  );
 }
 
 export function ingestUrl(url: string, autoCompile = true): Promise<Source> {

--- a/apps/web/src/components/inbox/SourceCard.tsx
+++ b/apps/web/src/components/inbox/SourceCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import type { IngestStatus, Source, SourceType } from "../../types/api";
 import { getOriginalUrl } from "../../api/sources";
 import { Badge, type BadgeTone } from "../shared/Badge";
@@ -94,7 +95,12 @@ export function SourceCard({ source, onRetry, retrying, onDelete, deleting, onRe
             </Badge>
           </div>
           <h3 className="mt-2 truncate text-sm font-semibold text-slate-900">
-            {titleText}
+            <Link
+              to={`/sources/${encodeURIComponent(source.id)}`}
+              className="hover:text-brand-700 hover:underline"
+            >
+              {titleText}
+            </Link>
           </h3>
           {source.source_url ? (
             <a

--- a/apps/web/src/components/inbox/SourceDetailView.tsx
+++ b/apps/web/src/components/inbox/SourceDetailView.tsx
@@ -1,0 +1,321 @@
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useSourceDetail } from "../../hooks/useSources";
+import { getBaseUrl } from "../../api/client";
+import { Badge, type BadgeTone } from "../shared/Badge";
+import { Card } from "../shared/Card";
+import { Spinner } from "../shared/Spinner";
+import type { IngestStatus, PipelineStep, SourceType } from "../../types/api";
+
+const STATUS_TONE: Record<IngestStatus, BadgeTone> = {
+  pending: "neutral",
+  processing: "info",
+  review_pending: "warning",
+  compiled: "success",
+  failed: "danger",
+};
+
+const STATUS_LABEL: Record<IngestStatus, string> = {
+  pending: "Pending",
+  processing: "Processing",
+  review_pending: "Review",
+  compiled: "Done",
+  failed: "Failed",
+};
+
+const TYPE_LABEL: Record<SourceType, string> = {
+  url: "URL",
+  pdf: "PDF",
+  youtube: "YouTube",
+  audio: "Audio",
+  text: "Note",
+  rss: "RSS",
+  email: "Email",
+  obsidian: "Obsidian",
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function StepIcon({ status }: { status: PipelineStep["status"] }) {
+  if (status === "complete") {
+    return (
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-100">
+        <svg className="h-4 w-4 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+    );
+  }
+  if (status === "active") {
+    return (
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-100">
+        <Spinner size={14} />
+      </div>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-rose-100">
+        <svg className="h-4 w-4 text-rose-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-100">
+      <div className="h-2.5 w-2.5 rounded-full bg-slate-300" />
+    </div>
+  );
+}
+
+export function SourceDetailView() {
+  const { id } = useParams<{ id: string }>();
+  const { data: source, isLoading, isError } = useSourceDetail(id);
+  const [selectedImg, setSelectedImg] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner size={24} />
+      </div>
+    );
+  }
+
+  if (isError || !source) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3">
+        <p className="text-sm text-slate-600">Source not found.</p>
+        <Link to="/inbox" className="text-sm text-brand-600 hover:underline">
+          Back to Inbox
+        </Link>
+      </div>
+    );
+  }
+
+  const baseUrl = getBaseUrl();
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="border-b border-slate-200 bg-white px-6 py-5">
+        <div className="flex items-center gap-3">
+          <Link to="/inbox" className="text-sm text-slate-500 hover:text-slate-700">
+            Inbox
+          </Link>
+          <span className="text-slate-300">/</span>
+          <span className="text-sm font-medium text-slate-900 truncate">
+            {source.title || "Untitled source"}
+          </span>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-3xl space-y-6">
+          {/* Metadata card */}
+          <Card className="p-5">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <h1 className="text-xl font-semibold text-slate-900 truncate">
+                  {source.title || "Untitled source"}
+                </h1>
+                {source.source_url ? (
+                  <a
+                    href={source.source_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-1 block truncate text-sm text-brand-600 hover:underline"
+                  >
+                    {source.source_url}
+                  </a>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge tone="brand">{TYPE_LABEL[source.source_type]}</Badge>
+                <Badge tone={STATUS_TONE[source.status]}>
+                  {STATUS_LABEL[source.status]}
+                </Badge>
+              </div>
+            </div>
+
+            <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
+              {source.author ? (
+                <div>
+                  <dt className="text-xs font-medium text-slate-500">Author</dt>
+                  <dd className="text-slate-900">{source.author}</dd>
+                </div>
+              ) : null}
+              {source.published_date ? (
+                <div>
+                  <dt className="text-xs font-medium text-slate-500">Published</dt>
+                  <dd className="text-slate-900">{source.published_date}</dd>
+                </div>
+              ) : null}
+              <div>
+                <dt className="text-xs font-medium text-slate-500">Ingested</dt>
+                <dd className="text-slate-900">{formatDate(source.ingested_at)}</dd>
+              </div>
+              {source.compiled_at ? (
+                <div>
+                  <dt className="text-xs font-medium text-slate-500">Compiled</dt>
+                  <dd className="text-slate-900">{formatDate(source.compiled_at)}</dd>
+                </div>
+              ) : null}
+              {source.token_count ? (
+                <div>
+                  <dt className="text-xs font-medium text-slate-500">Tokens</dt>
+                  <dd className="text-slate-900">{source.token_count.toLocaleString()}</dd>
+                </div>
+              ) : null}
+            </dl>
+
+            {source.error_message ? (
+              <div className="mt-4 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+                {source.error_message}
+              </div>
+            ) : null}
+          </Card>
+
+          {/* Pipeline steps */}
+          <Card className="p-5">
+            <h2 className="mb-4 text-base font-semibold text-slate-900">
+              Processing Pipeline
+            </h2>
+            <div className="relative">
+              {source.pipeline_steps.map((step, idx) => (
+                <div key={step.name} className="flex gap-3 pb-4 last:pb-0">
+                  <div className="flex flex-col items-center">
+                    <StepIcon status={step.status} />
+                    {idx < source.pipeline_steps.length - 1 ? (
+                      <div className="mt-1 h-full w-px bg-slate-200" />
+                    ) : null}
+                  </div>
+                  <div className="pt-0.5">
+                    <p className="text-sm font-medium text-slate-900">{step.name}</p>
+                    <p className="text-xs text-slate-500">{step.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          {/* Extracted images */}
+          {source.images.length > 0 ? (
+            <Card className="p-5">
+              <h2 className="mb-4 text-base font-semibold text-slate-900">
+                Extracted Images ({source.images.length})
+              </h2>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                {source.images.map((img) => {
+                  const imgUrl = `${baseUrl}/api/ingest/sources/${source.id}/images/${img.filename}`;
+                  return (
+                    <button
+                      key={img.filename}
+                      type="button"
+                      onClick={() => setSelectedImg(imgUrl)}
+                      className="group overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition hover:border-brand-300 hover:shadow"
+                    >
+                      <div className="flex items-center justify-center bg-slate-50 p-3">
+                        <img
+                          src={imgUrl}
+                          alt={img.label}
+                          className="max-h-32 w-auto object-contain"
+                          loading="lazy"
+                        />
+                      </div>
+                      <div className="flex items-center gap-2 border-t border-slate-100 px-3 py-2">
+                        <span
+                          className={`inline-block h-2 w-2 rounded-full ${
+                            img.kind === "table" ? "bg-amber-400" : "bg-brand-400"
+                          }`}
+                        />
+                        <span className="text-xs font-medium text-slate-700">
+                          {img.label}
+                        </span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </Card>
+          ) : null}
+
+          {/* Linked articles */}
+          {source.linked_articles.length > 0 ? (
+            <Card className="p-5">
+              <h2 className="mb-4 text-base font-semibold text-slate-900">
+                Compiled Articles ({source.linked_articles.length})
+              </h2>
+              <ul className="divide-y divide-slate-100">
+                {source.linked_articles.map((article) => (
+                  <li key={article.id}>
+                    <Link
+                      to={`/wiki/${encodeURIComponent(article.slug)}`}
+                      className="flex items-center gap-3 py-3 hover:bg-slate-50 -mx-2 px-2 rounded-md transition"
+                    >
+                      <Badge tone="brand">{article.page_type}</Badge>
+                      <span className="text-sm font-medium text-slate-900 truncate">
+                        {article.title}
+                      </span>
+                      <svg
+                        className="ml-auto h-4 w-4 text-slate-400"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Lightbox */}
+      {selectedImg ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-8"
+          onClick={() => setSelectedImg(null)}
+        >
+          <div
+            className="relative max-h-[90vh] max-w-[90vw]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img
+              src={selectedImg}
+              alt="Full size"
+              className="max-h-[85vh] max-w-full rounded-lg bg-white object-contain shadow-2xl"
+            />
+            <button
+              type="button"
+              onClick={() => setSelectedImg(null)}
+              className="absolute -right-3 -top-3 flex h-8 w-8 items-center justify-center rounded-full bg-white text-slate-600 shadow-lg hover:bg-slate-100"
+              aria-label="Close"
+            >
+              X
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useSources.ts
+++ b/apps/web/src/hooks/useSources.ts
@@ -8,6 +8,7 @@ import {
   approveDraft,
   deleteSource,
   getDraft,
+  getSourceDetail,
   ingestPdf,
   ingestUrl,
   listSources,
@@ -15,7 +16,7 @@ import {
   retryCompile,
   type ListSourcesParams,
 } from "../api/sources";
-import type { Source } from "../types/api";
+import type { Source, SourceDetailResponse } from "../types/api";
 
 const SOURCES_KEY = ["sources"] as const;
 
@@ -70,6 +71,18 @@ export function useDeleteSource() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: SOURCES_KEY });
     },
+  });
+}
+
+const SOURCE_DETAIL_KEY = ["source-detail"] as const;
+
+export function useSourceDetail(
+  sourceId: string | undefined,
+): UseQueryResult<SourceDetailResponse> {
+  return useQuery({
+    queryKey: [...SOURCE_DETAIL_KEY, sourceId],
+    queryFn: () => getSourceDetail(sourceId!),
+    enabled: !!sourceId,
   });
 }
 

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -58,6 +58,43 @@ export interface SourceContentResponse {
   title: string | null;
 }
 
+export interface PipelineStep {
+  name: string;
+  status: "complete" | "active" | "pending" | "failed";
+  description: string;
+}
+
+export interface SourceImageEntry {
+  filename: string;
+  kind: "figure" | "table";
+  label: string;
+}
+
+export interface LinkedArticleSummary {
+  id: string;
+  slug: string;
+  title: string;
+  page_type: PageType;
+}
+
+export interface SourceDetailResponse {
+  id: string;
+  source_type: SourceType;
+  source_url: string | null;
+  title: string | null;
+  author: string | null;
+  published_date: string | null;
+  status: IngestStatus;
+  ingested_at: string;
+  compiled_at: string | null;
+  token_count: number | null;
+  error_message: string | null;
+  has_original: boolean;
+  pipeline_steps: PipelineStep[];
+  images: SourceImageEntry[];
+  linked_articles: LinkedArticleSummary[];
+}
+
 export interface TagRef {
   id: string;
   name: string;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -203,6 +203,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/ingest/sources/{source_id}/detail:
+    get:
+      tags:
+      - Ingest
+      summary: Get Source Detail
+      description: Get full source detail with pipeline steps, images, and linked
+        articles.
+      operationId: get_source_detail_api_ingest_sources__source_id__detail_get
+      parameters:
+      - name: source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Source Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SourceDetailResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/ingest/sources/{source_id}/content:
     get:
       tags:
@@ -5330,6 +5358,27 @@ components:
       - status
       title: LLMTestResponse
       description: Response from LLM connection test.
+    LinkedArticleSummary:
+      properties:
+        id:
+          type: string
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+        page_type:
+          $ref: '#/components/schemas/PageType'
+          default: source
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      title: LinkedArticleSummary
+      description: Minimal article info for the source detail view.
     LintFindingKind:
       type: string
       enum:
@@ -5618,6 +5667,24 @@ components:
       title: PageType
       description: Type of wiki page — determines compilation pipeline and validation
         rules.
+    PipelineStep:
+      properties:
+        name:
+          type: string
+          title: Name
+        status:
+          type: string
+          title: Status
+        description:
+          type: string
+          title: Description
+      type: object
+      required:
+      - name
+      - status
+      - description
+      title: PipelineStep
+      description: A single step in the source processing pipeline.
     ProviderDetail:
       properties:
         enabled:
@@ -6336,6 +6403,111 @@ components:
       - title
       title: SourceContentResponse
       description: Raw text content of an ingested source for side-by-side reading.
+    SourceDetailResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        source_type:
+          $ref: '#/components/schemas/SourceType'
+        source_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Url
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        author:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Author
+        published_date:
+          anyOf:
+          - type: string
+            format: date
+          - type: 'null'
+          title: Published Date
+        status:
+          $ref: '#/components/schemas/IngestStatus'
+        ingested_at:
+          type: string
+          format: date-time
+          title: Ingested At
+        compiled_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Compiled At
+        token_count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Token Count
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+        has_original:
+          type: boolean
+          title: Has Original
+        pipeline_steps:
+          items:
+            $ref: '#/components/schemas/PipelineStep'
+          type: array
+          title: Pipeline Steps
+        images:
+          items:
+            $ref: '#/components/schemas/SourceImageEntry'
+          type: array
+          title: Images
+        linked_articles:
+          items:
+            $ref: '#/components/schemas/LinkedArticleSummary'
+          type: array
+          title: Linked Articles
+      type: object
+      required:
+      - id
+      - source_type
+      - source_url
+      - title
+      - author
+      - published_date
+      - status
+      - ingested_at
+      - compiled_at
+      - token_count
+      - error_message
+      - has_original
+      - pipeline_steps
+      - images
+      - linked_articles
+      title: SourceDetailResponse
+      description: Full source detail with pipeline steps, images, and linked articles.
+    SourceImageEntry:
+      properties:
+        filename:
+          type: string
+          title: Filename
+        kind:
+          type: string
+          title: Kind
+        label:
+          type: string
+          title: Label
+      type: object
+      required:
+      - filename
+      - kind
+      - label
+      title: SourceImageEntry
+      description: An extracted image entry for the source detail view.
     SourceResponse:
       properties:
         id:

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -12,11 +12,17 @@ from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
 from wikimind.ingest.adapters.pdf import PDFAdapter
 from wikimind.models import (
+    Article,
+    ArticleSource,
     IngestTextRequest,
     IngestURLRequest,
+    LinkedArticleSummary,
+    PipelineStep,
     Source,
     SourceContentResponse,
+    SourceDetailResponse,
     SourceImage,
+    SourceImageEntry,
 )
 from wikimind.services.factories import get_ingest_service
 from wikimind.services.ingest import IngestService
@@ -119,6 +125,107 @@ async def get_source(
 ):
     """Get source by ID."""
     return await service.get_source(source_id, session, user_id=user_id)
+
+
+@router.get("/sources/{source_id}/detail", response_model=SourceDetailResponse)
+async def get_source_detail(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Get full source detail with pipeline steps, images, and linked articles."""
+    source = await service.get_source(source_id, session, user_id=user_id)
+
+    # Build pipeline steps based on source status
+    pipeline_steps = _build_pipeline_steps(source)
+
+    # Query extracted images from source_image table
+    img_stmt = (
+        select(SourceImage.filename, SourceImage.kind)
+        .where(SourceImage.source_id == source_id, SourceImage.user_id == user_id)
+        .order_by(SourceImage.filename)
+    )
+    img_rows = (await session.exec(img_stmt)).all()
+    images: list[SourceImageEntry] = []
+    for filename, kind in img_rows:
+        stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+        parts = stem.rsplit("-", 1)
+        num = parts[1] if len(parts) == 2 and parts[1].isdigit() else stem
+        label = f"{'Table' if kind == 'table' else 'Figure'} {num}"
+        images.append(SourceImageEntry(filename=filename, kind=kind, label=label))
+
+    # Query linked articles via ArticleSource join table
+    art_stmt = (
+        select(Article.id, Article.slug, Article.title, Article.page_type)
+        .join(ArticleSource, ArticleSource.article_id == Article.id)  # type: ignore[arg-type]
+        .where(ArticleSource.source_id == source_id, Article.user_id == user_id)
+    )
+    art_rows = (await session.exec(art_stmt)).all()
+    linked_articles = [LinkedArticleSummary(id=row[0], slug=row[1], title=row[2], page_type=row[3]) for row in art_rows]
+
+    return SourceDetailResponse(
+        id=source.id,
+        source_type=source.source_type,
+        source_url=source.source_url,
+        title=source.title,
+        author=source.author,
+        published_date=source.published_date,
+        status=source.status,
+        ingested_at=source.ingested_at,
+        compiled_at=source.compiled_at,
+        token_count=source.token_count,
+        error_message=source.error_message,
+        has_original=source.has_original,
+        pipeline_steps=pipeline_steps,
+        images=images,
+        linked_articles=linked_articles,
+    )
+
+
+def _build_pipeline_steps(source: Source) -> list[PipelineStep]:
+    """Derive pipeline step statuses from the source's current state."""
+    status = source.status
+
+    if status == "failed":
+        return [
+            PipelineStep(name="Fetch", status="complete", description="Source fetched"),
+            PipelineStep(name="Extract", status="failed", description=source.error_message or "Failed"),
+            PipelineStep(name="Clean", status="pending", description="Normalize text"),
+            PipelineStep(name="Compile", status="pending", description="Generate article via LLM"),
+        ]
+
+    if status == "pending":
+        return [
+            PipelineStep(name="Fetch", status="pending", description="Fetch source content"),
+            PipelineStep(name="Extract", status="pending", description="Extract text & images"),
+            PipelineStep(name="Clean", status="pending", description="Normalize text"),
+            PipelineStep(name="Compile", status="pending", description="Generate article via LLM"),
+        ]
+
+    if status == "processing":
+        return [
+            PipelineStep(name="Fetch", status="complete", description="Source fetched"),
+            PipelineStep(name="Extract", status="complete", description="Text extracted"),
+            PipelineStep(name="Clean", status="complete", description="Text normalized"),
+            PipelineStep(name="Compile", status="active", description="Compiling via LLM..."),
+        ]
+
+    if status == "review_pending":
+        return [
+            PipelineStep(name="Fetch", status="complete", description="Source fetched"),
+            PipelineStep(name="Extract", status="complete", description="Text extracted"),
+            PipelineStep(name="Clean", status="complete", description="Text normalized"),
+            PipelineStep(name="Compile", status="complete", description="Draft ready for review"),
+        ]
+
+    # compiled
+    return [
+        PipelineStep(name="Fetch", status="complete", description="Source fetched"),
+        PipelineStep(name="Extract", status="complete", description="Text extracted"),
+        PipelineStep(name="Clean", status="complete", description="Text normalized"),
+        PipelineStep(name="Compile", status="complete", description="Article compiled"),
+    ]
 
 
 @router.get(

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -17,6 +17,7 @@ from wikimind.models import (
     IngestTextRequest,
     IngestURLRequest,
     LinkedArticleSummary,
+    PageType,
     PipelineStep,
     Source,
     SourceContentResponse,
@@ -162,7 +163,9 @@ async def get_source_detail(
         .where(ArticleSource.source_id == source_id, Article.user_id == user_id)
     )
     art_rows = (await session.exec(art_stmt)).all()
-    linked_articles = [LinkedArticleSummary(id=row[0], slug=row[1], title=row[2], page_type=row[3]) for row in art_rows]
+    linked_articles = [
+        LinkedArticleSummary(id=row[0], slug=row[1], title=row[2], page_type=PageType(row[3])) for row in art_rows
+    ]
 
     return SourceDetailResponse(
         id=source.id,

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -1080,6 +1080,51 @@ class SourceResponse(BaseModel):
     ingested_at: datetime
 
 
+class PipelineStep(BaseModel):
+    """A single step in the source processing pipeline."""
+
+    name: str
+    status: str  # "complete" | "active" | "pending" | "failed"
+    description: str
+
+
+class SourceImageEntry(BaseModel):
+    """An extracted image entry for the source detail view."""
+
+    filename: str
+    kind: str  # "figure" | "table"
+    label: str
+
+
+class LinkedArticleSummary(BaseModel):
+    """Minimal article info for the source detail view."""
+
+    id: str
+    slug: str
+    title: str
+    page_type: PageType = PageType.SOURCE
+
+
+class SourceDetailResponse(BaseModel):
+    """Full source detail with pipeline steps, images, and linked articles."""
+
+    id: str
+    source_type: SourceType
+    source_url: str | None
+    title: str | None
+    author: str | None
+    published_date: date | None
+    status: IngestStatus
+    ingested_at: datetime
+    compiled_at: datetime | None
+    token_count: int | None
+    error_message: str | None
+    has_original: bool
+    pipeline_steps: list[PipelineStep]
+    images: list[SourceImageEntry]
+    linked_articles: list[LinkedArticleSummary]
+
+
 class SourceContentResponse(BaseModel):
     """Raw text content of an ingested source for side-by-side reading."""
 


### PR DESCRIPTION
## Summary
- Add `GET /api/sources/{id}` endpoint returning full source metadata, pipeline steps, extracted images, and linked articles
- Add `SourceDetailView` React component with click-through navigation from the inbox source card
- Add Pydantic response models (`SourceDetailResponse`, `PipelineStepEntry`, `SourceImageEntry`, `LinkedArticleSummary`)

## Test plan
- [ ] Verify `GET /api/sources/{id}` returns expected fields for a source with pipeline data
- [ ] Verify 404 is returned for non-existent or other-user source IDs
- [ ] Click a source card in the inbox and confirm the detail view renders
- [ ] Confirm pipeline steps, images, and linked articles sections display correctly

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)