### PR TITLE
refactor: add RuntimeConfig wrapper to avoid Settings mutation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".merge_file_rEGcUG"
+      "filename": ".merge_file_mKzsQi"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -282,1052 +282,1444 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 243
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
+        "hashed_secret": "baee56b9b09cf5dca71d2f6ff73aeb3b254119b7",
         "is_verified": false,
         "line_number": 243
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "809d6b631f8d62e2cb81e389888335073ab8f5d2",
         "is_verified": false,
         "line_number": 257
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
+        "hashed_secret": "809d6b631f8d62e2cb81e389888335073ab8f5d2",
         "is_verified": false,
         "line_number": 257
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "19179043706fc62ad1fceda1a6f236e9b0b11216",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
+        "hashed_secret": "19179043706fc62ad1fceda1a6f236e9b0b11216",
         "is_verified": false,
         "line_number": 271
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
+        "hashed_secret": "631e2f5ec284ba734bba8d490e4318f7db17082c",
         "is_verified": false,
         "line_number": 285
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
+        "hashed_secret": "19602c0fe9f830612634a4b9d180a1f66fb7db76",
         "is_verified": false,
         "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
+        "hashed_secret": "0cb86991502ce9402d635bb4152579772cc57ef0",
         "is_verified": false,
         "line_number": 313
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
+        "hashed_secret": "b81024670ddd98ac3bf6fb8809cd49797b40c5e1",
         "is_verified": false,
         "line_number": 327
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
+        "hashed_secret": "bd048d6b0d60c5568ee94c2eee4dde82ff8481d1",
         "is_verified": false,
         "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
+        "hashed_secret": "9246ee65828fe8e921e1abce31645583c5a1eec0",
         "is_verified": false,
         "line_number": 355
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
+        "hashed_secret": "c850e330319f866d26f9726673543a7b12758736",
         "is_verified": false,
         "line_number": 369
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
+        "hashed_secret": "c7e6dee0dc5906f39eb5b1408d2a4ab3d9279de4",
         "is_verified": false,
         "line_number": 383
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
+        "hashed_secret": "2331e682df9816b28566f08017d2cd890ded4168",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
+        "hashed_secret": "a5e638f4bb0ada476d4f1af6a42965bf99ca8e17",
         "is_verified": false,
         "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
+        "hashed_secret": "c242e1253737a872dec5b6bf0e9a5a8a4cf53b88",
         "is_verified": false,
         "line_number": 425
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
+        "hashed_secret": "69119d7dfa548a0fe5a3729b6453e452b0366368",
         "is_verified": false,
         "line_number": 439
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
+        "hashed_secret": "ede4032351b131691563dedfd9f4d4cc8816bbf8",
         "is_verified": false,
         "line_number": 453
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
+        "hashed_secret": "c25f59a0146621ca22b43ecefdf3de3110dfd961",
         "is_verified": false,
         "line_number": 467
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
+        "hashed_secret": "4b13a3a7869e1a253813f56d1288f4d76341c95c",
         "is_verified": false,
         "line_number": 481
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
+        "hashed_secret": "07d45374191fc43f7e0073cc04641d1ee80f6729",
         "is_verified": false,
         "line_number": 495
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
+        "hashed_secret": "61ba149a3241b27c2fb7b0807b573c0d6f6424d9",
         "is_verified": false,
         "line_number": 509
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
+        "hashed_secret": "4b45c5af259493b93f66bb9b0bff150e6c12c34f",
         "is_verified": false,
         "line_number": 523
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
+        "hashed_secret": "e5f8ca96efb5c7b9c14f83a61ef44e7e2d05a56d",
         "is_verified": false,
         "line_number": 537
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
+        "hashed_secret": "bb9a4fb34d45864fd927db28aae676de80cdba7a",
         "is_verified": false,
         "line_number": 551
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
+        "hashed_secret": "9a4b8eab2df6bcdc029128fc4898af0138a65a1f",
         "is_verified": false,
         "line_number": 565
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
+        "hashed_secret": "46c79644e4f8195fae040e64dc5c5cec90c38843",
         "is_verified": false,
         "line_number": 579
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
+        "hashed_secret": "abe81a160a4490622ccb2f457aa2f4fd8bef9cf9",
         "is_verified": false,
         "line_number": 593
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
+        "hashed_secret": "77fe5df9eae0ba04cf04e0fc3e0dff2bed20920e",
         "is_verified": false,
         "line_number": 607
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
+        "hashed_secret": "464c0f9cb2110fab263f72b53f5a85b8ce328731",
         "is_verified": false,
         "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
+        "hashed_secret": "33de9f6f59fda59c8d9b1d62cd5a942359dc3d80",
         "is_verified": false,
         "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
+        "hashed_secret": "35b9f89ac4062a974e39ae477ecbc7a331cf938b",
         "is_verified": false,
         "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
+        "hashed_secret": "913571e02cbe4044f02e192a75b2cdd23cc8b9e6",
         "is_verified": false,
         "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
+        "hashed_secret": "277c4317f75644e426f581988442cbb109b9fec5",
         "is_verified": false,
         "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
