### PR TITLE
feat(mcp): add JWT authentication for HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -345,6 +345,14 @@
 # WIKIMIND_AUTH__COOKIE_DOMAIN=
 
 # ----------------------------------------------------------------------------
+# MCP Server (Model Context Protocol)
+# ----------------------------------------------------------------------------
+# JWT authentication for MCP HTTP transport. Stdio transport (local Claude
+# Desktop) never requires auth. Set to false to disable auth on HTTP too
+# (useful for local development).
+# WIKIMIND_MCP__REQUIRE_AUTH=true
+
+# ----------------------------------------------------------------------------
 # Production Deployment (docker-compose.prod.yml)
 # ----------------------------------------------------------------------------
 # These are read by docker-compose.prod.yml to configure the Postgres

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -295,14 +295,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 649
+        "line_number": 660
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 674
+        "line_number": 685
       }
     ],
     "src/wikimind/engine/providers/openai.py": [
@@ -424,5 +424,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-16T14:45:36Z"
+  "generated_at": "2026-05-16T23:03:52Z"
 }

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -326,6 +326,16 @@ class AuthConfig(BaseModel):
     dev_user_email: str = "dev@wikimind.local"
 
 
+class MCPConfig(BaseModel):
+    """MCP server configuration.
+
+    Controls authentication behavior for the MCP HTTP transport.
+    Stdio transport (local Claude Desktop) never requires auth.
+    """
+
+    require_auth: bool = True
+
+
 # Mapping from provider name → (Settings field for SecretStr key, raw env var name).
 # Used by both `get_api_key` and the auto-enable validator below.
 _PROVIDER_KEY_FIELDS: dict[str, tuple[str, str]] = {
@@ -386,6 +396,7 @@ class Settings(BaseSettings):
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
     concept_layer: ConceptLayerConfig = Field(default_factory=ConceptLayerConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    mcp: MCPConfig = Field(default_factory=MCPConfig)
 
     # Storage backend: "local" creates wiki/ and raw/ on the local filesystem;
     # "r2" delegates to Cloudflare R2 (wiki_dir / raw_dir are not needed).

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -1,0 +1,65 @@
+"""JWT authentication provider for MCP HTTP transport.
+
+Reuses the same JWT validation logic as the FastAPI auth middleware
+(same secret, algorithm, and payload structure) so that tokens issued
+by the WikiMind OAuth flow work seamlessly with the MCP server.
+
+Stdio transport (local Claude Desktop) does NOT use this provider.
+"""
+
+from __future__ import annotations
+
+import jwt
+import structlog
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+from wikimind.config import get_settings
+
+log = structlog.get_logger()
+
+
+class WikiMindJWTAuthProvider(TokenVerifier):
+    """Verify WikiMind JWT tokens for MCP HTTP transport.
+
+    Accepts the same Bearer tokens used by the FastAPI application.
+    Extracts user_id from the ``sub`` claim and stores it in
+    AccessToken.claims for tool handlers to read.
+    """
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Validate a JWT Bearer token and return an AccessToken.
+
+        Returns None if the token is invalid or expired, which causes
+        FastMCP to respond with a 401 Unauthorized.
+        """
+        settings = get_settings()
+
+        try:
+            payload = jwt.decode(
+                token,
+                settings.auth.jwt_secret_key,
+                algorithms=[settings.auth.jwt_algorithm],
+                options={"verify_aud": False},
+            )
+        except jwt.ExpiredSignatureError:
+            log.warning("mcp_auth: token expired")
+            return None
+        except jwt.InvalidTokenError:
+            log.warning("mcp_auth: invalid token")
+            return None
+
+        user_id = payload.get("sub")
+        if not user_id:
+            log.warning("mcp_auth: token missing 'sub' claim")
+            return None
+
+        # Extract email from payload (same logic as FastAPI auth middleware)
+        user_claim = payload.get("user")
+        email = user_claim.get("email", "") if isinstance(user_claim, dict) else payload.get("email", "")
+
+        return AccessToken(
+            token=token,
+            client_id=user_id,
+            scopes=[],
+            claims={"user_id": user_id, "email": email},
+        )

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -7,6 +7,8 @@ Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
   - wiki_list_sources: list ingested sources
 
 The server supports stdio (default) and HTTP transports.
+HTTP transport requires JWT authentication (configurable via
+``WIKIMIND_MCP__REQUIRE_AUTH``). Stdio transport never requires auth.
 
 Usage:
     wikimind mcp serve
@@ -25,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 from fastmcp import FastMCP
+from mcp.server.auth.middleware.auth_context import auth_context_var
 from pydantic import Field
 
 from wikimind.config import get_settings
@@ -86,9 +89,18 @@ mcp = FastMCP(
 async def _get_mcp_user_id() -> str:
     """Return the user ID for MCP operations.
 
-    In dev mode, uses the auto-provisioned dev user. MCP is a local
-    tool — it always runs in the same environment as the server.
+    When accessed via authenticated HTTP transport, extracts user_id
+    from the JWT token's claims (set by WikiMindJWTAuthProvider).
+    Falls back to the dev user for stdio transport or when auth is
+    disabled.
     """
+    # Check if we have an authenticated user from HTTP transport.
+    # WikiMindJWTAuthProvider sets client_id = user_id (from JWT "sub" claim).
+    auth_user = auth_context_var.get(None)
+    if auth_user is not None and auth_user.access_token.client_id:
+        return auth_user.access_token.client_id
+
+    # Fallback: stdio transport or dev mode — use dev user
     return await get_dev_user_id()
 
 
@@ -311,6 +323,8 @@ def run_server() -> None:
     """Run the WikiMind MCP server.
 
     Supports stdio (default) and HTTP transports via --transport flag.
+    HTTP transport enforces JWT authentication by default (configurable
+    via WIKIMIND_MCP__REQUIRE_AUTH).
     """
     parser = argparse.ArgumentParser(description="WikiMind MCP Server")
     parser.add_argument("--transport", choices=["stdio", "http"], default="stdio")
@@ -319,6 +333,11 @@ def run_server() -> None:
     args = parser.parse_args()
 
     if args.transport == "http":
+        settings = get_settings()
+        if settings.mcp.require_auth:
+            from wikimind.mcp.auth import WikiMindJWTAuthProvider  # noqa: PLC0415
+
+            mcp.auth = WikiMindJWTAuthProvider()
         mcp.run(transport="http", host=args.host, port=args.port)
     else:
         mcp.run(transport="stdio")

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,0 +1,251 @@
+"""Tests for MCP JWT authentication.
+
+Verifies the WikiMindJWTAuthProvider correctly validates JWTs and
+that tool handlers extract user_id from the auth context.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+from mcp.server.auth.middleware.auth_context import AuthenticatedUser, auth_context_var
+
+from tests.conftest import TEST_JWT_SECRET, TEST_USER_ID
+from wikimind.mcp.auth import WikiMindJWTAuthProvider
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_provider():
+    """Create an auth provider instance."""
+    return WikiMindJWTAuthProvider()
+
+
+@pytest.fixture
+def valid_token():
+    """Create a valid JWT token."""
+    payload = {
+        "sub": TEST_USER_ID,
+        "email": "test@example.com",
+        "exp": int(time.time()) + 3600,
+    }
+    return jwt.encode(payload, TEST_JWT_SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+def valid_token_nested_email():
+    """Create a valid JWT with email in nested user claim."""
+    payload = {
+        "sub": TEST_USER_ID,
+        "user": {"email": "nested@example.com"},
+        "exp": int(time.time()) + 3600,
+    }
+    return jwt.encode(payload, TEST_JWT_SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+def expired_token():
+    """Create an expired JWT token."""
+    payload = {
+        "sub": TEST_USER_ID,
+        "email": "test@example.com",
+        "exp": int(time.time()) - 3600,
+    }
+    return jwt.encode(payload, TEST_JWT_SECRET, algorithm="HS256")
+
+
+# ---------------------------------------------------------------------------
+# WikiMindJWTAuthProvider.verify_token
+# ---------------------------------------------------------------------------
+
+
+class TestWikiMindJWTAuthProvider:
+    """Test JWT verification for MCP HTTP transport."""
+
+    async def test_valid_token_returns_access_token(self, auth_provider, valid_token):
+        with patch("wikimind.mcp.auth.get_settings") as mock_settings:
+            mock_settings.return_value.auth.jwt_secret_key = TEST_JWT_SECRET
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            result = await auth_provider.verify_token(valid_token)
+
+            assert result is not None
+            assert result.client_id == TEST_USER_ID
+            assert result.claims["user_id"] == TEST_USER_ID
+            assert result.claims["email"] == "test@example.com"
+
+    async def test_nested_email_extraction(self, auth_provider, valid_token_nested_email):
+        with patch("wikimind.mcp.auth.get_settings") as mock_settings:
+            mock_settings.return_value.auth.jwt_secret_key = TEST_JWT_SECRET
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            result = await auth_provider.verify_token(valid_token_nested_email)
+
+            assert result is not None
+            assert result.claims["email"] == "nested@example.com"
+
+    async def test_expired_token_returns_none(self, auth_provider, expired_token):
+        with patch("wikimind.mcp.auth.get_settings") as mock_settings:
+            mock_settings.return_value.auth.jwt_secret_key = TEST_JWT_SECRET
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            result = await auth_provider.verify_token(expired_token)
+
+            assert result is None
+
+    async def test_invalid_token_returns_none(self, auth_provider):
+        with patch("wikimind.mcp.auth.get_settings") as mock_settings:
+            mock_settings.return_value.auth.jwt_secret_key = TEST_JWT_SECRET
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            result = await auth_provider.verify_token("not-a-valid-jwt")
+
+            assert result is None
+
+    async def test_wrong_secret_returns_none(self, auth_provider, valid_token):
+        with patch("wikimind.mcp.auth.get_settings") as mock_settings:
+            mock_settings.return_value.auth.jwt_secret_key = "wrong-secret"
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            result = await auth_provider.verify_token(valid_token)
+
+            assert result is None
+
+    async def test_missing_sub_claim_returns_none(self, auth_provider):
+        payload = {
+            "email": "test@example.com",
+            "exp": int(time.time()) + 3600,
+        }
+        token = jwt.encode(payload, TEST_JWT_SECRET, algorithm="HS256")
+
+        with patch("wikimind.mcp.auth.get_settings") as mock_settings:
+            mock_settings.return_value.auth.jwt_secret_key = TEST_JWT_SECRET
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            result = await auth_provider.verify_token(token)
+
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _get_mcp_user_id with auth context
+# ---------------------------------------------------------------------------
+
+
+class TestGetMCPUserIdWithAuth:
+    """Test that _get_mcp_user_id reads from auth context when available."""
+
+    async def test_returns_user_id_from_auth_context(self):
+        from fastmcp.server.auth import AccessToken
+
+        from wikimind.mcp.server import _get_mcp_user_id
+
+        access_token = AccessToken(
+            token="fake-token",
+            client_id=TEST_USER_ID,
+            scopes=[],
+            claims={"user_id": TEST_USER_ID, "email": "test@example.com"},
+        )
+        auth_user = AuthenticatedUser(auth_info=access_token)
+
+        token = auth_context_var.set(auth_user)
+        try:
+            result = await _get_mcp_user_id()
+            assert result == TEST_USER_ID
+        finally:
+            auth_context_var.reset(token)
+
+    async def test_falls_back_to_dev_user_when_no_auth_context(self):
+        from wikimind.mcp.server import _get_mcp_user_id
+
+        # Ensure auth_context_var is unset
+        token = auth_context_var.set(None)
+        try:
+            with patch("wikimind.mcp.server.get_dev_user_id", new_callable=AsyncMock) as mock:
+                mock.return_value = "dev-user-123"
+                result = await _get_mcp_user_id()
+                assert result == "dev-user-123"
+                mock.assert_called_once()
+        finally:
+            auth_context_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# run_server auth configuration
+# ---------------------------------------------------------------------------
+
+
+class TestRunServerAuthConfig:
+    """Test that run_server correctly applies auth for HTTP transport."""
+
+    def test_http_transport_sets_auth_when_require_auth_true(self):
+        from wikimind.mcp.server import mcp as mcp_server
+
+        # Reset any existing auth
+        mcp_server.auth = None
+
+        with (
+            patch("wikimind.mcp.server.get_settings") as mock_settings,
+            patch.object(mcp_server, "run") as mock_run,
+            patch("sys.argv", ["mcp-server", "--transport", "http"]),
+        ):
+            mock_settings.return_value.mcp.require_auth = True
+            mock_settings.return_value.auth.jwt_secret_key = TEST_JWT_SECRET
+            mock_settings.return_value.auth.jwt_algorithm = "HS256"
+
+            from wikimind.mcp.server import run_server
+
+            run_server()
+
+            # Auth should be set
+            assert mcp_server.auth is not None
+            assert isinstance(mcp_server.auth, WikiMindJWTAuthProvider)
+            mock_run.assert_called_once_with(transport="http", host="127.0.0.1", port=9100)
+
+        # Cleanup
+        mcp_server.auth = None
+
+    def test_http_transport_no_auth_when_require_auth_false(self):
+        from wikimind.mcp.server import mcp as mcp_server
+
+        # Reset any existing auth
+        mcp_server.auth = None
+
+        with (
+            patch("wikimind.mcp.server.get_settings") as mock_settings,
+            patch.object(mcp_server, "run") as mock_run,
+            patch("sys.argv", ["mcp-server", "--transport", "http"]),
+        ):
+            mock_settings.return_value.mcp.require_auth = False
+
+            from wikimind.mcp.server import run_server
+
+            run_server()
+
+            # Auth should NOT be set
+            assert mcp_server.auth is None
+            mock_run.assert_called_once_with(transport="http", host="127.0.0.1", port=9100)
+
+    def test_stdio_transport_never_sets_auth(self):
+        from wikimind.mcp.server import mcp as mcp_server
+
+        # Reset any existing auth
+        mcp_server.auth = None
+
+        with (
+            patch.object(mcp_server, "run") as mock_run,
+            patch("sys.argv", ["mcp-server", "--transport", "stdio"]),
+        ):
+            from wikimind.mcp.server import run_server
+
+            run_server()
+
+            # Auth should NOT be set for stdio
+            assert mcp_server.auth is None
+            mock_run.assert_called_once_with(transport="stdio")


### PR DESCRIPTION
## Summary

- Add `WikiMindJWTAuthProvider` (subclass of FastMCP `TokenVerifier`) that validates WikiMind JWT tokens for MCP HTTP transport
- Wire auth provider into `run_server()` when transport is HTTP and `WIKIMIND_MCP__REQUIRE_AUTH=true` (default)
- Extract authenticated user_id from auth context in tool handlers; stdio transport falls back to dev user
- Add `MCPConfig` settings class with `require_auth` field
- Add 11 unit tests covering token validation, auth context extraction, and server configuration

## Test plan

- [x] All 11 new tests in `tests/unit/test_mcp_auth.py` pass
- [x] All 17 existing tests in `tests/unit/test_mcp_server.py` still pass
- [x] Full unit test suite (1664 tests) passes
- [x] `ruff check` and `ruff format` clean
- [x] `mypy` passes on changed files

Closes #447 (PR 3: JWT auth for HTTP transport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)