### PR TITLE
feat(mcp): add synthesis, contradictions, health, graph tools + prompts

### DIFF
--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -1,10 +1,19 @@
-"""WikiMind MCP server — Phase 1 read-only tools over stdio transport.
+"""WikiMind MCP server — tools and prompts over stdio transport.
 
-Exposes four tools to MCP clients (Claude Desktop, Cursor, etc.):
-  - wiki_search:       full-text search across wiki articles
-  - wiki_get_article:  retrieve a full article by ID or slug
-  - wiki_ask:          ask a question against the wiki (Q&A agent)
-  - wiki_list_sources: list ingested sources
+Exposes tools to MCP clients (Claude Desktop, Cursor, etc.):
+  - wiki_search:              full-text search across wiki articles
+  - wiki_get_article:         retrieve a full article by ID or slug
+  - wiki_ask:                 ask a question against the wiki (Q&A agent)
+  - wiki_list_sources:        list ingested sources
+  - wiki_synthesize:          cross-cutting synthesis across selected articles
+  - wiki_list_contradictions: list contradictions between wiki articles
+  - wiki_get_health:          get wiki health report
+  - wiki_get_graph:           get the knowledge graph
+
+Prompts:
+  - compare_articles:  compare two wiki articles
+  - knowledge_gaps:    identify knowledge gaps in the wiki
+  - fact_check:        check a claim against wiki evidence
 
 The server supports stdio (default) and HTTP transports.
 
@@ -29,7 +38,9 @@ from pydantic import Field
 
 from wikimind.config import get_settings
 from wikimind.database import get_dev_user_id, get_session_factory, init_db
-from wikimind.models import QueryRequest
+from wikimind.engine.synthesis_compiler import SynthesisCompiler
+from wikimind.models import ContradictionStatus, QueryRequest
+from wikimind.services.contradiction import ContradictionService
 from wikimind.services.ingest import IngestService
 from wikimind.services.query import QueryService
 from wikimind.services.wiki import WikiService
@@ -72,7 +83,9 @@ mcp = FastMCP(
     instructions=(
         "WikiMind is a personal LLM-powered knowledge OS. "
         "Use these tools to search the wiki, read articles, "
-        "ask questions, and browse ingested sources."
+        "ask questions, browse ingested sources, synthesize "
+        "cross-cutting analyses, review contradictions, check "
+        "wiki health, and explore the knowledge graph."
     ),
     lifespan=_lifespan,
 )
@@ -300,6 +313,435 @@ async def wiki_list_sources(
         ],
         default=str,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_synthesize