+        "hashed_secret": "bb825e430f39d6916f767f4c13005538a5cdbdc8",
         "is_verified": false,
         "line_number": 691
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
+        "hashed_secret": "43da41818673a456391016bb02b6118435901e39",
         "is_verified": false,
         "line_number": 705
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
+        "hashed_secret": "a83b9abf07c3ae90cf415264d9b8c5eebd288576",
         "is_verified": false,
         "line_number": 719
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
+        "hashed_secret": "bef7e5a4b954eb168b1177964b64aa2893eb1f3f",
         "is_verified": false,
         "line_number": 733
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "hashed_secret": "32aa8419233ca002fd1c6395c2396f9ffab7665e",
         "is_verified": false,
         "line_number": 747
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "hashed_secret": "de8332bc01bb472ec01671180c199de943ea7c0b",
         "is_verified": false,
         "line_number": 761
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "hashed_secret": "46d3a0289ef342c49f3ea9bebc425d0b87ca13ff",
         "is_verified": false,
         "line_number": 775
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "hashed_secret": "e812e1be30f9f5cd62ba5b12e264f763327fbef2",
         "is_verified": false,
         "line_number": 789
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "hashed_secret": "34392dc4cc285def1561f6a2efe9a40b166c1f3f",
         "is_verified": false,
         "line_number": 803
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "hashed_secret": "cde2b6365cf3ef68dd6c2875fe2e4f11ec5ab73c",
         "is_verified": false,
         "line_number": 817
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "hashed_secret": "611c5b8dd1dd8dbd8c79bfb50ba38dfc26ef5948",
         "is_verified": false,
         "line_number": 831
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "hashed_secret": "25fa69c08292be6b4df403429dd942cf41a1c0fe",
         "is_verified": false,
         "line_number": 845
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "hashed_secret": "849995d88a4c80c4e43993364e29a8e11c76a366",
         "is_verified": false,
         "line_number": 859
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "hashed_secret": "a2571fccf5f451477164775b494d136157363533",
         "is_verified": false,
         "line_number": 873
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "hashed_secret": "199b25fe675bd3e4167a0336f72d3dd05c1521d7",
         "is_verified": false,
         "line_number": 887
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "hashed_secret": "8864f99bda4718bca7e537baff4bf53ead6da296",
         "is_verified": false,
         "line_number": 901
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "hashed_secret": "abe7004cca7bac28b16061eab7c442dcdb1906de",
         "is_verified": false,
         "line_number": 915
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "hashed_secret": "0eefcf1ba9b55810725120926cec0be786296e04",
         "is_verified": false,
         "line_number": 929
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 954
+        "line_number": 943
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "hashed_secret": "63530084619956e6be482e1c41c16b6112f93659",
         "is_verified": false,
-        "line_number": 954
+        "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 961
+        "line_number": 957
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "hashed_secret": "3708e3e879fd737fe523d7e62021b5e450d05659",
         "is_verified": false,
-        "line_number": 961
+        "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 968
+        "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "hashed_secret": "930488a6651c2079a878d5f5ba8a6230eb19cafe",
         "is_verified": false,
-        "line_number": 968
+        "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 986
+        "line_number": 985
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "hashed_secret": "a227efff73c6f6554d85f1563c52bc74950903bc",
         "is_verified": false,
-        "line_number": 986
+        "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 993
+        "line_number": 999
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "hashed_secret": "ce92f06737c09480c5961555720352fbb62ad564",
         "is_verified": false,
-        "line_number": 993
+        "line_number": 999
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1000
+        "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "hashed_secret": "2f1c01c866729b1dbb7cc894db08fad6b8ebe8ba",
         "is_verified": false,
-        "line_number": 1000
+        "line_number": 1013
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1009
+        "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "hashed_secret": "41272d853a5d4300c74abfba60def8df28226de9",
         "is_verified": false,
-        "line_number": 1009
+        "line_number": 1027
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1018
+        "line_number": 1041
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "hashed_secret": "38362c43189dbeb750c34fc4e759093fc2ae40d7",
         "is_verified": false,
-        "line_number": 1018
+        "line_number": 1041
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1025
+        "line_number": 1055
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "hashed_secret": "b53429db9387ea2988d73f00323b75e2dd611b25",
         "is_verified": false,
-        "line_number": 1025
+        "line_number": 1055
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1032
+        "line_number": 1069
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "hashed_secret": "a9fb990eedf4ee86e07a2a16fddc54d5a946a57a",
         "is_verified": false,
-        "line_number": 1032
+        "line_number": 1069
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1057
+        "line_number": 1083
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "hashed_secret": "0b4a5e8881bf861c456f18f14ede12e331dcdc2c",
         "is_verified": false,
-        "line_number": 1057
+        "line_number": 1083
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1064
+        "line_number": 1097
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "hashed_secret": "94dedc421fed0f0ad03d48c64bfce6a7d8892d67",
         "is_verified": false,
-        "line_number": 1064
+        "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1073
+        "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "hashed_secret": "e44a8f99d03a2713de8401fe7b6c38840c4fd0b8",
         "is_verified": false,
-        "line_number": 1073
+        "line_number": 1111
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1082
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
-        "is_verified": false,
-        "line_number": 1082
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1089
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
-        "is_verified": false,
-        "line_number": 1089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1098
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
-        "is_verified": false,
-        "line_number": 1098
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1107
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
-        "is_verified": false,
-        "line_number": 1107
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
-        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "hashed_secret": "297eedf88052d5d0bb50a8c9d747473eafdd5cb8",
         "is_verified": false,
         "line_number": 1125
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 1139
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4d1eb3f53fbcc75f4227896cdea74fc6b178adb1",
+        "is_verified": false,
+        "line_number": 1139
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "is_verified": false,
+        "line_number": 1153
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9fe5ca8b410f92004a7c36f163af70d298c21aaa",
+        "is_verified": false,
+        "line_number": 1153
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 1167
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "78a3a4d08b135c273ecf886e70600414812c2957",
+        "is_verified": false,
+        "line_number": 1167
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 1181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4f73e13042afab65a295a5d460ae2a9cddc9347a",
+        "is_verified": false,
+        "line_number": 1181
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "is_verified": false,
+        "line_number": 1195
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5ec5c2459f4c590e67745f34c8dd72943cdd126f",
+        "is_verified": false,
+        "line_number": 1195
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "is_verified": false,
+        "line_number": 1209
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "0913f897ea6d542be22e831044fba73f5ab104d6",
+        "is_verified": false,
+        "line_number": 1209
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 1223
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9d142eac59d6ff98669028db67395c79446fd438",
+        "is_verified": false,
+        "line_number": 1223
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 1237
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "69a321a74d40ff62fb9d091771af230a27aeadd8",
+        "is_verified": false,
+        "line_number": 1237
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 1251
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "1d0642e3e8482d4527fa5a504fcefdca33639f00",
+        "is_verified": false,
+        "line_number": 1251
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 1265
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c5ea7128505f08d93daebd01404c8f0514041d0a",
+        "is_verified": false,
+        "line_number": 1265
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 1279
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "04c037bc2ffa45c260802cd8d017b225b7f6efe8",
+        "is_verified": false,
+        "line_number": 1279
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 1293
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "00cebd0f263324d830f14a2e61418452df5dbcc8",
+        "is_verified": false,
+        "line_number": 1293
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 1307
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a02f9e2520cb0d0d0f541b831e48d435a1ec8eb9",
+        "is_verified": false,
+        "line_number": 1307
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 1321
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4817e44bf3ec20a2092386ee82aede6c7617d7ac",
+        "is_verified": false,
+        "line_number": 1321
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 1346
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 1346
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 1353
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 1353
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 1360
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 1360
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1378
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 1378
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1385
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 1385
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1392
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 1392
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1401
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 1401
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1410
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 1410
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1417
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 1417
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1424
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 1424
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1449
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 1449
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1456
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 1456
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1465
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 1465
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1474
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 1474
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1481
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 1481
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1490
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 1490
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1499
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 1499
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1517
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 1517
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
         "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
         "is_verified": false,
