### PR TITLE
feat(mcp): add write tools to MCP server

### DIFF
--- a/src/wikimind/mcp/__init__.py
+++ b/src/wikimind/mcp/__init__.py
@@ -1,1 +1,1 @@
-"""WikiMind MCP server — exposes read-only wiki tools via Model Context Protocol."""
+"""WikiMind MCP server — exposes read and write wiki tools via Model Context Protocol."""

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -1,10 +1,18 @@
-"""WikiMind MCP server — Phase 1 read-only tools over stdio transport.
+"""WikiMind MCP server — read and write tools over stdio transport.
 
-Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
+Exposes tools to MCP clients (Claude Desktop, Cursor, etc.):
+
+Read tools:
   - wiki_search:       full-text search across wiki articles
   - wiki_get_article:  retrieve a full article by ID or slug
   - wiki_ask:          ask a question against the wiki (Q&A agent)
   - wiki_list_sources: list ingested sources
+
+Write tools:
+  - wiki_ingest_url:   ingest a URL source into the wiki
+  - wiki_ingest_text:  ingest raw text into the wiki
+  - wiki_list_articles: list all articles with summaries
+  - wiki_recompile:    trigger recompilation of an article
 
 The server supports stdio (default) and HTTP transports.
 
@@ -72,7 +80,8 @@ mcp = FastMCP(
     instructions=(
         "WikiMind is a personal LLM-powered knowledge OS. "
         "Use these tools to search the wiki, read articles, "
-        "ask questions, and browse ingested sources."
+        "ask questions, browse ingested sources, ingest new content, "
+        "and trigger recompilation."
     ),
     lifespan=_lifespan,
 )