+# ---------------------------------------------------------------------------
+
+
+VALID_SYNTHESIS_TYPES = {"comparative", "chronological", "thematic", "gap_analysis"}
+
+
+@mcp.tool(
+    name="wiki_synthesize",
+    description=(
+        "Trigger cross-cutting synthesis across selected wiki articles. "
+        "This is WikiMind's killer feature: it compares, contrasts, and "
+        "finds patterns across multiple sources to produce a new synthesis "
+        "page. Provide article IDs to synthesize, and optionally specify "
+        "a synthesis type and guidance."
+    ),
+)
+async def wiki_synthesize(
+    article_ids: list[str] = Field(..., description="List of article UUIDs to synthesize (minimum 2)"),
+    synthesis_type: str | None = Field(
+        None,
+        description=(
+            "Type of synthesis: comparative, chronological, thematic, or gap_analysis. Omit for general synthesis."
+        ),
+    ),
+    guidance: str | None = Field(
+        None,
+        description="Optional guidance or focus question for the synthesis",
+    ),
+) -> str:
+    """Synthesize a cross-cutting analysis across multiple articles."""
+    if len(article_ids) < 2:
+        return json.dumps({"error": "At least 2 article IDs are required for synthesis"})
+
+    if synthesis_type and synthesis_type not in VALID_SYNTHESIS_TYPES:
+        return json.dumps({"error": f"Invalid synthesis_type. Must be one of: {sorted(VALID_SYNTHESIS_TYPES)}"})
+
+    query_parts: list[str] = []
+    if synthesis_type:
+        query_parts.append(f"{synthesis_type} analysis")
+    if guidance:
+        query_parts.append(guidance)
+    query = " — ".join(query_parts) if query_parts else "Cross-cutting synthesis"
+
+    user_id = await _get_mcp_user_id()
+    compiler = SynthesisCompiler(user_id=user_id)
+
+    async with _get_session() as session:
+        try:
+            result = await compiler.synthesize(
+                query=query,
+                session=session,
+                article_ids=article_ids,
+            )
+        except Exception as exc:
+            log.warning("wiki_synthesize failed", error=str(exc))
+            return json.dumps({"error": f"Synthesis failed: {exc}"})
+
+    if result is None:
+        return json.dumps(
+            {
+                "error": "Synthesis could not be performed. Ensure the article IDs are valid "
+                "and at least 2 articles exist."
+            }
+        )
+
+    article, compilation = result
+    return json.dumps(
+        {
+            "article_id": article.id,
+            "slug": article.slug,
+            "title": compilation.title,
+            "summary": compilation.summary,
+            "themes": compilation.themes,
+            "gaps": compilation.gaps,
+            "open_questions": compilation.open_questions,
+            "source_article_count": len(compilation.source_article_ids),
+            "content": compilation.article_body,
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_list_contradictions
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_list_contradictions",
+    description=(
+        "List contradictions detected between wiki articles. "
+        "Contradictions are conflicting claims found by the linter "
+        "across different articles. Filter by status to see active, "
+        "resolved, or dismissed contradictions."
+    ),
+)
+async def wiki_list_contradictions(
+    status: str | None = Field(
+        None,
+        description="Filter by status: 'active', 'resolved', or 'dismissed'. Omit for all.",
+    ),
+    limit: int = Field(50, description="Maximum results to return (max 100)"),
+) -> str:
+    """List contradictions between wiki articles."""
+    limit = min(max(1, limit), 100)
+
+    parsed_status: ContradictionStatus | None = None
+    if status:
+        try:
+            parsed_status = ContradictionStatus(status)
+        except ValueError:
+            valid = [s.value for s in ContradictionStatus]
+            return json.dumps({"error": f"Invalid status. Must be one of: {valid}"})
+
+    contradiction_service = ContradictionService()
+    async with _get_session() as session:
+        try:
+            results = await contradiction_service.list_contradictions(
+                session=session,
+                user_id=await _get_mcp_user_id(),
+                status=parsed_status,
+                limit=limit,
+            )
+        except Exception as exc:
+            log.warning("wiki_list_contradictions failed", error=str(exc))
+            return json.dumps({"error": f"Failed to list contradictions: {exc}"})
+
+    return json.dumps(
+        [
+            {
+                "id": c.id,
+                "claim_a": c.claim_a,
+                "claim_b": c.claim_b,
+                "article_a_id": c.article_a_id,
+                "article_b_id": c.article_b_id,
+                "article_a_title": c.article_a_title,
+                "article_b_title": c.article_b_title,
+                "status": c.status,
+                "detected_at": c.detected_at,
+                "resolution": c.resolution,
+            }
+            for c in results
+        ],
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_get_health
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_get_health",
+    description=(
+        "Get a wiki health report including orphan articles, stale articles, "
+        "linter findings, and contradiction counts. Use this to understand "
+        "the overall state and quality of the knowledge base."
+    ),
+)
+async def wiki_get_health() -> str:
+    """Get the wiki health report."""
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            report = await wiki_service.get_health(
+                session=session,
+                user_id=await _get_mcp_user_id(),
+            )
+        except Exception as exc:
+            log.warning("wiki_get_health failed", error=str(exc))
+            return json.dumps({"error": f"Failed to get health report: {exc}"})
+
+    return json.dumps(
+        {
+            "generated_at": report.generated_at,
+            "total_articles": report.total_articles,
+            "total_sources": report.total_sources,
+            "total_findings": report.total_findings,
+            "contradictions_count": report.contradictions_count,
+            "orphans_count": report.orphans_count,
+            "status": report.status,
+            "message": report.message,
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: wiki_get_graph
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="wiki_get_graph",
+    description=(
+        "Get the knowledge graph showing all articles and their "
+        "relationships (references, contradictions, synthesis links). "
+        "Optionally filter to relationships involving a specific article. "
+        "Returns nodes (articles) and edges (relationships)."
+    ),
+)
+async def wiki_get_graph(
+    article_slug: str | None = Field(
+        None,
+        description=(
+            "Optional article slug or ID to filter edges. When set, only edges involving this article are returned."
+        ),
+    ),
+) -> str:
+    """Get the knowledge graph with optional article filter."""
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        try:
+            graph = await wiki_service.get_graph(
+                session=session,
+                user_id=await _get_mcp_user_id(),
+                from_article=article_slug,
+            )
+        except Exception as exc:
+            log.warning("wiki_get_graph failed", error=str(exc))
+            return json.dumps({"error": f"Failed to get graph: {exc}"})
+
+    return json.dumps(
+        {
+            "node_count": len(graph.nodes),
+            "edge_count": len(graph.edges),
+            "nodes": [
+                {
+                    "id": n.id,
+                    "label": n.label,
+                    "concept_cluster": n.concept_cluster,
+                    "connection_count": n.connection_count,
+                    "confidence": n.confidence,
+                    "effective_confidence": n.effective_confidence,
+                }
+                for n in graph.nodes
+            ],
+            "edges": [
+                {
+                    "source": e.source,
+                    "target": e.target,
+                    "relation_type": e.relation_type,
+                    "context": e.context,
+                }
+                for e in graph.edges
+            ],
+        },
+        default=str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: compare_articles
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="compare_articles",
+    description=(
+        "Compare two wiki articles side-by-side. Fetches both articles "
+        "and builds a prompt identifying key agreements, disagreements, "
+        "and synthesis opportunities."
+    ),
+)
+async def compare_articles(
+    slug_a: str = Field(..., description="Slug or ID of the first article"),
+    slug_b: str = Field(..., description="Slug or ID of the second article"),
+) -> str:
+    """Build a comparison prompt for two wiki articles."""
+    wiki_service = WikiService()
+    async with _get_session() as session:
+        user_id = await _get_mcp_user_id()
+        try:
+            article_a = await wiki_service.get_article(id_or_slug=slug_a, session=session, user_id=user_id)
+            article_b = await wiki_service.get_article(id_or_slug=slug_b, session=session, user_id=user_id)
+        except Exception as exc:
+            return f"Error fetching articles: {exc}"
+
+    return (
+        f"Compare these two WikiMind articles and identify:\n"
+        f"1. Key agreements — where do they align?\n"
+        f"2. Key disagreements — where do they conflict?\n"
+        f"3. Synthesis opportunities — what new insights emerge from combining them?\n"
+        f"4. Knowledge gaps — what is missing from both?\n\n"
+        f"---\n\n"
+        f"## Article A: {article_a.title}\n\n"
+        f"{article_a.content}\n\n"
+        f"---\n\n"
+        f"## Article B: {article_b.title}\n\n"
+        f"{article_b.content}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt: knowledge_gaps
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="knowledge_gaps",
+    description=(
+        "Identify knowledge gaps in the wiki. Optionally focus on a specific "
+        "topic. Combines search results and health data to surface what's "
+        "missing, stale, or contradictory."
+    ),
+)
+async def knowledge_gaps(
+    topic: str | None = Field(
+        None,
+        description="Optional topic to focus the gap analysis on. Omit for general wiki health.",
+    ),
+) -> str:
+    """Build a knowledge-gap analysis prompt."""
+    wiki_service = WikiService()
+    user_id = await _get_mcp_user_id()
+
+    async with _get_session() as session:
+        try:
+            health = await wiki_service.get_health(session=session, user_id=user_id)
+        except Exception:
+            health = None
+
+        search_results = []
+        if topic:
+            with contextlib.suppress(Exception):
+                search_results = await wiki_service.search(q=topic, session=session, user_id=user_id, limit=10)
+
+    parts: list[str] = ["Analyze the WikiMind knowledge base and identify knowledge gaps.\n"]
+
+    if topic:
+        parts.append(f"Focus area: {topic}\n")
+
+    if health:
+        parts.append("## Wiki Health Summary\n")
+        parts.append(f"- Total articles: {health.total_articles}")
+        parts.append(f"- Total sources: {health.total_sources}")
+        if health.total_findings is not None:
+            parts.append(f"- Linter findings: {health.total_findings}")
+        if health.contradictions_count is not None:
+            parts.append(f"- Contradictions: {health.contradictions_count}")
+        if health.orphans_count is not None:
+            parts.append(f"- Orphan articles: {health.orphans_count}")
+        if health.message:
+            parts.append(f"- Status: {health.message}")
+        parts.append("")
+
+    if search_results:
+        parts.append(f"## Articles matching '{topic}'\n")
+        parts.extend(
+            f"- **{r.title}** (confidence: {r.confidence}): {r.summary or 'No summary'}" for r in search_results
+        )
+        parts.append("")
+
+    parts.append(
+        "\nBased on the above, identify:\n"
+        "1. What topics are missing or under-covered?\n"
+        "2. Which articles are stale and need updating?\n"
+        "3. What contradictions need resolution?\n"
+        "4. What connections between topics are missing?\n"
+        "5. Recommend specific actions to improve wiki coverage."
+    )
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Prompt: fact_check
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="fact_check",
+    description=(
+        "Fact-check a claim against the WikiMind knowledge base. "
+        "Searches the wiki for relevant evidence and builds a prompt "
+        "asking to evaluate the claim with supporting and contradicting "
+        "article excerpts."
+    ),
+)
+async def fact_check(
+    claim: str = Field(..., description="The claim to fact-check against the wiki"),
+) -> str:
+    """Build a fact-checking prompt with wiki evidence."""
+    wiki_service = WikiService()
+    user_id = await _get_mcp_user_id()
+
+    async with _get_session() as session:
+        try:
+            results = await wiki_service.search(q=claim, session=session, user_id=user_id, limit=5)
+        except Exception:
+            results = []
+
+    if not results:
+        return (
+            f'Fact-check this claim: "{claim}"\n\n'
+            "No relevant articles were found in the WikiMind knowledge base. "
+            "The claim cannot be verified or refuted with available evidence."
+        )
+
+    parts: list[str] = [
+        f"Fact-check this claim against the WikiMind knowledge base:\n\n"
+        f'**Claim:** "{claim}"\n\n'
+        f"## Relevant Wiki Articles\n"
+    ]
+
+    for r in results:
+        parts.append(f"### {r.title}")
+        parts.append(f"- Confidence: {r.confidence}")
+        parts.append(f"- Summary: {r.summary or 'No summary'}")
+        if r.source_count:
+            parts.append(f"- Based on {r.source_count} source(s)")
+        parts.append("")
+
+    parts.append(
+        "\nBased on the evidence above, evaluate the claim:\n"
+        "1. **Supported:** What evidence supports the claim?\n"
+        "2. **Contradicted:** What evidence contradicts the claim?\n"
+        "3. **Verdict:** Is the claim supported, contradicted, partially true, "
+        "or unverifiable based on available evidence?\n"
+        "4. **Confidence:** How confident is this assessment given the quality "
+        "and breadth of the evidence?"
+    )
+
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -16,8 +16,21 @@ from click.testing import CliRunner
 
 from tests.conftest import TEST_USER_ID
 from wikimind.cli.main import cli
-from wikimind.mcp.server import mcp as mcp_server
-from wikimind.mcp.server import wiki_get_article, wiki_list_sources, wiki_search
+from wikimind.mcp.server import (
+    compare_articles,
+    fact_check,
+    knowledge_gaps,
+    wiki_get_article,
+    wiki_get_graph,
+    wiki_get_health,
+    wiki_list_contradictions,
+    wiki_list_sources,
+    wiki_search,
+    wiki_synthesize,
+)
+from wikimind.mcp.server import (
+    mcp as mcp_server,
+)
 from wikimind.models import Article, ConfidenceLevel, PageType, Source
 
 if TYPE_CHECKING:
@@ -285,6 +298,10 @@ class TestMCPServerRegistration:
         assert "wiki_get_article" in tool_names
         assert "wiki_ask" in tool_names
         assert "wiki_list_sources" in tool_names
+        assert "wiki_synthesize" in tool_names
+        assert "wiki_list_contradictions" in tool_names
+        assert "wiki_get_health" in tool_names
+        assert "wiki_get_graph" in tool_names
 
     async def test_tool_descriptions_present(self):
         tools = await mcp_server.list_tools()
@@ -320,3 +337,410 @@ class TestMCPServerRegistration:
         # wiki_get_article id_or_slug param should have a description
         article_props = tools_by_name["wiki_get_article"].parameters.get("properties", {})
         assert "description" in article_props.get("id_or_slug", {}), "id_or_slug param missing Field description"
+
+    async def test_server_lists_prompts(self):
+        prompts = await mcp_server.list_prompts()
+        prompt_names = {p.name for p in prompts}
+        assert "compare_articles" in prompt_names
+        assert "knowledge_gaps" in prompt_names
+        assert "fact_check" in prompt_names
+
+    async def test_prompt_descriptions_present(self):
+        prompts = await mcp_server.list_prompts()
+        for prompt in prompts:
+            assert prompt.description, f"Prompt {prompt.name} missing description"
+            assert len(prompt.description) > 20, f"Prompt {prompt.name} description too short"
+
+
+# ---------------------------------------------------------------------------
+# wiki_synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestWikiSynthesize:
+    """Test the wiki_synthesize MCP tool."""
+
+    async def test_synthesize_too_few_articles(self):
+        result = await wiki_synthesize(article_ids=["one"])
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "At least 2" in parsed["error"]
+
+    async def test_synthesize_invalid_type(self):
+        result = await wiki_synthesize(article_ids=["a", "b"], synthesis_type="invalid")
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Invalid synthesis_type" in parsed["error"]
+
+    async def test_synthesize_success(self, db_session):
+        mock_article = AsyncMock()
+        mock_article.id = "synth-article-id"
+        mock_article.slug = "synth-slug"
+
+        mock_compilation = AsyncMock()
+        mock_compilation.title = "Synthesis Title"
+        mock_compilation.summary = "A synthesis summary"
+        mock_compilation.themes = ["theme1", "theme2"]
+        mock_compilation.gaps = ["gap1"]
+        mock_compilation.open_questions = ["q1"]
+        mock_compilation.source_article_ids = ["a", "b"]
+        mock_compilation.article_body = "# Synthesis body"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.SynthesisCompiler") as mock_compiler_cls,
+        ):
+            mock_compiler_cls.return_value.synthesize = AsyncMock(return_value=(mock_article, mock_compilation))
+
+            result = await wiki_synthesize(
+                article_ids=["a", "b"],
+                synthesis_type="comparative",
+                guidance="Focus on differences",
+            )
+            parsed = json.loads(result)
+
+            assert parsed["title"] == "Synthesis Title"
+            assert parsed["summary"] == "A synthesis summary"
+            assert parsed["themes"] == ["theme1", "theme2"]
+            assert parsed["gaps"] == ["gap1"]
+            assert parsed["article_id"] == "synth-article-id"
+
+    async def test_synthesize_returns_none(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.SynthesisCompiler") as mock_compiler_cls,
+        ):
+            mock_compiler_cls.return_value.synthesize = AsyncMock(return_value=None)
+
+            result = await wiki_synthesize(article_ids=["a", "b"], synthesis_type=None, guidance=None)
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "could not be performed" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# wiki_list_contradictions
+# ---------------------------------------------------------------------------
+
+
+class TestWikiListContradictions:
+    """Test the wiki_list_contradictions MCP tool."""
+
+    async def test_list_contradictions_returns_results(self, db_session):
+        mock_contradiction = AsyncMock()
+        mock_contradiction.id = "c-1"
+        mock_contradiction.claim_a = "Claim A"
+        mock_contradiction.claim_b = "Claim B"
+        mock_contradiction.article_a_id = "art-a"
+        mock_contradiction.article_b_id = "art-b"
+        mock_contradiction.article_a_title = "Article A"
+        mock_contradiction.article_b_title = "Article B"
+        mock_contradiction.status = "active"
+        mock_contradiction.detected_at = "2026-01-01"
+        mock_contradiction.resolution = None
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.ContradictionService") as mock_cls,
+        ):
+            mock_cls.return_value.list_contradictions = AsyncMock(return_value=[mock_contradiction])
+
+            result = await wiki_list_contradictions(status=None, limit=50)
+            parsed = json.loads(result)
+
+            assert isinstance(parsed, list)
+            assert len(parsed) == 1
+            assert parsed[0]["claim_a"] == "Claim A"
+            assert parsed[0]["article_a_title"] == "Article A"
+
+    async def test_list_contradictions_invalid_status(self):
+        result = await wiki_list_contradictions(status="invalid", limit=50)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Invalid status" in parsed["error"]
+
+    async def test_list_contradictions_empty(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.ContradictionService") as mock_cls,
+        ):
+            mock_cls.return_value.list_contradictions = AsyncMock(return_value=[])
+
+            result = await wiki_list_contradictions(status=None, limit=50)
+            parsed = json.loads(result)
+            assert parsed == []
+
+    async def test_list_contradictions_clamps_limit(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.ContradictionService") as mock_cls,
+        ):
+            mock_cls.return_value.list_contradictions = AsyncMock(return_value=[])
+
+            await wiki_list_contradictions(status=None, limit=999)
+            call_kwargs = mock_cls.return_value.list_contradictions.call_args
+            assert call_kwargs.kwargs["limit"] == 100
+
+
+# ---------------------------------------------------------------------------
+# wiki_get_health
+# ---------------------------------------------------------------------------
+
+
+class TestWikiGetHealth:
+    """Test the wiki_get_health MCP tool."""
+
+    async def test_get_health_returns_report(self, db_session):
+        mock_report = AsyncMock()
+        mock_report.generated_at = "2026-01-01T00:00:00"
+        mock_report.total_articles = 42
+        mock_report.total_sources = 15
+        mock_report.total_findings = 5
+        mock_report.contradictions_count = 2
+        mock_report.orphans_count = 3
+        mock_report.status = "healthy"
+        mock_report.message = None
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_health = AsyncMock(return_value=mock_report)
+
+            result = await wiki_get_health()
+            parsed = json.loads(result)
+
+            assert parsed["total_articles"] == 42
+            assert parsed["total_sources"] == 15
+            assert parsed["contradictions_count"] == 2
+            assert parsed["orphans_count"] == 3
+
+    async def test_get_health_handles_error(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_health = AsyncMock(side_effect=Exception("DB error"))
+
+            result = await wiki_get_health()
+            parsed = json.loads(result)
+            assert "error" in parsed
+
+
+# ---------------------------------------------------------------------------
+# wiki_get_graph
+# ---------------------------------------------------------------------------
+
+
+class TestWikiGetGraph:
+    """Test the wiki_get_graph MCP tool."""
+
+    async def test_get_graph_returns_nodes_and_edges(self, db_session):
+        mock_node = AsyncMock()
+        mock_node.id = "node-1"
+        mock_node.label = "Article One"
+        mock_node.concept_cluster = "testing"
+        mock_node.connection_count = 2
+        mock_node.confidence = "sourced"
+        mock_node.effective_confidence = 0.85
+
+        mock_edge = AsyncMock()
+        mock_edge.source = "node-1"
+        mock_edge.target = "node-2"
+        mock_edge.relation_type = "references"
+        mock_edge.context = "Related topic"
+
+        mock_graph = AsyncMock()
+        mock_graph.nodes = [mock_node]
+        mock_graph.edges = [mock_edge]
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_graph = AsyncMock(return_value=mock_graph)
+
+            result = await wiki_get_graph(article_slug=None)
+            parsed = json.loads(result)
+
+            assert parsed["node_count"] == 1
+            assert parsed["edge_count"] == 1
+            assert parsed["nodes"][0]["label"] == "Article One"
+            assert parsed["edges"][0]["relation_type"] == "references"
+
+    async def test_get_graph_with_article_filter(self, db_session):
+        mock_graph = AsyncMock()
+        mock_graph.nodes = []
+        mock_graph.edges = []
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_graph = AsyncMock(return_value=mock_graph)
+
+            result = await wiki_get_graph(article_slug="test-article")
+            parsed = json.loads(result)
+
+            assert parsed["node_count"] == 0
+            assert parsed["edge_count"] == 0
+
+            # Verify from_article was passed
+            call_kwargs = mock_wiki_cls.return_value.get_graph.call_args
+            assert call_kwargs.kwargs["from_article"] == "test-article"
+
+
+# ---------------------------------------------------------------------------
+# compare_articles prompt
+# ---------------------------------------------------------------------------
+
+
+class TestCompareArticlesPrompt:
+    """Test the compare_articles MCP prompt."""
+
+    async def test_compare_articles_builds_prompt(self, db_session):
+        mock_a = AsyncMock()
+        mock_a.title = "Article A"
+        mock_a.content = "Content of article A"
+
+        mock_b = AsyncMock()
+        mock_b.title = "Article B"
+        mock_b.content = "Content of article B"
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(side_effect=[mock_a, mock_b])
+
+            result = await compare_articles(slug_a="slug-a", slug_b="slug-b")
+
+            assert "Article A" in result
+            assert "Article B" in result
+            assert "agreements" in result
+            assert "disagreements" in result
+            assert "Synthesis opportunities" in result
+
+    async def test_compare_articles_handles_error(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_article = AsyncMock(side_effect=Exception("Not found"))
+
+            result = await compare_articles(slug_a="bad", slug_b="also-bad")
+            assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# knowledge_gaps prompt
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeGapsPrompt:
+    """Test the knowledge_gaps MCP prompt."""
+
+    async def test_knowledge_gaps_general(self, db_session):
+        mock_health = AsyncMock()
+        mock_health.total_articles = 10
+        mock_health.total_sources = 5
+        mock_health.total_findings = 3
+        mock_health.contradictions_count = 1
+        mock_health.orphans_count = 2
+        mock_health.message = None
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_health = AsyncMock(return_value=mock_health)
+
+            result = await knowledge_gaps(topic=None)
+
+            assert "Total articles: 10" in result
+            assert "knowledge gaps" in result.lower()
+            assert "missing" in result.lower()
+
+    async def test_knowledge_gaps_with_topic(self, db_session):
+        mock_health = AsyncMock()
+        mock_health.total_articles = 10
+        mock_health.total_sources = 5
+        mock_health.total_findings = None
+        mock_health.contradictions_count = None
+        mock_health.orphans_count = None
+        mock_health.message = "Run the linter"
+
+        mock_result = AsyncMock()
+        mock_result.title = "ML Overview"
+        mock_result.confidence = "sourced"
+        mock_result.summary = "Overview of machine learning"
+        mock_result.source_count = 3
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.get_health = AsyncMock(return_value=mock_health)
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[mock_result])
+
+            result = await knowledge_gaps(topic="machine learning")
+
+            assert "machine learning" in result
+            assert "ML Overview" in result
+
+
+# ---------------------------------------------------------------------------
+# fact_check prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFactCheckPrompt:
+    """Test the fact_check MCP prompt."""
+
+    async def test_fact_check_with_evidence(self, db_session):
+        mock_result = AsyncMock()
+        mock_result.title = "Climate Science"
+        mock_result.confidence = "sourced"
+        mock_result.summary = "An article about climate science"
+        mock_result.source_count = 5
+
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[mock_result])
+
+            result = await fact_check(claim="The earth is warming")
+
+            assert "The earth is warming" in result
+            assert "Climate Science" in result
+            assert "Supported" in result
+            assert "Contradicted" in result
+            assert "Verdict" in result
+
+    async def test_fact_check_no_evidence(self, db_session):
+        with (
+            patch("wikimind.mcp.server._get_session", return_value=_mock_session_ctx(db_session)),
+            patch("wikimind.mcp.server._get_mcp_user_id", return_value=TEST_USER_ID),
+            patch("wikimind.mcp.server.WikiService") as mock_wiki_cls,
+        ):
+            mock_wiki_cls.return_value.search = AsyncMock(return_value=[])
+
+            result = await fact_check(claim="Aliens built the pyramids")
+
+            assert "Aliens built the pyramids" in result
+            assert "No relevant articles" in result


### PR DESCRIPTION
## Summary

- Add 4 new MCP tools to the WikiMind MCP server: `wiki_synthesize` (cross-cutting synthesis across articles), `wiki_list_contradictions` (browse contradictions by status), `wiki_get_health` (wiki health report), and `wiki_get_graph` (knowledge graph with optional article filter)
- Add 3 MCP prompts: `compare_articles` (side-by-side comparison), `knowledge_gaps` (identify missing/stale content), and `fact_check` (evaluate claims against wiki evidence)
- All tools reuse existing service layer — no business logic duplication. 37 unit tests pass (20 new).

Server now exposes 8 tools and 3 prompts (up from 4 tools and 0 prompts).

## Test plan

- [x] All 37 MCP server unit tests pass (`uv run pytest tests/unit/test_mcp_server.py`)
- [x] Ruff lint and format pass on both changed files
- [x] Tool/prompt registration verified programmatically (8 tools, 3 prompts)
- [ ] CI passes lint, typecheck, test gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)