-        "line_number": 1134
+        "line_number": 1526
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
         "is_verified": false,
-        "line_number": 1134
+        "line_number": 1526
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
         "is_verified": false,
-        "line_number": 1141
+        "line_number": 1533
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
         "is_verified": false,
-        "line_number": 1141
+        "line_number": 1533
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
         "is_verified": false,
-        "line_number": 1150
+        "line_number": 1542
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
         "is_verified": false,
-        "line_number": 1150
+        "line_number": 1542
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
         "is_verified": false,
-        "line_number": 1175
+        "line_number": 1567
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
         "is_verified": false,
-        "line_number": 1175
+        "line_number": 1567
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
         "is_verified": false,
-        "line_number": 1193
+        "line_number": 1585
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
         "is_verified": false,
-        "line_number": 1193
+        "line_number": 1585
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
         "is_verified": false,
-        "line_number": 1200
+        "line_number": 1592
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
         "is_verified": false,
-        "line_number": 1200
+        "line_number": 1592
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1599
       },
       {
         "type": "Secret Keyword",
         "filename": ".secrets.baseline",
         "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1599
       }
     ],
     "Makefile": [
@@ -1602,5 +1994,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-16T13:50:17Z"
+  "generated_at": "2026-05-16T13:50:34Z"
 }

--- a/src/wikimind/api/routes/settings.py
+++ b/src/wikimind/api/routes/settings.py
@@ -11,7 +11,7 @@ from sqlmodel import func, select
 
 from wikimind._datetime import utcnow_naive
 from wikimind.api.deps import get_current_user_id
-from wikimind.config import get_api_key, get_settings
+from wikimind.config import get_api_key, get_runtime_config, get_settings
 from wikimind.database import get_session, get_session_factory
 from wikimind.engine.llm_router import _LLM_PROVIDER_ERRORS, get_llm_router
 from wikimind.models import Article, CompletionRequest, CostLog, Provider, TaskType, UserPreference
@@ -19,8 +19,6 @@ from wikimind.services.api_keys import get_user_api_key
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
-
-    from wikimind.config import Settings
 
 log = structlog.get_logger()
 
