### PR TITLE
feat(security): add rate limiting to auth, query, and ingest endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -307,6 +307,16 @@
 # WIKIMIND_DATABASE__ECHO=false
 
 # ----------------------------------------------------------------------------
+# Rate Limiting (issue #704)
+# ----------------------------------------------------------------------------
+# Per-user rate limits for sensitive endpoints. Backed by Redis when available;
+# falls back to in-memory for single-process dev mode.
+# WIKIMIND_RATE_LIMIT__ENABLED=true
+# WIKIMIND_RATE_LIMIT__AUTH_LIMIT=5/minute
+# WIKIMIND_RATE_LIMIT__QUERY_LIMIT=30/minute
+# WIKIMIND_RATE_LIMIT__INGEST_LIMIT=10/minute
+
+# ----------------------------------------------------------------------------
 # Authentication (OAuth2 / SSO)
 # ----------------------------------------------------------------------------
 # Auth is always on. In development mode (WIKIMIND_ENV=development), the system

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": ".merge_file_NCNMmo"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -150,6 +150,414 @@
         "hashed_secret": "f25e7e3dd1539e107ca4c4705ebe293496c38e10",
         "is_verified": false,
         "line_number": 251
+      }
+    ],
+    ".secrets.baseline": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "300ac668c782c666a9de0f2ccb59cea082255b5d",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c332c15e76c22a7f7125d03261e4218a2005a6ba",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "c332c15e76c22a7f7125d03261e4218a2005a6ba",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6116e7dbe0baf62ebaf5b48cfac17685433f6329",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6116e7dbe0baf62ebaf5b48cfac17685433f6329",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a74fc91112fd83cad3bde7a3b0d33ba0ec38a1e6",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "fdfb9a944df1fab3d6f24457abcde745ae8ed4ca",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "89fca188cc62ec16bbe156c5c68a9f19a8f1a70b",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "a87388adda751e88bdf867e02c7d123f8773ea29",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4361662517308d2a748756b80f393c6f493f878e",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "6d6ef05208124bf1476f74139b0a47dcd3b54cd3",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "93553d1d61c3294a318487ae6b66130aa0360214",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3fc5d3c65ff2c5dfca86da67cee536e4ed0941d",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8b4e0a96e912f8b494d0ed37e30a0686335e28a2",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "7eb469ff6f063674a453ff031b73397f2908082a",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "353e8061f2befecb6818ba0c034c632fb0bcae1b",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 278
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e286fb375a5f7b98d91f8180db3d887744194fce",
+        "is_verified": false,
+        "line_number": 278
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 287
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "d74a819dfe9c101c9359cf94ce47186b6b709dec",
+        "is_verified": false,
+        "line_number": 287
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b97bf3bc32886cf237ce196071c45eb3c8a3cbf9",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 303
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "302dce9f3d383caf84d97322e3befda428501f0a",
+        "is_verified": false,
+        "line_number": 303
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 312
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "9b7bc202b1094ee930e3226a979563175fd92d2f",
+        "is_verified": false,
+        "line_number": 312
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "e3bca62bb2a4a17fde529a52a127d68f4ec37d4f",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 339
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "4cc44161189d7df118daa128174ff40545e208a0",
+        "is_verified": false,
+        "line_number": 339
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 348
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f24f929bf081df0d1c5a51c12ae11489178512d3",
+        "is_verified": false,
+        "line_number": 348
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 355
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "44dadfe55a7bf9a02a7a025958ca42ba93bb8a2d",
+        "is_verified": false,
+        "line_number": 355
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 364
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "5a8c1d444e6c8021c015f210999479caa6467a99",
+        "is_verified": false,
+        "line_number": 364
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "8d1e4f5888895e9f5df12404d016f885c42fad0b",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "222c522af6ffd8cb970b793f1de8082b5832633b",
+        "is_verified": false,
+        "line_number": 398
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "222c522af6ffd8cb970b793f1de8082b5832633b",
+        "is_verified": false,
+        "line_number": 398
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f7d3aeffc1aa2155af7f1eae52f5a0af45e32b35",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 423
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "f923e0e1dc7e136a7a92499df32b4568961cba14",
+        "is_verified": false,
+        "line_number": 423
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
+        "is_verified": false,
+        "line_number": 430
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".secrets.baseline",
+        "hashed_secret": "b59bde01d759357b76673424b3800e369aa527ca",
+        "is_verified": false,
+        "line_number": 430
       }
     ],
     "Makefile": [
@@ -295,14 +703,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 656
+        "line_number": 674
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 681
+        "line_number": 699
       }
     ],
     "src/wikimind/engine/providers/openai.py": [
@@ -433,5 +841,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-18T01:37:28Z"
+  "generated_at": "2026-05-18T16:47:52Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
     "prometheus-fastapi-instrumentator>=7.0.0",
     # MCP (Model Context Protocol)
     "fastmcp>=3.0.2",
+    # Rate limiting
+    "slowapi>=0.1.9",
     # Utilities
     "python-slugify>=8.0.4",
     "python-dateutil>=2.9.0",

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -29,6 +29,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind.api.deps import require_user_id
 from wikimind.config import get_settings
 from wikimind.database import get_session
+from wikimind.middleware.rate_limit import limiter
 from wikimind.models import (
     DeleteAccountResponse,
     MagicLinkRequest,
@@ -118,6 +119,7 @@ _SAFE_REDIRECT_PATHS = ("/auth/tokens", "/settings", "/mcp/authorize/resume")
 
 
 @router.get("/login/{provider}")
+@limiter.limit(get_settings().rate_limit.auth_limit)
 async def login(provider: str, request: Request) -> RedirectResponse:
     """Redirect to OAuth2 provider's authorize URL."""
     settings = get_settings()
@@ -238,7 +240,9 @@ async def me(
 
 
 @router.post("/magic-link")
+@limiter.limit(get_settings().rate_limit.auth_limit)
 async def request_magic_link(
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
     body: MagicLinkRequest,
     service: UserService = Depends(get_user_service),
 ) -> MagicLinkResponse:
@@ -266,7 +270,9 @@ async def request_magic_link(
 
 
 @router.post("/magic-link/verify")
+@limiter.limit(get_settings().rate_limit.auth_limit)
 async def verify_magic_link(
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
     body: MagicLinkVerifyRequest,
     session: AsyncSession = Depends(get_session),
     service: UserService = Depends(get_user_service),

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -9,11 +9,13 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from starlette.requests import Request
 
 from wikimind.api.deps import get_current_user_id
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.ingest.adapters.pdf import PDFAdapter
+from wikimind.middleware.rate_limit import limiter
 from wikimind.models import (
     Article,
     ArticleSource,
@@ -53,18 +55,22 @@ router = APIRouter()
 
 
 @router.post("/url", response_model=Source)
+@limiter.limit(get_settings().rate_limit.ingest_limit)
 async def ingest_url(
-    request: IngestURLRequest,
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
+    body: IngestURLRequest,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
     user_id: str = Depends(get_current_user_id),
 ):
     """Ingest a web URL or YouTube video."""
-    return await service.ingest_url(str(request.url), session, auto_compile=request.auto_compile, user_id=user_id)
+    return await service.ingest_url(str(body.url), session, auto_compile=body.auto_compile, user_id=user_id)
 
 
 @router.post("/pdf", response_model=Source)
+@limiter.limit(get_settings().rate_limit.ingest_limit)
 async def ingest_pdf(
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
     file: UploadFile = File(...),
     auto_compile: bool = True,
     session: AsyncSession = Depends(get_session),
@@ -91,18 +97,20 @@ async def ingest_pdf(
 
 
 @router.post("/text", response_model=Source)
+@limiter.limit(get_settings().rate_limit.ingest_limit)
 async def ingest_text(
-    request: IngestTextRequest,
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
+    body: IngestTextRequest,
     session: AsyncSession = Depends(get_session),
     service: IngestService = Depends(get_ingest_service),
     user_id: str = Depends(get_current_user_id),
 ):
     """Ingest raw text or a note."""
     return await service.ingest_text(
-        request.content,
-        request.title,
+        body.content,
+        body.title,
         session,
-        auto_compile=request.auto_compile,
+        auto_compile=body.auto_compile,
         user_id=user_id,
     )
 

--- a/src/wikimind/api/routes/query.py
+++ b/src/wikimind/api/routes/query.py
@@ -8,9 +8,12 @@ import structlog
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import Response, StreamingResponse
 from sqlmodel.ext.asyncio.session import AsyncSession
+from starlette.requests import Request
 
 from wikimind.api.deps import get_current_user_id
+from wikimind.config import get_settings
 from wikimind.database import get_session, get_session_factory
+from wikimind.middleware.rate_limit import limiter
 from wikimind.models import (
     AskResponse,
     ConversationDetail,
@@ -30,8 +33,10 @@ router = APIRouter()
 
 
 @router.post("", response_model=AskResponse)
+@limiter.limit(get_settings().rate_limit.query_limit)
 async def ask(
-    request: QueryRequest,
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
+    body: QueryRequest,
     session: AsyncSession = Depends(get_session),
     service: QueryService = Depends(get_query_service),
     user_id: str = Depends(get_current_user_id),
@@ -42,12 +47,14 @@ async def ask(
     Otherwise the question is appended as a new turn in the existing
     conversation.
     """
-    return await service.ask(request, session, user_id=user_id)
+    return await service.ask(body, session, user_id=user_id)
 
 
 @router.post("/stream")
+@limiter.limit(get_settings().rate_limit.query_limit)
 async def ask_stream(
-    request: QueryRequest,
+    request: Request,  # noqa: ARG001 — required by slowapi limiter
+    body: QueryRequest,
     service: QueryService = Depends(get_query_service),
     user_id: str = Depends(get_current_user_id),
 ) -> StreamingResponse:
@@ -61,7 +68,7 @@ async def ask_stream(
     async def _event_generator() -> AsyncIterator[str]:
         async with get_session_factory()() as session:
             try:
-                async for event in service.ask_stream(request, session, user_id=user_id):
+                async for event in service.ask_stream(body, session, user_id=user_id):
                     yield event
             except asyncio.CancelledError:
                 log.info("SSE client disconnected, aborting stream")

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -317,6 +317,20 @@ class MCPConfig(BaseModel):
     client_enabled: bool = False
 
 
+class RateLimitConfig(BaseModel):
+    """Rate limiting configuration.
+
+    Controls per-user request rate limits for auth, query, and ingest
+    endpoints. Backed by Redis when available; falls back to in-memory
+    storage for single-process dev mode.
+    """
+
+    enabled: bool = True
+    auth_limit: str = "5/minute"
+    query_limit: str = "30/minute"
+    ingest_limit: str = "10/minute"
+
+
 class AuthConfig(BaseModel):
     """OAuth2 authentication configuration.
 
@@ -409,6 +423,7 @@ class Settings(BaseSettings):
     staleness: StalenessConfig = Field(default_factory=StalenessConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
     concept_layer: ConceptLayerConfig = Field(default_factory=ConceptLayerConfig)
+    rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
 

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -14,6 +14,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from slowapi.errors import RateLimitExceeded
 from sqlmodel import select
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import FileResponse, HTMLResponse
@@ -54,6 +55,7 @@ from wikimind.middleware.auth import AuthMiddleware
 from wikimind.middleware.correlation import CorrelationIdMiddleware
 from wikimind.middleware.error_handling import ErrorHandlingMiddleware
 from wikimind.middleware.logging_config import configure_logging
+from wikimind.middleware.rate_limit import limiter, rate_limit_exceeded_handler
 from wikimind.middleware.request_logging import RequestLoggingMiddleware
 from wikimind.middleware.security_headers import SecurityHeadersMiddleware
 from wikimind.models import IngestStatus, Source
@@ -221,6 +223,12 @@ app = FastAPI(
         {"name": "WebSocket", "description": "Real-time progress streams"},
     ],
 )
+
+# ---------------------------------------------------------------------------
+# Rate limiting — register slowapi limiter and 429 handler
+# ---------------------------------------------------------------------------
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 # ---------------------------------------------------------------------------
 # Prometheus metrics — exposes /metrics for scraping

--- a/src/wikimind/middleware/rate_limit.py
+++ b/src/wikimind/middleware/rate_limit.py
@@ -1,0 +1,67 @@
+"""Rate limiting middleware backed by Redis (or in-memory for dev).
+
+Uses slowapi to enforce per-user rate limits on auth, query, and ingest
+endpoints. When Redis is configured, limits are shared across workers;
+otherwise falls back to in-memory storage for single-process dev mode.
+
+The limiter key function extracts the user ID from ``request.state``
+(set by the auth middleware), falling back to the client IP for
+unauthenticated endpoints (e.g. login).
+"""
+
+from __future__ import annotations
+
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded  # noqa: TC002 — used at runtime in handler signature
+from slowapi.util import get_remote_address
+from starlette.requests import Request  # noqa: TC002 — used in function signatures consumed by slowapi
+from starlette.responses import JSONResponse
+
+from wikimind.config import get_settings
+
+
+def _key_func(request: Request) -> str:
+    """Extract rate limit key: user_id if authenticated, else client IP."""
+    user_id = getattr(getattr(request, "state", None), "user_id", None)
+    if user_id:
+        return user_id
+    return get_remote_address(request)
+
+
+def _create_limiter() -> Limiter:
+    """Create the rate limiter with current settings."""
+    settings = get_settings()
+    return Limiter(
+        key_func=_key_func,
+        storage_uri=settings.redis_url,
+        enabled=settings.rate_limit.enabled,
+    )
+
+
+limiter = _create_limiter()
+
+
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Return a standard 429 response with Retry-After header.
+
+    Formats the rate-limit error using the project's standard JSON
+    error envelope and includes a ``Retry-After`` header.
+    """
+    request_id = getattr(getattr(request, "state", None), "request_id", "unknown")
+
+    # Extract retry-after seconds from the exception headers if available
+    retry_after_seconds = "60"
+    if hasattr(exc, "headers") and exc.headers:
+        retry_after_seconds = exc.headers.get("Retry-After", "60")
+
+    return JSONResponse(
+        status_code=429,
+        content={
+            "error": {
+                "code": "rate_limited",
+                "message": f"Rate limit exceeded: {exc.detail}",
+                "request_id": request_id,
+            }
+        },
+        headers={"Retry-After": retry_after_seconds},
+    )

--- a/src/wikimind/middleware/rate_limit.py
+++ b/src/wikimind/middleware/rate_limit.py
@@ -57,7 +57,8 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     # limits.RateLimitItem with .get_expiry() returning seconds.
     retry_after_seconds = "60"
     with contextlib.suppress(Exception):
-        retry_after_seconds = str(exc.limit.limit.get_expiry())
+        if exc.limit and exc.limit.limit:
+            retry_after_seconds = str(exc.limit.limit.get_expiry())
 
     return JSONResponse(
         status_code=429,

--- a/src/wikimind/middleware/rate_limit.py
+++ b/src/wikimind/middleware/rate_limit.py
@@ -11,6 +11,8 @@ unauthenticated endpoints (e.g. login).
 
 from __future__ import annotations
 
+import contextlib
+
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded  # noqa: TC002 — used at runtime in handler signature
 from slowapi.util import get_remote_address
@@ -35,6 +37,7 @@ def _create_limiter() -> Limiter:
         key_func=_key_func,
         storage_uri=settings.redis_url,
         enabled=settings.rate_limit.enabled,
+        in_memory_fallback_enabled=True,
     )
 
 
@@ -49,10 +52,12 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     """
     request_id = getattr(getattr(request, "state", None), "request_id", "unknown")
 
-    # Extract retry-after seconds from the exception headers if available
+    # Derive retry window from the rate limit that was exceeded.
+    # exc.limit is a slowapi Limit wrapper whose .limit is a
+    # limits.RateLimitItem with .get_expiry() returning seconds.
     retry_after_seconds = "60"
-    if hasattr(exc, "headers") and exc.headers:
-        retry_after_seconds = exc.headers.get("Retry-After", "60")
+    with contextlib.suppress(Exception):
+        retry_after_seconds = str(exc.limit.limit.get_expiry())
 
     return JSONResponse(
         status_code=429,

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -70,7 +70,7 @@ class TestRateLimitKeyFunc:
 class TestRateLimitExceededHandler:
     """Test the 429 error response format."""
 
-    def test_handler_returns_429_with_retry_after(self):
+    def test_handler_derives_retry_after_from_limit_window(self):
         from wikimind.middleware.rate_limit import rate_limit_exceeded_handler
 
         request = MagicMock()
@@ -78,17 +78,17 @@ class TestRateLimitExceededHandler:
 
         exc = MagicMock()
         exc.detail = "5 per 1 minute"
-        exc.headers = {"Retry-After": "42"}
+        exc.limit.limit.get_expiry.return_value = 120
 
         response = rate_limit_exceeded_handler(request, exc)
         assert response.status_code == 429
-        assert response.headers.get("Retry-After") == "42"
+        assert response.headers.get("Retry-After") == "120"
         body = json.loads(response.body.decode())
         assert body["error"]["code"] == "rate_limited"
         assert body["error"]["request_id"] == "req-abc"
         assert "5 per 1 minute" in body["error"]["message"]
 
-    def test_handler_defaults_retry_after_to_60(self):
+    def test_handler_defaults_retry_after_to_60_on_error(self):
         from wikimind.middleware.rate_limit import rate_limit_exceeded_handler
 
         request = MagicMock()
@@ -96,7 +96,7 @@ class TestRateLimitExceededHandler:
 
         exc = MagicMock()
         exc.detail = "10 per 1 minute"
-        exc.headers = {}
+        exc.limit.limit.get_expiry.side_effect = AttributeError("no expiry")
 
         response = rate_limit_exceeded_handler(request, exc)
         assert response.headers.get("Retry-After") == "60"
@@ -109,7 +109,7 @@ class TestRateLimitExceededHandler:
 
         exc = MagicMock()
         exc.detail = "rate limited"
-        exc.headers = {"Retry-After": "30"}
+        exc.limit.limit.get_expiry.return_value = 30
 
         response = rate_limit_exceeded_handler(request, exc)
         body = json.loads(response.body.decode())

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,194 @@
+"""Unit tests for rate limiting middleware."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+class TestRateLimitConfig:
+    """Test that RateLimitConfig defaults are sensible."""
+
+    def test_defaults(self):
+        from wikimind.config import RateLimitConfig
+
+        cfg = RateLimitConfig()
+        assert cfg.enabled is True
+        assert cfg.auth_limit == "5/minute"
+        assert cfg.query_limit == "30/minute"
+        assert cfg.ingest_limit == "10/minute"
+
+    def test_custom_values(self):
+        from wikimind.config import RateLimitConfig
+
+        cfg = RateLimitConfig(
+            enabled=False,
+            auth_limit="10/minute",
+            query_limit="60/minute",
+            ingest_limit="20/minute",
+        )
+        assert cfg.enabled is False
+        assert cfg.auth_limit == "10/minute"
+        assert cfg.query_limit == "60/minute"
+        assert cfg.ingest_limit == "20/minute"
+
+
+class TestRateLimitKeyFunc:
+    """Test the key extraction function."""
+
+    def test_extracts_user_id(self):
+        from wikimind.middleware.rate_limit import _key_func
+
+        request = MagicMock()
+        request.state.user_id = "user-123"
+        assert _key_func(request) == "user-123"
+
+    def test_falls_back_to_ip(self):
+        from wikimind.middleware.rate_limit import _key_func
+
+        request = MagicMock()
+        request.state.user_id = None
+        request.client.host = "192.168.1.1"
+        assert _key_func(request) == "192.168.1.1"
+
+    def test_no_user_id_attr_falls_back_to_ip(self):
+        from wikimind.middleware.rate_limit import _key_func
+
+        request = MagicMock(spec=[])
+        request.state = None
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        assert _key_func(request) == "10.0.0.1"
+
+
+class TestRateLimitExceededHandler:
+    """Test the 429 error response format."""
+
+    def test_handler_returns_429_with_retry_after(self):
+        from wikimind.middleware.rate_limit import rate_limit_exceeded_handler
+
+        request = MagicMock()
+        request.state.request_id = "req-abc"
+
+        exc = MagicMock()
+        exc.detail = "5 per 1 minute"
+        exc.headers = {"Retry-After": "42"}
+
+        response = rate_limit_exceeded_handler(request, exc)
+        assert response.status_code == 429
+        assert response.headers.get("Retry-After") == "42"
+        body = json.loads(response.body.decode())
+        assert body["error"]["code"] == "rate_limited"
+        assert body["error"]["request_id"] == "req-abc"
+        assert "5 per 1 minute" in body["error"]["message"]
+
+    def test_handler_defaults_retry_after_to_60(self):
+        from wikimind.middleware.rate_limit import rate_limit_exceeded_handler
+
+        request = MagicMock()
+        request.state.request_id = "req-xyz"
+
+        exc = MagicMock()
+        exc.detail = "10 per 1 minute"
+        exc.headers = {}
+
+        response = rate_limit_exceeded_handler(request, exc)
+        assert response.headers.get("Retry-After") == "60"
+
+    def test_handler_missing_request_id(self):
+        from wikimind.middleware.rate_limit import rate_limit_exceeded_handler
+
+        request = MagicMock()
+        del request.state.request_id  # simulate missing attribute
+
+        exc = MagicMock()
+        exc.detail = "rate limited"
+        exc.headers = {"Retry-After": "30"}
+
+        response = rate_limit_exceeded_handler(request, exc)
+        body = json.loads(response.body.decode())
+        assert body["error"]["request_id"] == "unknown"
+
+
+class TestRateLimitIntegration:
+    """Integration tests: verify rate-limited endpoints return 429 when exceeded."""
+
+    @pytest.mark.asyncio
+    async def test_auth_login_rate_limited(self, client: AsyncClient):
+        """Auth login endpoint returns 429 after exceeding 5/minute limit."""
+        from wikimind.middleware.rate_limit import limiter
+
+        # Reset counters from any prior tests that hit this endpoint
+        limiter.reset()
+        limiter.enabled = True
+        try:
+            # The rate limit is 5/minute — make 6 requests
+            for _ in range(5):
+                resp = await client.get("/auth/login/google", follow_redirects=False)
+                # May be 307 (redirect) or 400 (no client_id) — both are fine
+                assert resp.status_code in (307, 302, 400)
+
+            # 6th request should be rate limited
+            resp = await client.get("/auth/login/google", follow_redirects=False)
+            assert resp.status_code == 429
+            assert "Retry-After" in resp.headers
+            body = resp.json()
+            assert body["error"]["code"] == "rate_limited"
+        finally:
+            limiter.reset()
+
+    @pytest.mark.asyncio
+    async def test_ingest_url_not_rate_limited_on_first_request(self, client: AsyncClient):
+        """First ingest request should not be rate-limited."""
+        from wikimind.middleware.rate_limit import limiter
+
+        limiter.reset()
+        limiter.enabled = True
+        try:
+            resp = await client.post(
+                "/api/ingest/url",
+                json={"url": "https://example.com/article"},
+            )
+            # Should not be 429 on first request (may fail for other reasons)
+            assert resp.status_code != 429
+        finally:
+            limiter.reset()
+
+    @pytest.mark.asyncio
+    async def test_query_not_rate_limited_on_first_request(self, client: AsyncClient):
+        """First query request should not be rate-limited."""
+        from wikimind.middleware.rate_limit import limiter
+
+        limiter.reset()
+        limiter.enabled = True
+        try:
+            resp = await client.post(
+                "/api/query",
+                json={"question": "What is AI?"},
+            )
+            # Should not be 429 on first request
+            assert resp.status_code != 429
+        finally:
+            limiter.reset()
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_disabled_allows_unlimited(self, client: AsyncClient):
+        """When rate limiting is disabled, no 429 responses are returned."""
+        from wikimind.middleware.rate_limit import limiter
+
+        limiter.reset()
+        limiter.enabled = False
+        try:
+            # Make more requests than the limit — none should be rate limited
+            for _ in range(10):
+                resp = await client.get("/auth/login/google", follow_redirects=False)
+                assert resp.status_code != 429
+        finally:
+            limiter.enabled = True
+            limiter.reset()

--- a/uv.lock
+++ b/uv.lock
@@ -918,6 +918,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298 },
+]
+
+[[package]]
 name = "deptry"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1984,6 +1996,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453 },
     { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044 },
     { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009 },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954 },
 ]
 
 [[package]]
@@ -4335,6 +4361,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5167,6 +5205,7 @@ dependencies = [
     { name = "python-slugify" },
     { name = "pyyaml" },
     { name = "redis" },
+    { name = "slowapi" },
     { name = "sqlmodel" },
     { name = "structlog" },
     { name = "toml" },
@@ -5293,6 +5332,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.15.9" },
     { name = "sentence-transformers", marker = "extra == 'search'", specifier = ">=3.2.1" },
     { name = "sentry-sdk", extras = ["fastapi"], marker = "extra == 'monitoring'", specifier = ">=2.0.0" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlmodel", specifier = ">=0.0.21" },
     { name = "structlog", specifier = ">=24.4.0" },
     { name = "toml", specifier = ">=0.10.2" },
@@ -5306,6 +5346,81 @@ requires-dist = [
     { name = "youtube-transcript-api", specifier = ">=0.6.3" },
 ]
 provides-extras = ["pdf", "export", "monitoring", "search", "transcribe", "dev", "test", "lint"]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666 },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601 },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057 },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099 },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457 },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351 },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748 },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783 },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977 },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336 },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756 },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255 },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848 },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433 },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013 },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326 },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444 },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237 },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563 },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198 },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441 },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836 },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259 },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851 },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446 },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056 },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359 },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479 },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271 },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573 },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205 },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452 },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842 },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075 },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719 },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643 },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805 },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990 },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670 },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357 },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269 },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894 },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197 },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363 },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418 },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914 },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417 },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797 },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350 },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223 },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287 },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593 },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631 },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875 },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164 },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163 },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723 },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652 },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807 },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061 },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667 },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392 },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296 },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539 },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969 },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554 },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993 },
+]
 
 [[package]]
 name = "youtube-transcript-api"


### PR DESCRIPTION
## Summary

- Adds per-user rate limiting via `slowapi` (Redis-backed in production, in-memory for dev) to protect auth, query, and ingest endpoints from brute-force and abuse
- Auth endpoints limited to 5/min, query to 30/min, ingest to 10/min — all configurable via `WIKIMIND_RATE_LIMIT__*` env vars
- Returns standard 429 JSON error envelope with `Retry-After` header

Closes #704

## Changes

- **pyproject.toml**: add `slowapi>=0.1.9` dependency
- **src/wikimind/config.py**: add `RateLimitConfig` with `enabled`, `auth_limit`, `query_limit`, `ingest_limit`
- **src/wikimind/middleware/rate_limit.py**: new module with limiter singleton, key function (user_id or IP), and 429 handler
- **src/wikimind/main.py**: register limiter state and exception handler
- **src/wikimind/api/routes/auth.py**: `@limiter.limit()` on login, magic-link, magic-link/verify
- **src/wikimind/api/routes/query.py**: `@limiter.limit()` on ask, stream
- **src/wikimind/api/routes/ingest.py**: `@limiter.limit()` on url, pdf, text
- **tests/unit/test_rate_limit.py**: unit + integration tests covering config, key extraction, 429 response format, and endpoint behavior
- **.env.example**: document new `WIKIMIND_RATE_LIMIT__*` settings

## Test plan

- [x] All 1665 unit tests pass
- [x] Ruff lint + format clean
- [x] Mypy passes on changed files (pre-existing ProxyHeadersMiddleware error in main.py is unrelated)
- [ ] Verify rate limiting works with real Redis in staging
- [ ] Confirm 429 response includes proper Retry-After header in browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)