### PR TITLE
refactor: unify extension and MCP tokens into single API Tokens page

### DIFF
--- a/apps/web-extension/src/popup/components/Settings.tsx
+++ b/apps/web-extension/src/popup/components/Settings.tsx
@@ -162,14 +162,14 @@ export function Settings({ onBack }: Props) {
           boxSizing: "border-box",
           outline: "none",
         }}
-        placeholder="Paste your API token"
+        placeholder="Paste your wmk_ API token"
       />
       <a
         href="#"
         onClick={(e) => {
           e.preventDefault();
           const cleanUrl = url.replace(/\/$/, "");
-          chrome.tabs.create({ url: `${cleanUrl}/auth/tokens` });
+          chrome.tabs.create({ url: `${cleanUrl}/settings` });
         }}
         style={{
           display: "block",
@@ -179,7 +179,7 @@ export function Settings({ onBack }: Props) {
           textDecoration: "none",
         }}
       >
-        Generate a token on your server &rarr;
+        Generate a token in Settings &rarr;
       </a>
 
       {error && (

--- a/apps/web/src/components/settings/ApiTokens.tsx
+++ b/apps/web/src/components/settings/ApiTokens.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Card } from "../shared/Card";
+import { Button } from "../shared/Button";
+import { apiFetch } from "../../api/client";
+
+interface TokenCreateResponse {
+  access_token: string;
+  token_type: string;
+  expires_at: string;
+  name: string;
+}
+
+async function createApiToken(name: string, expiresInDays: number): Promise<TokenCreateResponse> {
+  return apiFetch<TokenCreateResponse>("/auth/token", {
+    method: "POST",
+    body: { name, expires_in_days: expiresInDays },
+  });
+}
+
+export function ApiTokens() {
+  const [tokenName, setTokenName] = useState("api-token");
+  const [expiryDays, setExpiryDays] = useState(90);
+  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const createMutation = useMutation({
+    mutationFn: () => createApiToken(tokenName.trim() || "api-token", expiryDays),
+    onSuccess: (data) => {
+      setGeneratedToken(data.access_token);
+    },
+  });
+
+  const handleCopy = async () => {
+    if (!generatedToken) return;
+    await navigator.clipboard.writeText(generatedToken);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleReset = () => {
+    setGeneratedToken(null);
+    setCopied(false);
+    createMutation.reset();
+  };
+
+  return (
+    <Card className="p-4">
+      <p className="mb-3 text-sm text-slate-600">
+        Generate tokens for Claude Desktop, MCP Inspector, the WikiMind browser
+        extension, and any API client. Tokens use{" "}
+        <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+          Authorization: Bearer &lt;token&gt;
+        </code>{" "}
+        for authentication.
+      </p>
+
+      {generatedToken ? (
+        <div>
+          <p className="mb-2 text-xs font-semibold text-rose-600">
+            Copy this token now. You will not be able to see it again.
+          </p>
+          <div className="mb-3 break-all rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-xs text-slate-700">
+            {generatedToken}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button onClick={handleCopy} size="sm">
+              {copied ? "Copied!" : "Copy to Clipboard"}
+            </Button>
+            <Button variant="ghost" size="sm" onClick={handleReset}>
+              Generate Another
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-end gap-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">
+              Token name
+            </label>
+            <input
+              type="text"
+              value={tokenName}
+              onChange={(e) => setTokenName(e.target.value)}
+              placeholder="e.g. browser-extension"
+              className="w-48 rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-700 focus:border-brand-300 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">
+              Expires in
+            </label>
+            <select
+              value={expiryDays}
+              onChange={(e) => setExpiryDays(Number(e.target.value))}
+              className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 focus:border-brand-300 focus:outline-none"
+            >
+              <option value={30}>30 days</option>
+              <option value={90}>90 days</option>
+              <option value={180}>180 days</option>
+              <option value={365}>1 year</option>
+            </select>
+          </div>
+          <Button
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending}
+          >
+            {createMutation.isPending ? "Generating..." : "Generate Token"}
+          </Button>
+        </div>
+      )}
+
+      {createMutation.isError && (
+        <p className="mt-2 text-xs text-rose-600">
+          {createMutation.error instanceof Error
+            ? createMutation.error.message
+            : "Failed to create token"}
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -10,6 +10,7 @@ import { DoclingStatus } from "./DoclingStatus";
 import { SyncStatus } from "./SyncStatus";
 import { WikiExportPanel } from "./WikiExportPanel";
 import { ShareLinksPanel } from "./ShareLinksPanel";
+import { ApiTokens } from "./ApiTokens";
 import { MCPTokens } from "./MCPTokens";
 import { getSettings, updateSettings } from "../../api/settings";
 
@@ -97,6 +98,11 @@ export function SettingsView() {
         <section className="mb-8">
           <h2 className="mb-4 text-lg font-semibold text-slate-700">Share Links</h2>
           <ShareLinksPanel />
+        </section>
+
+        <section className="mb-8">
+          <h2 className="mb-4 text-lg font-semibold text-slate-700">API Tokens</h2>
+          <ApiTokens />
         </section>
 
         <section className="mb-8">

--- a/src/wikimind/api/routes/api_keys.py
+++ b/src/wikimind/api/routes/api_keys.py
@@ -3,6 +3,11 @@
 Lets authenticated users store, list, and delete their own LLM provider
 API keys.  Keys are encrypted at rest (Fernet + PBKDF2).  Responses
 never expose raw keys -- only provider names and masked hints.
+
+Note: These are *provider* API keys (e.g. OpenAI, Anthropic) for LLM
+access.  User-facing *API tokens* (Bearer tokens used by the browser
+extension, MCP clients, and other API consumers) are managed in
+``auth.py`` via the ``POST /auth/token`` endpoint.
 """
 
 from datetime import datetime

--- a/src/wikimind/api/routes/auth.py
+++ b/src/wikimind/api/routes/auth.py
@@ -114,7 +114,7 @@ def _callback_url(request: Request) -> str:
     return f"{scheme}://{host}/auth/callback"
 
 
-_SAFE_REDIRECT_PATHS = ("/auth/tokens", "/mcp/authorize/resume")
+_SAFE_REDIRECT_PATHS = ("/auth/tokens", "/settings", "/mcp/authorize/resume")
 
 
 @router.get("/login/{provider}")


### PR DESCRIPTION
## Summary

Closes #766.

- **Problem:** The browser extension and MCP clients both use `Authorization: Bearer <token>` but had separate UIs -- a standalone HTML page at `/auth/tokens` and no in-app settings section. Users had to navigate away from the app to generate tokens.
- **Solution:** Added an "API Tokens" section to the Settings page and updated the browser extension to link there instead of the standalone page. The standalone page remains functional for backward compatibility.

## Changes

- **New `ApiTokens.tsx` component** -- React component in `apps/web/src/components/settings/` that calls `POST /auth/token` to generate Bearer tokens inline in Settings. Description mentions Claude Desktop, MCP Inspector, the browser extension, and generic API clients.
- **`SettingsView.tsx`** -- Imports and renders the new API Tokens section between Share Links and System.
- **Browser extension `Settings.tsx`** -- Changed "Generate a token on your server" link from `/auth/tokens` to `/settings`. Updated placeholder to mention `wmk_` tokens.
- **`api_keys.py`** -- Added docstring note clarifying these are LLM provider keys, not user-facing API tokens.
- **`auth.py`** -- Added `/settings` to `_SAFE_REDIRECT_PATHS` so OAuth flows can redirect back to the Settings page.

## Test plan

- [x] `cd apps/web && npm run build` -- frontend builds cleanly
- [x] `cd apps/web-extension && npm run build` -- extension builds cleanly
- [x] `uv run ruff check src/ tests/` -- all checks passed
- [x] `uv run pytest tests/` -- 1671 passed (pre-existing failures in MCP server test and smoke test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)