@@ -298,6 +307,209 @@ async def wiki_list_sources(
             }
             for s in sources
         ],
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_ingest_url
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_ingest_url",
+    description=(
+        "Ingest a URL (web page or YouTube video) into the WikiMind knowledge base. "
+        "The content is fetched, cleaned, and scheduled for compilation into a wiki article. "
+        "Returns the created source record with its ID and status."
+    ),
+)
+async def wiki_ingest_url(
+    url: str = Field(..., description="The URL to ingest (web page or YouTube video)"),
+    title: str | None = Field(None, description="Optional title override for the source"),
+) -> str:
+    """Ingest a URL source into the wiki."""
+    if not url or not url.strip():
+        return json.dumps({"error": "URL cannot be empty"})
+
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        return json.dumps({"error": "URL must start with http:// or https://"})
+
+    ingest_service = IngestService()
+    async with _get_session() as session:
+        try:
+            source = await ingest_service.ingest_url(
+                url=url,
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception as exc:
+            log.warning("wiki_ingest_url failed", url=url, error=str(exc))
+            return json.dumps({"error": f"Ingestion failed: {exc}"})
+
+    return json.dumps(
+        {
+            "id": source.id,
+            "source_type": source.source_type,
+            "title": source.title or title,
+            "source_url": source.source_url,
+            "status": "scheduled_for_compilation",
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_ingest_text
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_ingest_text",
+    description=(
+        "Ingest raw text content into the WikiMind knowledge base. "
+        "The text is stored as a source and scheduled for compilation into a wiki article. "
+        "Useful for adding notes, excerpts, or any textual content to the wiki."
+    ),
+)
+async def wiki_ingest_text(
+    text: str = Field(..., description="The text content to ingest"),
+    title: str = Field(..., description="Title for the source"),
+) -> str:
+    """Ingest raw text content into the wiki."""
+    if not text or not text.strip():
+        return json.dumps({"error": "Text content cannot be empty"})
+
+    if not title or not title.strip():
+        return json.dumps({"error": "Title cannot be empty"})
+
+    ingest_service = IngestService()
+    async with _get_session() as session:
+        try:
+            source = await ingest_service.ingest_text(
+                content=text.strip(),
+                title=title.strip(),
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception as exc:
+            log.warning("wiki_ingest_text failed", title=title, error=str(exc))
+            return json.dumps({"error": f"Ingestion failed: {exc}"})
+
+    return json.dumps(
+        {
+            "id": source.id,
+            "source_type": source.source_type,
+            "title": source.title,
+            "status": "scheduled_for_compilation",
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_list_articles
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_list_articles",
+    description=(
+        "List all wiki articles with their summaries. "
+        "Returns article titles, slugs, summaries, confidence scores, "
+        "and source counts. Use this to browse the wiki content."
+    ),
+)
+async def wiki_list_articles(
+    limit: int = Field(20, description="Maximum number of articles to return (max 100)"),
+    offset: int = Field(0, description="Pagination offset (skip this many articles)"),
+) -> str:
+    """List wiki articles with summaries."""
+    limit = min(max(1, limit), 100)
+    offset = max(0, offset)
+
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            articles = await wiki_service.list_articles(
+                session=session,
+                user_id=await _get_mcp_user_id(),
+                limit=limit,
+                offset=offset,
+            )
+        except Exception as exc:
+            log.warning("wiki_list_articles failed", error=str(exc))
+            return json.dumps({"error": f"Failed to list articles: {exc}"})
+
+    return json.dumps(
+        [
+            {
+                "id": a.id,
+                "slug": a.slug,
+                "title": a.title,
+                "summary": a.summary,
+                "confidence": a.confidence,
+                "confidence_score": a.confidence_score,
+                "source_count": a.source_count,
+                "page_type": a.page_type,
+                "created_at": a.created_at,
+                "updated_at": a.updated_at,
+            }
+            for a in articles
+        ],
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_recompile
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_recompile",
+    description=(
+        "Trigger recompilation of a wiki article by its slug or ID. "
+        "This re-runs the LLM compiler on the article's sources to produce "
+        "an updated wiki page. Use when sources have changed or you want "
+        "to improve article quality."
+    ),
+)
+async def wiki_recompile(
+    article_slug: str = Field(..., description="Article slug or UUID to recompile"),
+) -> str:
+    """Trigger recompilation of a wiki article."""
+    if not article_slug or not article_slug.strip():
+        return json.dumps({"error": "Article slug cannot be empty"})
+
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            # First resolve the slug/id to the article's UUID
+            article_id = await wiki_service._resolve_article_id(
+                article_slug.strip(),
+                session,
+                user_id=await _get_mcp_user_id(),
+            )
+            if article_id is None:
+                return json.dumps({"error": "Article not found"})
+
+            result = await wiki_service.recompile_article(
+                article_id=article_id,
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception as exc:
+            log.warning("wiki_recompile failed", slug=article_slug, error=str(exc))
+            return json.dumps({"error": f"Recompilation failed: {exc}"})
+
+    return json.dumps(
+        {
+            "status": result.status,
+            "job_id": result.job_id,
+            "article_slug": article_slug.strip(),
+        },
         default=str,
     )
 

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -348,11 +348,15 @@ async def wiki_ingest_url(
             log.warning("wiki_ingest_url failed", url=url, error=str(exc))
             return json.dumps({"error": f"Ingestion failed: {exc}"})
 
+        # Apply user-provided title override (persisted by session commit)
+        if title and title.strip():
+            source.title = title.strip()
+
     return json.dumps(
         {
             "id": source.id,
             "source_type": source.source_type,
-            "title": source.title or title,
+            "title": source.title,
             "source_url": source.source_url,
             "status": "scheduled_for_compilation",
         },

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -282,9 +282,7 @@ class TestWikiIngestUrl:
         ):
             mock_ingest_cls.return_value.ingest_url = AsyncMock(return_value=mock_source)
 
-            result = await wiki_ingest_url(
-                url="https://example.com/page", title="My Custom Title"
-            )
+            result = await wiki_ingest_url(url="https://example.com/page", title="My Custom Title")
             parsed = json.loads(result)
 
             assert parsed["title"] == "My Custom Title"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -269,6 +269,27 @@ class TestWikiIngestUrl:
             assert parsed["title"] == "Example Page"
             assert parsed["status"] == "scheduled_for_compilation"
 
+    async def test_ingest_url_with_title_override(self, db_session):
+        mock_source = AsyncMock()
+        mock_source.id = "src-123"
+        mock_source.source_type = "url"
+        mock_source.title = "Fetched Title"
+        mock_source.source_url = "https://example.com/page"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.ingest_url = AsyncMock(return_value=mock_source)
+
+            result = await wiki_ingest_url(
+                url="https://example.com/page", title="My Custom Title"
+            )
+            parsed = json.loads(result)
+
+            assert parsed["title"] == "My Custom Title"
+            assert mock_source.title == "My Custom Title"
+
     async def test_ingest_url_empty_returns_error(self):
         result = await wiki_ingest_url(url="", title=None)
         parsed = json.loads(result)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -17,7 +17,15 @@ from click.testing import CliRunner
 from tests.conftest import TEST_USER_ID
 from wikimind.cli.main import cli
 from wikimind.mcp.server import mcp as mcp_server
-from wikimind.mcp.server import wiki_get_article, wiki_list_sources, wiki_search
+from wikimind.mcp.server import (
+    wiki_get_article,
+    wiki_ingest_text,
+    wiki_ingest_url,
+    wiki_list_articles,
+    wiki_list_sources,
+    wiki_recompile,
+    wiki_search,
+)
 from wikimind.models import Article, ConfidenceLevel, PageType, Source
 
 if TYPE_CHECKING:
@@ -233,6 +241,248 @@ class TestWikiListSources:
 
 
 # ---------------------------------------------------------------------------
+# wiki_ingest_url
+# ---------------------------------------------------------------------------
+
+
+class TestWikiIngestUrl:
+    """Test the wiki_ingest_url MCP tool."""
+
+    async def test_ingest_url_success(self, db_session):
+        mock_source = AsyncMock()
+        mock_source.id = "src-123"
+        mock_source.source_type = "url"
+        mock_source.title = "Example Page"
+        mock_source.source_url = "https://example.com/page"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.ingest_url = AsyncMock(return_value=mock_source)
+
+            result = await wiki_ingest_url(url="https://example.com/page", title=None)
+            parsed = json.loads(result)
+
+            assert parsed["id"] == "src-123"
+            assert parsed["source_type"] == "url"
+            assert parsed["title"] == "Example Page"
+            assert parsed["status"] == "scheduled_for_compilation"
+
+    async def test_ingest_url_empty_returns_error(self):
+        result = await wiki_ingest_url(url="", title=None)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "empty" in parsed["error"]
+
+    async def test_ingest_url_invalid_scheme_returns_error(self):
+        result = await wiki_ingest_url(url="ftp://example.com", title=None)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "http" in parsed["error"]
+
+    async def test_ingest_url_handles_exception(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.ingest_url = AsyncMock(
+                side_effect=Exception("Network error"),
+            )
+
+            result = await wiki_ingest_url(url="https://example.com/bad", title=None)
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "Network error" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# wiki_ingest_text
+# ---------------------------------------------------------------------------
+
+
+class TestWikiIngestText:
+    """Test the wiki_ingest_text MCP tool."""
+
+    async def test_ingest_text_success(self, db_session):
+        mock_source = AsyncMock()
+        mock_source.id = "src-456"
+        mock_source.source_type = "text"
+        mock_source.title = "My Notes"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.ingest_text = AsyncMock(return_value=mock_source)
+
+            result = await wiki_ingest_text(text="Some important content", title="My Notes")
+            parsed = json.loads(result)
+
+            assert parsed["id"] == "src-456"
+            assert parsed["source_type"] == "text"
+            assert parsed["title"] == "My Notes"
+            assert parsed["status"] == "scheduled_for_compilation"
+
+    async def test_ingest_text_empty_text_returns_error(self):
+        result = await wiki_ingest_text(text="", title="Title")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Text content" in parsed["error"]
+
+    async def test_ingest_text_empty_title_returns_error(self):
+        result = await wiki_ingest_text(text="Some content", title="")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Title" in parsed["error"]
+
+    async def test_ingest_text_handles_exception(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.ingest_text = AsyncMock(
+                side_effect=Exception("Storage full"),
+            )
+
+            result = await wiki_ingest_text(text="Content", title="Title")
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "Storage full" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# wiki_list_articles
+# ---------------------------------------------------------------------------
+
+
+class TestWikiListArticles:
+    """Test the wiki_list_articles MCP tool."""
+
+    async def test_list_articles_returns_results(self, db_session):
+        mock_article = AsyncMock()
+        mock_article.id = "art-123"
+        mock_article.slug = "test-article"
+        mock_article.title = "Test Article"
+        mock_article.summary = "A summary"
+        mock_article.confidence = "sourced"
+        mock_article.confidence_score = 0.85
+        mock_article.source_count = 2
+        mock_article.page_type = "source"
+        mock_article.created_at = "2026-01-01"
+        mock_article.updated_at = "2026-01-02"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.list_articles = AsyncMock(return_value=[mock_article])
+
+            result = await wiki_list_articles(limit=20, offset=0)
+            parsed = json.loads(result)
+
+            assert isinstance(parsed, list)
+            assert len(parsed) == 1
+            assert parsed[0]["title"] == "Test Article"
+            assert parsed[0]["slug"] == "test-article"
+            assert parsed[0]["source_count"] == 2
+
+    async def test_list_articles_empty(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.list_articles = AsyncMock(return_value=[])
+
+            result = await wiki_list_articles(limit=20, offset=0)
+            parsed = json.loads(result)
+            assert parsed == []
+
+    async def test_list_articles_clamps_limit(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.list_articles = AsyncMock(return_value=[])
+
+            await wiki_list_articles(limit=999, offset=0)
+            call_kwargs = mock_wiki_cls.return_value.list_articles.call_args
+            assert call_kwargs.kwargs["limit"] == 100
+
+    async def test_list_articles_clamps_negative_offset(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.list_articles = AsyncMock(return_value=[])
+
+            await wiki_list_articles(limit=20, offset=-5)
+            call_kwargs = mock_wiki_cls.return_value.list_articles.call_args
+            assert call_kwargs.kwargs["offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# wiki_recompile
+# ---------------------------------------------------------------------------
+
+
+class TestWikiRecompile:
+    """Test the wiki_recompile MCP tool."""
+
+    async def test_recompile_success(self, db_session):
+        mock_result = AsyncMock()
+        mock_result.status = "scheduled"
+        mock_result.job_id = "job-789"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value._resolve_article_id = AsyncMock(return_value="art-123")
+            mock_wiki_cls.return_value.recompile_article = AsyncMock(return_value=mock_result)
+
+            result = await wiki_recompile(article_slug="test-article")
+            parsed = json.loads(result)
+
+            assert parsed["status"] == "scheduled"
+            assert parsed["job_id"] == "job-789"
+            assert parsed["article_slug"] == "test-article"
+
+    async def test_recompile_empty_slug_returns_error(self):
+        result = await wiki_recompile(article_slug="")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "empty" in parsed["error"]
+
+    async def test_recompile_article_not_found(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value._resolve_article_id = AsyncMock(return_value=None)
+
+            result = await wiki_recompile(article_slug="nonexistent")
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "not found" in parsed["error"]
+
+    async def test_recompile_handles_exception(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value._resolve_article_id = AsyncMock(return_value="art-123")
+            mock_wiki_cls.return_value.recompile_article = AsyncMock(
+                side_effect=Exception("Article has manual edits"),
+            )
+
+            result = await wiki_recompile(article_slug="test-article")
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "manual edits" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
 # CLI commands
 # ---------------------------------------------------------------------------
 
@@ -285,6 +535,10 @@ class TestMCPServerRegistration:
         assert "wiki_get_article" in tool_names
         assert "wiki_ask" in tool_names
         assert "wiki_list_sources" in tool_names
+        assert "wiki_ingest_url" in tool_names
+        assert "wiki_ingest_text" in tool_names
+        assert "wiki_list_articles" in tool_names
+        assert "wiki_recompile" in tool_names
 
     async def test_tool_descriptions_present(self):
         tools = await mcp_server.list_tools()


### PR DESCRIPTION
## Summary

- Add four new MCP tools for write operations: `wiki_ingest_url`, `wiki_ingest_text`, `wiki_list_articles`, and `wiki_recompile`
- Each tool reuses the existing service layer (IngestService, WikiService) with proper input validation and structured JSON error responses
- Unit tests cover success paths, validation edge cases, and error handling for all new tools (16 new tests, all passing)

Closes #447 (PR 1: write tools)

## Test plan

- [x] All 33 MCP server tests pass (`tests/unit/test_mcp_server.py`)
- [x] Full unit test suite passes (1644 tests)
- [x] Ruff lint and format checks pass
- [ ] Manual test: invoke `wiki_ingest_url` via MCP client
- [ ] Manual test: invoke `wiki_ingest_text` via MCP client
- [ ] Manual test: invoke `wiki_list_articles` via MCP client
- [ ] Manual test: invoke `wiki_recompile` via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)