@@ -165,39 +163,39 @@ _OPENAI_COMPATIBLE_RUNTIME_REQUEST_FIELDS = (
 
 
 async def apply_runtime_llm_preferences() -> None:
-    """Apply persisted LLM runtime preferences to the in-memory settings singleton."""
+    """Load persisted LLM runtime preferences into the RuntimeConfig overlay.
+
+    Populates the RuntimeConfig in-memory cache from DB-stored UserPreference
+    rows. The Settings singleton is never mutated.
+    """
+    rc = get_runtime_config()
     settings = get_settings()
     async with get_session_factory()() as session:
         result = await session.exec(select(UserPreference))
         for pref in result.all():
             if pref.key == "llm.default_provider":
-                settings.llm.default_provider = pref.value
+                rc.set("llm.default_provider", pref.value)
             elif pref.key == "llm.monthly_budget_usd":
-                settings.llm.monthly_budget_usd = float(pref.value)
+                rc.set("llm.monthly_budget_usd", float(pref.value))
             elif pref.key == "llm.fallback_enabled":
-                settings.llm.fallback_enabled = pref.value.lower() == "true"
+                rc.set("llm.fallback_enabled", pref.value.lower() == "true")
             elif pref.key in _OPENAI_COMPATIBLE_PREF_MAP:
                 field_name = _OPENAI_COMPATIBLE_PREF_MAP[pref.key]
                 current_value = getattr(settings.llm.openai_compatible, field_name)
-                value = pref.value.lower() == "true" if isinstance(current_value, bool) else pref.value
-                setattr(settings.llm.openai_compatible, field_name, value)
-
-    cfg = settings.llm.openai_compatible
-    cfg.enabled = bool((cfg.enabled or get_api_key(Provider.OPENAI_COMPATIBLE.value)) and cfg.base_url and cfg.model)
+                value: object = pref.value.lower() == "true" if isinstance(current_value, bool) else pref.value
+                rc.set(f"llm.openai_compatible.{field_name}", value)
 
 
 def _has_required_provider_config(provider: Provider) -> bool:
     """Return whether non-secret runtime config exists for a provider."""
     if provider != Provider.OPENAI_COMPATIBLE:
         return True
-    cfg = get_settings().llm.openai_compatible
-    return bool(cfg.base_url and cfg.model)
+    rc = get_runtime_config()
+    return bool(rc.get_openai_compatible_base_url() and rc.get_openai_compatible_model())
 
 
-def _refresh_openai_compatible_enabled(settings: Settings) -> None:
-    """Refresh derived enabled state after runtime config changes."""
-    cfg = settings.llm.openai_compatible
-    cfg.enabled = bool((cfg.enabled or get_api_key(Provider.OPENAI_COMPATIBLE.value)) and cfg.base_url and cfg.model)
+def _refresh_openai_compatible_enabled() -> None:
+    """Invalidate provider cache after runtime config changes."""
     get_llm_router()._provider_cache.pop(Provider.OPENAI_COMPATIBLE, None)
 
 
@@ -231,7 +229,6 @@ async def _set_preference(key: str, value: str, user_id: str) -> None:
 
 async def _update_openai_compatible_base_url(
     request: SettingsUpdateRequest,
-    settings: Settings,
     user_id: str,
 ) -> bool:
     """Persist the configured OpenAI-compatible base URL if present."""
@@ -243,13 +240,12 @@ async def _update_openai_compatible_base_url(
         raise HTTPException(status_code=400, detail="OpenAI-compatible base URL must start with http:// or https://")
 
     await _set_preference("llm.openai_compatible.base_url", base_url, user_id)
-    settings.llm.openai_compatible.base_url = base_url
+    get_runtime_config().set("llm.openai_compatible.base_url", base_url)
     return True
 
 
 async def _update_openai_compatible_model(
     request: SettingsUpdateRequest,
-    settings: Settings,
     user_id: str,
 ) -> bool:
     """Persist the configured OpenAI-compatible model if present."""
@@ -261,18 +257,17 @@ async def _update_openai_compatible_model(
         raise HTTPException(status_code=400, detail="OpenAI-compatible model must not be empty")
 
     await _set_preference("llm.openai_compatible.model", model, user_id)
-    settings.llm.openai_compatible.model = model
+    get_runtime_config().set("llm.openai_compatible.model", model)
     return True
 
 
 async def _update_openai_compatible_bools(
     request: SettingsUpdateRequest,
-    settings: Settings,
     user_id: str,
 ) -> bool:
     """Persist OpenAI-compatible boolean capability flags."""
     updated = False
-    cfg = settings.llm.openai_compatible
+    rc = get_runtime_config()
     bool_updates = {
         "supports_json_response_format": request.openai_compatible_supports_json_response_format,
         "supports_stream_usage": request.openai_compatible_supports_stream_usage,
@@ -282,14 +277,13 @@ async def _update_openai_compatible_bools(
         if value is None:
             continue
         await _set_preference(f"llm.openai_compatible.{field_name}", str(value).lower(), user_id)
-        setattr(cfg, field_name, value)
+        rc.set(f"llm.openai_compatible.{field_name}", value)
         updated = True
     return updated
 
 
 async def _update_openai_compatible_max_tokens_field(
     request: SettingsUpdateRequest,
-    settings: Settings,
     user_id: str,
 ) -> bool:
     """Persist the max-tokens field selection if present."""
@@ -304,13 +298,12 @@ async def _update_openai_compatible_max_tokens_field(
         )
 
     await _set_preference("llm.openai_compatible.max_tokens_field", max_tokens_field, user_id)
-    settings.llm.openai_compatible.max_tokens_field = max_tokens_field
+    get_runtime_config().set("llm.openai_compatible.max_tokens_field", max_tokens_field)
     return True
 
 
 async def _update_openai_compatible_reasoning_format(
     request: SettingsUpdateRequest,
-    settings: Settings,
     user_id: str,
 ) -> bool:
     """Persist the reasoning payload style if present."""
@@ -325,22 +318,17 @@ async def _update_openai_compatible_reasoning_format(
         )
 
     await _set_preference("llm.openai_compatible.reasoning_format", reasoning_format, user_id)
-    if reasoning_format == "none":
-        settings.llm.openai_compatible.reasoning_format = "none"
-    elif reasoning_format == "openai":
-        settings.llm.openai_compatible.reasoning_format = "openai"
-    else:
-        settings.llm.openai_compatible.reasoning_format = "openrouter"
+    get_runtime_config().set("llm.openai_compatible.reasoning_format", reasoning_format)
     return True
 
 
 async def _update_openai_compatible_settings(
     request: SettingsUpdateRequest,
-    settings: Settings,
     user_id: str,
 ) -> bool:
-    """Persist runtime OpenAI-compatible settings and update the singleton."""
+    """Persist runtime OpenAI-compatible settings into RuntimeConfig."""
     updated = False
+    settings = get_settings()
 
     if not settings.is_dev and _has_openai_compatible_runtime_update(request):
         raise HTTPException(
@@ -348,11 +336,11 @@ async def _update_openai_compatible_settings(
             detail="OpenAI-compatible runtime settings are global and cannot be changed by users when auth is enabled",
         )
 
-    updated = await _update_openai_compatible_base_url(request, settings, user_id) or updated
-    updated = await _update_openai_compatible_model(request, settings, user_id) or updated
-    updated = await _update_openai_compatible_bools(request, settings, user_id) or updated
-    updated = await _update_openai_compatible_max_tokens_field(request, settings, user_id) or updated
-    updated = await _update_openai_compatible_reasoning_format(request, settings, user_id) or updated
+    updated = await _update_openai_compatible_base_url(request, user_id) or updated
+    updated = await _update_openai_compatible_model(request, user_id) or updated
+    updated = await _update_openai_compatible_bools(request, user_id) or updated
+    updated = await _update_openai_compatible_max_tokens_field(request, user_id) or updated
+    updated = await _update_openai_compatible_reasoning_format(request, user_id) or updated
 
     return updated
 
@@ -364,26 +352,32 @@ async def get_all_settings(
 ):
     """Return all application settings, with DB overrides applied."""
     settings = get_settings()
+    rc = get_runtime_config()
 
-    # Apply DB overrides
-    default_provider = await _get_preference("llm.default_provider") or settings.llm.default_provider
-    budget_pref = await _get_preference("llm.monthly_budget_usd")
-    monthly_budget = float(budget_pref) if budget_pref else settings.llm.monthly_budget_usd
-    fallback_pref = await _get_preference("llm.fallback_enabled")
-    fallback_enabled = (fallback_pref.lower() == "true") if fallback_pref else settings.llm.fallback_enabled
+    # Read effective values from RuntimeConfig (merges DB overrides with defaults)
+    default_provider = rc.get_default_provider()
+    monthly_budget = rc.get_monthly_budget_usd()
+    fallback_enabled = rc.get_fallback_enabled()
 
     # Check both env var/keyring keys and per-user BYOK database keys
     providers = {}
     for p in Provider:
         has_system_key = bool(get_api_key(p.value))
         has_user_key = bool(await get_user_api_key(session, user_id, p)) if not has_system_key else False
-        config_enabled = getattr(settings.llm, p.value).enabled
+        if p == Provider.OPENAI_COMPATIBLE:
+            config_enabled = rc.get_openai_compatible_enabled()
+            model = rc.get_openai_compatible_model()
+            base_url = rc.get_openai_compatible_base_url()
+        else:
+            config_enabled = getattr(settings.llm, p.value).enabled
+            model = getattr(settings.llm, p.value).model
+            base_url = None
         has_required_config = _has_required_provider_config(p)
         providers[p.value] = ProviderDetail(
             enabled=(config_enabled or has_user_key) and has_required_config,
-            model=getattr(settings.llm, p.value).model,
+            model=model,
             configured=has_system_key or has_user_key,
-            base_url=getattr(settings.llm, p.value).base_url if p == Provider.OPENAI_COMPATIBLE else None,
+            base_url=base_url if p == Provider.OPENAI_COMPATIBLE else None,
         )
 
     return AllSettingsResponse(
@@ -445,7 +439,7 @@ async def set_default_provider(
             )
 
     await _set_preference("llm.default_provider", request.provider, user_id)
-    settings.llm.default_provider = request.provider
+    get_runtime_config().set("llm.default_provider", request.provider)
     return DefaultProviderResponse(provider=request.provider, status="ok")
 
 
@@ -455,7 +449,7 @@ async def update_settings(
     user_id: str = Depends(get_current_user_id),
 ):
     """Update runtime settings. Changes persist to DB across restarts."""
-    settings = get_settings()
+    rc = get_runtime_config()
 
     if request.monthly_budget_usd is not None:
         if request.monthly_budget_usd <= 0:
@@ -465,7 +459,7 @@ async def update_settings(
             str(request.monthly_budget_usd),
             user_id,
         )
-        settings.llm.monthly_budget_usd = request.monthly_budget_usd
+        rc.set("llm.monthly_budget_usd", request.monthly_budget_usd)
 
     if request.fallback_enabled is not None:
         await _set_preference(
@@ -473,10 +467,10 @@ async def update_settings(
             str(request.fallback_enabled).lower(),
             user_id,
         )
-        settings.llm.fallback_enabled = request.fallback_enabled
+        rc.set("llm.fallback_enabled", request.fallback_enabled)
 
-    if await _update_openai_compatible_settings(request, settings, user_id):
-        _refresh_openai_compatible_enabled(settings)
+    if await _update_openai_compatible_settings(request, user_id):
+        _refresh_openai_compatible_enabled()
 
     if request.default_provider is not None:
         valid_providers = [p.value for p in Provider]
@@ -486,7 +480,7 @@ async def update_settings(
                 detail=(f"Unknown provider: {request.default_provider}"),
             )
         await _set_preference("llm.default_provider", request.default_provider, user_id)
-        settings.llm.default_provider = request.default_provider
+        rc.set("llm.default_provider", request.default_provider)
 
     return SettingsUpdateResponse(status="ok")
 
@@ -498,9 +492,10 @@ async def test_llm_connection(
 ):
     """Test if a provider is configured and reachable."""
     router_instance = get_llm_router()
+    rc = get_runtime_config()
     # Temporarily disable fallback so we only test the requested provider
-    original_fallback = router_instance.settings.llm.fallback_enabled
-    router_instance.settings.llm.fallback_enabled = False
+    original_fallback = rc.get_fallback_enabled()
+    rc.set("llm.fallback_enabled", False)
     try:
         request = CompletionRequest(
             system="You are a test assistant.",
@@ -528,7 +523,7 @@ async def test_llm_connection(
             error="Provider connection failed",
         )
     finally:
-        router_instance.settings.llm.fallback_enabled = original_fallback
+        rc.set("llm.fallback_enabled", original_fallback)
 
 
 @router.get(
@@ -540,7 +535,7 @@ async def get_llm_cost_breakdown(
 ):
     """Cost breakdown by provider and task type for current month."""
     start_of_month = utcnow_naive().replace(day=1, hour=0, minute=0, second=0)
-    settings = get_settings()
+    rc = get_runtime_config()
 
     async with get_session_factory()() as session:
         total_stmt = select(func.sum(CostLog.cost_usd)).where(
@@ -573,7 +568,7 @@ async def get_llm_cost_breakdown(
         task_result = await session.execute(task_stmt)
         task_rows = task_result.all()
 
-    budget = settings.llm.monthly_budget_usd
+    budget = rc.get_monthly_budget_usd()
     budget_pct = round(total / budget * 100, 1) if budget else 0.0
     month = utcnow_naive().strftime("%Y-%m")
 
@@ -616,11 +611,12 @@ async def get_llm_cost(
         result = await session.execute(cost_stmt)
         total = result.scalar() or 0.0
 
-    settings = get_settings()
+    rc = get_runtime_config()
+    budget = rc.get_monthly_budget_usd()
     return CostSummaryResponse(
         cost_this_month_usd=round(total, 4),
-        budget_usd=settings.llm.monthly_budget_usd,
-        budget_remaining_usd=round(settings.llm.monthly_budget_usd - total, 4),
+        budget_usd=budget,
+        budget_remaining_usd=round(budget - total, 4),
     )
 
 

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import os
 import re
+import threading
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import keyring
 import keyring.errors
@@ -544,6 +545,93 @@ def get_settings() -> Settings:
     settings.ensure_dirs()
     _reconcile_providers(settings)
     return settings
+
+
+# ---------------------------------------------------------------------------
+# RuntimeConfig — mutable overlay that keeps the Settings singleton immutable
+# ---------------------------------------------------------------------------
+
+
+class RuntimeConfig:
+    """Thread-safe mutable overlay for DB-persisted runtime settings.
+
+    Composes over the immutable Settings singleton. Callers read runtime
+    values (e.g. ``default_provider``, ``monthly_budget_usd``) from this
+    object. Values start as ``None`` (meaning "use the Settings default")
+    and are populated from the DB at startup or on write.
+
+    This replaces the previous pattern of mutating ``get_settings()`` directly.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._overrides: dict[str, Any] = {}
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a runtime override (thread-safe)."""
+        with self._lock:
+            self._overrides[key] = value
+
+    def get(self, key: str) -> Any | None:
+        """Get a runtime override, or None if not set."""
+        with self._lock:
+            return self._overrides.get(key)
+
+    def get_default_provider(self) -> str:
+        """Return the effective default LLM provider."""
+        override = self.get("llm.default_provider")
+        if override is not None:
+            return override
+        return get_settings().llm.default_provider
+
+    def get_monthly_budget_usd(self) -> float:
+        """Return the effective monthly budget."""
+        override = self.get("llm.monthly_budget_usd")
+        if override is not None:
+            return float(override)
+        return get_settings().llm.monthly_budget_usd
+
+    def get_fallback_enabled(self) -> bool:
+        """Return the effective fallback setting."""
+        override = self.get("llm.fallback_enabled")
+        if override is not None:
+            return bool(override)
+        return get_settings().llm.fallback_enabled
+
+    def get_openai_compatible_base_url(self) -> str:
+        """Return the effective OpenAI-compatible base URL."""
+        override = self.get("llm.openai_compatible.base_url")
+        if override is not None:
+            return override
+        return get_settings().llm.openai_compatible.base_url
+
+    def get_openai_compatible_model(self) -> str:
+        """Return the effective OpenAI-compatible model."""
+        override = self.get("llm.openai_compatible.model")
+        if override is not None:
+            return override
+        return get_settings().llm.openai_compatible.model
+
+    def get_openai_compatible_enabled(self) -> bool:
+        """Return whether the OpenAI-compatible provider is effectively enabled."""
+        base_url = self.get_openai_compatible_base_url()
+        model = self.get_openai_compatible_model()
+        settings = get_settings()
+        has_key = bool(settings._has_provider_key("openai_compatible") or settings.llm.openai_compatible.enabled)
+        return bool(has_key and base_url and model)
+
+    def get_openai_compatible_field(self, field_name: str) -> Any:
+        """Return an effective OpenAI-compatible config field value."""
+        override = self.get(f"llm.openai_compatible.{field_name}")
+        if override is not None:
+            return override
+        return getattr(get_settings().llm.openai_compatible, field_name)
+
+
+@lru_cache(maxsize=1)
+def get_runtime_config() -> RuntimeConfig:
+    """Return the singleton RuntimeConfig instance."""
+    return RuntimeConfig()
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/engine/llm_router.py
+++ b/src/wikimind/engine/llm_router.py
@@ -26,7 +26,7 @@ except ImportError:  # redis package not installed
 
 from wikimind._datetime import utcnow_naive
 from wikimind.api.routes.ws import emit_budget_exceeded, emit_budget_warning
-from wikimind.config import get_api_key, get_settings
+from wikimind.config import get_api_key, get_runtime_config, get_settings
 from wikimind.database import get_session_factory
 from wikimind.errors import UpstreamError
 from wikimind.models import CompletionRequest, CompletionResponse, CostLog, Provider, TaskType
@@ -142,6 +142,7 @@ class LLMRouter:
 
     def __init__(self):
         self.settings = get_settings()
+        self._rc = get_runtime_config()
         self._budget_warning_sent: dict[str, tuple[int, int]] = {}
         self._budget_exceeded_sent: dict[str, tuple[int, int]] = {}
         self._cached_spend: dict[str, float] = {}
@@ -150,7 +151,7 @@ class LLMRouter:
 
     def _get_provider_order(self, preferred: Provider | None) -> list[Provider]:
         """Return ordered list of providers to try."""
-        default = Provider(self.settings.llm.default_provider)
+        default = Provider(self._rc.get_default_provider())
         order = []
 
         if preferred:
@@ -161,21 +162,29 @@ class LLMRouter:
         # Add remaining enabled providers as fallbacks
         for p in Provider:
             if p not in order:
-                cfg = getattr(self.settings.llm, p.value, None)
-                if cfg and cfg.enabled:
-                    order.append(p)
+                if p == Provider.OPENAI_COMPATIBLE:
+                    if self._rc.get_openai_compatible_enabled():
+                        order.append(p)
+                else:
+                    cfg = getattr(self.settings.llm, p.value, None)
+                    if cfg and cfg.enabled:
+                        order.append(p)
 
         return order
 
     def _is_provider_available(self, provider: Provider) -> bool:
         """Check if a provider is enabled and has credentials."""
+        if provider == Provider.OPENAI_COMPATIBLE:
+            return bool(
+                get_api_key(provider.value)
+                and self._rc.get_openai_compatible_model()
+                and self._rc.get_openai_compatible_base_url()
+            )
         cfg = getattr(self.settings.llm, provider.value, None)
         if not cfg or not cfg.enabled:
             return False
         if provider in (Provider.OLLAMA, Provider.MOCK):
             return True  # No API key needed
-        if provider == Provider.OPENAI_COMPATIBLE:
-            return bool(get_api_key(provider.value) and cfg.model and cfg.base_url)
         return bool(get_api_key(provider.value))
 
     async def _get_provider_instance(
@@ -228,6 +237,8 @@ class LLMRouter:
 
     def _get_model(self, provider: Provider) -> str:
         """Return the configured model name for a provider."""
+        if provider == Provider.OPENAI_COMPATIBLE:
+            return self._rc.get_openai_compatible_model() or "unknown"
         cfg = getattr(self.settings.llm, provider.value, None)
         return cfg.model if cfg else "unknown"
 
@@ -303,7 +314,7 @@ class LLMRouter:
             self._cached_spend[user_id] = spend
             self._cache_expires_at[user_id] = now + self.settings.llm.budget_check_cache_seconds
 
-        budget = self.settings.llm.monthly_budget_usd
+        budget = self._rc.get_monthly_budget_usd()
         if budget <= 0:
             return
         pct = spend / budget * 100
@@ -409,7 +420,7 @@ class LLMRouter:
                     error=str(e),
                 )
                 last_error = e
-                if not self.settings.llm.fallback_enabled:
+                if not self._rc.get_fallback_enabled():
                     raise
 
         msg = f"All LLM providers failed. Last error: {last_error}"

--- a/src/wikimind/engine/providers/openai_compatible.py
+++ b/src/wikimind/engine/providers/openai_compatible.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import openai
 
-from wikimind.config import get_api_key, get_settings
+from wikimind.config import get_api_key, get_runtime_config, get_settings
 from wikimind.engine.provider_base import StreamSession, _calc_cost
 from wikimind.models import CompletionRequest, CompletionResponse, Provider
 
@@ -231,23 +231,24 @@ class OpenAICompatibleProvider:
 
 
 class ConfiguredOpenAICompatibleProvider(OpenAICompatibleProvider):
-    """OpenAI-compatible provider configured from ``settings.llm.openai_compatible``."""
+    """OpenAI-compatible provider configured from RuntimeConfig overlay."""
 
     def __init__(self, api_key_override: str | None = None) -> None:
         settings = get_settings()
+        rc = get_runtime_config()
         cfg = settings.llm.openai_compatible
         headers = self._default_headers(cfg.site_url, cfg.app_name)
         super().__init__(
             provider=Provider.OPENAI_COMPATIBLE,
             api_key_name="openai_compatible",
             api_key_override=api_key_override,
-            base_url=cfg.base_url or None,
+            base_url=rc.get_openai_compatible_base_url() or None,
             default_headers=headers,
-            supports_json_response_format=cfg.supports_json_response_format,
-            supports_stream_usage=cfg.supports_stream_usage,
-            supports_reasoning_effort=cfg.supports_reasoning_effort,
-            max_tokens_field=cast("MaxTokensField", cfg.max_tokens_field),
-            reasoning_format=cfg.reasoning_format,
+            supports_json_response_format=rc.get_openai_compatible_field("supports_json_response_format"),
+            supports_stream_usage=rc.get_openai_compatible_field("supports_stream_usage"),
+            supports_reasoning_effort=rc.get_openai_compatible_field("supports_reasoning_effort"),
+            max_tokens_field=cast("MaxTokensField", rc.get_openai_compatible_field("max_tokens_field")),
+            reasoning_format=rc.get_openai_compatible_field("reasoning_format"),
         )
 
     @staticmethod

--- a/tests/unit/test_budget_check.py
+++ b/tests/unit/test_budget_check.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from tests.conftest import TEST_USER_ID
+from wikimind.config import get_runtime_config
 from wikimind.engine import llm_router as llm_router_mod
 from wikimind.engine.llm_router import LLMRouter
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_config():
+    """Clear RuntimeConfig overrides between tests to avoid cross-pollution."""
+    rc = get_runtime_config()
+    yield
+    rc._overrides.clear()
 
 
 def _make_router(budget_usd=50.0, warning_pct=0.8, cache_seconds=60):
@@ -26,7 +37,13 @@ def _make_router(budget_usd=50.0, warning_pct=0.8, cache_seconds=60):
     )
     settings = SimpleNamespace(llm=llm_settings)
     with patch.object(llm_router_mod, "get_settings", return_value=settings):
-        return LLMRouter()
+        router = LLMRouter()
+    # Also set the RuntimeConfig override so that _check_budget reads the
+    # correct budget (RuntimeConfig.get_monthly_budget_usd calls get_settings()
+    # in wikimind.config, which won't see the test patch above after it exits).
+    rc = get_runtime_config()
+    rc.set("llm.monthly_budget_usd", budget_usd)
+    return router
 
 
 def _mock_session_factory(spend: float):

--- a/tests/unit/test_horizontal_scaling.py
+++ b/tests/unit/test_horizontal_scaling.py
@@ -10,9 +10,12 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from tests.conftest import TEST_USER_ID
 from wikimind.api.routes import ws as ws_mod
 from wikimind.api.routes.ws import ConnectionManager, _publish_to_redis
+from wikimind.config import get_runtime_config
 from wikimind.engine import llm_router as llm_router_mod
 from wikimind.engine.llm_router import LLMRouter
 
@@ -131,6 +134,14 @@ class TestPublishToRedis:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _reset_runtime_config():
+    """Clear RuntimeConfig overrides between tests to avoid cross-pollution."""
+    rc = get_runtime_config()
+    yield
+    rc._overrides.clear()
+
+
 def _make_router(budget_usd=50.0, warning_pct=0.8, cache_seconds=60):
     llm_settings = SimpleNamespace(
         default_provider="anthropic",
@@ -147,7 +158,13 @@ def _make_router(budget_usd=50.0, warning_pct=0.8, cache_seconds=60):
     )
     settings = SimpleNamespace(llm=llm_settings)
     with patch.object(llm_router_mod, "get_settings", return_value=settings):
-        return LLMRouter()
+        router = LLMRouter()
+    # Set the RuntimeConfig override so _check_budget reads the correct budget.
+    # RuntimeConfig.get_monthly_budget_usd() calls get_settings() in wikimind.config,
+    # not the patched reference in llm_router.
+    rc = get_runtime_config()
+    rc.set("llm.monthly_budget_usd", budget_usd)
+    return router
 
 
 def _mock_session_factory(spend: float):

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -317,7 +317,7 @@ async def test_ollama_provider_no_format_for_text() -> None:
     assert "format" not in call_kwargs
 
 
-def _router_with_settings(default="anthropic", **provider_overrides):
+def _router_with_settings(default="anthropic", fallback_enabled=True, **provider_overrides):
     cfgs = {
         "anthropic": SimpleNamespace(enabled=True, model="claude-sonnet-4-5"),
         "openai": SimpleNamespace(enabled=True, model="gpt-4o-mini"),
@@ -328,12 +328,28 @@ def _router_with_settings(default="anthropic", **provider_overrides):
     cfgs.update(provider_overrides)
     llm_settings = SimpleNamespace(
         default_provider=default,
-        fallback_enabled=True,
+        fallback_enabled=fallback_enabled,
         ollama_base_url="http://localhost:11434",
         **cfgs,
     )
     settings = SimpleNamespace(llm=llm_settings)
-    with patch.object(llm_router_mod, "get_settings", return_value=settings):
+
+    from wikimind.config import RuntimeConfig
+
+    rc = RuntimeConfig()
+    rc.set("llm.default_provider", default)
+    rc.set("llm.fallback_enabled", fallback_enabled)
+
+    # Populate openai_compatible RuntimeConfig overrides so they are available
+    # after the patch context exits (RuntimeConfig falls back to get_settings()).
+    oc_cfg = cfgs["openai_compatible"]
+    rc.set("llm.openai_compatible.base_url", getattr(oc_cfg, "base_url", ""))
+    rc.set("llm.openai_compatible.model", getattr(oc_cfg, "model", ""))
+
+    with (
+        patch.object(llm_router_mod, "get_settings", return_value=settings),
+        patch.object(llm_router_mod, "get_runtime_config", return_value=rc),
+    ):
         return LLMRouter()
 
 
@@ -464,8 +480,7 @@ async def test_router_complete_falls_through_to_next_provider() -> None:
 
 
 async def test_router_complete_no_fallback_raises() -> None:
-    router = _router_with_settings()
-    router.settings.llm.fallback_enabled = False
+    router = _router_with_settings(fallback_enabled=False)
     bad = SimpleNamespace(complete=AsyncMock(side_effect=openai.OpenAIError("boom")))
     with (
         patch.object(router, "_is_provider_available", return_value=True),
@@ -818,8 +833,7 @@ async def test_router_stream_complete_no_available_providers() -> None:
 
 async def test_router_stream_complete_no_fallback_raises() -> None:
     """stream_complete() raises immediately when fallback_enabled=False."""
-    router = _router_with_settings()
-    router.settings.llm.fallback_enabled = False
+    router = _router_with_settings(fallback_enabled=False)
     bad = SimpleNamespace(stream=AsyncMock(side_effect=openai.OpenAIError("boom")))
     with (
         patch.object(router, "_is_provider_available", return_value=True),

--- a/tests/unit/test_user_preference.py
+++ b/tests/unit/test_user_preference.py
@@ -8,12 +8,15 @@ Covers:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from wikimind.api.routes import settings as settings_mod
-from wikimind.models import UserPreference
+
+if TYPE_CHECKING:
+    from wikimind.models import UserPreference
 
 # ---------------------------------------------------------------------------
 # Session-factory helpers
@@ -151,35 +154,27 @@ async def test_patch_fallback(client) -> None:
 
 
 async def test_patch_openai_compatible_runtime_config(client) -> None:
-    """Patching OpenAI-compatible endpoint config updates runtime settings."""
+    """Patching OpenAI-compatible endpoint config updates RuntimeConfig (not Settings)."""
+    from wikimind.config import get_runtime_config
+
     session_factory, _ = _make_session_with_pref(None)
-    settings = settings_mod.get_settings()
-    original_base_url = settings.llm.openai_compatible.base_url
-    original_model = settings.llm.openai_compatible.model
-    original_supports_reasoning = settings.llm.openai_compatible.supports_reasoning_effort
-    original_reasoning_format = settings.llm.openai_compatible.reasoning_format
-    try:
-        with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
-            resp = await client.patch(
-                "/api/settings",
-                json={
-                    "openai_compatible_base_url": "https://openrouter.ai/api/v1/",
-                    "openai_compatible_model": "openai/gpt-4o-mini",
-                    "openai_compatible_supports_reasoning_effort": True,
-                    "openai_compatible_reasoning_format": "openrouter",
-                },
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "ok"
-        assert settings.llm.openai_compatible.base_url == "https://openrouter.ai/api/v1"
-        assert settings.llm.openai_compatible.model == "openai/gpt-4o-mini"
-        assert settings.llm.openai_compatible.supports_reasoning_effort is True
-        assert settings.llm.openai_compatible.reasoning_format == "openrouter"
-    finally:
-        settings.llm.openai_compatible.base_url = original_base_url
-        settings.llm.openai_compatible.model = original_model
-        settings.llm.openai_compatible.supports_reasoning_effort = original_supports_reasoning
-        settings.llm.openai_compatible.reasoning_format = original_reasoning_format
+    rc = get_runtime_config()
+    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+        resp = await client.patch(
+            "/api/settings",
+            json={
+                "openai_compatible_base_url": "https://openrouter.ai/api/v1/",
+                "openai_compatible_model": "openai/gpt-4o-mini",
+                "openai_compatible_supports_reasoning_effort": True,
+                "openai_compatible_reasoning_format": "openrouter",
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert rc.get_openai_compatible_base_url() == "https://openrouter.ai/api/v1"
+    assert rc.get_openai_compatible_model() == "openai/gpt-4o-mini"
+    assert rc.get_openai_compatible_field("supports_reasoning_effort") is True
+    assert rc.get_openai_compatible_field("reasoning_format") == "openrouter"
 
 
 async def test_patch_openai_compatible_rejects_invalid_base_url(client) -> None:
@@ -218,7 +213,7 @@ async def test_patch_openai_compatible_runtime_config_rejected_when_auth_enabled
     try:
         request = SettingsUpdateRequest(**payload)
         with pytest.raises(HTTPException) as exc_info:
-            await _update_openai_compatible_settings(request, settings, "user-1")
+            await _update_openai_compatible_settings(request, "user-1")
         assert exc_info.value.status_code == 403
         assert "runtime settings are global" in exc_info.value.detail
     finally:
@@ -238,16 +233,28 @@ async def test_patch_openai_compatible_rejects_invalid_reasoning_format(client) 
 
 
 async def test_get_settings_reflects_overrides(client) -> None:
-    """GET /settings should return DB-overridden values when preferences exist."""
-    budget_pref = UserPreference(key="llm.monthly_budget_usd", value="123.45")
-    fallback_pref = UserPreference(key="llm.fallback_enabled", value="false")
-    provider_pref = UserPreference(key="llm.default_provider", value="anthropic")
+    """GET /settings should return RuntimeConfig-overridden values."""
+    from wikimind.config import get_runtime_config
 
-    # _get_preference is called three times (default_provider, budget, fallback)
-    session_factory = _make_multi_call_session_factory([provider_pref, budget_pref, fallback_pref])
+    rc = get_runtime_config()
+    # Save originals
+    orig_budget = rc.get("llm.monthly_budget_usd")
+    orig_fallback = rc.get("llm.fallback_enabled")
+    orig_provider = rc.get("llm.default_provider")
 
-    with patch.object(settings_mod, "get_session_factory", return_value=session_factory):
+    rc.set("llm.monthly_budget_usd", 123.45)
+    rc.set("llm.fallback_enabled", False)
+    rc.set("llm.default_provider", "anthropic")
+    try:
         resp = await client.get("/api/settings")
+    finally:
+        # Restore originals
+        if orig_budget is not None:
+            rc.set("llm.monthly_budget_usd", orig_budget)
+        if orig_fallback is not None:
+            rc.set("llm.fallback_enabled", orig_fallback)
+        if orig_provider is not None:
+            rc.set("llm.default_provider", orig_provider)
 
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/unit/test_user_preference.py
+++ b/tests/unit/test_user_preference.py
@@ -18,6 +18,24 @@ from wikimind.api.routes import settings as settings_mod
 if TYPE_CHECKING:
     from wikimind.models import UserPreference
 
+
+# ---------------------------------------------------------------------------
+# RuntimeConfig isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_config():
+    """Reset RuntimeConfig overrides between tests."""
+    from wikimind.config import get_runtime_config
+
+    rc = get_runtime_config()
+    saved = rc._overrides.copy()
+    yield
+    rc._overrides.clear()
+    rc._overrides.update(saved)
+
+
 # ---------------------------------------------------------------------------
 # Session-factory helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Introduces a `RuntimeConfig` class in `config.py` — a thread-safe mutable overlay for DB-persisted runtime settings (default_provider, budget, fallback, openai_compatible fields)
- The `Settings` singleton is never mutated after startup; all runtime reads go through `RuntimeConfig` which falls back to Settings defaults when no override is set
- Updates `LLMRouter`, `ConfiguredOpenAICompatibleProvider`, and `/api/settings` routes to read from RuntimeConfig instead of mutating Settings

## Test plan

- [x] All 69 tests in `test_llm_router.py` and `test_user_preference.py` pass
- [x] Lint (ruff check) passes cleanly
- [x] Format (ruff format --check) passes
- [x] Mypy passes on all changed files (pre-existing errors in unrelated files only)

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)