### PR TITLE
feat(mcp): OAuth 2.1 Authorization Server for remote MCP connections

### DIFF
--- a/alembic/versions/0016_add_oauth_authorization_tables.py
+++ b/alembic/versions/0016_add_oauth_authorization_tables.py
@@ -1,0 +1,80 @@
+"""Add OAuth 2.1 authorization code and access token tables.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-05-16
+
+Supports the OAuth 2.1 Authorization Server for MCP remote connections.
+See issue #764.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0016"
+down_revision: str = "0015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    existing = inspector.get_table_names()
+
+    if "oauthauthorizationcode" not in existing:
+        op.create_table(
+            "oauthauthorizationcode",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("code", sa.String(), nullable=False),
+            sa.Column("user_id", sa.String(), sa.ForeignKey("user.id"), nullable=False),
+            sa.Column("client_id", sa.String(), nullable=False),
+            sa.Column("redirect_uri", sa.String(), nullable=False),
+            sa.Column("code_challenge", sa.String(), nullable=False),
+            sa.Column("state", sa.String(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            sa.Column("used", sa.Boolean(), nullable=False, server_default="0"),
+        )
+        op.create_index(
+            "ix_oauthauthorizationcode_code", "oauthauthorizationcode", ["code"]
+        )
+
+    if "oauthaccesstoken" not in existing:
+        op.create_table(
+            "oauthaccesstoken",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("token_hash", sa.String(), nullable=False),
+            sa.Column("user_id", sa.String(), sa.ForeignKey("user.id"), nullable=False),
+            sa.Column("client_id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            sa.Column("revoked", sa.Boolean(), nullable=False, server_default="0"),
+        )
+        op.create_index(
+            "ix_oauthaccesstoken_token_hash", "oauthaccesstoken", ["token_hash"]
+        )
+        op.create_index(
+            "ix_oauthaccesstoken_user_id", "oauthaccesstoken", ["user_id"]
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    existing = inspector.get_table_names()
+
+    if "oauthaccesstoken" in existing:
+        op.drop_index("ix_oauthaccesstoken_user_id", table_name="oauthaccesstoken")
+        op.drop_index("ix_oauthaccesstoken_token_hash", table_name="oauthaccesstoken")
+        op.drop_table("oauthaccesstoken")
+
+    if "oauthauthorizationcode" in existing:
+        op.drop_index(
+            "ix_oauthauthorizationcode_code", table_name="oauthauthorizationcode"
+        )
+        op.drop_table("oauthauthorizationcode")

--- a/alembic/versions/0017_add_oauth_authorization_tables.py
+++ b/alembic/versions/0017_add_oauth_authorization_tables.py
@@ -15,8 +15,8 @@ from sqlalchemy import inspect as sa_inspect
 
 from alembic import op
 
-revision: str = "0016"
-down_revision: str = "0015"
+revision: str = "0017"
+down_revision: str = "0016"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3577,6 +3577,213 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteAccountResponse'
+  /.well-known/oauth-authorization-server:
+    get:
+      tags:
+      - Auth
+      summary: Oauth Metadata
+      description: Return OAuth 2.1 Authorization Server Metadata per RFC 8414.
+      operationId: oauth_metadata__well_known_oauth_authorization_server_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /mcp/authorize:
+    get:
+      tags:
+      - Auth
+      summary: Authorize
+      description: 'OAuth 2.1 authorization endpoint.
+
+
+        Validates the authorization request parameters, stores them, and
+
+        either shows the consent screen (if logged in) or redirects to login.'
+      operationId: authorize_mcp_authorize_get
+      parameters:
+      - name: response_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Response Type
+      - name: client_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Client Id
+      - name: redirect_uri
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Redirect Uri
+      - name: code_challenge
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Code Challenge
+      - name: code_challenge_method
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Code Challenge Method
+      - name: state
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: State
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /mcp/authorize/resume:
+    get:
+      tags:
+      - Auth
+      summary: Authorize Resume
+      description: 'Resume authorization flow after login.
+
+
+        The user was redirected to login, and after successful login they
+
+        are sent back here. We now show the consent screen.'
+      operationId: authorize_resume_mcp_authorize_resume_get
+      parameters:
+      - name: rid
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Rid
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /mcp/authorize/decide:
+    post:
+      tags:
+      - Auth
+      summary: Authorize Decide
+      description: 'Handle consent decision (approve or deny).
+
+
+        On approval, generates an authorization code, stores it, and
+
+        redirects to the client''s redirect_uri with the code and state.'
+      operationId: authorize_decide_mcp_authorize_decide_post
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Body_authorize_decide_mcp_authorize_decide_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /mcp/token:
+    post:
+      tags:
+      - Auth
+      summary: Token Exchange
+      description: 'Exchange an authorization code for an access token (PKCE).
+
+
+        Validates the grant type, code, redirect_uri match, PKCE verifier,
+
+        and that the code hasn''t expired or been used. Returns a short-lived
+
+        access token with ``wmk_`` prefix.'
+      operationId: token_exchange_mcp_token_post
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Body_token_exchange_mcp_token_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /mcp/revoke:
+    post:
+      tags:
+      - Auth
+      summary: Revoke Token
+      description: 'Revoke an access token.
+
+
+        Per RFC 7009, always returns 200 even if the token is not found.'
+      operationId: revoke_token_mcp_revoke_post
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Body_revoke_token_mcp_revoke_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /health:
     get:
       summary: Health Check
@@ -4054,6 +4261,19 @@ components:
       - slug
       title: BacklinkEntry
       description: A backlink entry with human-readable metadata for the frontend.
+    Body_authorize_decide_mcp_authorize_decide_post:
+      properties:
+        request_id:
+          type: string
+          title: Request Id
+        decision:
+          type: string
+          title: Decision
+      type: object
+      required:
+      - request_id
+      - decision
+      title: Body_authorize_decide_mcp_authorize_decide_post
     Body_ingest_pdf_api_ingest_pdf_post:
       properties:
         file:
@@ -4064,6 +4284,40 @@ components:
       required:
       - file
       title: Body_ingest_pdf_api_ingest_pdf_post
+    Body_revoke_token_mcp_revoke_post:
+      properties:
+        token:
+          type: string
+          title: Token
+      type: object
+      required:
+      - token
+      title: Body_revoke_token_mcp_revoke_post
+    Body_token_exchange_mcp_token_post:
+      properties:
+        grant_type:
+          type: string
+          title: Grant Type
+        code:
+          type: string
+          title: Code
+        redirect_uri:
+          type: string
+          title: Redirect Uri
+        code_verifier:
+          type: string
+          title: Code Verifier
+        client_id:
+          type: string
+          title: Client Id
+      type: object
+      required:
+      - grant_type
+      - code
+      - redirect_uri
+      - code_verifier
+      - client_id
+      title: Body_token_exchange_mcp_token_post
     CaptureKind:
       type: string
       enum:

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -114,7 +114,7 @@ def _callback_url(request: Request) -> str:
     return f"{scheme}://{host}/auth/callback"
 
 
-_SAFE_REDIRECT_PATHS = ("/auth/tokens",)
+_SAFE_REDIRECT_PATHS = ("/auth/tokens", "/mcp/authorize/resume")
 
 
 @router.get("/login/{provider}")
@@ -154,7 +154,7 @@ async def login(provider: str, request: Request) -> RedirectResponse:
     # If a ?next= param was provided, store it in a short-lived cookie
     # so the callback can redirect back after login.
     next_url = request.query_params.get("next", "")
-    if next_url and next_url in _SAFE_REDIRECT_PATHS:
+    if next_url and any(next_url.startswith(p) for p in _SAFE_REDIRECT_PATHS):
         response.set_cookie(
             "wikimind_next",
             next_url,
@@ -199,7 +199,7 @@ async def callback(
     # The cookie value is validated against a strict allowlist to prevent
     # open redirect attacks (CodeQL py/url-redirection).
     next_url = request.cookies.get("wikimind_next", "")
-    if next_url not in _SAFE_REDIRECT_PATHS:
+    if not any(next_url.startswith(p) for p in _SAFE_REDIRECT_PATHS):
         next_url = "/callback"
     response = RedirectResponse(url=next_url, status_code=302)
     response.delete_cookie("wikimind_next", path="/")

--- a/src/wikimind/api/routes/mcp_oauth.py
+++ b/src/wikimind/api/routes/mcp_oauth.py
@@ -16,6 +16,7 @@ See issue #764.
 
 import base64
 import hashlib
+import html
 import secrets
 import uuid
 from datetime import timedelta
@@ -199,7 +200,7 @@ async def authorize(
     code_challenge_method: str | None = None,
     state: str | None = None,
 ) -> HTMLResponse:
-    """OAuth 2.1 authorization endpoint.
+    """Handle OAuth 2.1 authorization request.
 
     Validates the authorization request parameters, stores them, and
     either shows the consent screen (if logged in) or redirects to login.
@@ -234,7 +235,7 @@ async def authorize(
         # User is logged in — show consent screen
         return HTMLResponse(
             content=_CONSENT_PAGE_HTML.format(
-                client_id=_escape_html(client_id),
+                client_id=html.escape(client_id),
                 request_id=request_id,
             )
         )
@@ -270,7 +271,7 @@ async def authorize_resume(
 
     return HTMLResponse(
         content=_CONSENT_PAGE_HTML.format(
-            client_id=_escape_html(pending["client_id"]),
+            client_id=html.escape(pending["client_id"]),
             request_id=rid,
         )
     )

--- a/src/wikimind/api/routes/mcp_oauth.py
+++ b/src/wikimind/api/routes/mcp_oauth.py
@@ -1,0 +1,546 @@
+"""OAuth 2.1 Authorization Server for MCP remote connections.
+
+Implements RFC 8414 (OAuth Authorization Server Metadata), the
+authorization code grant with PKCE (RFC 7636), and token revocation
+(RFC 7009).  MCP clients (Claude.ai, MCP Inspector) use this flow
+to authenticate without manually copying PAT tokens.
+
+Endpoints:
+  GET  /.well-known/oauth-authorization-server  — metadata discovery
+  GET  /mcp/authorize    — authorization request (browser redirect)
+  POST /mcp/token        — exchange authorization code for access token
+  POST /mcp/revoke       — revoke an access token
+
+See issue #764.
+"""
+
+import base64
+import hashlib
+import secrets
+import uuid
+from datetime import timedelta
+
+import structlog
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.config import get_settings
+from wikimind.database import get_session
+from wikimind.models import OAuthAccessToken, OAuthAuthorizationCode
+
+log = structlog.get_logger()
+
+# Authorization codes expire after 5 minutes (OAuth 2.1 best practice).
+AUTH_CODE_TTL_SECONDS = 300
+
+# Access tokens expire after 1 hour.
+ACCESS_TOKEN_TTL_SECONDS = 3600
+
+# Router for /.well-known — mounted at root level in main.py.
+metadata_router = APIRouter()
+
+# Router for /mcp/* endpoints — mounted with prefix="/mcp" in main.py.
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# OAuth Metadata (RFC 8414)
+# ---------------------------------------------------------------------------
+
+
+@metadata_router.get("/.well-known/oauth-authorization-server")
+async def oauth_metadata() -> JSONResponse:
+    """Return OAuth 2.1 Authorization Server Metadata per RFC 8414."""
+    settings = get_settings()
+    issuer = settings.auth.public_url.rstrip("/") or "http://localhost:7842"
+    return JSONResponse(
+        content={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/mcp/authorize",
+            "token_endpoint": f"{issuer}/mcp/token",
+            "revocation_endpoint": f"{issuer}/mcp/revoke",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consent page HTML
+# ---------------------------------------------------------------------------
+
+
+_CONSENT_PAGE_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WikiMind — Authorize Application</title>
+<style>
+  * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         background: #f8fafc; color: #1e293b; min-height: 100vh;
+         display: flex; justify-content: center; align-items: center; }}
+  .card {{ background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.1);
+          padding: 32px; max-width: 420px; width: 100%; }}
+  h1 {{ font-size: 20px; margin-bottom: 8px; }}
+  .subtitle {{ font-size: 13px; color: #64748b; margin-bottom: 24px; }}
+  .client-name {{ font-weight: 600; color: #6366f1; }}
+  .permissions {{ background: #f1f5f9; border-radius: 8px; padding: 16px; margin: 16px 0; }}
+  .permissions h3 {{ font-size: 13px; color: #64748b; margin-bottom: 8px; }}
+  .permissions ul {{ list-style: none; padding: 0; }}
+  .permissions li {{ font-size: 13px; padding: 4px 0; }}
+  .permissions li::before {{ content: "\\2713 "; color: #22c55e; font-weight: bold; }}
+  .btn-row {{ display: flex; gap: 8px; margin-top: 20px; }}
+  .btn {{ flex: 1; padding: 10px; border: none; border-radius: 6px;
+         font-weight: 600; font-size: 13px; cursor: pointer; }}
+  .btn-approve {{ background: #6366f1; color: white; }}
+  .btn-approve:hover {{ background: #4f46e5; }}
+  .btn-deny {{ background: #e2e8f0; color: #475569; }}
+  .btn-deny:hover {{ background: #cbd5e1; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Authorize Application</h1>
+  <p class="subtitle">
+    <span class="client-name">{client_id}</span> wants to access your WikiMind knowledge base.
+  </p>
+  <div class="permissions">
+    <h3>This application will be able to:</h3>
+    <ul>
+      <li>Search your wiki articles</li>
+      <li>Read article content</li>
+      <li>Ask questions against your wiki</li>
+      <li>List your ingested sources</li>
+    </ul>
+  </div>
+  <div class="btn-row">
+    <form method="POST" action="/mcp/authorize/decide" style="flex:1;display:flex;">
+      <input type="hidden" name="request_id" value="{request_id}">
+      <input type="hidden" name="decision" value="deny">
+      <button type="submit" class="btn btn-deny" style="flex:1;">Deny</button>
+    </form>
+    <form method="POST" action="/mcp/authorize/decide" style="flex:1;display:flex;">
+      <input type="hidden" name="request_id" value="{request_id}">
+      <input type="hidden" name="decision" value="approve">
+      <button type="submit" class="btn btn-approve" style="flex:1;">Approve</button>
+    </form>
+  </div>
+</div>
+</body>
+</html>
+"""
+
+_LOGIN_REDIRECT_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WikiMind — Sign In Required</title>
+<style>
+  * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         background: #f8fafc; color: #1e293b; min-height: 100vh;
+         display: flex; justify-content: center; align-items: center; }}
+  .card {{ background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.1);
+          padding: 32px; max-width: 420px; width: 100%; text-align: center; }}
+  h1 {{ font-size: 20px; margin-bottom: 8px; }}
+  .subtitle {{ font-size: 13px; color: #64748b; margin-bottom: 24px; }}
+  .btn {{ display: block; width: 100%; padding: 10px; border: none; border-radius: 6px;
+         font-weight: 600; font-size: 13px; cursor: pointer; color: white;
+         text-decoration: none; margin-bottom: 8px; }}
+  .btn-google {{ background: #4285f4; }}
+  .btn-google:hover {{ background: #3367d6; }}
+  .btn-github {{ background: #374151; }}
+  .btn-github:hover {{ background: #1f2937; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Sign In Required</h1>
+  <p class="subtitle">Sign in to authorize the application.</p>
+  <a href="/auth/login/google?next=/mcp/authorize/resume?rid={request_id}" class="btn btn-google">
+    Sign in with Google
+  </a>
+  <a href="/auth/login/github?next=/mcp/authorize/resume?rid={request_id}" class="btn btn-github">
+    Sign in with GitHub
+  </a>
+</div>
+</body>
+</html>
+"""
+
+# In-memory store for pending authorization requests. These are ephemeral
+# and short-lived (5 minutes). A database table would survive restarts but
+# is unnecessary for authorization requests that expire quickly.
+_pending_requests: dict[str, dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# Authorization Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/authorize")
+async def authorize(
+    request: Request,
+    response_type: str | None = None,
+    client_id: str | None = None,
+    redirect_uri: str | None = None,
+    code_challenge: str | None = None,
+    code_challenge_method: str | None = None,
+    state: str | None = None,
+) -> HTMLResponse:
+    """OAuth 2.1 authorization endpoint.
+
+    Validates the authorization request parameters, stores them, and
+    either shows the consent screen (if logged in) or redirects to login.
+    """
+    # Validate required parameters
+    if response_type != "code":
+        raise HTTPException(status_code=400, detail="response_type must be 'code'")
+    if not client_id:
+        raise HTTPException(status_code=400, detail="client_id is required")
+    if not redirect_uri:
+        raise HTTPException(status_code=400, detail="redirect_uri is required")
+    if not code_challenge:
+        raise HTTPException(status_code=400, detail="code_challenge is required (PKCE)")
+    if code_challenge_method != "S256":
+        raise HTTPException(status_code=400, detail="code_challenge_method must be 'S256'")
+
+    # Store the authorization request
+    request_id = str(uuid.uuid4())
+    _pending_requests[request_id] = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "state": state,
+        "created_at": utcnow_naive(),
+    }
+
+    # Check if user is authenticated (has session cookie)
+    settings = get_settings()
+    user_id = _extract_user_id(request, settings)
+
+    if user_id:
+        # User is logged in — show consent screen
+        return HTMLResponse(
+            content=_CONSENT_PAGE_HTML.format(
+                client_id=_escape_html(client_id),
+                request_id=request_id,
+            )
+        )
+
+    # Not logged in — show login page
+    return HTMLResponse(content=_LOGIN_REDIRECT_HTML.format(request_id=request_id))
+
+
+@router.get("/authorize/resume")
+async def authorize_resume(
+    request: Request,
+    rid: str,
+) -> HTMLResponse:
+    """Resume authorization flow after login.
+
+    The user was redirected to login, and after successful login they
+    are sent back here. We now show the consent screen.
+    """
+    pending = _pending_requests.get(rid)
+    if not pending:
+        raise HTTPException(status_code=400, detail="Authorization request not found or expired")
+
+    # Verify the request hasn't expired (5 minutes)
+    age = (utcnow_naive() - pending["created_at"]).total_seconds()
+    if age > AUTH_CODE_TTL_SECONDS:
+        _pending_requests.pop(rid, None)
+        raise HTTPException(status_code=400, detail="Authorization request expired")
+
+    settings = get_settings()
+    user_id = _extract_user_id(request, settings)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    return HTMLResponse(
+        content=_CONSENT_PAGE_HTML.format(
+            client_id=_escape_html(pending["client_id"]),
+            request_id=rid,
+        )
+    )
+
+
+@router.post("/authorize/decide")
+async def authorize_decide(
+    request: Request,
+    request_id: str = Form(...),
+    decision: str = Form(...),
+    session: AsyncSession = Depends(get_session),
+) -> RedirectResponse:
+    """Handle consent decision (approve or deny).
+
+    On approval, generates an authorization code, stores it, and
+    redirects to the client's redirect_uri with the code and state.
+    """
+    pending = _pending_requests.pop(request_id, None)
+    if not pending:
+        raise HTTPException(status_code=400, detail="Authorization request not found or expired")
+
+    # Verify the request hasn't expired
+    age = (utcnow_naive() - pending["created_at"]).total_seconds()
+    if age > AUTH_CODE_TTL_SECONDS:
+        raise HTTPException(status_code=400, detail="Authorization request expired")
+
+    redirect_uri = pending["redirect_uri"]
+
+    if decision != "approve":
+        # Denied — redirect with error
+        sep = "&" if "?" in redirect_uri else "?"
+        deny_url = f"{redirect_uri}{sep}error=access_denied"
+        if pending.get("state"):
+            deny_url += f"&state={pending['state']}"
+        return RedirectResponse(url=deny_url, status_code=302)
+
+    # Get the authenticated user
+    settings = get_settings()
+    user_id = _extract_user_id(request, settings)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    # Generate authorization code
+    code = secrets.token_urlsafe(32)
+    now = utcnow_naive()
+    auth_code = OAuthAuthorizationCode(
+        code=code,
+        user_id=user_id,
+        client_id=pending["client_id"],
+        redirect_uri=redirect_uri,
+        code_challenge=pending["code_challenge"],
+        state=pending.get("state"),
+        created_at=now,
+        expires_at=now + timedelta(seconds=AUTH_CODE_TTL_SECONDS),
+    )
+    session.add(auth_code)
+    await session.commit()
+
+    log.info(
+        "oauth_code_issued",
+        client_id=pending["client_id"],
+        user_id=user_id,
+    )
+
+    # Redirect to client with code
+    sep = "&" if "?" in redirect_uri else "?"
+    approve_url = f"{redirect_uri}{sep}code={code}"
+    if pending.get("state"):
+        approve_url += f"&state={pending['state']}"
+
+    return RedirectResponse(url=approve_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# Token Endpoint
+# ---------------------------------------------------------------------------
+
+
+def _validate_auth_code(
+    auth_code: OAuthAuthorizationCode | None,
+    client_id: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> str | None:
+    """Validate an authorization code for token exchange.
+
+    Returns an error description string if validation fails, or None if valid.
+    """
+    if not auth_code:
+        return "Invalid authorization code"
+
+    # Check code state and binding
+    checks: list[tuple[bool, str]] = [
+        (utcnow_naive() > auth_code.expires_at, "Authorization code expired"),
+        (auth_code.used, "Authorization code already used"),
+        (auth_code.client_id != client_id, "client_id mismatch"),
+        (auth_code.redirect_uri != redirect_uri, "redirect_uri mismatch"),
+    ]
+    for failed, msg in checks:
+        if failed:
+            return msg
+
+    # Verify PKCE: S256 — hash the verifier and compare to stored challenge
+    verifier_hash = (
+        base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
+    )
+    if verifier_hash != auth_code.code_challenge:
+        return "PKCE verification failed"
+
+    return None
+
+
+@router.post("/token")
+async def token_exchange(
+    grant_type: str = Form(...),
+    code: str = Form(...),
+    redirect_uri: str = Form(...),
+    code_verifier: str = Form(...),
+    client_id: str = Form(...),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    """Exchange an authorization code for an access token (PKCE).
+
+    Validates the grant type, code, redirect_uri match, PKCE verifier,
+    and that the code hasn't expired or been used. Returns a short-lived
+    access token with ``wmk_`` prefix.
+    """
+    if grant_type != "authorization_code":
+        return JSONResponse(
+            status_code=400,
+            content={"error": "unsupported_grant_type"},
+        )
+
+    # Look up and validate the authorization code
+    result = await session.exec(select(OAuthAuthorizationCode).where(OAuthAuthorizationCode.code == code))
+    auth_code = result.one_or_none()
+
+    error = _validate_auth_code(auth_code, client_id, redirect_uri, code_verifier)
+    if error:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_grant", "error_description": error},
+        )
+    assert auth_code is not None  # validated above
+
+    # Mark code as used
+    auth_code.used = True
+    session.add(auth_code)
+
+    # Generate access token with wmk_ prefix
+    raw_token = f"wmk_{secrets.token_urlsafe(32)}"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+    now = utcnow_naive()
+    access_token = OAuthAccessToken(
+        token_hash=token_hash,
+        user_id=auth_code.user_id,
+        client_id=client_id,
+        created_at=now,
+        expires_at=now + timedelta(seconds=ACCESS_TOKEN_TTL_SECONDS),
+    )
+    session.add(access_token)
+    await session.commit()
+
+    log.info(
+        "oauth_token_issued",
+        client_id=client_id,
+        user_id=auth_code.user_id,
+    )
+
+    return JSONResponse(
+        content={
+            "access_token": raw_token,
+            "token_type": "bearer",
+            "expires_in": ACCESS_TOKEN_TTL_SECONDS,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token Revocation (RFC 7009)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/revoke")
+async def revoke_token(
+    token: str = Form(...),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    """Revoke an access token.
+
+    Per RFC 7009, always returns 200 even if the token is not found.
+    """
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    result = await session.exec(select(OAuthAccessToken).where(OAuthAccessToken.token_hash == token_hash))
+    access_token = result.one_or_none()
+
+    if access_token:
+        access_token.revoked = True
+        session.add(access_token)
+        await session.commit()
+        log.info("oauth_token_revoked", client_id=access_token.client_id)
+
+    # RFC 7009: always return 200
+    return JSONResponse(content={})
+
+
+# ---------------------------------------------------------------------------
+# Token validation helper (used by MCP auth)
+# ---------------------------------------------------------------------------
+
+
+async def validate_oauth_token(token: str, session: AsyncSession) -> str | None:
+    """Validate an OAuth access token and return the user_id if valid.
+
+    Returns None if the token is invalid, expired, or revoked.
+    """
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    result = await session.exec(select(OAuthAccessToken).where(OAuthAccessToken.token_hash == token_hash))
+    access_token = result.one_or_none()
+
+    if not access_token:
+        return None
+    if access_token.revoked:
+        return None
+    if utcnow_naive() > access_token.expires_at:
+        return None
+
+    return access_token.user_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_user_id(request: Request, settings) -> str | None:
+    """Extract user_id from the session cookie JWT, if present.
+
+    Returns None if not authenticated. Does not raise.
+    """
+    import jwt  # noqa: PLC0415 — deferred to keep module-level imports clean
+
+    # In dev mode with auto-auth, the middleware sets request.state.user_id
+    user_id = getattr(request.state, "user_id", None)
+    if user_id:
+        return user_id
+
+    token = request.cookies.get(settings.auth.cookie_name, "")
+    if not token:
+        return None
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.auth.jwt_secret_key,
+            algorithms=[settings.auth.jwt_algorithm],
+            options={"verify_aud": False},
+        )
+        return payload.get("sub")
+    except jwt.InvalidTokenError:
+        return None
+
+
+def _escape_html(text: str) -> str:
+    """Escape HTML special characters to prevent XSS in the consent page."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#x27;")
+    )

--- a/src/wikimind/api/routes/mcp_oauth.py
+++ b/src/wikimind/api/routes/mcp_oauth.py
@@ -236,12 +236,12 @@ async def authorize(
         return HTMLResponse(
             content=_CONSENT_PAGE_HTML.format(
                 client_id=html.escape(client_id),
-                request_id=request_id,
+                request_id=html.escape(request_id),
             )
         )
 
     # Not logged in — show login page
-    return HTMLResponse(content=_LOGIN_REDIRECT_HTML.format(request_id=request_id))
+    return HTMLResponse(content=_LOGIN_REDIRECT_HTML.format(request_id=html.escape(request_id)))
 
 
 @router.get("/authorize/resume")
@@ -272,7 +272,7 @@ async def authorize_resume(
     return HTMLResponse(
         content=_CONSENT_PAGE_HTML.format(
             client_id=html.escape(pending["client_id"]),
-            request_id=rid,
+            request_id=html.escape(rid),
         )
     )
 

--- a/src/wikimind/main.py
+++ b/src/wikimind/main.py
@@ -32,6 +32,7 @@ from wikimind.api.routes import (
     ingest,
     jobs,
     lint,
+    mcp_oauth,
     mcp_tokens,
     query,
     saved_searches,
@@ -69,10 +70,12 @@ _API_ONLY_PREFIXES = (
     "/auth/",
     "/docs",
     "/health",
+    "/mcp/",
     "/metrics",
     "/public/",
     "/redoc",
     "/openapi.json",
+    "/.well-known/",
     "/ws",
 )
 
@@ -277,6 +280,11 @@ app.include_router(sharing.public_router, tags=["Sharing"])
 app.include_router(health.router, tags=["Admin"])
 app.include_router(ws.router, tags=["WebSocket"])
 app.include_router(auth.router, prefix="/auth", tags=["Auth"])
+
+# MCP OAuth 2.1 Authorization Server — metadata at /.well-known/... (root),
+# authorization/token/revocation at /mcp/* (root).
+app.include_router(mcp_oauth.metadata_router, tags=["Auth"])
+app.include_router(mcp_oauth.router, prefix="/mcp", tags=["Auth"])
 
 # ---------------------------------------------------------------------------
 # Exception handlers — normalize all error responses to the standard envelope

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -141,6 +141,6 @@ async def validate_mcp_token(token: str, session: AsyncSession) -> str | None:
                 return None
             return oauth.user_id
     except Exception:
-        pass
+        log.debug("OAuthAccessToken table not available or query failed")
 
     return None

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -94,7 +94,7 @@ class WikiMindAuthProvider(TokenVerifier):
         return AccessToken(token=token, client_id=user_id, scopes=[])
 
 
-async def validate_mcp_token(token: str, session: "AsyncSession") -> str | None:
+async def validate_mcp_token(token: str, session: AsyncSession) -> str | None:
     """Validate an MCP access token (PAT or OAuth) and return the user_id.
 
     Checks both ``mcp_access_token`` and ``oauthaccesstoken`` tables.

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -9,10 +9,14 @@ entirely. See ADR-027.
 from __future__ import annotations
 
 import hashlib
+from typing import TYPE_CHECKING
 
 import jwt
 import structlog
 from fastmcp.server.auth import AccessToken, TokenVerifier
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind._datetime import utcnow_naive
 from wikimind.database import get_session_factory

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -104,18 +104,15 @@ async def validate_mcp_token(token: str, session: AsyncSession) -> str | None:
     Checks both ``mcp_access_token`` and ``oauthaccesstoken`` tables.
     Returns the user_id if the token is valid, or None if invalid/expired/revoked.
     """
-    import hashlib
+    from sqlmodel import select  # noqa: PLC0415
 
-    from sqlmodel import select
-
-    from wikimind._datetime import utcnow_naive
+    from wikimind._datetime import utcnow_naive  # noqa: PLC0415
+    from wikimind.models import MCPAccessToken  # noqa: PLC0415
 
     token_hash = hashlib.sha256(token.encode()).hexdigest()
     now = utcnow_naive()
 
     # Check MCPAccessToken table (PATs)
-    from wikimind.models import MCPAccessToken
-
     stmt = select(MCPAccessToken).where(
         MCPAccessToken.token_hash == token_hash,
         MCPAccessToken.revoked == False,  # noqa: E712
@@ -131,7 +128,7 @@ async def validate_mcp_token(token: str, session: AsyncSession) -> str | None:
 
     # Check OAuthAccessToken table
     try:
-        from wikimind.models import OAuthAccessToken
+        from wikimind.models import OAuthAccessToken  # noqa: PLC0415
 
         stmt2 = select(OAuthAccessToken).where(
             OAuthAccessToken.token_hash == token_hash,

--- a/src/wikimind/mcp/auth.py
+++ b/src/wikimind/mcp/auth.py
@@ -92,3 +92,54 @@ class WikiMindAuthProvider(TokenVerifier):
             raise ValueError(msg)
 
         return AccessToken(token=token, client_id=user_id, scopes=[])
+
+
+async def validate_mcp_token(token: str, session: "AsyncSession") -> str | None:
+    """Validate an MCP access token (PAT or OAuth) and return the user_id.
+
+    Checks both ``mcp_access_token`` and ``oauthaccesstoken`` tables.
+    Returns the user_id if the token is valid, or None if invalid/expired/revoked.
+    """
+    import hashlib
+
+    from sqlmodel import select
+
+    from wikimind._datetime import utcnow_naive
+
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    now = utcnow_naive()
+
+    # Check MCPAccessToken table (PATs)
+    from wikimind.models import MCPAccessToken
+
+    stmt = select(MCPAccessToken).where(
+        MCPAccessToken.token_hash == token_hash,
+        MCPAccessToken.revoked == False,  # noqa: E712
+    )
+    result = await session.exec(stmt)
+    pat = result.one_or_none()
+    if pat:
+        if pat.expires_at and pat.expires_at < now:
+            return None
+        pat.last_used_at = now
+        await session.commit()
+        return pat.user_id
+
+    # Check OAuthAccessToken table
+    try:
+        from wikimind.models import OAuthAccessToken
+
+        stmt2 = select(OAuthAccessToken).where(
+            OAuthAccessToken.token_hash == token_hash,
+            OAuthAccessToken.revoked == False,  # noqa: E712
+        )
+        result2 = await session.exec(stmt2)
+        oauth = result2.one_or_none()
+        if oauth:
+            if oauth.expires_at and oauth.expires_at < now:
+                return None
+            return oauth.user_id
+    except Exception:
+        pass
+
+    return None

--- a/src/wikimind/middleware/auth.py
+++ b/src/wikimind/middleware/auth.py
@@ -18,7 +18,15 @@ from starlette.responses import JSONResponse, Response
 
 from wikimind.config import get_settings
 
-EXEMPT_PATHS = {"/health", "/health/deep", "/metrics", "/docs", "/openapi.json", "/redoc"}
+EXEMPT_PATHS = {
+    "/health",
+    "/health/deep",
+    "/metrics",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+    "/.well-known/oauth-authorization-server",
+}
 EXEMPT_PREFIXES = (
     "/auth/login/",
     "/auth/callback",
@@ -26,6 +34,9 @@ EXEMPT_PREFIXES = (
     "/auth/magic-link",
     "/assets/",
     "/public/",
+    "/mcp/token",
+    "/mcp/revoke",
+    "/mcp/authorize",
 )
 # Static frontend files that must load without auth so users can see the login page.
 # NOTE: .png and .svg are intentionally excluded — API-served images

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -585,6 +585,43 @@ class RssFeed(SQLModel, table=True):
     created_at: datetime = Field(default_factory=utcnow_naive)
 
 
+class OAuthAuthorizationCode(SQLModel, table=True):
+    """Short-lived OAuth 2.1 authorization code for MCP client flows.
+
+    Created when a user approves an MCP client's authorization request.
+    Exchanged for an access token at the token endpoint. Codes expire
+    after 5 minutes and can only be used once (``used`` flag).
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    code: str = Field(index=True)
+    user_id: str = Field(foreign_key="user.id")
+    client_id: str
+    redirect_uri: str
+    code_challenge: str  # S256 hash
+    state: str | None = None
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    expires_at: datetime
+    used: bool = False
+
+
+class OAuthAccessToken(SQLModel, table=True):
+    """OAuth 2.1 access token issued to MCP clients.
+
+    Created during the token exchange (authorization_code grant).
+    Tokens use the ``wmk_`` prefix and are validated by the MCP auth
+    provider alongside PAT tokens.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    token_hash: str = Field(index=True)  # SHA-256 of the raw token
+    user_id: str = Field(foreign_key="user.id", index=True)
+    client_id: str
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    expires_at: datetime
+    revoked: bool = False
+
+
 class CompilationDraft(SQLModel, table=True):
     """Draft compilation output awaiting user review before finalizing.
 

--- a/tests/unit/test_mcp_oauth.py
+++ b/tests/unit/test_mcp_oauth.py
@@ -1,0 +1,592 @@
+"""Tests for MCP OAuth 2.1 Authorization Server (issue #764).
+
+Covers:
+- OAuth metadata endpoint (RFC 8414)
+- Authorization flow (request -> consent -> code -> redirect)
+- Token exchange with PKCE verification
+- Token revocation (RFC 7009)
+- Expired authorization codes
+- Invalid PKCE verifier
+- OAuth access token validation for MCP
+"""
+
+import base64
+import hashlib
+import secrets
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind._datetime import utcnow_naive
+from wikimind.api.routes.mcp_oauth import _pending_requests
+from wikimind.models import OAuthAccessToken, OAuthAuthorizationCode
+
+
+def _make_pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE code_verifier and its S256 code_challenge."""
+    verifier = secrets.token_urlsafe(32)
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+# ---------------------------------------------------------------------------
+# OAuth Metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_oauth_metadata_returns_valid_config(client: AsyncClient) -> None:
+    """GET /.well-known/oauth-authorization-server returns RFC 8414 metadata."""
+    resp = await client.get(
+        "/.well-known/oauth-authorization-server",
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["response_types_supported"] == ["code"]
+    assert data["grant_types_supported"] == ["authorization_code"]
+    assert data["code_challenge_methods_supported"] == ["S256"]
+    assert data["token_endpoint_auth_methods_supported"] == ["none"]
+    assert "/mcp/authorize" in data["authorization_endpoint"]
+    assert "/mcp/token" in data["token_endpoint"]
+    assert "/mcp/revoke" in data["revocation_endpoint"]
+
+
+# ---------------------------------------------------------------------------
+# Authorization Flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_authorize_requires_response_type_code(client: AsyncClient) -> None:
+    """GET /mcp/authorize with missing response_type returns 400."""
+    resp = await client.get(
+        "/mcp/authorize",
+        params={"client_id": "test", "redirect_uri": "http://localhost/cb"},
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_authorize_requires_pkce(client: AsyncClient) -> None:
+    """GET /mcp/authorize without code_challenge returns 400."""
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "test",
+            "redirect_uri": "http://localhost/cb",
+        },
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_authorize_shows_consent_page_when_authenticated(
+    client: AsyncClient,
+) -> None:
+    """GET /mcp/authorize shows consent page for authenticated user (dev mode)."""
+    _, challenge = _make_pkce_pair()
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "test-mcp-client",
+            "redirect_uri": "http://localhost:9999/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "abc123",
+        },
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert "test-mcp-client" in body
+    assert "Authorize Application" in body
+    assert "Approve" in body
+    assert "Deny" in body
+
+
+# ---------------------------------------------------------------------------
+# Full Authorization + Token Exchange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_full_oauth_flow_with_pkce(client: AsyncClient) -> None:
+    """Full flow: authorize -> approve -> token exchange with valid PKCE."""
+    verifier, challenge = _make_pkce_pair()
+    redirect_uri = "http://localhost:9999/callback"
+    client_id = "test-mcp-client"
+    state = "test-state-123"
+
+    # Step 1: Start authorization
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        },
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+
+    # Extract the request_id from the consent page
+    body = resp.text
+    import re
+
+    match = re.search(r'name="request_id" value="([^"]+)"', body)
+    assert match, "Could not find request_id in consent page"
+    request_id = match.group(1)
+
+    # Step 2: Approve
+    resp = await client.post(
+        "/mcp/authorize/decide",
+        data={"request_id": request_id, "decision": "approve"},
+        headers={"Accept": "text/html", "Content-Type": "application/x-www-form-urlencoded"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert location.startswith(redirect_uri)
+    assert f"state={state}" in location
+
+    # Extract the authorization code from the redirect
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(location)
+    params = parse_qs(parsed.query)
+    assert "code" in params
+    code = params["code"][0]
+
+    # Step 3: Exchange code for token
+    resp = await client.post(
+        "/mcp/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": verifier,
+            "client_id": client_id,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 200
+    token_data = resp.json()
+    assert token_data["token_type"] == "bearer"
+    assert token_data["expires_in"] == 3600
+    assert token_data["access_token"].startswith("wmk_")
+
+
+@pytest.mark.anyio
+async def test_deny_redirects_with_error(client: AsyncClient) -> None:
+    """Denying authorization redirects with error=access_denied."""
+    _, challenge = _make_pkce_pair()
+    redirect_uri = "http://localhost:9999/callback"
+
+    # Start authorization
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "test-client",
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "s1",
+        },
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    import re
+
+    match = re.search(r'name="request_id" value="([^"]+)"', resp.text)
+    assert match
+    request_id = match.group(1)
+
+    # Deny
+    resp = await client.post(
+        "/mcp/authorize/decide",
+        data={"request_id": request_id, "decision": "deny"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert "error=access_denied" in location
+    assert "state=s1" in location
+
+
+# ---------------------------------------------------------------------------
+# Token Exchange Error Cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_token_exchange_invalid_grant_type(client: AsyncClient) -> None:
+    """POST /mcp/token with unsupported grant_type returns error."""
+    resp = await client.post(
+        "/mcp/token",
+        data={
+            "grant_type": "client_credentials",
+            "code": "fake",
+            "redirect_uri": "http://localhost/cb",
+            "code_verifier": "fake",
+            "client_id": "test",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "unsupported_grant_type"
+
+
+@pytest.mark.anyio
+async def test_token_exchange_invalid_code(client: AsyncClient) -> None:
+    """POST /mcp/token with non-existent code returns error."""
+    resp = await client.post(
+        "/mcp/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "nonexistent-code",
+            "redirect_uri": "http://localhost/cb",
+            "code_verifier": "fake",
+            "client_id": "test",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.anyio
+async def test_token_exchange_wrong_pkce_verifier(client: AsyncClient) -> None:
+    """POST /mcp/token with incorrect PKCE verifier returns error."""
+    verifier, challenge = _make_pkce_pair()
+    redirect_uri = "http://localhost:9999/callback"
+    client_id = "test-client"
+
+    # Get a valid authorization code
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    import re
+
+    match = re.search(r'name="request_id" value="([^"]+)"', resp.text)
+    assert match
+    request_id = match.group(1)
+
+    resp = await client.post(
+        "/mcp/authorize/decide",
+        data={"request_id": request_id, "decision": "approve"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        follow_redirects=False,
+    )
+    from urllib.parse import parse_qs, urlparse
+
+    code = parse_qs(urlparse(resp.headers["location"]).query)["code"][0]
+
+    # Try to exchange with wrong verifier
+    resp = await client.post(
+        "/mcp/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": "wrong-verifier-value",
+            "client_id": client_id,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert data["error"] == "invalid_grant"
+    assert "PKCE" in data["error_description"]
+
+
+@pytest.mark.anyio
+async def test_token_exchange_code_already_used(client: AsyncClient) -> None:
+    """POST /mcp/token with already-used code returns error."""
+    verifier, challenge = _make_pkce_pair()
+    redirect_uri = "http://localhost:9999/callback"
+    client_id = "test-client"
+
+    # Get authorization code
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    import re
+
+    match = re.search(r'name="request_id" value="([^"]+)"', resp.text)
+    assert match
+    request_id = match.group(1)
+
+    resp = await client.post(
+        "/mcp/authorize/decide",
+        data={"request_id": request_id, "decision": "approve"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        follow_redirects=False,
+    )
+    from urllib.parse import parse_qs, urlparse
+
+    code = parse_qs(urlparse(resp.headers["location"]).query)["code"][0]
+
+    # First exchange — should succeed
+    token_params = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": verifier,
+        "client_id": client_id,
+    }
+    resp1 = await client.post(
+        "/mcp/token",
+        data=token_params,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp1.status_code == 200
+
+    # Second exchange — should fail (code already used)
+    resp2 = await client.post(
+        "/mcp/token",
+        data=token_params,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp2.status_code == 400
+    assert resp2.json()["error"] == "invalid_grant"
+    assert "already used" in resp2.json()["error_description"]
+
+
+# ---------------------------------------------------------------------------
+# Expired Authorization Code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_expired_authorization_code_rejected(
+    db_session: AsyncSession,
+    client: AsyncClient,
+) -> None:
+    """Token exchange rejects an expired authorization code."""
+    verifier, challenge = _make_pkce_pair()
+    now = utcnow_naive()
+
+    # Insert an expired code directly
+    expired_code = OAuthAuthorizationCode(
+        code="expired-code-123",
+        user_id="test-user",
+        client_id="test-client",
+        redirect_uri="http://localhost/cb",
+        code_challenge=challenge,
+        created_at=now - timedelta(minutes=10),
+        expires_at=now - timedelta(minutes=5),
+    )
+    db_session.add(expired_code)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/mcp/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "expired-code-123",
+            "redirect_uri": "http://localhost/cb",
+            "code_verifier": verifier,
+            "client_id": "test-client",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 400
+    assert "expired" in resp.json()["error_description"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Token Revocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_token_revocation(client: AsyncClient) -> None:
+    """POST /mcp/revoke revokes a valid access token."""
+    verifier, challenge = _make_pkce_pair()
+    redirect_uri = "http://localhost:9999/callback"
+    client_id = "test-client"
+
+    # Get a valid access token through the full flow
+    resp = await client.get(
+        "/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    import re
+
+    match = re.search(r'name="request_id" value="([^"]+)"', resp.text)
+    assert match
+    request_id = match.group(1)
+
+    resp = await client.post(
+        "/mcp/authorize/decide",
+        data={"request_id": request_id, "decision": "approve"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        follow_redirects=False,
+    )
+    from urllib.parse import parse_qs, urlparse
+
+    code = parse_qs(urlparse(resp.headers["location"]).query)["code"][0]
+
+    resp = await client.post(
+        "/mcp/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": verifier,
+            "client_id": client_id,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    access_token = resp.json()["access_token"]
+
+    # Revoke the token
+    resp = await client.post(
+        "/mcp/revoke",
+        data={"token": access_token},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_revoke_unknown_token_returns_200(client: AsyncClient) -> None:
+    """POST /mcp/revoke with unknown token still returns 200 (RFC 7009)."""
+    resp = await client.post(
+        "/mcp/revoke",
+        data={"token": "wmk_nonexistent_token"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# MCP Token Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_validate_mcp_token_valid(db_session: AsyncSession) -> None:
+    """validate_mcp_token returns user_id for a valid OAuth token."""
+    from wikimind.mcp.auth import validate_mcp_token
+
+    raw_token = f"wmk_{secrets.token_urlsafe(32)}"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    now = utcnow_naive()
+
+    access_token = OAuthAccessToken(
+        token_hash=token_hash,
+        user_id="test-user",
+        client_id="test-client",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    db_session.add(access_token)
+    await db_session.commit()
+
+    user_id = await validate_mcp_token(raw_token, db_session)
+    assert user_id == "test-user"
+
+
+@pytest.mark.anyio
+async def test_validate_mcp_token_revoked(db_session: AsyncSession) -> None:
+    """validate_mcp_token returns None for a revoked token."""
+    from wikimind.mcp.auth import validate_mcp_token
+
+    raw_token = f"wmk_{secrets.token_urlsafe(32)}"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    now = utcnow_naive()
+
+    access_token = OAuthAccessToken(
+        token_hash=token_hash,
+        user_id="test-user",
+        client_id="test-client",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        revoked=True,
+    )
+    db_session.add(access_token)
+    await db_session.commit()
+
+    user_id = await validate_mcp_token(raw_token, db_session)
+    assert user_id is None
+
+
+@pytest.mark.anyio
+async def test_validate_mcp_token_expired(db_session: AsyncSession) -> None:
+    """validate_mcp_token returns None for an expired token."""
+    from wikimind.mcp.auth import validate_mcp_token
+
+    raw_token = f"wmk_{secrets.token_urlsafe(32)}"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    now = utcnow_naive()
+
+    access_token = OAuthAccessToken(
+        token_hash=token_hash,
+        user_id="test-user",
+        client_id="test-client",
+        created_at=now - timedelta(hours=2),
+        expires_at=now - timedelta(hours=1),
+    )
+    db_session.add(access_token)
+    await db_session.commit()
+
+    user_id = await validate_mcp_token(raw_token, db_session)
+    assert user_id is None
+
+
+@pytest.mark.anyio
+async def test_validate_mcp_token_wrong_prefix(db_session: AsyncSession) -> None:
+    """validate_mcp_token returns None for tokens without wmk_ prefix."""
+    from wikimind.mcp.auth import validate_mcp_token
+
+    user_id = await validate_mcp_token("not_a_wmk_token", db_session)
+    assert user_id is None
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_requests():
+    """Clear the in-memory pending requests between tests."""
+    _pending_requests.clear()
+    yield
+    _pending_requests.clear()


### PR DESCRIPTION
## Summary

WikiMind needs to act as an OAuth 2.1 Authorization Server so MCP clients (Claude.ai, MCP Inspector) can authenticate via standard OAuth flow instead of manually copying PAT tokens.

- Implement RFC 8414 OAuth metadata discovery at `/.well-known/oauth-authorization-server`
- Add authorization endpoint with PKCE (S256) support and HTML consent screen
- Add token endpoint issuing `wmk_`-prefixed access tokens (1h TTL, stored as SHA-256 hashes)
- Add token revocation endpoint per RFC 7009
- Create `OAuthAuthorizationCode` and `OAuthAccessToken` database models with Alembic migration
- Add MCP auth provider (`src/wikimind/mcp/auth.py`) for validating OAuth-issued tokens

## Test plan

- [x] OAuth metadata endpoint returns valid RFC 8414 config
- [x] Authorization flow validates required params (response_type=code, PKCE)
- [x] Consent page renders for authenticated users
- [x] Full flow: authorize -> approve -> code -> token exchange with valid PKCE
- [x] Deny redirects with error=access_denied
- [x] Token exchange rejects invalid grant_type
- [x] Token exchange rejects non-existent codes
- [x] Token exchange rejects wrong PKCE verifier
- [x] Token exchange rejects already-used codes
- [x] Expired authorization codes are rejected
- [x] Token revocation works, unknown tokens return 200 (RFC 7009)
- [x] MCP token validation: valid, revoked, expired, wrong prefix

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)