### PR TITLE
feat(mcp): comprehensive MCP server — 13 tools, 3 resources, 4 prompts, JWT auth (#447)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -345,6 +345,12 @@
 # WIKIMIND_AUTH__COOKIE_DOMAIN=
 
 # ----------------------------------------------------------------------------
+# MCP Server (Model Context Protocol)
+# ----------------------------------------------------------------------------
+# Require JWT auth for HTTP transport (stdio always skips auth)
+# WIKIMIND_MCP__REQUIRE_AUTH=true
+
+# ----------------------------------------------------------------------------
 # Production Deployment (docker-compose.prod.yml)
 # ----------------------------------------------------------------------------
 # These are read by docker-compose.prod.yml to configure the Postgres

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -295,14 +295,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 649
+        "line_number": 656
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 674
+        "line_number": 681
       }
     ],
     "src/wikimind/engine/providers/openai.py": [
@@ -391,6 +391,15 @@
         "line_number": 184
       }
     ],
+    "tests/unit/test_mcp_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_mcp_auth.py",
+        "hashed_secret": "493e54566ff3d0a381d1d10754cdfabf5c3bef40",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
     "tests/unit/test_postgres_engine.py": [
       {
         "type": "Basic Auth Credentials",
@@ -424,5 +433,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-16T14:45:36Z"
+  "generated_at": "2026-05-18T01:37:28Z"
 }

--- a/alembic/versions/0016_add_mcp_access_token.py
+++ b/alembic/versions/0016_add_mcp_access_token.py
@@ -46,6 +46,9 @@ def downgrade() -> None:
     conn = op.get_bind()
     inspector = sa_inspect(conn)
     if "mcp_access_token" in inspector.get_table_names():
-        op.drop_index("ix_mcp_access_token_token_hash", table_name="mcp_access_token")
-        op.drop_index("ix_mcp_access_token_user_id", table_name="mcp_access_token")
+        indexes = [idx["name"] for idx in inspector.get_indexes("mcp_access_token")]
+        if "ix_mcp_access_token_token_hash" in indexes:
+            op.drop_index("ix_mcp_access_token_token_hash", table_name="mcp_access_token")
+        if "ix_mcp_access_token_user_id" in indexes:
+            op.drop_index("ix_mcp_access_token_user_id", table_name="mcp_access_token")
         op.drop_table("mcp_access_token")

--- a/alembic/versions/0016_add_mcp_access_token.py
+++ b/alembic/versions/0016_add_mcp_access_token.py
@@ -1,0 +1,51 @@
+"""Add mcp_access_token table for personal access token authentication.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-05-16
+
+Personal access tokens (PATs) allow MCP clients like Claude Desktop to
+authenticate with the WikiMind API using long-lived bearer tokens instead
+of browser-session JWTs. See ADR-027.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0016"
+down_revision: str = "0015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    if "mcp_access_token" not in inspector.get_table_names():
+        op.create_table(
+            "mcp_access_token",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("user_id", sa.String(), sa.ForeignKey("user.id"), nullable=False),
+            sa.Column("name", sa.String(100), nullable=False),
+            sa.Column("token_hash", sa.String(), nullable=False),
+            sa.Column("token_prefix", sa.String(12), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("last_used_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+            sa.Column("revoked", sa.Boolean(), nullable=False, server_default="0"),
+        )
+        op.create_index("ix_mcp_access_token_user_id", "mcp_access_token", ["user_id"])
+        op.create_index("ix_mcp_access_token_token_hash", "mcp_access_token", ["token_hash"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    if "mcp_access_token" in inspector.get_table_names():
+        op.drop_index("ix_mcp_access_token_token_hash", table_name="mcp_access_token")
+        op.drop_index("ix_mcp_access_token_user_id", table_name="mcp_access_token")
+        op.drop_table("mcp_access_token")

--- a/apps/web/src/components/settings/MCPTokens.tsx
+++ b/apps/web/src/components/settings/MCPTokens.tsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card } from "../shared/Card";
+import { Button } from "../shared/Button";
+import { Spinner } from "../shared/Spinner";
+import { apiFetch } from "../../api/client";
+
+interface MCPToken {
+  id: string;
+  name: string;
+  token_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked: boolean;
+}
+
+interface MCPTokenCreateResponse {
+  id: string;
+  token: string;
+  name: string;
+  created_at: string;
+}
+
+function listMCPTokens(): Promise<MCPToken[]> {
+  return apiFetch<MCPToken[]>("/api/settings/mcp-tokens");
+}
+
+function createMCPToken(name: string): Promise<MCPTokenCreateResponse> {
+  return apiFetch<MCPTokenCreateResponse>("/api/settings/mcp-tokens", {
+    method: "POST",
+    body: { name },
+  });
+}
+
+function revokeMCPToken(tokenId: string): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>(`/api/settings/mcp-tokens/${tokenId}`, {
+    method: "DELETE",
+  });
+}
+
+export function MCPTokens() {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [tokenName, setTokenName] = useState("");
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const queryClient = useQueryClient();
+
+  const { data: tokens, isLoading } = useQuery({
+    queryKey: ["mcp-tokens"],
+    queryFn: listMCPTokens,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createMCPToken,
+    onSuccess: (data) => {
+      setNewToken(data.token);
+      setTokenName("");
+      queryClient.invalidateQueries({ queryKey: ["mcp-tokens"] });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: revokeMCPToken,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["mcp-tokens"] });
+    },
+  });
+
+  const handleCreate = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (tokenName.trim()) {
+      createMutation.mutate(tokenName.trim());
+    }
+  };
+
+  const handleCopy = async () => {
+    if (newToken) {
+      await navigator.clipboard.writeText(newToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setShowCreateModal(false);
+    setNewToken(null);
+    setTokenName("");
+    setCopied(false);
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="p-4">
+        <div className="flex items-center justify-center py-4">
+          <Spinner size={20} />
+        </div>
+      </Card>
+    );
+  }
+
+  const activeTokens = tokens?.filter((t) => !t.revoked) ?? [];
+  const revokedTokens = tokens?.filter((t) => t.revoked) ?? [];
+
+  return (
+    <>
+      <Card className="p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <p className="text-sm text-slate-500">
+            Personal access tokens for MCP clients like Claude Desktop.
+          </p>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setShowCreateModal(true)}
+          >
+            Generate Token
+          </Button>
+        </div>
+
+        {activeTokens.length === 0 && revokedTokens.length === 0 ? (
+          <p className="py-4 text-center text-sm text-slate-400">
+            No tokens yet. Generate one to connect MCP clients.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                <th className="pb-2 font-medium">Name</th>
+                <th className="pb-2 font-medium">Token</th>
+                <th className="pb-2 font-medium">Created</th>
+                <th className="pb-2 font-medium">Last used</th>
+                <th className="pb-2 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {activeTokens.map((token) => (
+                <tr
+                  key={token.id}
+                  className="border-b border-slate-100 last:border-0"
+                >
+                  <td className="py-2 text-slate-700">{token.name}</td>
+                  <td className="py-2">
+                    <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">
+                      {token.token_prefix}...
+                    </code>
+                  </td>
+                  <td className="py-2 text-slate-500">
+                    {formatDate(token.created_at)}
+                  </td>
+                  <td className="py-2 text-slate-500">
+                    {token.last_used_at
+                      ? formatDate(token.last_used_at)
+                      : "Never"}
+                  </td>
+                  <td className="py-2 text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => revokeMutation.mutate(token.id)}
+                      disabled={revokeMutation.isPending}
+                    >
+                      Revoke
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {revokedTokens.map((token) => (
+                <tr
+                  key={token.id}
+                  className="border-b border-slate-100 opacity-50 last:border-0"
+                >
+                  <td className="py-2 text-slate-400 line-through">
+                    {token.name}
+                  </td>
+                  <td className="py-2">
+                    <code className="rounded bg-slate-50 px-1.5 py-0.5 text-xs text-slate-400">
+                      {token.token_prefix}...
+                    </code>
+                  </td>
+                  <td className="py-2 text-slate-400">
+                    {formatDate(token.created_at)}
+                  </td>
+                  <td className="py-2 text-slate-400">Revoked</td>
+                  <td />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      {/* Create / reveal modal */}
+      {showCreateModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+            {newToken ? (
+              <>
+                <h3 className="mb-2 text-lg font-semibold text-slate-900">
+                  Token Created
+                </h3>
+                <p className="mb-3 text-sm text-amber-600">
+                  Copy this token now. It will not be shown again.
+                </p>
+                <div className="mb-4 flex items-center gap-2">
+                  <code className="flex-1 break-all rounded bg-slate-100 px-3 py-2 text-sm text-slate-800">
+                    {newToken}
+                  </code>
+                  <Button variant="primary" size="sm" onClick={handleCopy}>
+                    {copied ? "Copied" : "Copy"}
+                  </Button>
+                </div>
+                <div className="flex justify-end">
+                  <Button variant="ghost" size="sm" onClick={handleCloseModal}>
+                    Done
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <form onSubmit={handleCreate}>
+                <h3 className="mb-4 text-lg font-semibold text-slate-900">
+                  Generate MCP Token
+                </h3>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Token name
+                </label>
+                <input
+                  type="text"
+                  value={tokenName}
+                  onChange={(e) => setTokenName(e.target.value)}
+                  placeholder="e.g. Claude Desktop"
+                  className="mb-4 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-brand-300 focus:outline-none"
+                  maxLength={100}
+                  autoFocus
+                />
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    type="button"
+                    onClick={handleCloseModal}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    type="submit"
+                    disabled={!tokenName.trim() || createMutation.isPending}
+                  >
+                    {createMutation.isPending ? "Generating..." : "Generate"}
+                  </Button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -10,6 +10,7 @@ import { DoclingStatus } from "./DoclingStatus";
 import { SyncStatus } from "./SyncStatus";
 import { WikiExportPanel } from "./WikiExportPanel";
 import { ShareLinksPanel } from "./ShareLinksPanel";
+import { MCPTokens } from "./MCPTokens";
 import { getSettings, updateSettings } from "../../api/settings";
 
 export function SettingsView() {
@@ -86,6 +87,11 @@ export function SettingsView() {
         <section className="mb-8">
           <h2 className="mb-4 text-lg font-semibold text-slate-700">Export</h2>
           <WikiExportPanel />
+        </section>
+
+        <section className="mb-8">
+          <h2 className="mb-4 text-lg font-semibold text-slate-700">MCP API Tokens</h2>
+          <MCPTokens />
         </section>
 
         <section className="mb-8">

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2461,6 +2461,80 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiKeyListResponse'
+  /api/settings/mcp-tokens:
+    get:
+      tags:
+      - Settings
+      summary: List Mcp Tokens
+      description: List all MCP tokens for the current user (never returns plaintext).
+      operationId: list_mcp_tokens_api_settings_mcp_tokens_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/MCPTokenResponse'
+                type: array
+                title: Response List Mcp Tokens Api Settings Mcp Tokens Get
+    post:
+      tags:
+      - Settings
+      summary: Create Mcp Token
+      description: 'Generate a new MCP personal access token.
+
+
+        The plaintext token is returned ONCE in the response. It is never
+
+        stored — only the SHA-256 hash is persisted.'
+      operationId: create_mcp_token_api_settings_mcp_tokens_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MCPTokenCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MCPTokenCreateResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/settings/mcp-tokens/{token_id}:
+    delete:
+      tags:
+      - Settings
+      summary: Revoke Mcp Token
+      description: Revoke an MCP token (soft delete — sets revoked=True).
+      operationId: revoke_mcp_token_api_settings_mcp_tokens__token_id__delete
+      parameters:
+      - name: token_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Token Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MCPTokenRevokeResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/admin/stats:
     get:
       tags:
@@ -5642,6 +5716,85 @@ components:
       - error
       title: LintSeverity
       description: Severity level for a lint finding.
+    MCPTokenCreateRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Name
+      type: object
+      required:
+      - name
+      title: MCPTokenCreateRequest
+      description: Request to generate a new MCP personal access token.
+    MCPTokenCreateResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        token:
+          type: string
+          title: Token
+        name:
+          type: string
+          title: Name
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - token
+      - name
+      - created_at
+      title: MCPTokenCreateResponse
+      description: Response after creating an MCP token (plaintext shown ONCE).
+    MCPTokenResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        token_prefix:
+          type: string
+          title: Token Prefix
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        last_used_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Used At
+        revoked:
+          type: boolean
+          title: Revoked
+      type: object
+      required:
+      - id
+      - name
+      - token_prefix
+      - created_at
+      - last_used_at
+      - revoked
+      title: MCPTokenResponse
+      description: API response for an existing MCP token (never includes plaintext).
+    MCPTokenRevokeResponse:
+      properties:
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - status
+      title: MCPTokenRevokeResponse
+      description: Response after revoking an MCP token.
     MagicLinkRequest:
       properties:
         email:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,7 @@ pythonVersion = "3.11"
 typeCheckingMode = "standard"
 reportMissingImports = false
 reportMissingTypeStubs = false
+reportAssignmentType = false  # SQLModel __tablename__ = "..." triggers false positive
 
 # ---------- Pytest ----------
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ ignore = [
 "scripts/**/*.py" = ["T20", "S", "EM"]
 "alembic/**/*.py" = ["N"]
 "vulture_whitelist.py" = ["B018", "F405", "PGH004"]  # Intentional dead-code references for vulture
+"src/wikimind/mcp/server.py" = ["PLC0415", "F401"]  # Side-effect imports deferred until after mcp instance creation
 
 [tool.ruff.lint.isort]
 known-first-party = ["wikimind"]

--- a/src/wikimind/api/routes/mcp_tokens.py
+++ b/src/wikimind/api/routes/mcp_tokens.py
@@ -1,0 +1,123 @@
+"""MCP personal access token management endpoints.
+
+Mounted at ``/api/settings/mcp-tokens`` — users generate, list, and revoke
+personal access tokens for authenticating MCP clients (Claude Desktop, etc.).
+See ADR-027.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+
+from wikimind.api.deps import get_current_user_id
+from wikimind.database import get_session
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.models import (
+    MCPAccessToken,
+    MCPTokenCreateRequest,
+    MCPTokenCreateResponse,
+    MCPTokenResponse,
+    MCPTokenRevokeResponse,
+)
+
+log = structlog.get_logger()
+
+router = APIRouter()
+
+
+def _generate_pat() -> tuple[str, str, str]:
+    """Generate a personal access token.
+
+    Returns:
+        Tuple of (raw_token, token_hash, token_prefix).
+    """
+    raw_token = f"wmk_{secrets.token_hex(16)}"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    token_prefix = raw_token[:12]
+    return raw_token, token_hash, token_prefix
+
+
+@router.post("", response_model=MCPTokenCreateResponse)
+async def create_mcp_token(
+    request: MCPTokenCreateRequest,
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> MCPTokenCreateResponse:
+    """Generate a new MCP personal access token.
+
+    The plaintext token is returned ONCE in the response. It is never
+    stored — only the SHA-256 hash is persisted.
+    """
+    raw_token, token_hash, token_prefix = _generate_pat()
+
+    token_row = MCPAccessToken(
+        user_id=user_id,
+        name=request.name,
+        token_hash=token_hash,
+        token_prefix=token_prefix,
+    )
+    session.add(token_row)
+    await session.commit()
+    await session.refresh(token_row)
+
+    log.info("MCP token created", token_id=token_row.id, name=request.name)
+
+    return MCPTokenCreateResponse(
+        id=token_row.id,
+        token=raw_token,
+        name=token_row.name,
+        created_at=token_row.created_at,
+    )
+
+
+@router.get("", response_model=list[MCPTokenResponse])
+async def list_mcp_tokens(
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> list[MCPTokenResponse]:
+    """List all MCP tokens for the current user (never returns plaintext)."""
+    stmt = (
+        select(MCPAccessToken).where(MCPAccessToken.user_id == user_id).order_by(MCPAccessToken.created_at.desc())  # type: ignore[attr-defined]
+    )
+    result = await session.exec(stmt)
+    tokens = result.all()
+    return [
+        MCPTokenResponse(
+            id=t.id,
+            name=t.name,
+            token_prefix=t.token_prefix,
+            created_at=t.created_at,
+            last_used_at=t.last_used_at,
+            revoked=t.revoked,
+        )
+        for t in tokens
+    ]
+
+
+@router.delete("/{token_id}", response_model=MCPTokenRevokeResponse)
+async def revoke_mcp_token(
+    token_id: str,
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> MCPTokenRevokeResponse:
+    """Revoke an MCP token (soft delete — sets revoked=True)."""
+    token_row = await session.get(MCPAccessToken, token_id)
+    if not token_row or token_row.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Token not found")
+
+    token_row.revoked = True
+    session.add(token_row)
+    await session.commit()
+
+    log.info("MCP token revoked", token_id=token_id)
+
+    return MCPTokenRevokeResponse(status="revoked")

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -293,6 +293,12 @@ class EmbeddingConfig(BaseModel):
         return self
 
 
+class MCPConfig(BaseModel):
+    """MCP server configuration."""
+
+    require_auth: bool = True  # applies to HTTP transport only
+
+
 class AuthConfig(BaseModel):
     """OAuth2 authentication configuration.
 
@@ -386,6 +392,7 @@ class Settings(BaseSettings):
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
     concept_layer: ConceptLayerConfig = Field(default_factory=ConceptLayerConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    mcp: MCPConfig = Field(default_factory=MCPConfig)
 
     # Storage backend: "local" creates wiki/ and raw/ on the local filesystem;
     # "r2" delegates to Cloudflare R2 (wiki_dir / raw_dir are not needed).

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -32,6 +32,7 @@ from wikimind.api.routes import (
     ingest,
     jobs,
     lint,
+    mcp_tokens,
     query,
     saved_searches,
     sharing,
@@ -257,6 +258,7 @@ api_router.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
 api_router.include_router(lint.router, prefix="/lint", tags=["Lint"])
 api_router.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
 api_router.include_router(api_keys.router, prefix="/settings/api-keys", tags=["Settings"])
+api_router.include_router(mcp_tokens.router, prefix="/settings/mcp-tokens", tags=["Settings"])
 api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])
 api_router.include_router(export.router, prefix="/wiki", tags=["Export"])
 api_router.include_router(tags.router, prefix="/tags", tags=["Tags"])

--- a/src/wikimind/mcp/__init__.py
+++ b/src/wikimind/mcp/__init__.py
@@ -1,1 +1,1 @@
-"""WikiMind MCP server — exposes read-only wiki tools via Model Context Protocol."""
+"""WikiMind MCP server — tools, resources, and prompts for knowledge base access."""

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -1,23 +1,73 @@
-"""JWT authentication for MCP HTTP transport.
+"""Authentication for MCP HTTP transport — supports both JWTs and PATs.
 
-Validates tokens using the same secret and algorithm as the FastAPI
-auth middleware. Stdio transport skips auth entirely.
+JWTs are validated using the same secret and algorithm as the FastAPI
+auth middleware. Personal access tokens (PATs) use the ``wmk_`` prefix
+and are validated by SHA-256 hash lookup. Stdio transport skips auth
+entirely. See ADR-027.
 """
 
 from __future__ import annotations
 
+import hashlib
+
 import jwt
+import structlog
 from fastmcp.server.auth import AccessToken, TokenVerifier
 
+from wikimind._datetime import utcnow_naive
+from wikimind.database import get_session_factory
+from wikimind.models import MCPAccessToken
 
-class WikiMindJWTAuthProvider(TokenVerifier):
-    """Validate WikiMind JWT tokens for MCP HTTP transport."""
+log = structlog.get_logger()
+
+
+class WikiMindAuthProvider(TokenVerifier):
+    """Validate WikiMind JWT or PAT tokens for MCP HTTP transport."""
 
     def __init__(self, secret: str) -> None:
         super().__init__()
         self._secret = secret
 
     async def verify_token(self, token: str) -> AccessToken | None:
+        """Route to PAT or JWT validation based on token prefix."""
+        if token.startswith("wmk_"):
+            return await self._verify_pat(token)
+        return await self._verify_jwt(token)
+
+    async def _verify_pat(self, token: str) -> AccessToken:
+        """Validate a personal access token by hash lookup."""
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+        from sqlmodel import select  # noqa: PLC0415 — deferred to avoid circular import
+
+        async with get_session_factory()() as session:
+            result = await session.exec(select(MCPAccessToken).where(MCPAccessToken.token_hash == token_hash))
+            token_row = result.one_or_none()
+
+            if token_row is None:
+                msg = "Invalid token"
+                raise ValueError(msg)
+
+            if token_row.revoked:
+                msg = "Token has been revoked"
+                raise ValueError(msg)
+
+            if token_row.expires_at is not None and token_row.expires_at < utcnow_naive():
+                msg = "Token expired"
+                raise ValueError(msg)
+
+            # Update last_used_at
+            token_row.last_used_at = utcnow_naive()
+            session.add(token_row)
+            await session.commit()
+
+            return AccessToken(
+                token=token,
+                client_id=token_row.user_id,
+                scopes=[],
+            )
+
+    async def _verify_jwt(self, token: str) -> AccessToken:
         """Decode and validate a JWT token, returning an AccessToken."""
         try:
             payload = jwt.decode(token, self._secret, algorithms=["HS256"])

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -1,0 +1,35 @@
+"""JWT authentication for MCP HTTP transport.
+
+Validates tokens using the same secret and algorithm as the FastAPI
+auth middleware. Stdio transport skips auth entirely.
+"""
+from __future__ import annotations
+
+import jwt
+from fastmcp.server.auth import TokenVerifier
+from mcp.server.auth.provider import AccessToken
+
+
+class WikiMindJWTAuthProvider(TokenVerifier):
+    """Validate WikiMind JWT tokens for MCP HTTP transport."""
+
+    def __init__(self, secret: str) -> None:
+        super().__init__()
+        self._secret = secret
+
+    async def verify_token(self, token: str) -> AccessToken:
+        try:
+            payload = jwt.decode(token, self._secret, algorithms=["HS256"])
+        except jwt.ExpiredSignatureError as exc:
+            msg = "Token expired"
+            raise ValueError(msg) from exc
+        except jwt.InvalidTokenError as exc:
+            msg = "Invalid token"
+            raise ValueError(msg) from exc
+
+        user_id = payload.get("sub")
+        if not user_id:
+            msg = "Token missing 'sub' claim"
+            raise ValueError(msg)
+
+        return AccessToken(token=token, client_id=user_id, scopes=[])

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -70,7 +70,15 @@ class WikiMindAuthProvider(TokenVerifier):
     async def _verify_jwt(self, token: str) -> AccessToken:
         """Decode and validate a JWT token, returning an AccessToken."""
         try:
-            payload = jwt.decode(token, self._secret, algorithms=["HS256"])
+            from wikimind.config import get_settings  # noqa: PLC0415
+
+            settings = get_settings()
+            payload = jwt.decode(
+                token,
+                self._secret,
+                algorithms=[settings.auth.jwt_algorithm],
+                options={"verify_aud": False},
+            )
         except jwt.ExpiredSignatureError as exc:
             msg = "Token expired"
             raise ValueError(msg) from exc

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -3,11 +3,11 @@
 Validates tokens using the same secret and algorithm as the FastAPI
 auth middleware. Stdio transport skips auth entirely.
 """
+
 from __future__ import annotations
 
 import jwt
-from fastmcp.server.auth import TokenVerifier
-from mcp.server.auth.provider import AccessToken
+from fastmcp.server.auth import AccessToken, TokenVerifier
 
 
 class WikiMindJWTAuthProvider(TokenVerifier):
@@ -17,7 +17,8 @@ class WikiMindJWTAuthProvider(TokenVerifier):
         super().__init__()
         self._secret = secret
 
-    async def verify_token(self, token: str) -> AccessToken:
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Decode and validate a JWT token, returning an AccessToken."""
         try:
             payload = jwt.decode(token, self._secret, algorithms=["HS256"])
         except jwt.ExpiredSignatureError as exc:

--- a/src/wikimind/mcp/prompts.py
+++ b/src/wikimind/mcp/prompts.py
@@ -1,0 +1,110 @@
+"""MCP prompts for the WikiMind server.
+
+Prompts instruct the LLM to use tools in sequence. They do NOT pre-compute
+data — the LLM handles errors naturally via tool calls.
+
+Prompts:
+  - wiki_onboarding: no params, instructs tool usage
+  - research_topic(topic): instructs search -> read -> synthesize
+  - compare_articles(slug_a, slug_b): instructs fetch both + compare
+  - knowledge_gaps(topic?): with/without topic variants
+"""
+
+from __future__ import annotations
+
+from wikimind.mcp.server import mcp
+
+# ---------------------------------------------------------------------------
+# Prompt: wiki_onboarding
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="wiki_onboarding",
+    description="Get oriented with your WikiMind knowledge base",
+)
+async def prompt_onboarding() -> str:
+    """Generate an onboarding prompt that instructs tool usage."""
+    return (
+        "The user has connected to their WikiMind knowledge base.\n\n"
+        "1. Call wiki_overview() to understand what's in the knowledge base\n"
+        "2. Summarize the wiki's scope in 2-3 sentences\n"
+        "3. List the major topic areas with article counts\n"
+        "4. Highlight the 3 most recent or substantial articles\n"
+        "5. Suggest 3 questions the user could ask based on the wiki's contents\n"
+        "6. Note any areas that seem underdeveloped"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: research_topic
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="research_topic",
+    description="Research a topic using your WikiMind knowledge base",
+)
+async def prompt_research_topic(topic: str) -> str:
+    """Generate a research prompt for a topic."""
+    return (
+        f'Research "{topic}" using the WikiMind knowledge base.\n\n'
+        f'1. Call wiki_search("{topic}") to find relevant articles\n'
+        "2. For each relevant result, call wiki_get_article(slug) to read the content\n"
+        "3. Synthesize findings into a comprehensive overview\n"
+        "4. Identify what the wiki covers well vs what's missing\n"
+        "5. Suggest follow-up questions or areas to explore"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: compare_articles
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="compare_articles",
+    description="Compare two wiki articles",
+)
+async def prompt_compare_articles(slug_a: str, slug_b: str) -> str:
+    """Generate a comparison prompt for two articles."""
+    return (
+        "Compare these two WikiMind articles.\n\n"
+        f'1. Call wiki_get_article("{slug_a}") and wiki_get_article("{slug_b}")\n'
+        "2. Identify key agreements between the articles\n"
+        "3. Identify disagreements or contradictions\n"
+        "4. Highlight what each article covers that the other doesn't\n"
+        "5. Suggest whether a synthesis would be valuable"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: knowledge_gaps
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="knowledge_gaps",
+    description="Find gaps in your WikiMind knowledge base",
+)
+async def prompt_knowledge_gaps(topic: str = "") -> str:
+    """Generate a knowledge gaps analysis prompt."""
+    if topic:
+        return (
+            f'Analyze knowledge gaps about "{topic}" in the WikiMind knowledge base.\n\n'
+            f'1. Call wiki_search("{topic}") to find existing coverage\n'
+            "2. Call wiki_get_health() to check overall wiki quality\n"
+            "3. Identify: topics not covered, articles with low confidence,\n"
+            "   stale content, missing connections between related articles\n"
+            "4. Prioritize gaps by importance\n"
+            "5. Suggest sources or topics to add"
+        )
+    return (
+        "Analyze the overall health and gaps of the WikiMind knowledge base.\n\n"
+        "1. Call wiki_overview() to understand scope\n"
+        "2. Call wiki_get_health() to get quality metrics\n"
+        "3. Identify: orphaned articles, stale content, contradictions,\n"
+        "   topics with thin coverage\n"
+        "4. Prioritize issues by impact\n"
+        "5. Recommend actions to improve the knowledge base"
+    )

--- a/src/wikimind/mcp/resources.py
+++ b/src/wikimind/mcp/resources.py
@@ -1,0 +1,117 @@
+"""MCP resources for the WikiMind server.
+
+Resources:
+  - wikimind://index: static, flat article list (capped at 500)
+  - wikimind://articles/{slug}: template, markdown content
+  - wikimind://sources/{source_id}: template, JSON metadata
+"""
+
+from __future__ import annotations
+
+import json
+
+import structlog
+
+from wikimind.mcp.server import _get_mcp_user_id, _get_session, mcp
+
+log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Resource: wikimind://index
+# ---------------------------------------------------------------------------
+
+
+@mcp.resource(
+    "wikimind://index",
+    name="wiki_index",
+    description="Table of contents — all articles with slugs, titles, and concepts",
+    mime_type="application/json",
+)
+async def resource_index() -> str:
+    """Return a flat article index (capped at 500 articles)."""
+    user_id = await _get_mcp_user_id()
+    async with _get_session() as session:
+        from wikimind.services.wiki import WikiService  # noqa: PLC0415
+
+        wiki_svc = WikiService()
+        articles = await wiki_svc.list_articles(
+            session=session,
+            user_id=user_id,
+            limit=500,
+            offset=0,
+        )
+        data = {
+            "articles": [
+                {
+                    "slug": a.slug,
+                    "title": a.title,
+                    "page_type": a.page_type,
+                    "concepts": a.concepts,
+                }
+                for a in articles
+            ]
+        }
+        return json.dumps(data, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Resource: wikimind://articles/{slug}
+# ---------------------------------------------------------------------------
+
+
+@mcp.resource(
+    "wikimind://articles/{slug}",
+    name="article",
+    description="Full article content as markdown",
+    mime_type="text/markdown",
+)
+async def resource_article(slug: str) -> str:
+    """Return article content as markdown."""
+    user_id = await _get_mcp_user_id()
+    async with _get_session() as session:
+        from wikimind.services.wiki import WikiService  # noqa: PLC0415
+
+        wiki_svc = WikiService()
+        article = await wiki_svc.get_article(
+            id_or_slug=slug,
+            session=session,
+            user_id=user_id,
+        )
+        return article.content or ""
+
+
+# ---------------------------------------------------------------------------
+# Resource: wikimind://sources/{source_id}
+# ---------------------------------------------------------------------------
+
+
+@mcp.resource(
+    "wikimind://sources/{source_id}",
+    name="source",
+    description="Source ingestion metadata",
+    mime_type="application/json",
+)
+async def resource_source(source_id: str) -> str:
+    """Return source metadata as JSON."""
+    user_id = await _get_mcp_user_id()
+    async with _get_session() as session:
+        from wikimind.services.ingest import IngestService  # noqa: PLC0415
+
+        ingest_svc = IngestService()
+        source = await ingest_svc.get_source(
+            source_id=source_id,
+            session=session,
+            user_id=user_id,
+        )
+        return json.dumps(
+            {
+                "id": source.id,
+                "title": source.title,
+                "source_type": source.source_type,
+                "status": source.status,
+                "url": source.source_url,
+                "ingested_at": str(source.ingested_at) if source.ingested_at else None,
+            },
+            default=str,
+        )

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -376,9 +376,9 @@ async def _tool_wiki_get_source_status(
 # These modules import `mcp` from this file and register their own tools,
 # resources, and prompts via decorators. We import them here to trigger
 # registration at module load time.
-import wikimind.mcp.prompts as _prompts_module  # noqa: E402, F401, I001
-import wikimind.mcp.resources as _resources_module  # noqa: E402, F401
-import wikimind.mcp.tools_analysis as _analysis_module  # noqa: E402, F401
+import wikimind.mcp.prompts as _prompts_module  # noqa: E402, F401 — side-effect registration
+import wikimind.mcp.resources as _resources_module  # noqa: E402, F401 — side-effect registration
+import wikimind.mcp.tools_analysis as _analysis_module  # noqa: E402, F401 — side-effect registration
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -1,25 +1,7 @@
-"""WikiMind MCP server — tools, resources, and prompts over stdio transport.
+"""WikiMind MCP server — 13 tools, 3 resources, 4 prompts.
 
-Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
-  - wiki_search:       full-text search across wiki articles
-  - wiki_get_article:  retrieve a full article by ID or slug
-  - wiki_ask:          ask a question against the wiki (Q&A agent)
-  - wiki_list_sources: list ingested sources
-
-Resources (browseable URIs):
-  - wikimind://articles/{slug}:  individual article content
-  - wikimind://sources/{id}:     source metadata
-
-Prompts (pre-built templates):
-  - research_topic(topic):       search wiki + synthesize findings
-  - summarize_article(slug):     get article + create summary
-
-The server supports stdio (default) and HTTP transports.
-
-Usage:
-    wikimind mcp serve
-    wikimind mcp serve --transport http --port 9100
-    python -m wikimind.mcp.server
+Exposes the WikiMind knowledge base to MCP clients (Claude Desktop,
+AI agents). Supports stdio (local, no auth) and HTTP (JWT auth) transports.
 """
 
 from __future__ import annotations
@@ -27,90 +9,84 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
-import logging
-import sys
 from typing import TYPE_CHECKING, Any
 
 import structlog
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP  # noqa: F401 — Context used by tool handlers in later tasks
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from wikimind.config import get_settings
-from wikimind.database import get_dev_user_id, get_session_factory, init_db
+from wikimind.database import get_session_factory, init_db
+from wikimind.mcp.auth import WikiMindJWTAuthProvider  # noqa: F401 — used in run_server (Task 9)
 from wikimind.models import QueryRequest
 from wikimind.services.ingest import IngestService
 from wikimind.services.query import QueryService
 from wikimind.services.wiki import WikiService
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
-# ---------------------------------------------------------------------------
-# Logging — stderr so it does not interfere with stdio transport
-# ---------------------------------------------------------------------------
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[logging.StreamHandler(sys.stderr)],
-)
+    from collections.abc import AsyncIterator
 
 log = structlog.get_logger()
 
-# MCP spec version pinned for stability (see issue #447 risk: spec churn).
-MCP_SPEC_VERSION = "2025-03-26"
+# Valid enum values for input validation
+_VALID_PAGE_TYPES = {"source", "concept", "synthesis", "answer"}
+_VALID_INGEST_STATUSES = {"pending", "processing", "compiled", "failed"}
+_VALID_SYNTHESIS_TYPES = {"comparative", "chronological", "thematic", "gap_analysis"}
 
 
 @contextlib.asynccontextmanager
-async def _lifespan(_server: FastMCP) -> AsyncGenerator[dict[str, Any], None]:
-    """Initialize the database on server startup."""
+async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
+    """Initialize database on MCP server startup."""
     settings = get_settings()
     settings.ensure_dirs()
     await init_db()
-    log.info(
-        "WikiMind MCP server started",
-        mcp_spec_version=MCP_SPEC_VERSION,
-        data_dir=settings.data_dir,
-    )
+    log.info("WikiMind MCP server started", tool_count=len(server._tool_manager._tools))
     yield {}
 
 
 mcp = FastMCP(
     name="wikimind",
     instructions=(
-        "WikiMind is a personal LLM-powered knowledge OS. "
-        "Use these tools to search the wiki, read articles, "
-        "ask questions, and browse ingested sources."
+        "WikiMind is your personal knowledge base. Start with wiki_overview() to see "
+        "what's in it. Browse with wiki_list_articles() or wiki_list_concepts(). "
+        "Search with wiki_search(). Read articles with wiki_get_article(). For deep "
+        "analysis, use wiki_synthesize(). To add knowledge, use wiki_ingest_url() "
+        "or wiki_ingest_text(). Check ingestion progress with wiki_get_source_status()."
     ),
     lifespan=_lifespan,
 )
 
 
 # ---------------------------------------------------------------------------
-# Session helper — standalone (not FastAPI DI)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
 async def _get_mcp_user_id() -> str:
     """Return the user ID for MCP operations.
 
-    In dev mode, uses the auto-provisioned dev user. MCP is a local
-    tool — it always runs in the same environment as the server.
+    In dev mode, uses the auto-provisioned dev user.
+    In production, this should be overridden by auth context.
     """
+    settings = get_settings()
+    if not settings.is_dev:
+        msg = "Authentication required (production mode)"
+        raise ToolError(msg)
+    from wikimind.database import get_dev_user_id  # noqa: PLC0415
+
     return await get_dev_user_id()
 
 
 @contextlib.asynccontextmanager
 async def _get_session():
-    """Yield an async database session for MCP tool handlers."""
+    """Yield an async database session for MCP tool handlers.
+
+    Read-only tools should NOT commit. Write tools commit explicitly.
+    """
     factory = get_session_factory()
     async with factory() as session:
-        try:
-            yield session
-            await session.commit()
-        except Exception:
-            await session.rollback()
-            raise
+        yield session
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -23,6 +23,16 @@ Prompts:
 
 from __future__ import annotations
 
+# When run as `python -m wikimind.mcp.server`, this module is __main__.
+# Side-effect imports at the bottom (tools_analysis, resources, prompts) do
+# `from wikimind.mcp.server import mcp` — without this alias they'd create
+# a second module instance with its own mcp. Must be set before any of
+# those imports execute.
+import sys
+
+if __name__ == "__main__":
+    sys.modules.setdefault("wikimind.mcp.server", sys.modules[__name__])
+
 import argparse
 import contextlib
 import json
@@ -411,12 +421,4 @@ def run_server() -> None:
 
 
 if __name__ == "__main__":
-    # When run as `python -m wikimind.mcp.server`, this module is __main__.
-    # Side-effect imports (tools_analysis, resources, prompts) do
-    # `from wikimind.mcp.server import mcp` which would create a SECOND
-    # module instance with its own `mcp`. Register __main__ under the
-    # package name so all modules share the same `mcp` instance.
-    import sys
-
-    sys.modules.setdefault("wikimind.mcp.server", sys.modules[__name__])
     run_server()

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -98,7 +98,7 @@ async def _get_mcp_user_id() -> str:
     if not settings.is_dev:
         msg = "Authentication required (production mode)"
         raise ToolError(msg)
-    from wikimind.database import get_dev_user_id  # noqa: PLC0415
+    from wikimind.database import get_dev_user_id
 
     return await get_dev_user_id()
 
@@ -275,7 +275,7 @@ async def wiki_ask(
 )
 async def _tool_wiki_overview(ctx: Context) -> dict[str, Any]:
     """Delegate to discovery module."""
-    from wikimind.mcp.tools_discovery import wiki_overview  # noqa: PLC0415
+    from wikimind.mcp.tools_discovery import wiki_overview
 
     return await wiki_overview(ctx)
 
@@ -296,7 +296,7 @@ async def _tool_wiki_list_articles(
     offset: int = Field(0, description="Pagination offset (>= 0)"),
 ) -> dict[str, Any]:
     """Delegate to discovery module."""
-    from wikimind.mcp.tools_discovery import wiki_list_articles  # noqa: PLC0415
+    from wikimind.mcp.tools_discovery import wiki_list_articles
 
     return await wiki_list_articles(ctx, concept=concept, page_type=page_type, limit=limit, offset=offset)
 
@@ -313,7 +313,7 @@ async def _tool_wiki_list_concepts(
     include_empty: bool = Field(False, description="Include concepts with zero articles"),
 ) -> dict[str, Any]:
     """Delegate to discovery module."""
-    from wikimind.mcp.tools_discovery import wiki_list_concepts  # noqa: PLC0415
+    from wikimind.mcp.tools_discovery import wiki_list_concepts
 
     return await wiki_list_concepts(ctx, include_empty=include_empty)
 
@@ -337,7 +337,7 @@ async def _tool_wiki_ingest_url(
     title: str = Field("", description="Optional title override (max 200 chars)"),
 ) -> dict[str, Any]:
     """Ingest a URL into the wiki."""
-    from wikimind.mcp.tools_write import wiki_ingest_url  # noqa: PLC0415
+    from wikimind.mcp.tools_write import wiki_ingest_url
 
     user_id = await _get_mcp_user_id()
     return await wiki_ingest_url(url=url, title=title, user_id=user_id)
@@ -356,7 +356,7 @@ async def _tool_wiki_ingest_text(
     title: str = Field(..., description="Title for the source (1-200 chars, required)"),
 ) -> dict[str, Any]:
     """Ingest raw text into the wiki."""
-    from wikimind.mcp.tools_write import wiki_ingest_text  # noqa: PLC0415
+    from wikimind.mcp.tools_write import wiki_ingest_text
 
     user_id = await _get_mcp_user_id()
     return await wiki_ingest_text(text=text, title=title, user_id=user_id)
@@ -373,7 +373,7 @@ async def _tool_wiki_get_source_status(
     source_id: str = Field(..., description="Source ID to check"),
 ) -> dict[str, Any]:
     """Check ingestion progress."""
-    from wikimind.mcp.tools_write import wiki_get_source_status  # noqa: PLC0415
+    from wikimind.mcp.tools_write import wiki_get_source_status
 
     user_id = await _get_mcp_user_id()
     return await wiki_get_source_status(source_id=source_id, user_id=user_id)
@@ -383,12 +383,14 @@ async def _tool_wiki_get_source_status(
 # Tier 4 — Analysis tools, resources, prompts (self-registering modules)
 # ---------------------------------------------------------------------------
 
-# These modules import `mcp` from this file and register their own tools,
-# resources, and prompts via decorators. We import them here to trigger
-# registration at module load time.
-import wikimind.mcp.prompts as _prompts_module  # noqa: E402, F401 — side-effect registration
-import wikimind.mcp.resources as _resources_module  # noqa: E402, F401 — side-effect registration
-import wikimind.mcp.tools_analysis as _analysis_module  # noqa: E402, F401 — side-effect registration
+def _register_modules() -> None:
+    """Import side-effect modules that register tools, resources, and prompts on `mcp`."""
+    import wikimind.mcp.prompts  # registers 4 prompts
+    import wikimind.mcp.resources  # registers 3 resources
+    import wikimind.mcp.tools_analysis  # registers 4 tier-4 tools
+
+
+_register_modules()
 
 # ---------------------------------------------------------------------------
 # Entry point
@@ -408,7 +410,7 @@ def run_server() -> None:
     args = parser.parse_args()
 
     if args.transport == "http":
-        from wikimind.mcp.auth import WikiMindAuthProvider  # noqa: PLC0415
+        from wikimind.mcp.auth import WikiMindAuthProvider
 
         settings = get_settings()
         if settings.mcp.require_auth:

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -1,10 +1,18 @@
-"""WikiMind MCP server — Phase 1 read-only tools over stdio transport.
+"""WikiMind MCP server — tools, resources, and prompts over stdio transport.
 
 Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
   - wiki_search:       full-text search across wiki articles
   - wiki_get_article:  retrieve a full article by ID or slug
   - wiki_ask:          ask a question against the wiki (Q&A agent)
   - wiki_list_sources: list ingested sources
+
+Resources (browseable URIs):
+  - wikimind://articles/{slug}:  individual article content
+  - wikimind://sources/{id}:     source metadata
+
+Prompts (pre-built templates):
+  - research_topic(topic):       search wiki + synthesize findings
+  - summarize_article(slug):     get article + create summary
 
 The server supports stdio (default) and HTTP transports.
 
@@ -299,6 +307,171 @@ async def wiki_list_sources(
             for s in sources
         ],
         default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resource: wikimind://articles/{slug}
+# ---------------------------------------------------------------------------
+
+
+@mcp.resource(
+    "wikimind://articles/{slug}",
+    name="article",
+    description="Read a wiki article by slug. Returns the full markdown content.",
+    mime_type="text/markdown",
+)
+async def resource_article(slug: str) -> str:
+    """Return article content as a browseable MCP resource."""
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            article = await wiki_service.get_article(
+                id_or_slug=slug,
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    header = f"# {article.title}\n\n"
+    summary = f"**Summary:** {article.summary}\n\n" if article.summary else ""
+    content = article.content or ""
+    return f"{header}{summary}{content}"
+
+
+# ---------------------------------------------------------------------------
+# Resource: wikimind://sources/{id}
+# ---------------------------------------------------------------------------
+
+
+@mcp.resource(
+    "wikimind://sources/{source_id}",
+    name="source",
+    description="Read source metadata by ID. Returns ingestion details as JSON.",
+    mime_type="application/json",
+)
+async def resource_source(source_id: str) -> str:
+    """Return source metadata as a browseable MCP resource."""
+    ingest_service = IngestService()
+    async with _get_session() as session:
+        try:
+            source = await ingest_service.get_source(
+                source_id=source_id,
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    return json.dumps(
+        {
+            "id": source.id,
+            "source_type": source.source_type,
+            "title": source.title,
+            "source_url": source.source_url,
+            "author": source.author,
+            "status": source.status,
+            "ingested_at": source.ingested_at,
+            "compiled_at": source.compiled_at,
+            "token_count": source.token_count,
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: research_topic
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="research_topic",
+    description=(
+        "Research a topic using the WikiMind knowledge base. "
+        "Searches for relevant articles and synthesizes findings "
+        "into a comprehensive overview."
+    ),
+)
+async def prompt_research_topic(topic: str) -> str:
+    """Generate a research prompt that searches the wiki and synthesizes findings."""
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        results = await wiki_service.search(
+            q=topic,
+            session=session,
+            user_id=await _get_mcp_user_id(),
+            limit=5,
+        )
+
+    if not results:
+        return (
+            f"I want to research the topic: {topic}\n\n"
+            "No existing articles were found in the WikiMind knowledge base. "
+            "Please provide a general overview of this topic and suggest "
+            "sources that could be ingested to build knowledge on it."
+        )
+
+    articles_section = "\n".join(f"- **{r.title}** (slug: {r.slug}): {r.summary or 'No summary'}" for r in results)
+    return (
+        f"I want to research the topic: {topic}\n\n"
+        f"The following relevant articles exist in my WikiMind knowledge base:\n"
+        f"{articles_section}\n\n"
+        f"Please synthesize the key findings from these articles into a "
+        f"comprehensive overview of '{topic}'. Highlight connections between "
+        f"articles, identify gaps in coverage, and suggest follow-up questions."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: summarize_article
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="summarize_article",
+    description=(
+        "Summarize a specific wiki article. Retrieves the article "
+        "by slug and creates a structured summary with key points."
+    ),
+)
+async def prompt_summarize_article(slug: str) -> str:
+    """Generate a summary prompt for a specific wiki article."""
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            article = await wiki_service.get_article(
+                id_or_slug=slug,
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception:
+            return (
+                f"Article with slug '{slug}' was not found in the knowledge base. "
+                "Please use wiki_search to find available articles first."
+            )
+
+    content = article.content or "No content available."
+    sources_info = ""
+    if article.sources:
+        sources_list = "\n".join(
+            f"- {s.title or s.source_url or 'Unknown source'} ({s.source_type})" for s in article.sources
+        )
+        sources_info = f"\n\nSources used:\n{sources_list}"
+
+    return (
+        f"Please summarize the following wiki article.\n\n"
+        f"**Title:** {article.title}\n"
+        f"**Confidence:** {article.confidence}\n"
+        f"**Type:** {article.page_type}\n"
+        f"{sources_info}\n\n"
+        f"---\n\n"
+        f"{content}\n\n"
+        f"---\n\n"
+        f"Provide a structured summary with:\n"
+        f"1. Key points (3-5 bullet points)\n"
+        f"2. Main conclusions or takeaways\n"
+        f"3. Any caveats or limitations noted in the article"
     )
 
 

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -2,6 +2,23 @@
 
 Exposes the WikiMind knowledge base to MCP clients (Claude Desktop,
 AI agents). Supports stdio (local, no auth) and HTTP (JWT auth) transports.
+
+Tools by tier:
+  - Discovery (Tier 1): wiki_overview, wiki_list_articles, wiki_list_concepts
+  - Read/Search (Tier 2): wiki_search, wiki_get_article, wiki_ask
+  - Write (Tier 3): wiki_ingest_url, wiki_ingest_text, wiki_get_source_status
+  - Analysis (Tier 4): wiki_synthesize, wiki_get_health, wiki_list_sources, wiki_get_graph
+
+Resources:
+  - wikimind://index — article table of contents
+  - wikimind://articles/{slug} — full article markdown
+  - wikimind://sources/{source_id} — source metadata JSON
+
+Prompts:
+  - wiki_onboarding — orient with the knowledge base
+  - research_topic — search + read + synthesize workflow
+  - compare_articles — fetch and compare two articles
+  - knowledge_gaps — identify gaps in coverage
 """
 
 from __future__ import annotations
@@ -12,15 +29,13 @@ import json
 from typing import TYPE_CHECKING, Any
 
 import structlog
-from fastmcp import Context, FastMCP  # noqa: F401 — Context used by tool handlers in later tasks
+from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from wikimind.config import get_settings
 from wikimind.database import get_session_factory, init_db
-from wikimind.mcp.auth import WikiMindJWTAuthProvider  # noqa: F401 — used in run_server (Task 9)
 from wikimind.models import QueryRequest
-from wikimind.services.ingest import IngestService
 from wikimind.services.query import QueryService
 from wikimind.services.wiki import WikiService
 
@@ -41,7 +56,7 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     settings = get_settings()
     settings.ensure_dirs()
     await init_db()
-    log.info("WikiMind MCP server started", tool_count=len(server._tool_manager._tools))
+    log.info("WikiMind MCP server started", tool_count=len(server._tool_manager._tools))  # type: ignore[attr-defined]
     yield {}
 
 
@@ -90,7 +105,7 @@ async def _get_session():
 
 
 # ---------------------------------------------------------------------------
-# Tool: wiki_search
+# Tier 2 — Read/Search tools
 # ---------------------------------------------------------------------------
 
 
@@ -101,6 +116,7 @@ async def _get_session():
         "summaries, and IDs ranked by relevance. Use this to find "
         "articles on a topic before reading the full content."
     ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
 )
 async def wiki_search(
     query: str = Field(..., description="Search query string (minimum 2 characters)"),
@@ -136,11 +152,6 @@ async def wiki_search(
     )
 
 
-# ---------------------------------------------------------------------------
-# Tool: wiki_get_article
-# ---------------------------------------------------------------------------
-
-
 @mcp.tool(
     name="wiki_get_article",
     description=(
@@ -148,6 +159,7 @@ async def wiki_search(
         "Returns the article title, markdown content, sources, and metadata. "
         "Use wiki_search first to find the article ID."
     ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
 )
 async def wiki_get_article(
     id_or_slug: str = Field(..., description="Article UUID or URL slug"),
@@ -189,11 +201,6 @@ async def wiki_get_article(
     )
 
 
-# ---------------------------------------------------------------------------
-# Tool: wiki_ask
-# ---------------------------------------------------------------------------
-
-
 @mcp.tool(
     name="wiki_ask",
     description=(
@@ -202,6 +209,7 @@ async def wiki_get_article(
         "an answer with citations. Use this for complex questions "
         "that span multiple articles."
     ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": True},
 )
 async def wiki_ask(
     question: str = Field(..., description="The question to ask against the wiki knowledge base"),
@@ -242,213 +250,135 @@ async def wiki_ask(
 
 
 # ---------------------------------------------------------------------------
-# Tool: wiki_list_sources
+# Tier 1 — Discovery tools (registered from tools_discovery module)
 # ---------------------------------------------------------------------------
 
 
 @mcp.tool(
-    name="wiki_list_sources",
+    name="wiki_overview",
     description=(
-        "List ingested sources in the WikiMind knowledge base. "
-        "Shows what content has been fed into the wiki (URLs, PDFs, "
-        "text, YouTube). Optionally filter by status."
+        "Get a high-level overview of the knowledge base. Returns article counts, "
+        "concept taxonomy, recent articles, and page type breakdown. "
+        "Call this first to understand what's in the wiki."
     ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
 )
-async def wiki_list_sources(
-    status: str | None = Field(None, description="Optional status filter (e.g. 'compiled', 'pending')"),
-    limit: int = Field(20, description="Maximum number of results (default 20, max 100)"),
-) -> str:
-    """List ingested sources with optional status filtering."""
-    limit = min(max(1, limit), 100)
-    ingest_service = IngestService()
+async def _tool_wiki_overview(ctx: Context) -> dict[str, Any]:
+    """Delegate to discovery module."""
+    from wikimind.mcp.tools_discovery import wiki_overview  # noqa: PLC0415
 
-    async with _get_session() as session:
-        sources = await ingest_service.list_sources(
-            session=session,
-            user_id=await _get_mcp_user_id(),
-            status=status,
-            limit=limit,
-        )
-
-    return json.dumps(
-        [
-            {
-                "id": s.id,
-                "source_type": s.source_type,
-                "title": s.title,
-                "source_url": s.source_url,
-                "ingested_at": s.ingested_at,
-                "compiled_at": s.compiled_at,
-            }
-            for s in sources
-        ],
-        default=str,
-    )
+    return await wiki_overview(ctx)
 
 
-# ---------------------------------------------------------------------------
-# Resource: wikimind://articles/{slug}
-# ---------------------------------------------------------------------------
-
-
-@mcp.resource(
-    "wikimind://articles/{slug}",
-    name="article",
-    description="Read a wiki article by slug. Returns the full markdown content.",
-    mime_type="text/markdown",
-)
-async def resource_article(slug: str) -> str:
-    """Return article content as a browseable MCP resource."""
-    wiki_service = WikiService()
-    async with _get_session() as session:
-        try:
-            article = await wiki_service.get_article(
-                id_or_slug=slug,
-                session=session,
-                user_id=await _get_mcp_user_id(),
-            )
-        except Exception as exc:
-            return f"Error: {exc}"
-
-    header = f"# {article.title}\n\n"
-    summary = f"**Summary:** {article.summary}\n\n" if article.summary else ""
-    content = article.content or ""
-    return f"{header}{summary}{content}"
-
-
-# ---------------------------------------------------------------------------
-# Resource: wikimind://sources/{id}
-# ---------------------------------------------------------------------------
-
-
-@mcp.resource(
-    "wikimind://sources/{source_id}",
-    name="source",
-    description="Read source metadata by ID. Returns ingestion details as JSON.",
-    mime_type="application/json",
-)
-async def resource_source(source_id: str) -> str:
-    """Return source metadata as a browseable MCP resource."""
-    ingest_service = IngestService()
-    async with _get_session() as session:
-        try:
-            source = await ingest_service.get_source(
-                source_id=source_id,
-                session=session,
-                user_id=await _get_mcp_user_id(),
-            )
-        except Exception as exc:
-            return json.dumps({"error": str(exc)})
-
-    return json.dumps(
-        {
-            "id": source.id,
-            "source_type": source.source_type,
-            "title": source.title,
-            "source_url": source.source_url,
-            "author": source.author,
-            "status": source.status,
-            "ingested_at": source.ingested_at,
-            "compiled_at": source.compiled_at,
-            "token_count": source.token_count,
-        },
-        default=str,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Prompt: research_topic
-# ---------------------------------------------------------------------------
-
-
-@mcp.prompt(
-    name="research_topic",
+@mcp.tool(
+    name="wiki_list_articles",
     description=(
-        "Research a topic using the WikiMind knowledge base. "
-        "Searches for relevant articles and synthesizes findings "
-        "into a comprehensive overview."
+        "List wiki articles with optional filtering by concept or page type. "
+        "Supports pagination. Use to browse the knowledge base contents."
     ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
 )
-async def prompt_research_topic(topic: str) -> str:
-    """Generate a research prompt that searches the wiki and synthesizes findings."""
-    wiki_service = WikiService()
-    async with _get_session() as session:
-        results = await wiki_service.search(
-            q=topic,
-            session=session,
-            user_id=await _get_mcp_user_id(),
-            limit=5,
-        )
+async def _tool_wiki_list_articles(
+    ctx: Context,
+    concept: str | None = Field(None, description="Optional concept name to filter by"),
+    page_type: str | None = Field(None, description="Optional page type: source, concept, synthesis, or answer"),
+    limit: int = Field(20, description="Maximum results (default 20, max 100)"),
+    offset: int = Field(0, description="Pagination offset (>= 0)"),
+) -> dict[str, Any]:
+    """Delegate to discovery module."""
+    from wikimind.mcp.tools_discovery import wiki_list_articles  # noqa: PLC0415
 
-    if not results:
-        return (
-            f"I want to research the topic: {topic}\n\n"
-            "No existing articles were found in the WikiMind knowledge base. "
-            "Please provide a general overview of this topic and suggest "
-            "sources that could be ingested to build knowledge on it."
-        )
-
-    articles_section = "\n".join(f"- **{r.title}** (slug: {r.slug}): {r.summary or 'No summary'}" for r in results)
-    return (
-        f"I want to research the topic: {topic}\n\n"
-        f"The following relevant articles exist in my WikiMind knowledge base:\n"
-        f"{articles_section}\n\n"
-        f"Please synthesize the key findings from these articles into a "
-        f"comprehensive overview of '{topic}'. Highlight connections between "
-        f"articles, identify gaps in coverage, and suggest follow-up questions."
-    )
+    return await wiki_list_articles(ctx, concept=concept, page_type=page_type, limit=limit, offset=offset)
 
 
-# ---------------------------------------------------------------------------
-# Prompt: summarize_article
-# ---------------------------------------------------------------------------
-
-
-@mcp.prompt(
-    name="summarize_article",
+@mcp.tool(
+    name="wiki_list_concepts",
     description=(
-        "Summarize a specific wiki article. Retrieves the article "
-        "by slug and creates a structured summary with key points."
+        "List concept taxonomy with article counts. Shows how the knowledge base is organized into topic areas."
     ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
 )
-async def prompt_summarize_article(slug: str) -> str:
-    """Generate a summary prompt for a specific wiki article."""
-    wiki_service = WikiService()
-    async with _get_session() as session:
-        try:
-            article = await wiki_service.get_article(
-                id_or_slug=slug,
-                session=session,
-                user_id=await _get_mcp_user_id(),
-            )
-        except Exception:
-            return (
-                f"Article with slug '{slug}' was not found in the knowledge base. "
-                "Please use wiki_search to find available articles first."
-            )
+async def _tool_wiki_list_concepts(
+    ctx: Context,
+    include_empty: bool = Field(False, description="Include concepts with zero articles"),
+) -> dict[str, Any]:
+    """Delegate to discovery module."""
+    from wikimind.mcp.tools_discovery import wiki_list_concepts  # noqa: PLC0415
 
-    content = article.content or "No content available."
-    sources_info = ""
-    if article.sources:
-        sources_list = "\n".join(
-            f"- {s.title or s.source_url or 'Unknown source'} ({s.source_type})" for s in article.sources
-        )
-        sources_info = f"\n\nSources used:\n{sources_list}"
+    return await wiki_list_concepts(ctx, include_empty=include_empty)
 
-    return (
-        f"Please summarize the following wiki article.\n\n"
-        f"**Title:** {article.title}\n"
-        f"**Confidence:** {article.confidence}\n"
-        f"**Type:** {article.page_type}\n"
-        f"{sources_info}\n\n"
-        f"---\n\n"
-        f"{content}\n\n"
-        f"---\n\n"
-        f"Provide a structured summary with:\n"
-        f"1. Key points (3-5 bullet points)\n"
-        f"2. Main conclusions or takeaways\n"
-        f"3. Any caveats or limitations noted in the article"
-    )
+
+# ---------------------------------------------------------------------------
+# Tier 3 — Write tools (registered from tools_write module)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_ingest_url",
+    description=(
+        "Ingest a web page or PDF into the wiki. Returns immediately with a "
+        "source_id. Use wiki_get_source_status to check progress. "
+        "Only http:// and https:// URLs are allowed."
+    ),
+    annotations={"readOnlyHint": False, "idempotentHint": False, "openWorldHint": True},
+)
+async def _tool_wiki_ingest_url(
+    url: str = Field(..., description="URL to ingest (http/https only)"),
+    title: str = Field("", description="Optional title override (max 200 chars)"),
+) -> dict[str, Any]:
+    """Ingest a URL into the wiki."""
+    from wikimind.mcp.tools_write import wiki_ingest_url  # noqa: PLC0415
+
+    user_id = await _get_mcp_user_id()
+    return await wiki_ingest_url(url=url, title=title, user_id=user_id)
+
+
+@mcp.tool(
+    name="wiki_ingest_text",
+    description=(
+        "Ingest raw text content into the wiki. Returns immediately with a "
+        "source_id. Use wiki_get_source_status to check progress."
+    ),
+    annotations={"readOnlyHint": False, "idempotentHint": False, "openWorldHint": True},
+)
+async def _tool_wiki_ingest_text(
+    text: str = Field(..., description="Text content to ingest (1-100000 chars)"),
+    title: str = Field(..., description="Title for the source (1-200 chars, required)"),
+) -> dict[str, Any]:
+    """Ingest raw text into the wiki."""
+    from wikimind.mcp.tools_write import wiki_ingest_text  # noqa: PLC0415
+
+    user_id = await _get_mcp_user_id()
+    return await wiki_ingest_text(text=text, title=title, user_id=user_id)
+
+
+@mcp.tool(
+    name="wiki_get_source_status",
+    description=(
+        "Check the ingestion status of a source. Use the source_id returned by wiki_ingest_url or wiki_ingest_text."
+    ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+async def _tool_wiki_get_source_status(
+    source_id: str = Field(..., description="Source ID to check"),
+) -> dict[str, Any]:
+    """Check ingestion progress."""
+    from wikimind.mcp.tools_write import wiki_get_source_status  # noqa: PLC0415
+
+    user_id = await _get_mcp_user_id()
+    return await wiki_get_source_status(source_id=source_id, user_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# Tier 4 — Analysis tools, resources, prompts (self-registering modules)
+# ---------------------------------------------------------------------------
+
+# These modules import `mcp` from this file and register their own tools,
+# resources, and prompts via decorators. We import them here to trigger
+# registration at module load time.
+import wikimind.mcp.prompts as _prompts_module  # noqa: E402, F401, I001
+import wikimind.mcp.resources as _resources_module  # noqa: E402, F401
+import wikimind.mcp.tools_analysis as _analysis_module  # noqa: E402, F401
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +390,7 @@ def run_server() -> None:
     """Run the WikiMind MCP server.
 
     Supports stdio (default) and HTTP transports via --transport flag.
+    HTTP transport enables JWT authentication.
     """
     parser = argparse.ArgumentParser(description="WikiMind MCP Server")
     parser.add_argument("--transport", choices=["stdio", "http"], default="stdio")
@@ -468,7 +399,14 @@ def run_server() -> None:
     args = parser.parse_args()
 
     if args.transport == "http":
-        mcp.run(transport="http", host=args.host, port=args.port)
+        from wikimind.mcp.auth import WikiMindJWTAuthProvider  # noqa: PLC0415
+
+        settings = get_settings()
+        if settings.mcp.require_auth:
+            auth_provider = WikiMindJWTAuthProvider(secret=settings.auth.jwt_secret_key)
+            mcp.run(transport="http", host=args.host, port=args.port, auth=auth_provider)
+        else:
+            mcp.run(transport="http", host=args.host, port=args.port)
     else:
         mcp.run(transport="stdio")
 

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -61,7 +61,7 @@ _VALID_SYNTHESIS_TYPES = {"comparative", "chronological", "thematic", "gap_analy
 
 
 @contextlib.asynccontextmanager
-async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
+async def _lifespan(_server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     """Initialize database on MCP server startup."""
     settings = get_settings()
     settings.ensure_dirs()

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -91,9 +91,20 @@ mcp = FastMCP(
 async def _get_mcp_user_id() -> str:
     """Return the user ID for MCP operations.
 
-    In dev mode, uses the auto-provisioned dev user.
-    In production, this should be overridden by auth context.
+    Checks FastMCP's auth context first (set by WikiMindAuthProvider for HTTP
+    transport). Falls back to the auto-provisioned dev user in dev mode.
     """
+    # Try to get user from FastMCP auth context (HTTP transport)
+    try:
+        from fastmcp.server.dependencies import get_access_token
+
+        token = get_access_token()
+        if token and token.client_id:
+            return token.client_id
+    except Exception:
+        log.debug("No FastMCP auth context available, falling back")
+
+    # Fall back to dev user in dev mode
     settings = get_settings()
     if not settings.is_dev:
         msg = "Authentication required (production mode)"

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -408,11 +408,11 @@ def run_server() -> None:
     args = parser.parse_args()
 
     if args.transport == "http":
-        from wikimind.mcp.auth import WikiMindJWTAuthProvider  # noqa: PLC0415
+        from wikimind.mcp.auth import WikiMindAuthProvider  # noqa: PLC0415
 
         settings = get_settings()
         if settings.mcp.require_auth:
-            auth_provider = WikiMindJWTAuthProvider(secret=settings.auth.jwt_secret_key)
+            auth_provider = WikiMindAuthProvider(secret=settings.auth.jwt_secret_key)
             mcp.run(transport="http", host=args.host, port=args.port, auth=auth_provider)
         else:
             mcp.run(transport="http", host=args.host, port=args.port)

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -380,7 +380,6 @@ import wikimind.mcp.prompts as _prompts_module  # noqa: E402, F401 — side-effe
 import wikimind.mcp.resources as _resources_module  # noqa: E402, F401 — side-effect registration
 import wikimind.mcp.tools_analysis as _analysis_module  # noqa: E402, F401 — side-effect registration
 
-
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -411,4 +411,12 @@ def run_server() -> None:
 
 
 if __name__ == "__main__":
+    # When run as `python -m wikimind.mcp.server`, this module is __main__.
+    # Side-effect imports (tools_analysis, resources, prompts) do
+    # `from wikimind.mcp.server import mcp` which would create a SECOND
+    # module instance with its own `mcp`. Register __main__ under the
+    # package name so all modules share the same `mcp` instance.
+    import sys
+
+    sys.modules.setdefault("wikimind.mcp.server", sys.modules[__name__])
     run_server()

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -56,7 +56,7 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     settings = get_settings()
     settings.ensure_dirs()
     await init_db()
-    log.info("WikiMind MCP server started", tool_count=len(server._tool_manager._tools))  # type: ignore[attr-defined]
+    log.info("WikiMind MCP server started")
     yield {}
 
 

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -383,6 +383,7 @@ async def _tool_wiki_get_source_status(
 # Tier 4 — Analysis tools, resources, prompts (self-registering modules)
 # ---------------------------------------------------------------------------
 
+
 def _register_modules() -> None:
     """Import side-effect modules that register tools, resources, and prompts on `mcp`."""
     import wikimind.mcp.prompts  # registers 4 prompts

--- a/src/wikimind/mcp/tools_analysis.py
+++ b/src/wikimind/mcp/tools_analysis.py
@@ -1,0 +1,284 @@
+"""Analysis tools (Tier 4) for the WikiMind MCP server.
+
+Tools: wiki_synthesize, wiki_get_health, wiki_list_sources, wiki_get_graph.
+These are registered on the FastMCP instance in server.py via decorators.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastmcp import Context  # noqa: TC002 — required at runtime for FastMCP function parsing
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+from sqlalchemy import func
+from sqlmodel import select
+
+from wikimind.mcp.server import (
+    _VALID_INGEST_STATUSES,
+    _VALID_SYNTHESIS_TYPES,
+    _get_mcp_user_id,
+    _get_session,
+    mcp,
+)
+from wikimind.models import Contradiction, ContradictionStatus
+
+log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_synthesize
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_synthesize",
+    description=(
+        "Synthesize a cross-cutting analysis from 2-10 wiki articles. "
+        "Produces a new synthesis page combining insights from the selected articles. "
+        "Always runs synchronously with progress reporting."
+    ),
+    annotations={"readOnlyHint": False, "idempotentHint": False, "openWorldHint": True},
+)
+async def wiki_synthesize(
+    ctx: Context,
+    article_ids: list[str] = Field(..., description="List of 2-10 article IDs to synthesize (no duplicates)"),
+    synthesis_type: str = Field("thematic", description="Type: comparative, chronological, thematic, or gap_analysis"),
+    guidance: str = Field("", description="Optional guidance for the synthesis (max 1000 chars)"),
+) -> dict:
+    """Create a synthesis page from multiple articles."""
+    # Validate article_ids count
+    if len(article_ids) < 2:
+        msg = "At least 2 article_ids are required for synthesis"
+        raise ToolError(msg)
+    if len(article_ids) > 10:
+        msg = "Maximum 10 article_ids allowed for synthesis"
+        raise ToolError(msg)
+
+    # Check for duplicates
+    if len(set(article_ids)) != len(article_ids):
+        msg = "article_ids must not contain duplicates"
+        raise ToolError(msg)
+
+    # Validate synthesis_type
+    if synthesis_type not in _VALID_SYNTHESIS_TYPES:
+        msg = f"Invalid synthesis_type '{synthesis_type}'. Must be one of: {', '.join(sorted(_VALID_SYNTHESIS_TYPES))}"
+        raise ToolError(msg)
+
+    # Validate guidance length
+    if guidance and len(guidance) > 1000:
+        msg = "guidance must be 1000 characters or fewer"
+        raise ToolError(msg)
+
+    try:
+        user_id = await _get_mcp_user_id()
+
+        # Build a query from synthesis_type and guidance
+        query = f"{synthesis_type} synthesis"
+        if guidance:
+            query = f"{guidance} ({synthesis_type})"
+
+        async with _get_session() as session:
+            from wikimind.engine.synthesis_compiler import SynthesisCompiler  # noqa: PLC0415
+
+            # Report progress: fetching articles
+            await ctx.report_progress(1, len(article_ids) + 1)
+
+            compiler = SynthesisCompiler(user_id=user_id)
+            result = await compiler.synthesize(
+                query=query,
+                session=session,
+                article_ids=article_ids,
+            )
+
+            # Report progress: LLM synthesis complete
+            await ctx.report_progress(len(article_ids) + 1, len(article_ids) + 1)
+
+            if result is None:
+                msg = "Synthesis failed — could not produce a result. Verify the article IDs exist and contain content."
+                raise ToolError(msg)
+
+            article, compilation = result
+            await ctx.log(f"Synthesis complete: {article.title}", level="info")
+
+            return {
+                "title": article.title,
+                "content": compilation.article_body,
+                "themes": compilation.themes if hasattr(compilation, "themes") else [],
+            }
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_synthesize failed", error=str(exc))
+        msg = f"Synthesis failed: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_get_health
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_get_health",
+    description=(
+        "Get health metrics for the knowledge base: article counts, orphans, "
+        "contradictions, stuck sources, and compilation success rate."
+    ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+async def wiki_get_health(ctx: Context) -> dict:
+    """Return knowledge base health metrics."""
+    try:
+        await _get_mcp_user_id()
+        async with _get_session() as session:
+            from wikimind.services.admin import AdminService  # noqa: PLC0415
+
+            admin_svc = AdminService()
+            stats = await admin_svc.get_stats(session)
+
+            # Count active contradictions
+            contradiction_stmt = (
+                select(func.count())
+                .select_from(Contradiction)
+                .where(Contradiction.status == ContradictionStatus.ACTIVE)
+            )
+            contradiction_result = await session.execute(contradiction_stmt)
+            contradiction_count = contradiction_result.scalar() or 0
+
+            await ctx.log(
+                f"Health: {stats.article_count} articles, "
+                f"{stats.orphan_count} orphans, "
+                f"{contradiction_count} contradictions",
+                level="info",
+            )
+
+            return {
+                "article_count": stats.article_count,
+                "source_count": stats.source_count,
+                "orphan_count": stats.orphan_count,
+                "contradiction_count": contradiction_count,
+                "stuck_source_count": stats.stuck_sources,
+                "compilation_success_rate": stats.compilation_success_rate,
+            }
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_get_health failed", error=str(exc))
+        msg = f"Failed to get health metrics: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_list_sources (rewrite)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_list_sources",
+    description=(
+        "List ingested sources in the WikiMind knowledge base. "
+        "Shows what content has been fed into the wiki (URLs, PDFs, "
+        "text, YouTube). Optionally filter by status."
+    ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+async def wiki_list_sources(
+    status: str | None = Field(None, description="Optional status filter: pending, processing, compiled, or failed"),
+    limit: int = Field(20, description="Maximum number of results (default 20, max 100)"),
+) -> list[dict]:
+    """List ingested sources with optional status filtering."""
+    # Validate status enum
+    if status is not None and status not in _VALID_INGEST_STATUSES:
+        msg = f"Invalid status '{status}'. Must be one of: {', '.join(sorted(_VALID_INGEST_STATUSES))}"
+        raise ToolError(msg)
+
+    limit = min(max(1, limit), 100)
+
+    try:
+        user_id = await _get_mcp_user_id()
+        async with _get_session() as session:
+            from wikimind.services.ingest import IngestService  # noqa: PLC0415
+
+            ingest_service = IngestService()
+            sources = await ingest_service.list_sources(
+                session=session,
+                user_id=user_id,
+                status=status,
+                limit=limit,
+            )
+
+            return [
+                {
+                    "id": s.id,
+                    "title": s.title,
+                    "source_type": s.source_type,
+                    "status": s.status,
+                    "ingested_at": str(s.ingested_at) if s.ingested_at else None,
+                }
+                for s in sources
+            ]
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_list_sources failed", error=str(exc))
+        msg = f"Failed to list sources: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_get_graph
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_get_graph",
+    description=(
+        "Get the knowledge graph showing relationships between articles. "
+        "Returns nodes (articles) and edges (relationships). "
+        "Optionally filter to edges involving a specific article."
+    ),
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+async def wiki_get_graph(
+    article_slug: str | None = Field(None, description="Optional article slug to filter graph edges"),
+) -> dict:
+    """Return the knowledge graph (nodes and edges)."""
+    try:
+        user_id = await _get_mcp_user_id()
+        async with _get_session() as session:
+            from wikimind.services.wiki import WikiService  # noqa: PLC0415
+
+            wiki_svc = WikiService()
+            graph = await wiki_svc.get_graph(
+                session=session,
+                user_id=user_id,
+                from_article=article_slug,
+            )
+
+            return {
+                "nodes": [
+                    {
+                        "id": n.id,
+                        "title": n.label,
+                        "type": n.concept_cluster,
+                        "confidence": n.confidence,
+                    }
+                    for n in graph.nodes
+                ],
+                "edges": [
+                    {
+                        "source": e.source,
+                        "target": e.target,
+                        "relation": e.relation_type.value
+                        if hasattr(e.relation_type, "value")
+                        else str(e.relation_type),
+                    }
+                    for e in graph.edges
+                ],
+            }
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_get_graph failed", error=str(exc))
+        msg = f"Failed to get graph: {exc}"
+        raise ToolError(msg) from exc

--- a/src/wikimind/mcp/tools_discovery.py
+++ b/src/wikimind/mcp/tools_discovery.py
@@ -1,0 +1,248 @@
+"""Discovery tools (Tier 1) for WikiMind MCP server.
+
+Provides high-level browsing of the knowledge base:
+  - wiki_overview: article/concept counts + recent articles
+  - wiki_list_articles: paginated article listing with filters
+  - wiki_list_concepts: concept taxonomy with article counts
+
+Each function is a standalone async callable. The integration task will
+wire these into the FastMCP server via @mcp.tool() decorators.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from fastmcp.exceptions import ToolError
+
+from wikimind.database import get_session_factory
+
+if TYPE_CHECKING:
+    from fastmcp import Context
+
+log = structlog.get_logger()
+
+# Valid enum values for input validation
+_VALID_PAGE_TYPES = {"source", "concept", "synthesis", "answer"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_mcp_user_id() -> str:
+    """Return the user ID for MCP operations.
+
+    In dev mode, uses the auto-provisioned dev user.
+    In production, this should be overridden by auth context.
+    """
+    from wikimind.config import get_settings  # noqa: PLC0415
+
+    settings = get_settings()
+    if not settings.is_dev:
+        msg = "Authentication required (production mode)"
+        raise ToolError(msg)
+    from wikimind.database import get_dev_user_id  # noqa: PLC0415
+
+    return await get_dev_user_id()
+
+
+@contextlib.asynccontextmanager
+async def _get_session():
+    """Yield an async database session for MCP tool handlers.
+
+    Read-only tools should NOT commit. Write tools commit explicitly.
+    """
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_overview
+# ---------------------------------------------------------------------------
+
+
+async def wiki_overview(ctx: Context) -> dict[str, Any]:
+    """Get a high-level overview of the knowledge base.
+
+    Returns article counts, concept taxonomy, recent articles, and
+    page type breakdown. Call this first to understand what's in the wiki.
+
+    Annotations: readOnlyHint=True, idempotentHint=True, openWorldHint=False
+    """
+    try:
+        user_id = await _get_mcp_user_id()
+        async with _get_session() as session:
+            from wikimind.services.admin import AdminService  # noqa: PLC0415
+            from wikimind.services.wiki import WikiService  # noqa: PLC0415
+
+            wiki_svc = WikiService()
+            admin_svc = AdminService()
+
+            stats = await admin_svc.get_stats(session)
+            concepts = await wiki_svc.get_concepts(session, user_id, include_empty=False)
+            articles = await wiki_svc.list_articles(session, user_id, limit=5, offset=0)
+
+            await ctx.log(
+                f"Wiki has {stats.article_count} articles across {len(concepts)} concepts",
+                level="info",
+            )
+
+            return {
+                "article_count": stats.article_count,
+                "source_count": stats.source_count,
+                "concept_count": len(concepts),
+                "concepts": [{"name": c.name, "article_count": c.article_count} for c in concepts[:20]],
+                "recent_articles": [
+                    {
+                        "slug": a.slug,
+                        "title": a.title,
+                        "summary": a.summary,
+                        "updated_at": str(a.updated_at),
+                    }
+                    for a in articles[:5]
+                ],
+                "page_type_breakdown": stats.articles_by_page_type,
+            }
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_overview failed", error=str(exc))
+        msg = f"Failed to get wiki overview: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_list_articles
+# ---------------------------------------------------------------------------
+
+
+async def wiki_list_articles(
+    ctx: Context,
+    concept: str | None = None,
+    page_type: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List wiki articles with optional filtering and pagination.
+
+    Args:
+        ctx: MCP context for logging.
+        concept: Optional concept name to filter by.
+        page_type: Optional page type filter (source, concept, synthesis, answer).
+        limit: Maximum results (default 20, max 100).
+        offset: Pagination offset (>= 0).
+
+    Returns:
+        Dict with articles list and pagination metadata.
+
+    Annotations: readOnlyHint=True, idempotentHint=True, openWorldHint=False
+    """
+    try:
+        # Input validation
+        if page_type is not None and page_type not in _VALID_PAGE_TYPES:
+            msg = f"Invalid page_type '{page_type}'. Must be one of: {', '.join(sorted(_VALID_PAGE_TYPES))}"
+            raise ToolError(msg)
+        if offset < 0:
+            msg = "offset must be >= 0"
+            raise ToolError(msg)
+
+        # Clamp limit to 1-100 range
+        clamped = False
+        original_limit = limit
+        limit = max(1, min(limit, 100))
+        if limit != original_limit:
+            clamped = True
+
+        user_id = await _get_mcp_user_id()
+        async with _get_session() as session:
+            from wikimind.services.wiki import WikiService  # noqa: PLC0415
+
+            wiki_svc = WikiService()
+            articles = await wiki_svc.list_articles(
+                session,
+                user_id,
+                concept=concept,
+                page_type=page_type,
+                limit=limit,
+                offset=offset,
+            )
+
+            await ctx.log(f"Listed {len(articles)} articles (offset={offset})", level="info")
+
+            result: dict[str, Any] = {
+                "articles": [
+                    {
+                        "slug": a.slug,
+                        "title": a.title,
+                        "summary": a.summary,
+                        "concepts": a.concepts,
+                        "page_type": a.page_type,
+                        "source_count": a.source_count,
+                        "confidence": a.confidence,
+                        "updated_at": str(a.updated_at),
+                    }
+                    for a in articles
+                ],
+            }
+            if clamped:
+                result["warning"] = f"limit clamped to {limit} (requested {original_limit}, max 100)"
+            return result
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_list_articles failed", error=str(exc))
+        msg = f"Failed to list articles: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_list_concepts
+# ---------------------------------------------------------------------------
+
+
+async def wiki_list_concepts(
+    ctx: Context,
+    include_empty: bool = False,
+) -> dict[str, Any]:
+    """List concept taxonomy with article counts.
+
+    Args:
+        ctx: MCP context for logging.
+        include_empty: If True, include concepts with zero articles (default False).
+
+    Returns:
+        Dict with concepts list.
+
+    Annotations: readOnlyHint=True, idempotentHint=True, openWorldHint=False
+    """
+    try:
+        user_id = await _get_mcp_user_id()
+        async with _get_session() as session:
+            from wikimind.services.wiki import WikiService  # noqa: PLC0415
+
+            wiki_svc = WikiService()
+            concepts = await wiki_svc.get_concepts(session, user_id, include_empty=include_empty)
+
+            await ctx.log(f"Found {len(concepts)} concepts", level="info")
+
+            return {
+                "concepts": [
+                    {
+                        "name": c.name,
+                        "article_count": c.article_count,
+                        "concept_kind": c.concept_kind,
+                    }
+                    for c in concepts
+                ],
+            }
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_list_concepts failed", error=str(exc))
+        msg = f"Failed to list concepts: {exc}"
+        raise ToolError(msg) from exc

--- a/src/wikimind/mcp/tools_discovery.py
+++ b/src/wikimind/mcp/tools_discovery.py
@@ -36,9 +36,20 @@ _VALID_PAGE_TYPES = {"source", "concept", "synthesis", "answer"}
 async def _get_mcp_user_id() -> str:
     """Return the user ID for MCP operations.
 
-    In dev mode, uses the auto-provisioned dev user.
-    In production, this should be overridden by auth context.
+    Checks FastMCP's auth context first (set by WikiMindAuthProvider for HTTP
+    transport). Falls back to the auto-provisioned dev user in dev mode.
     """
+    # Try to get user from FastMCP auth context (HTTP transport)
+    try:
+        from fastmcp.server.dependencies import get_access_token  # noqa: PLC0415
+
+        token = get_access_token()
+        if token and token.client_id:
+            return token.client_id
+    except Exception:
+        log.debug("No FastMCP auth context available, falling back")
+
+    # Fall back to dev user in dev mode
     from wikimind.config import get_settings  # noqa: PLC0415
 
     settings = get_settings()
@@ -77,24 +88,34 @@ async def wiki_overview(ctx: Context) -> dict[str, Any]:
     try:
         user_id = await _get_mcp_user_id()
         async with _get_session() as session:
-            from wikimind.services.admin import AdminService  # noqa: PLC0415
+            from wikimind.services.ingest import IngestService  # noqa: PLC0415
             from wikimind.services.wiki import WikiService  # noqa: PLC0415
 
             wiki_svc = WikiService()
-            admin_svc = AdminService()
+            ingest_svc = IngestService()
 
-            stats = await admin_svc.get_stats(session)
             concepts = await wiki_svc.get_concepts(session, user_id, include_empty=False)
             articles = await wiki_svc.list_articles(session, user_id, limit=5, offset=0)
+            # Use a large limit to count all user sources instead of system-wide stats
+            user_sources = await ingest_svc.list_sources(session, user_id=user_id, limit=10000)
+
+            source_count = len(user_sources)
+
+            # Compute page type breakdown from recent articles (fetch a larger batch)
+            all_articles = await wiki_svc.list_articles(session, user_id, limit=10000, offset=0)
+            page_type_breakdown: dict[str, int] = {}
+            for a in all_articles:
+                pt = a.page_type or "unknown"
+                page_type_breakdown[pt] = page_type_breakdown.get(pt, 0) + 1
 
             await ctx.log(
-                f"Wiki has {stats.article_count} articles across {len(concepts)} concepts",
+                f"Wiki has {len(all_articles)} articles across {len(concepts)} concepts",
                 level="info",
             )
 
             return {
-                "article_count": stats.article_count,
-                "source_count": stats.source_count,
+                "article_count": len(all_articles),
+                "source_count": source_count,
                 "concept_count": len(concepts),
                 "concepts": [{"name": c.name, "article_count": c.article_count} for c in concepts[:20]],
                 "recent_articles": [
@@ -106,7 +127,7 @@ async def wiki_overview(ctx: Context) -> dict[str, Any]:
                     }
                     for a in articles[:5]
                 ],
-                "page_type_breakdown": stats.articles_by_page_type,
+                "page_type_breakdown": page_type_breakdown,
             }
     except ToolError:
         raise

--- a/src/wikimind/mcp/tools_write.py
+++ b/src/wikimind/mcp/tools_write.py
@@ -1,0 +1,270 @@
+"""Write tools (Tier 3) for the WikiMind MCP server.
+
+Standalone async functions that implement wiki_ingest_url, wiki_ingest_text,
+and wiki_get_source_status. These are NOT decorated with @mcp.tool yet —
+they will be registered in server.py in a later task.
+
+Design decisions (from spec):
+- Return source_id only, NOT job_id (job_id has a race condition)
+- wiki_get_source_status polls Source.status field directly
+- URL validation: only http/https (SSRF protection)
+- Title override: update source.title after ingest if provided
+- Dedup: if source already exists, return {status: "already_exists"}
+- Text validation: 1-100000 chars, title 1-200 chars
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from fastmcp.exceptions import ToolError
+from sqlmodel import select
+
+from wikimind.database import get_session_factory
+from wikimind.errors import IngestError, NotFoundError
+from wikimind.models import ArticleSource, IngestStatus
+from wikimind.services.factories import get_ingest_service
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Session helper (mirrors server.py pattern for write operations)
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _get_session() -> AsyncIterator[AsyncSession]:
+    """Yield an async database session for write tool handlers."""
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session
+
+
+# ---------------------------------------------------------------------------
+# wiki_ingest_url
+# ---------------------------------------------------------------------------
+
+
+async def wiki_ingest_url(url: str, title: str, user_id: str) -> dict[str, Any]:
+    """Ingest a web page or PDF into the wiki.
+
+    Returns immediately with a source_id. Use wiki_get_source_status to check
+    progress.
+
+    Args:
+        url: URL to ingest (http/https only).
+        title: Optional title override (max 200 chars). Pass empty string for none.
+        user_id: The authenticated user's ID.
+
+    Returns:
+        Dict with source_id and status. Status is "queued" for new sources,
+        "already_exists" for duplicates (with article_slug if available).
+
+    Raises:
+        ToolError: On invalid input or ingestion failure.
+    """
+    # Validate URL scheme (SSRF protection)
+    if not url.startswith(("http://", "https://")):
+        msg = "Only http:// and https:// URLs are allowed"
+        raise ToolError(msg)
+
+    # Validate title length
+    if title and len(title) > 200:
+        msg = "Title must be 200 characters or fewer"
+        raise ToolError(msg)
+
+    try:
+        ingest_svc = get_ingest_service()
+        async with _get_session() as session:
+            source = await ingest_svc.ingest_url(url, session, user_id=user_id)
+
+            # Detect dedup hit: compiled_at is already set for existing sources
+            if source.compiled_at is not None:
+                result: dict[str, Any] = {
+                    "source_id": source.id,
+                    "status": "already_exists",
+                }
+                # Find linked article slug if available
+                article_slug = await _find_article_slug_for_source(session, source.id)
+                if article_slug:
+                    result["article_slug"] = article_slug
+                return result
+
+            # Apply title override for new sources
+            if title:
+                source.title = title
+
+            await session.commit()
+
+            return {"source_id": source.id, "status": "queued"}
+    except ToolError:
+        raise
+    except IngestError as exc:
+        msg = f"Ingestion failed: {exc.message}"
+        raise ToolError(msg) from exc
+    except Exception as exc:
+        log.error("wiki_ingest_url failed", url=url, error=str(exc))
+        msg = f"Ingestion failed: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# wiki_ingest_text
+# ---------------------------------------------------------------------------
+
+
+async def wiki_ingest_text(text: str, title: str, user_id: str) -> dict[str, Any]:
+    """Ingest raw text content into the wiki.
+
+    Returns immediately with a source_id. Use wiki_get_source_status to check
+    progress.
+
+    Args:
+        text: Text content to ingest (1-100000 chars).
+        title: Title for the source (1-200 chars, required).
+        user_id: The authenticated user's ID.
+
+    Returns:
+        Dict with source_id and status. Status is "queued" for new sources,
+        "already_exists" for duplicates (with article_slug if available).
+
+    Raises:
+        ToolError: On invalid input or ingestion failure.
+    """
+    # Validate text length
+    if not text or len(text) < 1:
+        msg = "Text content must be at least 1 character"
+        raise ToolError(msg)
+    if len(text) > 100000:
+        msg = "Text content must be 100000 characters or fewer"
+        raise ToolError(msg)
+
+    # Validate title
+    if not title or len(title) < 1:
+        msg = "Title is required (1-200 characters)"
+        raise ToolError(msg)
+    if len(title) > 200:
+        msg = "Title must be 200 characters or fewer"
+        raise ToolError(msg)
+
+    try:
+        ingest_svc = get_ingest_service()
+        async with _get_session() as session:
+            source = await ingest_svc.ingest_text(text, title, session, user_id=user_id)
+
+            # Detect dedup hit: compiled_at is already set for existing sources
+            if source.compiled_at is not None:
+                result: dict[str, Any] = {
+                    "source_id": source.id,
+                    "status": "already_exists",
+                }
+                article_slug = await _find_article_slug_for_source(session, source.id)
+                if article_slug:
+                    result["article_slug"] = article_slug
+                return result
+
+            await session.commit()
+
+            return {"source_id": source.id, "status": "queued"}
+    except ToolError:
+        raise
+    except IngestError as exc:
+        msg = f"Ingestion failed: {exc.message}"
+        raise ToolError(msg) from exc
+    except Exception as exc:
+        log.error("wiki_ingest_text failed", error=str(exc))
+        msg = f"Ingestion failed: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# wiki_get_source_status
+# ---------------------------------------------------------------------------
+
+# Map IngestStatus enum values to MCP-facing status strings
+_STATUS_MAP: dict[IngestStatus, str] = {
+    IngestStatus.PENDING: "queued",
+    IngestStatus.PROCESSING: "processing",
+    IngestStatus.COMPILED: "compiled",
+    IngestStatus.FAILED: "failed",
+}
+
+
+async def wiki_get_source_status(source_id: str, user_id: str) -> dict[str, Any]:
+    """Check the ingestion status of a source.
+
+    Use the source_id returned by wiki_ingest_url or wiki_ingest_text.
+
+    Args:
+        source_id: Source ID to check.
+        user_id: The authenticated user's ID.
+
+    Returns:
+        Dict with source_id, status, title, and optionally article_slug or error.
+
+    Raises:
+        ToolError: If source not found or other failure.
+    """
+    try:
+        ingest_svc = get_ingest_service()
+        async with _get_session() as session:
+            source = await ingest_svc.get_source(source_id, session, user_id=user_id)
+
+            status = _STATUS_MAP.get(source.status, source.status.value)
+            result: dict[str, Any] = {
+                "source_id": source.id,
+                "status": status,
+                "title": source.title,
+            }
+
+            # If compiled, include the linked article slug
+            if source.status == IngestStatus.COMPILED:
+                article_slug = await _find_article_slug_for_source(session, source.id)
+                if article_slug:
+                    result["article_slug"] = article_slug
+
+            # If failed, include error message
+            if source.status == IngestStatus.FAILED and source.error_message:
+                result["error"] = source.error_message
+
+            return result
+    except NotFoundError as exc:
+        msg = f"Source not found: {source_id}"
+        raise ToolError(msg) from exc
+    except ToolError:
+        raise
+    except Exception as exc:
+        log.error("wiki_get_source_status failed", source_id=source_id, error=str(exc))
+        msg = f"Failed to check status: {exc}"
+        raise ToolError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _find_article_slug_for_source(session: AsyncSession, source_id: str) -> str | None:
+    """Find the article slug linked to a source via the ArticleSource join table.
+
+    Returns None if no article is linked yet.
+    """
+    from wikimind.models import Article  # noqa: PLC0415
+
+    stmt = (
+        select(Article.slug)
+        .join(ArticleSource, onclause=ArticleSource.article_id == Article.id)  # type: ignore[arg-type]
+        .where(ArticleSource.source_id == source_id)
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    return row

--- a/src/wikimind/mcp/tools_write.py
+++ b/src/wikimind/mcp/tools_write.py
@@ -84,7 +84,13 @@ async def wiki_ingest_url(url: str, title: str, user_id: str) -> dict[str, Any]:
     try:
         ingest_svc = get_ingest_service()
         async with _get_session() as session:
-            source = await ingest_svc.ingest_url(url, session, user_id=user_id)
+            # Disable auto_compile so we can apply title override before compilation
+            source = await ingest_svc.ingest_url(
+                url,
+                session,
+                user_id=user_id,
+                auto_compile=False,
+            )
 
             # Detect dedup hit: compiled_at is already set for existing sources
             if source.compiled_at is not None:
@@ -98,11 +104,14 @@ async def wiki_ingest_url(url: str, title: str, user_id: str) -> dict[str, Any]:
                     result["article_slug"] = article_slug
                 return result
 
-            # Apply title override for new sources
+            # Apply title override BEFORE committing so the compiler sees it
             if title:
                 source.title = title
 
             await session.commit()
+
+            # Schedule compilation after title is persisted
+            await ingest_svc._schedule_compile(source)
 
             return {"source_id": source.id, "status": "queued"}
     except ToolError:

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -484,6 +484,27 @@ class ArticleTag(SQLModel, table=True):
     created_at: datetime = Field(default_factory=utcnow_naive)
 
 
+class MCPAccessToken(SQLModel, table=True):
+    """Personal access token for MCP API authentication.
+
+    Tokens use the ``wmk_`` prefix for easy identification. Only the
+    SHA-256 hash is stored; the plaintext is shown once at creation and
+    never persisted. See ADR-027.
+    """
+
+    __tablename__ = "mcp_access_token"
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
+    name: str = Field(max_length=100)
+    token_hash: str  # SHA-256 hash (never store plaintext)
+    token_prefix: str = Field(max_length=12)  # "wmk_ab12..." for display
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None
+    revoked: bool = False
+
+
 class ShareLink(SQLModel, table=True):
     """A signed, revocable read-only share link for a single article.
 
@@ -2236,3 +2257,40 @@ class WikiExportResponse(BaseModel):
     format: WikiExportFormat
     article_count: int
     filename: str
+
+
+# ---------------------------------------------------------------------------
+# MCP Personal Access Token request/response models (ADR-027)
+# ---------------------------------------------------------------------------
+
+
+class MCPTokenCreateRequest(BaseModel):
+    """Request to generate a new MCP personal access token."""
+
+    name: str = Field(min_length=1, max_length=100)
+
+
+class MCPTokenCreateResponse(BaseModel):
+    """Response after creating an MCP token (plaintext shown ONCE)."""
+
+    id: str
+    token: str  # Plaintext — shown only at creation, never stored
+    name: str
+    created_at: datetime
+
+
+class MCPTokenResponse(BaseModel):
+    """API response for an existing MCP token (never includes plaintext)."""
+
+    id: str
+    name: str
+    token_prefix: str
+    created_at: datetime
+    last_used_at: datetime | None
+    revoked: bool
+
+
+class MCPTokenRevokeResponse(BaseModel):
+    """Response after revoking an MCP token."""
+
+    status: str

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -492,7 +492,7 @@ class MCPAccessToken(SQLModel, table=True):
     never persisted. See ADR-027.
     """
 
-    __tablename__ = "mcp_access_token"
+    __tablename__: str = "mcp_access_token"  # pyright: declared_attr workaround
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     user_id: str = Field(foreign_key="user.id", index=True)

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -492,7 +492,7 @@ class MCPAccessToken(SQLModel, table=True):
     never persisted. See ADR-027.
     """
 
-    __tablename__: str = "mcp_access_token"  # pyright: declared_attr workaround
+    __tablename__ = "mcp_access_token"
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     user_id: str = Field(foreign_key="user.id", index=True)

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -492,7 +492,7 @@ class MCPAccessToken(SQLModel, table=True):
     never persisted. See ADR-027.
     """
 
-    __tablename__ = "mcp_access_token"  # type: ignore[assignment]
+    __tablename__ = "mcp_access_token"
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     user_id: str = Field(foreign_key="user.id", index=True)

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -492,7 +492,7 @@ class MCPAccessToken(SQLModel, table=True):
     never persisted. See ADR-027.
     """
 
-    __tablename__ = "mcp_access_token"
+    __tablename__ = "mcp_access_token"  # type: ignore[assignment]
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     user_id: str = Field(foreign_key="user.id", index=True)

--- a/tests/unit/test_mcp_analysis_resources_prompts.py
+++ b/tests/unit/test_mcp_analysis_resources_prompts.py
@@ -1,0 +1,563 @@
+"""Tests for MCP analysis tools, resources, and prompts.
+
+Tests Tasks 6, 7, and 8 of the MCP server implementation plan.
+Each function is tested directly with mocked services and sessions.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import TEST_USER_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _mock_session_ctx(session):
+    """Build an async context manager that yields the given session."""
+    yield session
+
+
+def _patch_user_and_session(session=None):
+    """Return a context manager that patches _get_mcp_user_id and _get_session."""
+    mock_session = session or AsyncMock()
+
+    class _Patches:
+        def __enter__(self):
+            self.p1 = patch(
+                "wikimind.mcp.tools_analysis._get_mcp_user_id",
+                new=AsyncMock(return_value=TEST_USER_ID),
+            )
+            self.p2 = patch(
+                "wikimind.mcp.tools_analysis._get_session",
+                return_value=_mock_session_ctx(mock_session),
+            )
+            self.p1.start()
+            self.p2.start()
+            return self
+
+        def __exit__(self, *args):
+            self.p1.stop()
+            self.p2.stop()
+
+    return _Patches()
+
+
+def _patch_resources_user_and_session(session=None):
+    """Return a context manager that patches user/session for resources module."""
+    mock_session = session or AsyncMock()
+
+    class _Patches:
+        def __enter__(self):
+            self.p1 = patch(
+                "wikimind.mcp.resources._get_mcp_user_id",
+                new=AsyncMock(return_value=TEST_USER_ID),
+            )
+            self.p2 = patch(
+                "wikimind.mcp.resources._get_session",
+                return_value=_mock_session_ctx(mock_session),
+            )
+            self.p1.start()
+            self.p2.start()
+            return self
+
+        def __exit__(self, *args):
+            self.p1.stop()
+            self.p2.stop()
+
+    return _Patches()
+
+
+# ---------------------------------------------------------------------------
+# Task 6: wiki_synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestWikiSynthesize:
+    """Test the wiki_synthesize MCP tool."""
+
+    async def test_synthesize_success(self):
+        from wikimind.mcp.tools_analysis import wiki_synthesize
+
+        mock_article = MagicMock()
+        mock_article.title = "Synthesis: AI Trends"
+
+        mock_compilation = MagicMock()
+        mock_compilation.article_body = "AI is evolving rapidly..."
+        mock_compilation.themes = ["deep learning", "transformers"]
+
+        mock_ctx = AsyncMock()
+
+        with (
+            _patch_user_and_session(),
+            patch("wikimind.engine.synthesis_compiler.SynthesisCompiler") as mock_compiler_cls,
+        ):
+            mock_compiler_cls.return_value.synthesize = AsyncMock(return_value=(mock_article, mock_compilation))
+
+            result = await wiki_synthesize(
+                ctx=mock_ctx,
+                article_ids=["id-1", "id-2", "id-3"],
+                synthesis_type="thematic",
+                guidance="Focus on recent trends",
+            )
+
+            assert result["title"] == "Synthesis: AI Trends"
+            assert result["content"] == "AI is evolving rapidly..."
+            assert result["themes"] == ["deep learning", "transformers"]
+
+            # Verify progress was reported
+            mock_ctx.report_progress.assert_called()
+
+    async def test_synthesize_rejects_less_than_2_articles(self):
+        from wikimind.mcp.tools_analysis import wiki_synthesize
+
+        mock_ctx = AsyncMock()
+
+        with pytest.raises(Exception, match="At least 2"):
+            await wiki_synthesize(
+                ctx=mock_ctx,
+                article_ids=["id-1"],
+                synthesis_type="thematic",
+                guidance="",
+            )
+
+    async def test_synthesize_rejects_more_than_10_articles(self):
+        from wikimind.mcp.tools_analysis import wiki_synthesize
+
+        mock_ctx = AsyncMock()
+        ids = [f"id-{i}" for i in range(11)]
+
+        with pytest.raises(Exception, match="Maximum 10"):
+            await wiki_synthesize(
+                ctx=mock_ctx,
+                article_ids=ids,
+                synthesis_type="thematic",
+                guidance="",
+            )
+
+    async def test_synthesize_rejects_duplicate_ids(self):
+        from wikimind.mcp.tools_analysis import wiki_synthesize
+
+        mock_ctx = AsyncMock()
+
+        with pytest.raises(Exception, match="duplicates"):
+            await wiki_synthesize(
+                ctx=mock_ctx,
+                article_ids=["id-1", "id-1", "id-2"],
+                synthesis_type="thematic",
+                guidance="",
+            )
+
+    async def test_synthesize_rejects_invalid_type(self):
+        from wikimind.mcp.tools_analysis import wiki_synthesize
+
+        mock_ctx = AsyncMock()
+
+        with pytest.raises(Exception, match="Invalid synthesis_type"):
+            await wiki_synthesize(
+                ctx=mock_ctx,
+                article_ids=["id-1", "id-2"],
+                synthesis_type="invalid_type",
+                guidance="",
+            )
+
+    async def test_synthesize_reports_progress(self):
+        from wikimind.mcp.tools_analysis import wiki_synthesize
+
+        mock_article = MagicMock()
+        mock_article.title = "Synthesis Result"
+
+        mock_compilation = MagicMock()
+        mock_compilation.article_body = "Content"
+        mock_compilation.themes = []
+
+        mock_ctx = AsyncMock()
+
+        with (
+            _patch_user_and_session(),
+            patch("wikimind.engine.synthesis_compiler.SynthesisCompiler") as mock_compiler_cls,
+        ):
+            mock_compiler_cls.return_value.synthesize = AsyncMock(return_value=(mock_article, mock_compilation))
+
+            await wiki_synthesize(
+                ctx=mock_ctx,
+                article_ids=["id-1", "id-2"],
+                synthesis_type="comparative",
+                guidance="",
+            )
+
+            # Progress: 1/(2+1) and 3/3
+            assert mock_ctx.report_progress.call_count == 2
+            calls = mock_ctx.report_progress.call_args_list
+            assert calls[0].args == (1, 3)
+            assert calls[1].args == (3, 3)
+
+
+# ---------------------------------------------------------------------------
+# Task 6: wiki_get_health
+# ---------------------------------------------------------------------------
+
+
+class TestWikiGetHealth:
+    """Test the wiki_get_health MCP tool."""
+
+    async def test_returns_correct_fields(self):
+        from wikimind.mcp.tools_analysis import wiki_get_health
+
+        mock_stats = MagicMock()
+        mock_stats.article_count = 42
+        mock_stats.source_count = 15
+        mock_stats.orphan_count = 3
+        mock_stats.stuck_sources = 1
+        mock_stats.compilation_success_rate = 0.95
+
+        mock_ctx = AsyncMock()
+        mock_session = AsyncMock()
+
+        # Mock the contradiction count query
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = 7
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _patch_user_and_session(mock_session),
+            patch("wikimind.services.admin.AdminService") as mock_admin_cls,
+        ):
+            mock_admin_cls.return_value.get_stats = AsyncMock(return_value=mock_stats)
+
+            result = await wiki_get_health(ctx=mock_ctx)
+
+            assert result["article_count"] == 42
+            assert result["source_count"] == 15
+            assert result["orphan_count"] == 3
+            assert result["contradiction_count"] == 7
+            assert result["stuck_source_count"] == 1
+            assert result["compilation_success_rate"] == 0.95
+
+
+# ---------------------------------------------------------------------------
+# Task 6: wiki_list_sources (rewritten)
+# ---------------------------------------------------------------------------
+
+
+class TestWikiListSourcesAnalysis:
+    """Test the rewritten wiki_list_sources MCP tool."""
+
+    async def test_returns_structured_list(self):
+        from wikimind.mcp.tools_analysis import wiki_list_sources
+
+        mock_source = MagicMock()
+        mock_source.id = "src-1"
+        mock_source.title = "Example Source"
+        mock_source.source_type = "url"
+        mock_source.status = "compiled"
+        mock_source.ingested_at = "2026-01-01T00:00:00"
+
+        with _patch_user_and_session(), patch("wikimind.services.ingest.IngestService") as mock_ingest_cls:
+            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[mock_source])
+
+            result = await wiki_list_sources(status=None, limit=20)
+
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0]["id"] == "src-1"
+            assert result[0]["title"] == "Example Source"
+            assert result[0]["source_type"] == "url"
+            assert result[0]["status"] == "compiled"
+
+    async def test_rejects_invalid_status(self):
+        from wikimind.mcp.tools_analysis import wiki_list_sources
+
+        with pytest.raises(Exception, match="Invalid status"):
+            await wiki_list_sources(status="bogus", limit=20)
+
+    async def test_clamps_limit(self):
+        from wikimind.mcp.tools_analysis import wiki_list_sources
+
+        with _patch_user_and_session(), patch("wikimind.services.ingest.IngestService") as mock_ingest_cls:
+            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[])
+
+            await wiki_list_sources(status=None, limit=999)
+
+            call_kwargs = mock_ingest_cls.return_value.list_sources.call_args
+            assert call_kwargs.kwargs["limit"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Task 6: wiki_get_graph
+# ---------------------------------------------------------------------------
+
+
+class TestWikiGetGraph:
+    """Test the wiki_get_graph MCP tool."""
+
+    async def test_returns_nodes_and_edges(self):
+        from wikimind.mcp.tools_analysis import wiki_get_graph
+
+        mock_node = MagicMock()
+        mock_node.id = "art-1"
+        mock_node.label = "Test Article"
+        mock_node.concept_cluster = "machine-learning"
+        mock_node.confidence = "sourced"
+
+        mock_edge = MagicMock()
+        mock_edge.source = "art-1"
+        mock_edge.target = "art-2"
+        mock_edge.relation_type = MagicMock(value="references")
+
+        mock_graph = MagicMock()
+        mock_graph.nodes = [mock_node]
+        mock_graph.edges = [mock_edge]
+
+        with _patch_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.get_graph = AsyncMock(return_value=mock_graph)
+
+            result = await wiki_get_graph(article_slug=None)
+
+            assert len(result["nodes"]) == 1
+            assert result["nodes"][0]["id"] == "art-1"
+            assert result["nodes"][0]["title"] == "Test Article"
+            assert result["nodes"][0]["type"] == "machine-learning"
+            assert result["nodes"][0]["confidence"] == "sourced"
+
+            assert len(result["edges"]) == 1
+            assert result["edges"][0]["source"] == "art-1"
+            assert result["edges"][0]["target"] == "art-2"
+            assert result["edges"][0]["relation"] == "references"
+
+    async def test_filters_by_article_slug(self):
+        from wikimind.mcp.tools_analysis import wiki_get_graph
+
+        mock_graph = MagicMock()
+        mock_graph.nodes = []
+        mock_graph.edges = []
+
+        with _patch_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.get_graph = AsyncMock(return_value=mock_graph)
+
+            await wiki_get_graph(article_slug="test-article")
+
+            call_kwargs = mock_wiki_cls.return_value.get_graph.call_args
+            assert call_kwargs.kwargs["from_article"] == "test-article"
+
+
+# ---------------------------------------------------------------------------
+# Task 7: Resources
+# ---------------------------------------------------------------------------
+
+
+class TestResourceIndex:
+    """Test the wikimind://index resource."""
+
+    async def test_returns_article_list(self):
+        from wikimind.mcp.resources import resource_index
+
+        mock_article = MagicMock()
+        mock_article.slug = "test-article"
+        mock_article.title = "Test Article"
+        mock_article.page_type = "source"
+        mock_article.concepts = ["machine-learning"]
+
+        with _patch_resources_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.list_articles = AsyncMock(return_value=[mock_article])
+
+            result = await resource_index()
+            parsed = json.loads(result)
+
+            assert "articles" in parsed
+            assert len(parsed["articles"]) == 1
+            assert parsed["articles"][0]["slug"] == "test-article"
+            assert parsed["articles"][0]["title"] == "Test Article"
+            assert parsed["articles"][0]["page_type"] == "source"
+            assert parsed["articles"][0]["concepts"] == ["machine-learning"]
+
+    async def test_capped_at_500(self):
+        from wikimind.mcp.resources import resource_index
+
+        with _patch_resources_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.list_articles = AsyncMock(return_value=[])
+
+            await resource_index()
+
+            call_kwargs = mock_wiki_cls.return_value.list_articles.call_args
+            assert call_kwargs.kwargs["limit"] == 500
+
+
+class TestResourceArticle:
+    """Test the wikimind://articles/{slug} resource."""
+
+    async def test_returns_markdown_content(self):
+        from wikimind.mcp.resources import resource_article
+
+        mock_article = MagicMock()
+        mock_article.content = "# Hello World\n\nThis is article content."
+
+        with _patch_resources_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_article)
+
+            result = await resource_article(slug="hello-world")
+
+            assert result == "# Hello World\n\nThis is article content."
+
+    async def test_returns_empty_string_when_no_content(self):
+        from wikimind.mcp.resources import resource_article
+
+        mock_article = MagicMock()
+        mock_article.content = None
+
+        with _patch_resources_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_article)
+
+            result = await resource_article(slug="empty")
+            assert result == ""
+
+    async def test_not_found_raises(self):
+        from wikimind.errors import NotFoundError
+        from wikimind.mcp.resources import resource_article
+
+        with _patch_resources_user_and_session(), patch("wikimind.services.wiki.WikiService") as mock_wiki_cls:
+            mock_wiki_cls.return_value.get_article = AsyncMock(side_effect=NotFoundError("Article not found"))
+
+            with pytest.raises(NotFoundError):
+                await resource_article(slug="nonexistent")
+
+
+class TestResourceSource:
+    """Test the wikimind://sources/{source_id} resource."""
+
+    async def test_returns_metadata_json(self):
+        from wikimind.mcp.resources import resource_source
+
+        mock_source = MagicMock()
+        mock_source.id = "src-123"
+        mock_source.title = "Test Source"
+        mock_source.source_type = "url"
+        mock_source.status = "compiled"
+        mock_source.source_url = "https://example.com"
+        mock_source.ingested_at = "2026-01-01T00:00:00"
+
+        with (
+            _patch_resources_user_and_session(),
+            patch("wikimind.services.ingest.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.get_source = AsyncMock(return_value=mock_source)
+
+            result = await resource_source(source_id="src-123")
+            parsed = json.loads(result)
+
+            assert parsed["id"] == "src-123"
+            assert parsed["title"] == "Test Source"
+            assert parsed["source_type"] == "url"
+            assert parsed["status"] == "compiled"
+            assert parsed["url"] == "https://example.com"
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Prompts
+# ---------------------------------------------------------------------------
+
+
+class TestPromptOnboarding:
+    """Test the wiki_onboarding prompt."""
+
+    async def test_returns_onboarding_instructions(self):
+        from wikimind.mcp.prompts import prompt_onboarding
+
+        result = await prompt_onboarding()
+
+        assert "wiki_overview()" in result
+        assert "knowledge base" in result
+        assert "topic areas" in result
+        assert "underdeveloped" in result
+
+    async def test_has_numbered_steps(self):
+        from wikimind.mcp.prompts import prompt_onboarding
+
+        result = await prompt_onboarding()
+
+        # Should have 6 numbered steps
+        for i in range(1, 7):
+            assert f"{i}." in result
+
+
+class TestPromptResearchTopic:
+    """Test the research_topic prompt."""
+
+    async def test_includes_topic(self):
+        from wikimind.mcp.prompts import prompt_research_topic
+
+        result = await prompt_research_topic(topic="quantum computing")
+
+        assert "quantum computing" in result
+        assert 'wiki_search("quantum computing")' in result
+
+    async def test_instructs_search_then_read(self):
+        from wikimind.mcp.prompts import prompt_research_topic
+
+        result = await prompt_research_topic(topic="AI safety")
+
+        assert "wiki_search" in result
+        assert "wiki_get_article" in result
+        assert "Synthesize" in result
+
+
+class TestPromptCompareArticles:
+    """Test the compare_articles prompt."""
+
+    async def test_includes_both_slugs(self):
+        from wikimind.mcp.prompts import prompt_compare_articles
+
+        result = await prompt_compare_articles(slug_a="article-one", slug_b="article-two")
+
+        assert "article-one" in result
+        assert "article-two" in result
+        assert "wiki_get_article" in result
+
+    async def test_mentions_agreements_and_disagreements(self):
+        from wikimind.mcp.prompts import prompt_compare_articles
+
+        result = await prompt_compare_articles(slug_a="a", slug_b="b")
+
+        assert "agreements" in result
+        assert "disagreements" in result or "contradictions" in result
+        assert "synthesis" in result
+
+
+class TestPromptKnowledgeGaps:
+    """Test the knowledge_gaps prompt."""
+
+    async def test_with_topic(self):
+        from wikimind.mcp.prompts import prompt_knowledge_gaps
+
+        result = await prompt_knowledge_gaps(topic="machine learning")
+
+        assert "machine learning" in result
+        assert "wiki_search" in result
+        assert "wiki_get_health()" in result
+        assert "gaps" in result.lower()
+
+    async def test_without_topic(self):
+        from wikimind.mcp.prompts import prompt_knowledge_gaps
+
+        result = await prompt_knowledge_gaps(topic="")
+
+        assert "wiki_overview()" in result
+        assert "wiki_get_health()" in result
+        assert "orphaned" in result
+        assert "contradictions" in result
+
+    async def test_default_topic_is_empty(self):
+        from wikimind.mcp.prompts import prompt_knowledge_gaps
+
+        result = await prompt_knowledge_gaps()
+
+        # Should use the "without topic" variant
+        assert "wiki_overview()" in result
+        assert "overall health" in result.lower()

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,4 +1,5 @@
 """Tests for MCP JWT authentication."""
+
 from __future__ import annotations
 
 import time
@@ -34,26 +35,26 @@ class TestJWTValidation:
     async def test_expired_token_raises(self):
         provider = WikiMindJWTAuthProvider(secret=SECRET)
         token = _make_token(_valid_payload(exp=int(time.time()) - 100))
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="Token expired"):
             await provider.verify_token(token)
 
     @pytest.mark.asyncio
     async def test_wrong_secret_raises(self):
         provider = WikiMindJWTAuthProvider(secret=SECRET)
         token = _make_token(_valid_payload(), secret="wrong-secret")
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="Invalid token"):
             await provider.verify_token(token)
 
     @pytest.mark.asyncio
     async def test_missing_sub_raises(self):
         provider = WikiMindJWTAuthProvider(secret=SECRET)
         token = _make_token({"email": "x@y.com", "exp": int(time.time()) + 3600})
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="missing 'sub' claim"):
             await provider.verify_token(token)
 
     @pytest.mark.asyncio
     async def test_non_hs256_algorithm_rejected(self):
         provider = WikiMindJWTAuthProvider(secret=SECRET)
         token = jwt.encode(_valid_payload(), SECRET, algorithm="HS384")
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="Invalid token"):
             await provider.verify_token(token)

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -7,7 +7,7 @@ import time
 import jwt
 import pytest
 
-from wikimind.mcp.auth import WikiMindJWTAuthProvider
+from wikimind.mcp.auth import WikiMindAuthProvider
 
 SECRET = "test-secret-key-at-least-32-chars-long"
 USER_ID = "test-user-123"
@@ -26,35 +26,35 @@ def _valid_payload(**overrides) -> dict:
 class TestJWTValidation:
     @pytest.mark.asyncio
     async def test_valid_token_returns_user_id(self):
-        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        provider = WikiMindAuthProvider(secret=SECRET)
         token = _make_token(_valid_payload())
         result = await provider.verify_token(token)
         assert result.client_id == USER_ID
 
     @pytest.mark.asyncio
     async def test_expired_token_raises(self):
-        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        provider = WikiMindAuthProvider(secret=SECRET)
         token = _make_token(_valid_payload(exp=int(time.time()) - 100))
         with pytest.raises(ValueError, match="Token expired"):
             await provider.verify_token(token)
 
     @pytest.mark.asyncio
     async def test_wrong_secret_raises(self):
-        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        provider = WikiMindAuthProvider(secret=SECRET)
         token = _make_token(_valid_payload(), secret="wrong-secret")
         with pytest.raises(ValueError, match="Invalid token"):
             await provider.verify_token(token)
 
     @pytest.mark.asyncio
     async def test_missing_sub_raises(self):
-        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        provider = WikiMindAuthProvider(secret=SECRET)
         token = _make_token({"email": "x@y.com", "exp": int(time.time()) + 3600})
         with pytest.raises(ValueError, match="missing 'sub' claim"):
             await provider.verify_token(token)
 
     @pytest.mark.asyncio
     async def test_non_hs256_algorithm_rejected(self):
-        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        provider = WikiMindAuthProvider(secret=SECRET)
         token = jwt.encode(_valid_payload(), SECRET, algorithm="HS384")
         with pytest.raises(ValueError, match="Invalid token"):
             await provider.verify_token(token)

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,0 +1,59 @@
+"""Tests for MCP JWT authentication."""
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+
+from wikimind.mcp.auth import WikiMindJWTAuthProvider
+
+SECRET = "test-secret-key-at-least-32-chars-long"
+USER_ID = "test-user-123"
+
+
+def _make_token(payload: dict, secret: str = SECRET) -> str:
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _valid_payload(**overrides) -> dict:
+    base = {"sub": USER_ID, "email": "test@test.com", "exp": int(time.time()) + 3600}
+    base.update(overrides)
+    return base
+
+
+class TestJWTValidation:
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_user_id(self):
+        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        token = _make_token(_valid_payload())
+        result = await provider.verify_token(token)
+        assert result.client_id == USER_ID
+
+    @pytest.mark.asyncio
+    async def test_expired_token_raises(self):
+        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        token = _make_token(_valid_payload(exp=int(time.time()) - 100))
+        with pytest.raises(Exception):
+            await provider.verify_token(token)
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_raises(self):
+        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        token = _make_token(_valid_payload(), secret="wrong-secret")
+        with pytest.raises(Exception):
+            await provider.verify_token(token)
+
+    @pytest.mark.asyncio
+    async def test_missing_sub_raises(self):
+        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        token = _make_token({"email": "x@y.com", "exp": int(time.time()) + 3600})
+        with pytest.raises(Exception):
+            await provider.verify_token(token)
+
+    @pytest.mark.asyncio
+    async def test_non_hs256_algorithm_rejected(self):
+        provider = WikiMindJWTAuthProvider(secret=SECRET)
+        token = jwt.encode(_valid_payload(), SECRET, algorithm="HS384")
+        with pytest.raises(Exception):
+            await provider.verify_token(token)

--- a/tests/unit/test_mcp_discovery.py
+++ b/tests/unit/test_mcp_discovery.py
@@ -97,22 +97,28 @@ class TestWikiOverview:
     @pytest.mark.asyncio
     async def test_returns_article_and_concept_counts(self):
         ctx = _mock_ctx()
-        stats = _mock_stats(article_count=42, source_count=15)
         concepts = [
             _mock_concept("Machine Learning", article_count=10),
             _mock_concept("NLP", article_count=5),
         ]
-        articles = [
+        recent_articles = [
             _mock_article(slug="recent-1", title="Recent One"),
             _mock_article(slug="recent-2", title="Recent Two"),
         ]
+        all_articles = [
+            _mock_article(slug="a1", page_type="source"),
+            _mock_article(slug="a2", page_type="source"),
+            _mock_article(slug="a3", page_type="concept"),
+        ]
+        mock_sources = [MagicMock(), MagicMock(), MagicMock()]  # 3 sources
 
         mock_wiki_svc = MagicMock()
         mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
-        mock_wiki_svc.list_articles = AsyncMock(return_value=articles)
+        # First call returns recent (limit=5), second call returns all (limit=10000)
+        mock_wiki_svc.list_articles = AsyncMock(side_effect=[recent_articles, all_articles])
 
-        mock_admin_svc = MagicMock()
-        mock_admin_svc.get_stats = AsyncMock(return_value=stats)
+        mock_ingest_svc = MagicMock()
+        mock_ingest_svc.list_sources = AsyncMock(return_value=mock_sources)
 
         with (
             patch(
@@ -129,37 +135,36 @@ class TestWikiOverview:
                 return_value=mock_wiki_svc,
             ),
             patch(
-                "wikimind.services.admin.AdminService",
-                return_value=mock_admin_svc,
+                "wikimind.services.ingest.IngestService",
+                return_value=mock_ingest_svc,
             ),
         ):
             result = await wiki_overview(ctx)
 
-            assert result["article_count"] == 42
-            assert result["source_count"] == 15
+            assert result["article_count"] == 3
+            assert result["source_count"] == 3
             assert result["concept_count"] == 2
             assert len(result["concepts"]) == 2
             assert result["concepts"][0]["name"] == "Machine Learning"
             assert result["concepts"][0]["article_count"] == 10
             assert result["page_type_breakdown"] == {
-                "source": 7,
-                "concept": 2,
-                "synthesis": 1,
+                "source": 2,
+                "concept": 1,
             }
 
     @pytest.mark.asyncio
     async def test_returns_max_5_recent_articles(self):
         ctx = _mock_ctx()
-        stats = _mock_stats()
         concepts = [_mock_concept("Topic")]
         articles = [_mock_article(slug=f"article-{i}") for i in range(7)]
+        all_articles = [_mock_article(slug=f"all-{i}") for i in range(7)]
 
         mock_wiki_svc = MagicMock()
         mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
-        mock_wiki_svc.list_articles = AsyncMock(return_value=articles)
+        mock_wiki_svc.list_articles = AsyncMock(side_effect=[articles, all_articles])
 
-        mock_admin_svc = MagicMock()
-        mock_admin_svc.get_stats = AsyncMock(return_value=stats)
+        mock_ingest_svc = MagicMock()
+        mock_ingest_svc.list_sources = AsyncMock(return_value=[])
 
         with (
             patch(
@@ -176,8 +181,8 @@ class TestWikiOverview:
                 return_value=mock_wiki_svc,
             ),
             patch(
-                "wikimind.services.admin.AdminService",
-                return_value=mock_admin_svc,
+                "wikimind.services.ingest.IngestService",
+                return_value=mock_ingest_svc,
             ),
         ):
             result = await wiki_overview(ctx)
@@ -187,15 +192,16 @@ class TestWikiOverview:
     @pytest.mark.asyncio
     async def test_logs_info_message(self):
         ctx = _mock_ctx()
-        stats = _mock_stats(article_count=3)
         concepts = [_mock_concept("A"), _mock_concept("B")]
+        all_articles = [_mock_article(slug=f"a{i}") for i in range(3)]
 
         mock_wiki_svc = MagicMock()
         mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
-        mock_wiki_svc.list_articles = AsyncMock(return_value=[])
+        # First call: recent articles (limit=5), second call: all articles (limit=10000)
+        mock_wiki_svc.list_articles = AsyncMock(side_effect=[[], all_articles])
 
-        mock_admin_svc = MagicMock()
-        mock_admin_svc.get_stats = AsyncMock(return_value=stats)
+        mock_ingest_svc = MagicMock()
+        mock_ingest_svc.list_sources = AsyncMock(return_value=[])
 
         with (
             patch(
@@ -212,8 +218,8 @@ class TestWikiOverview:
                 return_value=mock_wiki_svc,
             ),
             patch(
-                "wikimind.services.admin.AdminService",
-                return_value=mock_admin_svc,
+                "wikimind.services.ingest.IngestService",
+                return_value=mock_ingest_svc,
             ),
         ):
             await wiki_overview(ctx)
@@ -224,8 +230,8 @@ class TestWikiOverview:
     async def test_wraps_unexpected_errors_in_tool_error(self):
         ctx = _mock_ctx()
 
-        mock_admin_svc = MagicMock()
-        mock_admin_svc.get_stats = AsyncMock(side_effect=RuntimeError("DB connection lost"))
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(side_effect=RuntimeError("DB connection lost"))
 
         with (
             patch(
@@ -238,8 +244,8 @@ class TestWikiOverview:
                 return_value=_mock_session_ctx(),
             ),
             patch(
-                "wikimind.services.admin.AdminService",
-                return_value=mock_admin_svc,
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
             ),
             pytest.raises(ToolError, match="Failed to get wiki overview"),
         ):

--- a/tests/unit/test_mcp_discovery.py
+++ b/tests/unit/test_mcp_discovery.py
@@ -1,0 +1,589 @@
+"""Tests for WikiMind MCP discovery tools (Tier 1).
+
+Tests wiki_overview, wiki_list_articles, and wiki_list_concepts
+with mocked service layer dependencies.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from wikimind.mcp.tools_discovery import (
+    wiki_list_articles,
+    wiki_list_concepts,
+    wiki_overview,
+)
+
+TEST_USER_ID = "test-user"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _mock_session_ctx(session=None):
+    """Build an async context manager that yields the given session."""
+    yield session or MagicMock()
+
+
+def _mock_ctx() -> MagicMock:
+    """Create a mock MCP Context with async log method."""
+    ctx = MagicMock()
+    ctx.log = AsyncMock()
+    return ctx
+
+
+def _mock_stats(**overrides):
+    """Create a mock SystemStats object."""
+    defaults = {
+        "article_count": 10,
+        "source_count": 5,
+        "concept_count": 3,
+        "articles_by_page_type": {"source": 7, "concept": 2, "synthesis": 1},
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _mock_concept(name: str, article_count: int = 2, concept_kind: str = "topic"):
+    """Create a mock Concept object."""
+    mock = MagicMock()
+    mock.name = name
+    mock.article_count = article_count
+    mock.concept_kind = concept_kind
+    return mock
+
+
+def _mock_article(
+    slug: str = "test-article",
+    title: str = "Test Article",
+    summary: str = "A summary",
+    concepts: list | None = None,
+    page_type: str = "source",
+    source_count: int = 1,
+    confidence: str = "sourced",
+    updated_at: str = "2026-01-01T00:00:00",
+):
+    """Create a mock ArticleSummaryResponse object."""
+    mock = MagicMock()
+    mock.slug = slug
+    mock.title = title
+    mock.summary = summary
+    mock.concepts = concepts or ["ml"]
+    mock.page_type = page_type
+    mock.source_count = source_count
+    mock.confidence = confidence
+    mock.updated_at = updated_at
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# wiki_overview
+# ---------------------------------------------------------------------------
+
+
+class TestWikiOverview:
+    """Test the wiki_overview discovery tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_article_and_concept_counts(self):
+        ctx = _mock_ctx()
+        stats = _mock_stats(article_count=42, source_count=15)
+        concepts = [
+            _mock_concept("Machine Learning", article_count=10),
+            _mock_concept("NLP", article_count=5),
+        ]
+        articles = [
+            _mock_article(slug="recent-1", title="Recent One"),
+            _mock_article(slug="recent-2", title="Recent Two"),
+        ]
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
+        mock_wiki_svc.list_articles = AsyncMock(return_value=articles)
+
+        mock_admin_svc = MagicMock()
+        mock_admin_svc.get_stats = AsyncMock(return_value=stats)
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+            patch(
+                "wikimind.services.admin.AdminService",
+                return_value=mock_admin_svc,
+            ),
+        ):
+            result = await wiki_overview(ctx)
+
+            assert result["article_count"] == 42
+            assert result["source_count"] == 15
+            assert result["concept_count"] == 2
+            assert len(result["concepts"]) == 2
+            assert result["concepts"][0]["name"] == "Machine Learning"
+            assert result["concepts"][0]["article_count"] == 10
+            assert result["page_type_breakdown"] == {
+                "source": 7,
+                "concept": 2,
+                "synthesis": 1,
+            }
+
+    @pytest.mark.asyncio
+    async def test_returns_max_5_recent_articles(self):
+        ctx = _mock_ctx()
+        stats = _mock_stats()
+        concepts = [_mock_concept("Topic")]
+        articles = [_mock_article(slug=f"article-{i}") for i in range(7)]
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
+        mock_wiki_svc.list_articles = AsyncMock(return_value=articles)
+
+        mock_admin_svc = MagicMock()
+        mock_admin_svc.get_stats = AsyncMock(return_value=stats)
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+            patch(
+                "wikimind.services.admin.AdminService",
+                return_value=mock_admin_svc,
+            ),
+        ):
+            result = await wiki_overview(ctx)
+
+            assert len(result["recent_articles"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_logs_info_message(self):
+        ctx = _mock_ctx()
+        stats = _mock_stats(article_count=3)
+        concepts = [_mock_concept("A"), _mock_concept("B")]
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
+        mock_wiki_svc.list_articles = AsyncMock(return_value=[])
+
+        mock_admin_svc = MagicMock()
+        mock_admin_svc.get_stats = AsyncMock(return_value=stats)
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+            patch(
+                "wikimind.services.admin.AdminService",
+                return_value=mock_admin_svc,
+            ),
+        ):
+            await wiki_overview(ctx)
+
+            ctx.log.assert_called_once_with("Wiki has 3 articles across 2 concepts", level="info")
+
+    @pytest.mark.asyncio
+    async def test_wraps_unexpected_errors_in_tool_error(self):
+        ctx = _mock_ctx()
+
+        mock_admin_svc = MagicMock()
+        mock_admin_svc.get_stats = AsyncMock(side_effect=RuntimeError("DB connection lost"))
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.admin.AdminService",
+                return_value=mock_admin_svc,
+            ),
+            pytest.raises(ToolError, match="Failed to get wiki overview"),
+        ):
+            await wiki_overview(ctx)
+
+
+# ---------------------------------------------------------------------------
+# wiki_list_articles
+# ---------------------------------------------------------------------------
+
+
+class TestWikiListArticles:
+    """Test the wiki_list_articles discovery tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_articles_with_pagination(self):
+        ctx = _mock_ctx()
+        articles = [
+            _mock_article(slug="a1", title="Article 1"),
+            _mock_article(slug="a2", title="Article 2"),
+        ]
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.list_articles = AsyncMock(return_value=articles)
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            result = await wiki_list_articles(ctx, limit=20, offset=0)
+
+            assert len(result["articles"]) == 2
+            assert result["articles"][0]["slug"] == "a1"
+            assert result["articles"][1]["title"] == "Article 2"
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_page_type(self):
+        ctx = _mock_ctx()
+
+        with pytest.raises(ToolError, match="Invalid page_type"):
+            await wiki_list_articles(ctx, page_type="invalid_type")
+
+    @pytest.mark.asyncio
+    async def test_rejects_negative_offset(self):
+        ctx = _mock_ctx()
+
+        with pytest.raises(ToolError, match="offset must be >= 0"):
+            await wiki_list_articles(ctx, offset=-1)
+
+    @pytest.mark.asyncio
+    async def test_clamps_limit_to_100(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.list_articles = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            result = await wiki_list_articles(ctx, limit=500)
+
+            # Verify service was called with clamped limit
+            call_kwargs = mock_wiki_svc.list_articles.call_args
+            assert call_kwargs[1]["limit"] == 100
+            # Verify warning in response
+            assert "warning" in result
+            assert "clamped" in result["warning"]
+
+    @pytest.mark.asyncio
+    async def test_clamps_limit_minimum_to_1(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.list_articles = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            result = await wiki_list_articles(ctx, limit=0)
+
+            call_kwargs = mock_wiki_svc.list_articles.call_args
+            assert call_kwargs[1]["limit"] == 1
+            assert "warning" in result
+
+    @pytest.mark.asyncio
+    async def test_passes_concept_and_page_type_filters(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.list_articles = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            await wiki_list_articles(ctx, concept="Machine Learning", page_type="synthesis")
+
+            call_kwargs = mock_wiki_svc.list_articles.call_args
+            assert call_kwargs[1]["concept"] == "Machine Learning"
+            assert call_kwargs[1]["page_type"] == "synthesis"
+
+    @pytest.mark.asyncio
+    async def test_accepts_all_valid_page_types(self):
+        ctx = _mock_ctx()
+
+        for pt in ("source", "concept", "synthesis", "answer"):
+            mock_wiki_svc = MagicMock()
+            mock_wiki_svc.list_articles = AsyncMock(return_value=[])
+
+            with (
+                patch(
+                    "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                    new_callable=AsyncMock,
+                    return_value=TEST_USER_ID,
+                ),
+                patch(
+                    "wikimind.mcp.tools_discovery._get_session",
+                    return_value=_mock_session_ctx(),
+                ),
+                patch(
+                    "wikimind.services.wiki.WikiService",
+                    return_value=mock_wiki_svc,
+                ),
+            ):
+                # Should not raise
+                await wiki_list_articles(ctx, page_type=pt)
+
+    @pytest.mark.asyncio
+    async def test_wraps_unexpected_errors_in_tool_error(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.list_articles = AsyncMock(side_effect=RuntimeError("timeout"))
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+            pytest.raises(ToolError, match="Failed to list articles"),
+        ):
+            await wiki_list_articles(ctx)
+
+
+# ---------------------------------------------------------------------------
+# wiki_list_concepts
+# ---------------------------------------------------------------------------
+
+
+class TestWikiListConcepts:
+    """Test the wiki_list_concepts discovery tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_concepts_with_article_counts(self):
+        ctx = _mock_ctx()
+        concepts = [
+            _mock_concept("Machine Learning", article_count=10, concept_kind="topic"),
+            _mock_concept("NLP", article_count=5, concept_kind="domain"),
+        ]
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            result = await wiki_list_concepts(ctx)
+
+            assert len(result["concepts"]) == 2
+            assert result["concepts"][0]["name"] == "Machine Learning"
+            assert result["concepts"][0]["article_count"] == 10
+            assert result["concepts"][0]["concept_kind"] == "topic"
+            assert result["concepts"][1]["name"] == "NLP"
+            assert result["concepts"][1]["concept_kind"] == "domain"
+
+    @pytest.mark.asyncio
+    async def test_excludes_empty_concepts_by_default(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            await wiki_list_concepts(ctx)
+
+            call_kwargs = mock_wiki_svc.get_concepts.call_args
+            assert call_kwargs[1]["include_empty"] is False
+
+    @pytest.mark.asyncio
+    async def test_includes_empty_concepts_when_requested(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            await wiki_list_concepts(ctx, include_empty=True)
+
+            call_kwargs = mock_wiki_svc.get_concepts.call_args
+            assert call_kwargs[1]["include_empty"] is True
+
+    @pytest.mark.asyncio
+    async def test_logs_concept_count(self):
+        ctx = _mock_ctx()
+        concepts = [_mock_concept("A"), _mock_concept("B"), _mock_concept("C")]
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(return_value=concepts)
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+        ):
+            await wiki_list_concepts(ctx)
+
+            ctx.log.assert_called_once_with("Found 3 concepts", level="info")
+
+    @pytest.mark.asyncio
+    async def test_wraps_unexpected_errors_in_tool_error(self):
+        ctx = _mock_ctx()
+
+        mock_wiki_svc = MagicMock()
+        mock_wiki_svc.get_concepts = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        with (
+            patch(
+                "wikimind.mcp.tools_discovery._get_mcp_user_id",
+                new_callable=AsyncMock,
+                return_value=TEST_USER_ID,
+            ),
+            patch(
+                "wikimind.mcp.tools_discovery._get_session",
+                return_value=_mock_session_ctx(),
+            ),
+            patch(
+                "wikimind.services.wiki.WikiService",
+                return_value=mock_wiki_svc,
+            ),
+            pytest.raises(ToolError, match="Failed to list concepts"),
+        ):
+            await wiki_list_concepts(ctx)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -16,8 +16,18 @@ from click.testing import CliRunner
 
 from tests.conftest import TEST_USER_ID
 from wikimind.cli.main import cli
-from wikimind.mcp.server import mcp as mcp_server
-from wikimind.mcp.server import wiki_get_article, wiki_list_sources, wiki_search
+from wikimind.mcp.server import (
+    mcp as mcp_server,
+)
+from wikimind.mcp.server import (
+    prompt_research_topic,
+    prompt_summarize_article,
+    resource_article,
+    resource_source,
+    wiki_get_article,
+    wiki_list_sources,
+    wiki_search,
+)
 from wikimind.models import Article, ConfidenceLevel, PageType, Source
 
 if TYPE_CHECKING:
@@ -320,3 +330,280 @@ class TestMCPServerRegistration:
         # wiki_get_article id_or_slug param should have a description
         article_props = tools_by_name["wiki_get_article"].parameters.get("properties", {})
         assert "description" in article_props.get("id_or_slug", {}), "id_or_slug param missing Field description"
+
+
+# ---------------------------------------------------------------------------
+# MCP Resources
+# ---------------------------------------------------------------------------
+
+
+class TestResourceArticle:
+    """Test the wikimind://articles/{slug} MCP resource."""
+
+    async def test_resource_article_returns_content(self, db_session, sample_article):
+        mock_response = AsyncMock()
+        mock_response.title = "Test Article"
+        mock_response.summary = "A test article about testing."
+        mock_response.content = "Full article content here."
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
+
+            result = await resource_article(slug="test-article")
+
+            assert "# Test Article" in result
+            assert "A test article about testing." in result
+            assert "Full article content here." in result
+
+    async def test_resource_article_not_found(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(
+                side_effect=Exception("Article not found"),
+            )
+
+            result = await resource_article(slug="nonexistent")
+            assert "Error:" in result
+            assert "not found" in result
+
+    async def test_resource_article_no_summary(self, db_session):
+        mock_response = AsyncMock()
+        mock_response.title = "No Summary Article"
+        mock_response.summary = None
+        mock_response.content = "Content only."
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
+
+            result = await resource_article(slug="no-summary")
+
+            assert "# No Summary Article" in result
+            assert "Content only." in result
+            assert "**Summary:**" not in result
+
+
+class TestResourceSource:
+    """Test the wikimind://sources/{id} MCP resource."""
+
+    async def test_resource_source_returns_metadata(self, db_session, sample_source):
+        mock_source = AsyncMock()
+        mock_source.id = "src-123"
+        mock_source.source_type = "url"
+        mock_source.title = "Test Source"
+        mock_source.source_url = "https://example.com/test"
+        mock_source.author = "Test Author"
+        mock_source.status = "compiled"
+        mock_source.ingested_at = "2026-01-01"
+        mock_source.compiled_at = "2026-01-02"
+        mock_source.token_count = 1500
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.get_source = AsyncMock(return_value=mock_source)
+
+            result = await resource_source(source_id="src-123")
+            parsed = json.loads(result)
+
+            assert parsed["id"] == "src-123"
+            assert parsed["source_type"] == "url"
+            assert parsed["title"] == "Test Source"
+            assert parsed["source_url"] == "https://example.com/test"
+            assert parsed["author"] == "Test Author"
+            assert parsed["status"] == "compiled"
+            assert parsed["token_count"] == 1500
+
+    async def test_resource_source_not_found(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
+        ):
+            mock_ingest_cls.return_value.get_source = AsyncMock(
+                side_effect=Exception("Source not found"),
+            )
+
+            result = await resource_source(source_id="nonexistent")
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "not found" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# MCP Prompts
+# ---------------------------------------------------------------------------
+
+
+class TestPromptResearchTopic:
+    """Test the research_topic MCP prompt."""
+
+    async def test_research_topic_with_results(self, db_session):
+        mock_result = AsyncMock(
+            title="Machine Learning Basics",
+            slug="machine-learning-basics",
+            summary="An intro to ML concepts.",
+        )
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[mock_result])
+
+            result = await prompt_research_topic(topic="machine learning")
+
+            assert "machine learning" in result
+            assert "Machine Learning Basics" in result
+            assert "machine-learning-basics" in result
+            assert "synthesize" in result.lower()
+
+    async def test_research_topic_no_results(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[])
+
+            result = await prompt_research_topic(topic="quantum computing")
+
+            assert "quantum computing" in result
+            assert "No existing articles" in result
+            assert "suggest" in result.lower()
+
+    async def test_research_topic_multiple_results(self, db_session):
+        mock_results = [
+            AsyncMock(title="Article One", slug="article-one", summary="First article."),
+            AsyncMock(title="Article Two", slug="article-two", summary="Second article."),
+        ]
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=mock_results)
+
+            result = await prompt_research_topic(topic="testing")
+
+            assert "Article One" in result
+            assert "Article Two" in result
+            assert "article-one" in result
+            assert "article-two" in result
+
+
+class TestPromptSummarizeArticle:
+    """Test the summarize_article MCP prompt."""
+
+    async def test_summarize_article_found(self, db_session):
+        mock_source = AsyncMock()
+        mock_source.title = "Original Paper"
+        mock_source.source_url = "https://example.com/paper"
+        mock_source.source_type = "url"
+
+        mock_response = AsyncMock()
+        mock_response.title = "Test Article"
+        mock_response.confidence = "sourced"
+        mock_response.page_type = "source"
+        mock_response.content = "This is the article content."
+        mock_response.sources = [mock_source]
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
+
+            result = await prompt_summarize_article(slug="test-article")
+
+            assert "Test Article" in result
+            assert "This is the article content." in result
+            assert "Original Paper" in result
+            assert "Key points" in result
+
+    async def test_summarize_article_not_found(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(
+                side_effect=Exception("Article not found"),
+            )
+
+            result = await prompt_summarize_article(slug="nonexistent")
+
+            assert "nonexistent" in result
+            assert "not found" in result
+            assert "wiki_search" in result
+
+    async def test_summarize_article_no_sources(self, db_session):
+        mock_response = AsyncMock()
+        mock_response.title = "Standalone Article"
+        mock_response.confidence = "inferred"
+        mock_response.page_type = "concept"
+        mock_response.content = "Content without sources."
+        mock_response.sources = []
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
+
+            result = await prompt_summarize_article(slug="standalone")
+
+            assert "Standalone Article" in result
+            assert "Content without sources." in result
+            assert "Sources used:" not in result
+
+
+# ---------------------------------------------------------------------------
+# Resource & Prompt registration
+# ---------------------------------------------------------------------------
+
+
+class TestMCPResourceRegistration:
+    """Test that MCP resources are properly registered on the server."""
+
+    async def test_server_lists_resource_templates(self):
+        templates = await mcp_server.list_resource_templates()
+        template_names = {t.name for t in templates}
+        assert "article" in template_names
+        assert "source" in template_names
+
+    async def test_article_resource_template_uri(self):
+        templates = await mcp_server.list_resource_templates()
+        by_name = {t.name: t for t in templates}
+        assert "wikimind://articles/{slug}" in by_name["article"].uri_template
+
+    async def test_source_resource_template_uri(self):
+        templates = await mcp_server.list_resource_templates()
+        by_name = {t.name: t for t in templates}
+        assert "wikimind://sources/{source_id}" in by_name["source"].uri_template
+
+    async def test_resource_descriptions_present(self):
+        templates = await mcp_server.list_resource_templates()
+        for t in templates:
+            assert t.description, f"Resource template {t.name} missing description"
+
+
+class TestMCPPromptRegistration:
+    """Test that MCP prompts are properly registered on the server."""
+
+    async def test_server_lists_prompts(self):
+        prompts = await mcp_server.list_prompts()
+        prompt_names = {p.name for p in prompts}
+        assert "research_topic" in prompt_names
+        assert "summarize_article" in prompt_names
+
+    async def test_prompt_descriptions_present(self):
+        prompts = await mcp_server.list_prompts()
+        for p in prompts:
+            assert p.description, f"Prompt {p.name} missing description"
+            assert len(p.description) > 20, f"Prompt {p.name} description too short"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -20,12 +20,7 @@ from wikimind.mcp.server import (
     mcp as mcp_server,
 )
 from wikimind.mcp.server import (
-    prompt_research_topic,
-    prompt_summarize_article,
-    resource_article,
-    resource_source,
     wiki_get_article,
-    wiki_list_sources,
     wiki_search,
 )
 from wikimind.models import Article, ConfidenceLevel, PageType, Source
@@ -189,60 +184,6 @@ class TestWikiGetArticle:
 
 
 # ---------------------------------------------------------------------------
-# wiki_list_sources
-# ---------------------------------------------------------------------------
-
-
-class TestWikiListSources:
-    """Test the wiki_list_sources MCP tool."""
-
-    async def test_list_sources_returns_results(self, db_session, sample_source):
-        mock_source = AsyncMock()
-        mock_source.id = sample_source.id
-        mock_source.source_type = "url"
-        mock_source.title = "Test Source"
-        mock_source.source_url = "https://example.com/test"
-        mock_source.ingested_at = "2026-01-01"
-        mock_source.compiled_at = None
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
-        ):
-            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[mock_source])
-
-            result = await wiki_list_sources(limit=20)
-            parsed = json.loads(result)
-
-            assert isinstance(parsed, list)
-            assert len(parsed) == 1
-            assert parsed[0]["title"] == "Test Source"
-            assert parsed[0]["source_type"] == "url"
-
-    async def test_list_sources_empty(self, db_session):
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
-        ):
-            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[])
-
-            result = await wiki_list_sources(limit=20)
-            parsed = json.loads(result)
-            assert parsed == []
-
-    async def test_list_sources_clamps_limit(self, db_session):
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
-        ):
-            mock_ingest_cls.return_value.list_sources = AsyncMock(return_value=[])
-
-            await wiki_list_sources(limit=999)
-            call_kwargs = mock_ingest_cls.return_value.list_sources.call_args
-            assert call_kwargs.kwargs["limit"] == 100
-
-
-# ---------------------------------------------------------------------------
 # CLI commands
 # ---------------------------------------------------------------------------
 
@@ -291,10 +232,27 @@ class TestMCPServerRegistration:
     async def test_server_lists_tools(self):
         tools = await mcp_server.list_tools()
         tool_names = {t.name for t in tools}
+        # Tier 1: Discovery
+        assert "wiki_overview" in tool_names
+        assert "wiki_list_articles" in tool_names
+        assert "wiki_list_concepts" in tool_names
+        # Tier 2: Read/Search
         assert "wiki_search" in tool_names
         assert "wiki_get_article" in tool_names
         assert "wiki_ask" in tool_names
+        # Tier 3: Write
+        assert "wiki_ingest_url" in tool_names
+        assert "wiki_ingest_text" in tool_names
+        assert "wiki_get_source_status" in tool_names
+        # Tier 4: Analysis
+        assert "wiki_synthesize" in tool_names
+        assert "wiki_get_health" in tool_names
         assert "wiki_list_sources" in tool_names
+        assert "wiki_get_graph" in tool_names
+
+    async def test_server_has_13_tools(self):
+        tools = await mcp_server.list_tools()
+        assert len(tools) == 13
 
     async def test_tool_descriptions_present(self):
         tools = await mcp_server.list_tools()
@@ -337,237 +295,6 @@ class TestMCPServerRegistration:
 # ---------------------------------------------------------------------------
 
 
-class TestResourceArticle:
-    """Test the wikimind://articles/{slug} MCP resource."""
-
-    async def test_resource_article_returns_content(self, db_session, sample_article):
-        mock_response = AsyncMock()
-        mock_response.title = "Test Article"
-        mock_response.summary = "A test article about testing."
-        mock_response.content = "Full article content here."
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
-
-            result = await resource_article(slug="test-article")
-
-            assert "# Test Article" in result
-            assert "A test article about testing." in result
-            assert "Full article content here." in result
-
-    async def test_resource_article_not_found(self, db_session):
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.get_article = AsyncMock(
-                side_effect=Exception("Article not found"),
-            )
-
-            result = await resource_article(slug="nonexistent")
-            assert "Error:" in result
-            assert "not found" in result
-
-    async def test_resource_article_no_summary(self, db_session):
-        mock_response = AsyncMock()
-        mock_response.title = "No Summary Article"
-        mock_response.summary = None
-        mock_response.content = "Content only."
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
-
-            result = await resource_article(slug="no-summary")
-
-            assert "# No Summary Article" in result
-            assert "Content only." in result
-            assert "**Summary:**" not in result
-
-
-class TestResourceSource:
-    """Test the wikimind://sources/{id} MCP resource."""
-
-    async def test_resource_source_returns_metadata(self, db_session, sample_source):
-        mock_source = AsyncMock()
-        mock_source.id = "src-123"
-        mock_source.source_type = "url"
-        mock_source.title = "Test Source"
-        mock_source.source_url = "https://example.com/test"
-        mock_source.author = "Test Author"
-        mock_source.status = "compiled"
-        mock_source.ingested_at = "2026-01-01"
-        mock_source.compiled_at = "2026-01-02"
-        mock_source.token_count = 1500
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
-        ):
-            mock_ingest_cls.return_value.get_source = AsyncMock(return_value=mock_source)
-
-            result = await resource_source(source_id="src-123")
-            parsed = json.loads(result)
-
-            assert parsed["id"] == "src-123"
-            assert parsed["source_type"] == "url"
-            assert parsed["title"] == "Test Source"
-            assert parsed["source_url"] == "https://example.com/test"
-            assert parsed["author"] == "Test Author"
-            assert parsed["status"] == "compiled"
-            assert parsed["token_count"] == 1500
-
-    async def test_resource_source_not_found(self, db_session):
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.IngestService") as mock_ingest_cls,
-        ):
-            mock_ingest_cls.return_value.get_source = AsyncMock(
-                side_effect=Exception("Source not found"),
-            )
-
-            result = await resource_source(source_id="nonexistent")
-            parsed = json.loads(result)
-            assert "error" in parsed
-            assert "not found" in parsed["error"]
-
-
-# ---------------------------------------------------------------------------
-# MCP Prompts
-# ---------------------------------------------------------------------------
-
-
-class TestPromptResearchTopic:
-    """Test the research_topic MCP prompt."""
-
-    async def test_research_topic_with_results(self, db_session):
-        mock_result = AsyncMock(
-            title="Machine Learning Basics",
-            slug="machine-learning-basics",
-            summary="An intro to ML concepts.",
-        )
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.search = AsyncMock(return_value=[mock_result])
-
-            result = await prompt_research_topic(topic="machine learning")
-
-            assert "machine learning" in result
-            assert "Machine Learning Basics" in result
-            assert "machine-learning-basics" in result
-            assert "synthesize" in result.lower()
-
-    async def test_research_topic_no_results(self, db_session):
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.search = AsyncMock(return_value=[])
-
-            result = await prompt_research_topic(topic="quantum computing")
-
-            assert "quantum computing" in result
-            assert "No existing articles" in result
-            assert "suggest" in result.lower()
-
-    async def test_research_topic_multiple_results(self, db_session):
-        mock_results = [
-            AsyncMock(title="Article One", slug="article-one", summary="First article."),
-            AsyncMock(title="Article Two", slug="article-two", summary="Second article."),
-        ]
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.search = AsyncMock(return_value=mock_results)
-
-            result = await prompt_research_topic(topic="testing")
-
-            assert "Article One" in result
-            assert "Article Two" in result
-            assert "article-one" in result
-            assert "article-two" in result
-
-
-class TestPromptSummarizeArticle:
-    """Test the summarize_article MCP prompt."""
-
-    async def test_summarize_article_found(self, db_session):
-        mock_source = AsyncMock()
-        mock_source.title = "Original Paper"
-        mock_source.source_url = "https://example.com/paper"
-        mock_source.source_type = "url"
-
-        mock_response = AsyncMock()
-        mock_response.title = "Test Article"
-        mock_response.confidence = "sourced"
-        mock_response.page_type = "source"
-        mock_response.content = "This is the article content."
-        mock_response.sources = [mock_source]
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
-
-            result = await prompt_summarize_article(slug="test-article")
-
-            assert "Test Article" in result
-            assert "This is the article content." in result
-            assert "Original Paper" in result
-            assert "Key points" in result
-
-    async def test_summarize_article_not_found(self, db_session):
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.get_article = AsyncMock(
-                side_effect=Exception("Article not found"),
-            )
-
-            result = await prompt_summarize_article(slug="nonexistent")
-
-            assert "nonexistent" in result
-            assert "not found" in result
-            assert "wiki_search" in result
-
-    async def test_summarize_article_no_sources(self, db_session):
-        mock_response = AsyncMock()
-        mock_response.title = "Standalone Article"
-        mock_response.confidence = "inferred"
-        mock_response.page_type = "concept"
-        mock_response.content = "Content without sources."
-        mock_response.sources = []
-
-        with (
-            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
-            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
-        ):
-            mock_wiki_cls.return_value.get_article = AsyncMock(return_value=mock_response)
-
-            result = await prompt_summarize_article(slug="standalone")
-
-            assert "Standalone Article" in result
-            assert "Content without sources." in result
-            assert "Sources used:" not in result
-
-
-# ---------------------------------------------------------------------------
-# Resource & Prompt registration
-# ---------------------------------------------------------------------------
-
-
 class TestMCPResourceRegistration:
     """Test that MCP resources are properly registered on the server."""
 
@@ -593,14 +320,25 @@ class TestMCPResourceRegistration:
             assert t.description, f"Resource template {t.name} missing description"
 
 
+# ---------------------------------------------------------------------------
+# MCP Prompts
+# ---------------------------------------------------------------------------
+
+
 class TestMCPPromptRegistration:
     """Test that MCP prompts are properly registered on the server."""
 
     async def test_server_lists_prompts(self):
         prompts = await mcp_server.list_prompts()
         prompt_names = {p.name for p in prompts}
+        assert "wiki_onboarding" in prompt_names
         assert "research_topic" in prompt_names
-        assert "summarize_article" in prompt_names
+        assert "compare_articles" in prompt_names
+        assert "knowledge_gaps" in prompt_names
+
+    async def test_server_has_4_prompts(self):
+        prompts = await mcp_server.list_prompts()
+        assert len(prompts) == 4
 
     async def test_prompt_descriptions_present(self):
         prompts = await mcp_server.list_prompts()

--- a/tests/unit/test_mcp_tokens.py
+++ b/tests/unit/test_mcp_tokens.py
@@ -1,0 +1,330 @@
+"""Tests for MCP personal access token authentication (ADR-027).
+
+Covers token generation format, hash storage, PAT validation (valid,
+revoked, expired, nonexistent), JWT fallback, and API endpoints
+(generate, list, revoke).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from tests.conftest import TEST_USER_ID
+from wikimind._datetime import utcnow_naive
+from wikimind.api.routes.mcp_tokens import _generate_pat
+from wikimind.models import MCPAccessToken
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Token generation unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGeneration:
+    """Test the _generate_pat helper."""
+
+    def test_token_format(self) -> None:
+        """Token starts with wmk_ prefix and is 36 chars total."""
+        raw, _hash, _prefix = _generate_pat()
+        assert raw.startswith("wmk_")
+        # wmk_ (4) + 32 hex chars = 36
+        assert len(raw) == 36
+
+    def test_hash_is_sha256(self) -> None:
+        """Token hash matches SHA-256 of the raw token."""
+        raw, token_hash, _prefix = _generate_pat()
+        expected = hashlib.sha256(raw.encode()).hexdigest()
+        assert token_hash == expected
+
+    def test_prefix_is_first_12_chars(self) -> None:
+        """Token prefix is the first 12 characters of the raw token."""
+        raw, _hash, prefix = _generate_pat()
+        assert prefix == raw[:12]
+        assert prefix.startswith("wmk_")
+
+    def test_tokens_are_unique(self) -> None:
+        """Successive calls produce different tokens."""
+        raw1, _, _ = _generate_pat()
+        raw2, _, _ = _generate_pat()
+        assert raw1 != raw2
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMCPToken:
+    """Test POST /api/settings/mcp-tokens."""
+
+    @pytest.mark.anyio
+    async def test_create_token(self, client: AsyncClient) -> None:
+        """Creating a token returns plaintext once and correct metadata."""
+        resp = await client.post(
+            "/api/settings/mcp-tokens",
+            json={"name": "Claude Desktop"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Claude Desktop"
+        assert data["token"].startswith("wmk_")
+        assert "id" in data
+        assert "created_at" in data
+
+    @pytest.mark.anyio
+    async def test_create_token_empty_name_rejected(self, client: AsyncClient) -> None:
+        """Empty name is rejected by validation."""
+        resp = await client.post(
+            "/api/settings/mcp-tokens",
+            json={"name": ""},
+        )
+        assert resp.status_code == 422
+
+
+class TestListMCPTokens:
+    """Test GET /api/settings/mcp-tokens."""
+
+    @pytest.mark.anyio
+    async def test_list_tokens_empty(self, client: AsyncClient) -> None:
+        """List returns empty array when no tokens exist."""
+        resp = await client.get("/api/settings/mcp-tokens")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.anyio
+    async def test_list_tokens_after_create(self, client: AsyncClient) -> None:
+        """Created tokens appear in the list without plaintext."""
+        # Create two tokens
+        await client.post("/api/settings/mcp-tokens", json={"name": "Token A"})
+        await client.post("/api/settings/mcp-tokens", json={"name": "Token B"})
+
+        resp = await client.get("/api/settings/mcp-tokens")
+        assert resp.status_code == 200
+        tokens = resp.json()
+        assert len(tokens) == 2
+        names = {t["name"] for t in tokens}
+        assert names == {"Token A", "Token B"}
+
+        # Plaintext must NOT appear in list response
+        for t in tokens:
+            assert "token" not in t
+            assert t["token_prefix"].startswith("wmk_")
+
+    @pytest.mark.anyio
+    async def test_list_tokens_ordered_newest_first(self, client: AsyncClient) -> None:
+        """Tokens are ordered by created_at descending."""
+        await client.post("/api/settings/mcp-tokens", json={"name": "First"})
+        await client.post("/api/settings/mcp-tokens", json={"name": "Second"})
+
+        resp = await client.get("/api/settings/mcp-tokens")
+        tokens = resp.json()
+        assert tokens[0]["name"] == "Second"
+        assert tokens[1]["name"] == "First"
+
+
+class TestRevokeMCPToken:
+    """Test DELETE /api/settings/mcp-tokens/{token_id}."""
+
+    @pytest.mark.anyio
+    async def test_revoke_token(self, client: AsyncClient) -> None:
+        """Revoking a token sets revoked=True."""
+        create_resp = await client.post(
+            "/api/settings/mcp-tokens",
+            json={"name": "Revocable"},
+        )
+        token_id = create_resp.json()["id"]
+
+        resp = await client.delete(f"/api/settings/mcp-tokens/{token_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "revoked"
+
+        # Verify it shows as revoked in list
+        list_resp = await client.get("/api/settings/mcp-tokens")
+        revoked_tokens = [t for t in list_resp.json() if t["id"] == token_id]
+        assert len(revoked_tokens) == 1
+        assert revoked_tokens[0]["revoked"] is True
+
+    @pytest.mark.anyio
+    async def test_revoke_nonexistent_token(self, client: AsyncClient) -> None:
+        """Revoking a nonexistent token returns 404."""
+        resp = await client.delete("/api/settings/mcp-tokens/does-not-exist")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PAT validation tests (auth provider)
+# ---------------------------------------------------------------------------
+
+
+class TestPATValidation:
+    """Test the MCP auth provider's PAT validation path."""
+
+    @pytest.mark.anyio
+    async def test_valid_pat(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A valid, non-revoked, non-expired PAT returns an AccessToken."""
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        raw_token = f"wmk_{secrets.token_hex(16)}"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        token_row = MCPAccessToken(
+            user_id=TEST_USER_ID,
+            name="Test Token",
+            token_hash=token_hash,
+            token_prefix=raw_token[:12],
+        )
+        db_session.add(token_row)
+        await db_session.commit()
+
+        provider = WikiMindAuthProvider(secret="unused-for-pat")
+
+        with patch("wikimind.mcp.auth.get_session_factory", return_value=session_factory):
+            access_token = await provider.verify_token(raw_token)
+
+        assert access_token is not None
+        assert access_token.client_id == TEST_USER_ID
+
+    @pytest.mark.anyio
+    async def test_revoked_pat_rejected(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A revoked PAT raises ValueError."""
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        raw_token = f"wmk_{secrets.token_hex(16)}"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        token_row = MCPAccessToken(
+            user_id=TEST_USER_ID,
+            name="Revoked Token",
+            token_hash=token_hash,
+            token_prefix=raw_token[:12],
+            revoked=True,
+        )
+        db_session.add(token_row)
+        await db_session.commit()
+
+        provider = WikiMindAuthProvider(secret="unused")
+
+        with (
+            patch("wikimind.mcp.auth.get_session_factory", return_value=session_factory),
+            pytest.raises(ValueError, match="revoked"),
+        ):
+            await provider.verify_token(raw_token)
+
+    @pytest.mark.anyio
+    async def test_expired_pat_rejected(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """An expired PAT raises ValueError."""
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        raw_token = f"wmk_{secrets.token_hex(16)}"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        token_row = MCPAccessToken(
+            user_id=TEST_USER_ID,
+            name="Expired Token",
+            token_hash=token_hash,
+            token_prefix=raw_token[:12],
+            expires_at=utcnow_naive() - timedelta(hours=1),
+        )
+        db_session.add(token_row)
+        await db_session.commit()
+
+        provider = WikiMindAuthProvider(secret="unused")
+
+        with (
+            patch("wikimind.mcp.auth.get_session_factory", return_value=session_factory),
+            pytest.raises(ValueError, match="expired"),
+        ):
+            await provider.verify_token(raw_token)
+
+    @pytest.mark.anyio
+    async def test_nonexistent_pat_rejected(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A PAT with no matching hash raises ValueError."""
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        raw_token = f"wmk_{secrets.token_hex(16)}"
+        provider = WikiMindAuthProvider(secret="unused")
+
+        with (
+            patch("wikimind.mcp.auth.get_session_factory", return_value=session_factory),
+            pytest.raises(ValueError, match="Invalid token"),
+        ):
+            await provider.verify_token(raw_token)
+
+
+# ---------------------------------------------------------------------------
+# JWT validation fallback
+# ---------------------------------------------------------------------------
+
+
+class TestJWTFallback:
+    """Test that non-PAT tokens still route to JWT validation."""
+
+    @pytest.mark.anyio
+    async def test_jwt_still_works(self) -> None:
+        """A valid JWT is still accepted via the auth provider."""
+        import jwt as pyjwt
+
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        secret = "test-jwt-secret-key-for-tests!!"  # pragma: allowlist secret
+        token = pyjwt.encode({"sub": "user-123"}, secret, algorithm="HS256")
+
+        provider = WikiMindAuthProvider(secret=secret)
+        access_token = await provider.verify_token(token)
+        assert access_token is not None
+        assert access_token.client_id == "user-123"
+
+    @pytest.mark.anyio
+    async def test_invalid_jwt_rejected(self) -> None:
+        """An invalid JWT raises ValueError."""
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        provider = WikiMindAuthProvider(secret="my-secret")
+        with pytest.raises(ValueError, match="Invalid token"):
+            await provider.verify_token("not.a.valid.jwt")
+
+    @pytest.mark.anyio
+    async def test_expired_jwt_rejected(self) -> None:
+        """An expired JWT raises ValueError."""
+        import jwt as pyjwt
+
+        from wikimind.mcp.auth import WikiMindAuthProvider
+
+        secret = "test-jwt-secret-key-for-tests!!"  # pragma: allowlist secret
+        past = utcnow_naive() - timedelta(hours=1)
+        token = pyjwt.encode(
+            {"sub": "user-123", "exp": past},
+            secret,
+            algorithm="HS256",
+        )
+
+        provider = WikiMindAuthProvider(secret=secret)
+        with pytest.raises(ValueError, match="expired"):
+            await provider.verify_token(token)

--- a/tests/unit/test_mcp_write.py
+++ b/tests/unit/test_mcp_write.py
@@ -64,6 +64,7 @@ class TestWikiIngestUrl:
             mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
             mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
             mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+            mock_factory.return_value._schedule_compile = AsyncMock()
 
             result = await wiki_ingest_url(
                 url="https://example.com/article",
@@ -72,6 +73,8 @@ class TestWikiIngestUrl:
             )
 
             assert result == {"source_id": "src-001", "status": "queued"}
+            # Verify compilation was scheduled after commit
+            mock_factory.return_value._schedule_compile.assert_called_once_with(source)
 
     @pytest.mark.asyncio
     async def test_ingest_url_rejects_file_scheme(self):
@@ -112,6 +115,7 @@ class TestWikiIngestUrl:
             mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
             mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
             mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+            mock_factory.return_value._schedule_compile = AsyncMock()
 
             await wiki_ingest_url(
                 url="https://example.com/article",
@@ -119,10 +123,11 @@ class TestWikiIngestUrl:
                 user_id=TEST_USER_ID,
             )
 
-            # Verify title was set on the source object
+            # Verify title was set on the source object BEFORE compilation
             assert source.title == "Custom Title"
-            # Verify session.commit() was called
+            # Verify session.commit() was called before _schedule_compile
             session.commit.assert_called_once()
+            mock_factory.return_value._schedule_compile.assert_called_once_with(source)
 
     @pytest.mark.asyncio
     async def test_ingest_url_dedup_returns_already_exists(self):
@@ -172,6 +177,7 @@ class TestWikiIngestUrl:
             mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
             mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
             mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+            mock_factory.return_value._schedule_compile = AsyncMock()
 
             result = await wiki_ingest_url(
                 url="https://example.com/duplicate",

--- a/tests/unit/test_mcp_write.py
+++ b/tests/unit/test_mcp_write.py
@@ -1,0 +1,490 @@
+"""Tests for WikiMind MCP write tools (Tier 3).
+
+Tests wiki_ingest_url, wiki_ingest_text, and wiki_get_source_status
+with mocked service layer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from wikimind.mcp.tools_write import (
+    wiki_get_source_status,
+    wiki_ingest_text,
+    wiki_ingest_url,
+)
+from wikimind.models.enums import IngestStatus
+
+TEST_USER_ID = "test-user-123"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source(
+    source_id: str = "src-001",
+    title: str | None = "Test Source",
+    status: IngestStatus = IngestStatus.PENDING,
+    compiled_at: datetime | None = None,
+    error_message: str | None = None,
+) -> MagicMock:
+    """Create a mock Source object."""
+    source = MagicMock()
+    source.id = source_id
+    source.title = title
+    source.status = status
+    source.compiled_at = compiled_at
+    source.error_message = error_message
+    return source
+
+
+# ---------------------------------------------------------------------------
+# wiki_ingest_url
+# ---------------------------------------------------------------------------
+
+
+class TestWikiIngestUrl:
+    """Test the wiki_ingest_url tool."""
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_returns_source_id_and_queued(self):
+        source = _make_source(compiled_at=None)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+
+            result = await wiki_ingest_url(
+                url="https://example.com/article",
+                title="",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result == {"source_id": "src-001", "status": "queued"}
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_rejects_file_scheme(self):
+        with pytest.raises(ToolError, match="Only http:// and https://"):
+            await wiki_ingest_url(
+                url="file:///etc/passwd",
+                title="",
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_rejects_ftp_scheme(self):
+        with pytest.raises(ToolError, match="Only http:// and https://"):
+            await wiki_ingest_url(
+                url="ftp://example.com/file",
+                title="",
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_rejects_long_title(self):
+        with pytest.raises(ToolError, match="200 characters"):
+            await wiki_ingest_url(
+                url="https://example.com",
+                title="x" * 201,
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_applies_title_override(self):
+        source = _make_source(compiled_at=None)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+
+            await wiki_ingest_url(
+                url="https://example.com/article",
+                title="Custom Title",
+                user_id=TEST_USER_ID,
+            )
+
+            # Verify title was set on the source object
+            assert source.title == "Custom Title"
+            # Verify session.commit() was called
+            session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_dedup_returns_already_exists(self):
+        source = _make_source(
+            compiled_at=datetime(2026, 1, 1),
+            status=IngestStatus.COMPILED,
+        )
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+            patch(
+                "wikimind.mcp.tools_write._find_article_slug_for_source",
+                new_callable=AsyncMock,
+                return_value="existing-article",
+            ),
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+
+            result = await wiki_ingest_url(
+                url="https://example.com/duplicate",
+                title="",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "already_exists"
+            assert result["source_id"] == "src-001"
+            assert result["article_slug"] == "existing-article"
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_dedup_without_article_slug(self):
+        source = _make_source(compiled_at=datetime(2026, 1, 1))
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+            patch(
+                "wikimind.mcp.tools_write._find_article_slug_for_source",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_url = AsyncMock(return_value=source)
+
+            result = await wiki_ingest_url(
+                url="https://example.com/duplicate",
+                title="",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "already_exists"
+            assert "article_slug" not in result
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_wraps_ingest_error(self):
+        from wikimind.errors import IngestError
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_url = AsyncMock(side_effect=IngestError("Network timeout"))
+
+            with pytest.raises(ToolError, match="Ingestion failed"):
+                await wiki_ingest_url(
+                    url="https://example.com/timeout",
+                    title="",
+                    user_id=TEST_USER_ID,
+                )
+
+
+# ---------------------------------------------------------------------------
+# wiki_ingest_text
+# ---------------------------------------------------------------------------
+
+
+class TestWikiIngestText:
+    """Test the wiki_ingest_text tool."""
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_returns_source_id_and_queued(self):
+        source = _make_source(compiled_at=None)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_text = AsyncMock(return_value=source)
+
+            result = await wiki_ingest_text(
+                text="Some interesting content to ingest.",
+                title="My Note",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result == {"source_id": "src-001", "status": "queued"}
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_rejects_empty_text(self):
+        with pytest.raises(ToolError, match="at least 1 character"):
+            await wiki_ingest_text(
+                text="",
+                title="Title",
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_rejects_too_long_text(self):
+        with pytest.raises(ToolError, match="100000 characters"):
+            await wiki_ingest_text(
+                text="x" * 100001,
+                title="Title",
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_rejects_empty_title(self):
+        with pytest.raises(ToolError, match="Title is required"):
+            await wiki_ingest_text(
+                text="Some content",
+                title="",
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_rejects_long_title(self):
+        with pytest.raises(ToolError, match="200 characters"):
+            await wiki_ingest_text(
+                text="Some content",
+                title="x" * 201,
+                user_id=TEST_USER_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_dedup_returns_already_exists(self):
+        source = _make_source(
+            compiled_at=datetime(2026, 1, 1),
+            status=IngestStatus.COMPILED,
+        )
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+            patch(
+                "wikimind.mcp.tools_write._find_article_slug_for_source",
+                new_callable=AsyncMock,
+                return_value="dedup-article",
+            ),
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_text = AsyncMock(return_value=source)
+
+            result = await wiki_ingest_text(
+                text="Duplicate content",
+                title="Duplicate Title",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "already_exists"
+            assert result["source_id"] == "src-001"
+            assert result["article_slug"] == "dedup-article"
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_wraps_ingest_error(self):
+        from wikimind.errors import IngestError
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.ingest_text = AsyncMock(side_effect=IngestError("Parse error"))
+
+            with pytest.raises(ToolError, match="Ingestion failed"):
+                await wiki_ingest_text(
+                    text="Some content",
+                    title="Title",
+                    user_id=TEST_USER_ID,
+                )
+
+
+# ---------------------------------------------------------------------------
+# wiki_get_source_status
+# ---------------------------------------------------------------------------
+
+
+class TestWikiGetSourceStatus:
+    """Test the wiki_get_source_status tool."""
+
+    @pytest.mark.asyncio
+    async def test_status_pending_returns_queued(self):
+        source = _make_source(status=IngestStatus.PENDING)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(return_value=source)
+
+            result = await wiki_get_source_status(
+                source_id="src-001",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["source_id"] == "src-001"
+            assert result["status"] == "queued"
+            assert result["title"] == "Test Source"
+
+    @pytest.mark.asyncio
+    async def test_status_processing(self):
+        source = _make_source(status=IngestStatus.PROCESSING)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(return_value=source)
+
+            result = await wiki_get_source_status(
+                source_id="src-001",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "processing"
+
+    @pytest.mark.asyncio
+    async def test_status_compiled_includes_article_slug(self):
+        source = _make_source(status=IngestStatus.COMPILED)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+            patch(
+                "wikimind.mcp.tools_write._find_article_slug_for_source",
+                new_callable=AsyncMock,
+                return_value="compiled-article",
+            ),
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(return_value=source)
+
+            result = await wiki_get_source_status(
+                source_id="src-001",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "compiled"
+            assert result["article_slug"] == "compiled-article"
+
+    @pytest.mark.asyncio
+    async def test_status_failed_includes_error(self):
+        source = _make_source(
+            status=IngestStatus.FAILED,
+            error_message="LLM rate limit exceeded",
+        )
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(return_value=source)
+
+            result = await wiki_get_source_status(
+                source_id="src-001",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "failed"
+            assert result["error"] == "LLM rate limit exceeded"
+
+    @pytest.mark.asyncio
+    async def test_status_not_found_raises_tool_error(self):
+        from wikimind.errors import NotFoundError
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(side_effect=NotFoundError("Source not found"))
+
+            with pytest.raises(ToolError, match="Source not found"):
+                await wiki_get_source_status(
+                    source_id="nonexistent",
+                    user_id=TEST_USER_ID,
+                )
+
+    @pytest.mark.asyncio
+    async def test_status_compiled_without_article_slug(self):
+        source = _make_source(status=IngestStatus.COMPILED)
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+            patch(
+                "wikimind.mcp.tools_write._find_article_slug_for_source",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(return_value=source)
+
+            result = await wiki_get_source_status(
+                source_id="src-001",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "compiled"
+            assert "article_slug" not in result
+
+    @pytest.mark.asyncio
+    async def test_status_failed_without_error_message(self):
+        source = _make_source(
+            status=IngestStatus.FAILED,
+            error_message=None,
+        )
+
+        with (
+            patch("wikimind.mcp.tools_write._get_session") as mock_session_ctx,
+            patch("wikimind.mcp.tools_write.get_ingest_service") as mock_factory,
+        ):
+            session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+            mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_factory.return_value.get_source = AsyncMock(return_value=source)
+
+            result = await wiki_get_source_status(
+                source_id="src-001",
+                user_id=TEST_USER_ID,
+            )
+
+            assert result["status"] == "failed"
+            assert "error" not in result


### PR DESCRIPTION
## Summary
- 13 tools across 4 tiers: discovery, read/search, write, analysis
- 3 resources: wikimind://index, articles/{slug}, sources/{source_id}
- 4 prompts: onboarding, research_topic, compare_articles, knowledge_gaps
- JWT auth for HTTP transport, stdio for local use
- Proper tool annotations, structured output, ToolError error handling
- Progress reporting and MCP logging

Consolidates and supersedes PRs #753, #760, #763.

## Test plan
- [ ] All unit tests pass (make verify)
- [ ] MCP Inspector shows all 13 tools, 3 resources, 4 prompts
- [ ] wiki_overview returns structured data
- [ ] wiki_ingest_url queues ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)