### PR TITLE
fix: restore feature code from empty squash merges (#751-#761)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,6 +35,11 @@ const HealthView = lazy(() =>
 const SettingsView = lazy(() =>
   import("./components/settings/SettingsView").then((m) => ({ default: m.SettingsView }))
 );
+const ShareManagementView = lazy(() =>
+  import("./components/settings/ShareManagementView").then((m) => ({
+    default: m.ShareManagementView,
+  }))
+);
 const SynthesisView = lazy(() =>
   import("./components/synthesis/SynthesisView").then((m) => ({ default: m.SynthesisView }))
 );
@@ -77,6 +82,7 @@ function AuthenticatedApp() {
             <Route path="/graph" element={<GraphView />} />
             <Route path="/health" element={<HealthView />} />
             <Route path="/settings" element={<SettingsView />} />
+            <Route path="/settings/shares" element={<ShareManagementView />} />
             <Route path="/admin" element={<AdminDashboard />} />
             <Route path="*" element={<Navigate to="/inbox" replace />} />
           </Routes>

--- a/apps/web/src/api/wiki.ts
+++ b/apps/web/src/api/wiki.ts
@@ -152,3 +152,63 @@ export interface SynthesisSuggestion {
 export function getSynthesisSuggestions(): Promise<SynthesisSuggestion[]> {
   return apiFetch<SynthesisSuggestion[]>("/api/wiki/synthesis/suggestions");
 }
+
+// ---------------------------------------------------------------------------
+// Synthesis wizard (preview → refine → confirm)
+// ---------------------------------------------------------------------------
+
+export type SynthesisType =
+  | "comparative"
+  | "chronological"
+  | "thematic"
+  | "gap_analysis";
+
+export interface PreviewSynthesisRequest {
+  synthesis_type: SynthesisType;
+  article_ids: string[];
+  guidance?: string;
+}
+
+export interface SynthesisPreviewResponse {
+  preview_id: string;
+  title: string;
+  draft_markdown: string;
+  themes: string[];
+  source_count: number;
+}
+
+export interface RefineSynthesisRequest {
+  preview_id: string;
+  feedback: string;
+}
+
+export interface ConfirmSynthesisRequest {
+  preview_id: string;
+}
+
+export function previewSynthesis(
+  body: PreviewSynthesisRequest,
+): Promise<SynthesisPreviewResponse> {
+  return apiFetch<SynthesisPreviewResponse>("/api/wiki/synthesis/preview", {
+    method: "POST",
+    body,
+  });
+}
+
+export function refineSynthesis(
+  body: RefineSynthesisRequest,
+): Promise<SynthesisPreviewResponse> {
+  return apiFetch<SynthesisPreviewResponse>("/api/wiki/synthesis/refine", {
+    method: "POST",
+    body,
+  });
+}
+
+export function confirmSynthesis(
+  body: ConfirmSynthesisRequest,
+): Promise<SynthesisResponse> {
+  return apiFetch<SynthesisResponse>("/api/wiki/synthesis/confirm", {
+    method: "POST",
+    body,
+  });
+}

--- a/apps/web/src/api/wiki.ts
+++ b/apps/web/src/api/wiki.ts
@@ -141,3 +141,14 @@ export function createSynthesis(
 export function listSynthesisPages(): Promise<Article[]> {
   return apiFetch<Article[]>("/api/wiki/synthesis");
 }
+
+export interface SynthesisSuggestion {
+  article_ids: string[];
+  article_titles: string[];
+  reason: string;
+  suggested_type: string;
+}
+
+export function getSynthesisSuggestions(): Promise<SynthesisSuggestion[]> {
+  return apiFetch<SynthesisSuggestion[]>("/api/wiki/synthesis/suggestions");
+}

--- a/apps/web/src/components/settings/ShareLinksPanel.tsx
+++ b/apps/web/src/components/settings/ShareLinksPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "../shared/Card";
 import { Spinner } from "../shared/Spinner";
@@ -10,6 +11,7 @@ import type { ShareLink } from "../../api/sharing";
 
 export function ShareLinksPanel() {
   const queryClient = useQueryClient();
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const { data: links = [], isLoading } = useQuery({
     queryKey: ["share-links-all"],
@@ -22,6 +24,22 @@ export function ShareLinksPanel() {
       queryClient.invalidateQueries({ queryKey: ["share-links-all"] });
     },
   });
+
+  const handleCopy = useCallback(async (link: ShareLink) => {
+    const url = getPublicArticleUrl(link.token);
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      const input = document.createElement("input");
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    }
+    setCopiedId(link.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  }, []);
 
   const activeLinks = links.filter((l: ShareLink) => !l.revoked);
 
@@ -58,15 +76,23 @@ export function ShareLinksPanel() {
               {link.view_count} view{link.view_count !== 1 ? "s" : ""}
               {link.expires_at
                 ? ` · expires ${new Date(link.expires_at).toLocaleDateString()}`
-                : ""}
+                : " · no expiry"}
               {" · created "}
               {new Date(link.created_at).toLocaleDateString()}
             </div>
           </div>
           <button
+            onClick={() => handleCopy(link)}
+            className="shrink-0 rounded border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50"
+            data-testid={`copy-link-${link.id}`}
+          >
+            {copiedId === link.id ? "Copied!" : "Copy URL"}
+          </button>
+          <button
             onClick={() => revokeMutation.mutate(link.id)}
             disabled={revokeMutation.isPending}
             className="shrink-0 rounded border border-rose-200 bg-white px-2.5 py-1 text-xs font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50"
+            data-testid={`revoke-link-${link.id}`}
           >
             Revoke
           </button>

--- a/apps/web/src/components/settings/ShareManagementView.tsx
+++ b/apps/web/src/components/settings/ShareManagementView.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card } from "../shared/Card";
+import { Spinner } from "../shared/Spinner";
+import {
+  getPublicArticleUrl,
+  listShareLinks,
+  revokeShareLink,
+} from "../../api/sharing";
+import type { ShareLink } from "../../api/sharing";
+
+export function ShareManagementView() {
+  const queryClient = useQueryClient();
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const { data: links = [], isLoading } = useQuery({
+    queryKey: ["share-links-all"],
+    queryFn: () => listShareLinks(),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (linkId: string) => revokeShareLink(linkId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["share-links-all"] });
+    },
+  });
+
+  const handleCopy = useCallback(async (link: ShareLink) => {
+    const url = getPublicArticleUrl(link.token);
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      const input = document.createElement("input");
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    }
+    setCopiedId(link.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  }, []);
+
+  const activeLinks = links.filter((l: ShareLink) => !l.revoked);
+  const revokedLinks = links.filter((l: ShareLink) => l.revoked);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner size={32} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-6">
+        <h1 className="mb-2 text-2xl font-bold text-slate-900">Share Links</h1>
+        <p className="mb-6 text-sm text-slate-500">
+          Manage all public share links for your wiki articles.
+        </p>
+
+        <section className="mb-8">
+          <h2 className="mb-3 text-lg font-semibold text-slate-700">
+            Active ({activeLinks.length})
+          </h2>
+          {activeLinks.length === 0 ? (
+            <Card className="p-4">
+              <p className="text-sm text-slate-500">
+                No active share links. Use the Share button on any article to
+                create one.
+              </p>
+            </Card>
+          ) : (
+            <Card className="divide-y divide-slate-100">
+              {activeLinks.map((link: ShareLink) => (
+                <div
+                  key={link.id}
+                  className="flex items-center gap-4 px-4 py-3"
+                  data-testid={`share-link-row-${link.id}`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-slate-800">
+                      {link.article_title ?? "Untitled"}
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-slate-400">
+                      <span>
+                        Created{" "}
+                        {new Date(link.created_at).toLocaleDateString()}
+                      </span>
+                      <span>
+                        {link.expires_at
+                          ? `Expires ${new Date(link.expires_at).toLocaleDateString()}`
+                          : "No expiry"}
+                      </span>
+                      <span>
+                        {link.view_count} view
+                        {link.view_count !== 1 ? "s" : ""}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleCopy(link)}
+                    className="shrink-0 rounded border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50"
+                    data-testid={`copy-link-${link.id}`}
+                  >
+                    {copiedId === link.id ? "Copied!" : "Copy URL"}
+                  </button>
+                  <button
+                    onClick={() => revokeMutation.mutate(link.id)}
+                    disabled={revokeMutation.isPending}
+                    className="shrink-0 rounded border border-rose-200 bg-white px-2.5 py-1 text-xs font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50"
+                    data-testid={`revoke-link-${link.id}`}
+                  >
+                    Revoke
+                  </button>
+                </div>
+              ))}
+            </Card>
+          )}
+        </section>
+
+        {revokedLinks.length > 0 && (
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-slate-700">
+              Revoked ({revokedLinks.length})
+            </h2>
+            <Card className="divide-y divide-slate-100 opacity-60">
+              {revokedLinks.map((link: ShareLink) => (
+                <div
+                  key={link.id}
+                  className="flex items-center gap-4 px-4 py-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-slate-500 line-through">
+                      {link.article_title ?? "Untitled"}
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-slate-400">
+                      <span>
+                        Created{" "}
+                        {new Date(link.created_at).toLocaleDateString()}
+                      </span>
+                      <span>
+                        {link.view_count} view
+                        {link.view_count !== 1 ? "s" : ""}
+                      </span>
+                      <span className="font-medium text-rose-400">Revoked</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </Card>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/synthesis/SynthesisView.tsx
+++ b/apps/web/src/components/synthesis/SynthesisView.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -8,122 +7,9 @@ import {
   getSynthesisSuggestions,
 } from "../../api/wiki";
 import { Spinner } from "../shared/Spinner";
+import { SynthesisWizard } from "./SynthesisWizard";
 import type { Article } from "../../types/api";
 import type { SynthesisResponse, SynthesisSuggestion } from "../../api/wiki";
-
-function SynthesisForm({
-  onCreated,
-}: {
-  onCreated: (resp: SynthesisResponse) => void;
-}) {
-  const [query, setQuery] = useState("");
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [showArticlePicker, setShowArticlePicker] = useState(false);
-
-  const { data: articles } = useQuery({
-    queryKey: ["articles", { page_type: "source" }],
-    queryFn: () => listArticles({ page_type: "source", limit: 200 }),
-  });
-
-  const mutation = useMutation({
-    mutationFn: createSynthesis,
-    onSuccess: (data) => onCreated(data),
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (query.trim().length < 3) return;
-    mutation.mutate({
-      query: query.trim(),
-      article_ids: selectedIds.length > 0 ? selectedIds : undefined,
-    });
-  };
-
-  const toggleArticle = (id: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
-    );
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      <div>
-        <label
-          htmlFor="synthesis-query"
-          className="block text-sm font-medium text-slate-700"
-        >
-          Synthesis topic or question
-        </label>
-        <input
-          id="synthesis-query"
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder='e.g. "Compare transformer architectures across my papers"'
-          className="mt-1 block w-full rounded-lg border border-slate-300 px-4 py-2.5 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
-          disabled={mutation.isPending}
-          data-testid="synthesis-query-input"
-        />
-      </div>
-
-      <div>
-        <button
-          type="button"
-          onClick={() => setShowArticlePicker(!showArticlePicker)}
-          className="text-sm text-indigo-600 hover:text-indigo-800"
-        >
-          {showArticlePicker
-            ? "Hide article picker"
-            : `Select specific articles (${selectedIds.length} selected)`}
-        </button>
-
-        {showArticlePicker && articles && (
-          <div className="mt-3 max-h-60 space-y-1 overflow-y-auto rounded-lg border border-slate-200 bg-white p-3">
-            {articles.map((article) => (
-              <label
-                key={article.id}
-                className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-slate-50"
-              >
-                <input
-                  type="checkbox"
-                  checked={selectedIds.includes(article.id)}
-                  onChange={() => toggleArticle(article.id)}
-                  className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                />
-                <span className="truncate text-slate-700">{article.title}</span>
-                <span className="ml-auto text-xs text-slate-400">
-                  {article.page_type}
-                </span>
-              </label>
-            ))}
-            {articles.length === 0 && (
-              <p className="py-2 text-center text-sm text-slate-400">
-                No source articles found. Ingest some sources first.
-              </p>
-            )}
-          </div>
-        )}
-      </div>
-
-      {mutation.isError && (
-        <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
-          {(mutation.error as Error)?.message ||
-            "Failed to create synthesis. Make sure you have at least 2 relevant articles."}
-        </div>
-      )}
-
-      <button
-        type="submit"
-        disabled={mutation.isPending || query.trim().length < 3}
-        className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-        data-testid="synthesis-submit-btn"
-      >
-        {mutation.isPending && <Spinner size={14} />}
-        {mutation.isPending ? "Synthesizing..." : "Synthesize"}
-      </button>
-    </form>
-  );
-}
 
 function SynthesisCard({ article }: { article: Article }) {
   const navigate = useNavigate();
@@ -281,7 +167,7 @@ export function SynthesisView() {
             <h2 className="mb-4 text-base font-semibold text-slate-800">
               New Synthesis
             </h2>
-            <SynthesisForm onCreated={handleCreated} />
+            <SynthesisWizard onCreated={handleCreated} />
           </div>
 
           {/* Suggested Syntheses */}

--- a/apps/web/src/components/synthesis/SynthesisView.tsx
+++ b/apps/web/src/components/synthesis/SynthesisView.tsx
@@ -5,10 +5,11 @@ import {
   createSynthesis,
   listSynthesisPages,
   listArticles,
+  getSynthesisSuggestions,
 } from "../../api/wiki";
 import { Spinner } from "../shared/Spinner";
 import type { Article } from "../../types/api";
-import type { SynthesisResponse } from "../../api/wiki";
+import type { SynthesisResponse, SynthesisSuggestion } from "../../api/wiki";
 
 function SynthesisForm({
   onCreated,
@@ -156,6 +157,62 @@ function SynthesisCard({ article }: { article: Article }) {
   );
 }
 
+function SuggestionCard({
+  suggestion,
+  onCreateSynthesis,
+  isCreating,
+}: {
+  suggestion: SynthesisSuggestion;
+  onCreateSynthesis: (suggestion: SynthesisSuggestion) => void;
+  isCreating: boolean;
+}) {
+  const typeLabels: Record<string, string> = {
+    shared_concepts: "Shared Concepts",
+    contradiction: "Contradictions",
+    same_topic_different_sources: "Different Perspectives",
+  };
+
+  const typeColors: Record<string, string> = {
+    shared_concepts: "bg-blue-50 text-blue-700",
+    contradiction: "bg-amber-50 text-amber-700",
+    same_topic_different_sources: "bg-emerald-50 text-emerald-700",
+  };
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${typeColors[suggestion.suggested_type] || "bg-slate-50 text-slate-700"}`}
+          >
+            {typeLabels[suggestion.suggested_type] || suggestion.suggested_type}
+          </span>
+          <p className="mt-2 text-sm text-slate-600">{suggestion.reason}</p>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {suggestion.article_titles.map((title, idx) => (
+              <span
+                key={idx}
+                className="inline-flex items-center rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-600"
+              >
+                {title}
+              </span>
+            ))}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => onCreateSynthesis(suggestion)}
+          disabled={isCreating}
+          className="ml-3 shrink-0 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:opacity-50"
+          data-testid="suggestion-create-btn"
+        >
+          {isCreating ? "Creating..." : "Create"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function SynthesisView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -165,8 +222,31 @@ export function SynthesisView() {
     queryFn: listSynthesisPages,
   });
 
+  const { data: suggestions, isLoading: suggestionsLoading } = useQuery({
+    queryKey: ["synthesis-suggestions"],
+    queryFn: getSynthesisSuggestions,
+  });
+
+  const suggestionMutation = useMutation({
+    mutationFn: createSynthesis,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["synthesis-pages"] });
+      queryClient.invalidateQueries({ queryKey: ["synthesis-suggestions"] });
+      queryClient.invalidateQueries({ queryKey: ["articles"] });
+      navigate(`/wiki/${encodeURIComponent(data.slug)}`);
+    },
+  });
+
+  const handleCreateFromSuggestion = (suggestion: SynthesisSuggestion) => {
+    suggestionMutation.mutate({
+      query: suggestion.reason,
+      article_ids: suggestion.article_ids,
+    });
+  };
+
   const handleCreated = (resp: SynthesisResponse) => {
     queryClient.invalidateQueries({ queryKey: ["synthesis-pages"] });
+    queryClient.invalidateQueries({ queryKey: ["synthesis-suggestions"] });
     queryClient.invalidateQueries({ queryKey: ["articles"] });
     navigate(`/wiki/${encodeURIComponent(resp.slug)}`);
   };
@@ -203,6 +283,29 @@ export function SynthesisView() {
             </h2>
             <SynthesisForm onCreated={handleCreated} />
           </div>
+
+          {/* Suggested Syntheses */}
+          {suggestionsLoading ? (
+            <div className="mt-8 flex items-center gap-2 text-sm text-slate-500">
+              <Spinner size={16} /> Loading suggestions...
+            </div>
+          ) : suggestions && suggestions.length > 0 ? (
+            <div className="mt-8">
+              <h2 className="mb-4 text-base font-semibold text-slate-800">
+                Suggested Syntheses
+              </h2>
+              <div className="space-y-3">
+                {suggestions.map((s, idx) => (
+                  <SuggestionCard
+                    key={idx}
+                    suggestion={s}
+                    onCreateSynthesis={handleCreateFromSuggestion}
+                    isCreating={suggestionMutation.isPending}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
 
           <div className="mt-10">
             <h2 className="mb-4 text-base font-semibold text-slate-800">

--- a/apps/web/src/components/synthesis/SynthesisView.tsx
+++ b/apps/web/src/components/synthesis/SynthesisView.tsx
@@ -3,7 +3,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   createSynthesis,
   listSynthesisPages,
-  listArticles,
   getSynthesisSuggestions,
 } from "../../api/wiki";
 import { Spinner } from "../shared/Spinner";

--- a/apps/web/src/components/synthesis/SynthesisWizard.tsx
+++ b/apps/web/src/components/synthesis/SynthesisWizard.tsx
@@ -1,0 +1,475 @@
+import { useState, useMemo } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import {
+  listArticles,
+  previewSynthesis,
+  refineSynthesis,
+  confirmSynthesis,
+} from "../../api/wiki";
+import type {
+  SynthesisType,
+  SynthesisPreviewResponse,
+  SynthesisResponse,
+} from "../../api/wiki";
+import { Button } from "../shared/Button";
+import { Card } from "../shared/Card";
+import { Badge } from "../shared/Badge";
+import { Spinner } from "../shared/Spinner";
+
+const SYNTHESIS_TYPES: {
+  value: SynthesisType;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "comparative",
+    label: "Comparative",
+    description:
+      "Compare and contrast key ideas, methods, or findings across selected articles.",
+  },
+  {
+    value: "chronological",
+    label: "Chronological",
+    description:
+      "Trace the evolution of ideas or developments over time across your sources.",
+  },
+  {
+    value: "thematic",
+    label: "Thematic",
+    description:
+      "Identify and organize recurring themes, patterns, and connections.",
+  },
+  {
+    value: "gap_analysis",
+    label: "Gap Analysis",
+    description:
+      "Find contradictions, missing perspectives, and areas needing further research.",
+  },
+];
+
+type WizardStep = 1 | 2 | 3 | 4;
+
+interface SynthesisWizardProps {
+  onCreated: (resp: SynthesisResponse) => void;
+  onCancel?: () => void;
+}
+
+export function SynthesisWizard({ onCreated, onCancel }: SynthesisWizardProps) {
+  const [step, setStep] = useState<WizardStep>(1);
+  const [synthesisType, setSynthesisType] = useState<SynthesisType | null>(
+    null,
+  );
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [guidance, setGuidance] = useState("");
+  const [preview, setPreview] = useState<SynthesisPreviewResponse | null>(null);
+  const [feedback, setFeedback] = useState("");
+
+  const { data: articles, isLoading: articlesLoading } = useQuery({
+    queryKey: ["articles", { page_type: "source" }],
+    queryFn: () => listArticles({ page_type: "source", limit: 200 }),
+  });
+
+  const filteredArticles = useMemo(() => {
+    if (!articles) return [];
+    if (!searchQuery.trim()) return articles;
+    const q = searchQuery.toLowerCase();
+    return articles.filter(
+      (a) =>
+        a.title.toLowerCase().includes(q) ||
+        (a.summary && a.summary.toLowerCase().includes(q)),
+    );
+  }, [articles, searchQuery]);
+
+  const previewMutation = useMutation({
+    mutationFn: previewSynthesis,
+    onSuccess: (data) => {
+      setPreview(data);
+      setStep(4);
+    },
+  });
+
+  const refineMutation = useMutation({
+    mutationFn: refineSynthesis,
+    onSuccess: (data) => {
+      setPreview(data);
+      setFeedback("");
+    },
+  });
+
+  const confirmMutation = useMutation({
+    mutationFn: confirmSynthesis,
+    onSuccess: (data) => onCreated(data),
+  });
+
+  const toggleArticle = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  };
+
+  const handlePreview = () => {
+    if (!synthesisType || selectedIds.length < 2) return;
+    previewMutation.mutate({
+      synthesis_type: synthesisType,
+      article_ids: selectedIds,
+      guidance: guidance.trim() || undefined,
+    });
+  };
+
+  const handleRefine = () => {
+    if (!preview || !feedback.trim()) return;
+    refineMutation.mutate({
+      preview_id: preview.preview_id,
+      feedback: feedback.trim(),
+    });
+  };
+
+  const handleConfirm = () => {
+    if (!preview) return;
+    confirmMutation.mutate({ preview_id: preview.preview_id });
+  };
+
+  const canAdvance = (): boolean => {
+    switch (step) {
+      case 1:
+        return synthesisType !== null;
+      case 2:
+        return selectedIds.length >= 2;
+      case 3:
+        return true;
+      case 4:
+        return preview !== null;
+    }
+  };
+
+  const stepLabels = ["Type", "Articles", "Guidance", "Review"];
+
+  return (
+    <div className="space-y-6">
+      {/* Progress indicator */}
+      <nav aria-label="Wizard progress" className="flex items-center gap-2">
+        {stepLabels.map((label, idx) => {
+          const stepNum = (idx + 1) as WizardStep;
+          const isActive = step === stepNum;
+          const isComplete = step > stepNum;
+          return (
+            <div key={label} className="flex items-center gap-2">
+              {idx > 0 && (
+                <div
+                  className={`h-px w-6 ${isComplete ? "bg-indigo-400" : "bg-slate-200"}`}
+                />
+              )}
+              <div
+                className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium ${
+                  isActive
+                    ? "bg-indigo-600 text-white"
+                    : isComplete
+                      ? "bg-indigo-100 text-indigo-700"
+                      : "bg-slate-100 text-slate-400"
+                }`}
+              >
+                {isComplete ? (
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2.5}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4.5 12.75l6 6 9-13.5"
+                    />
+                  </svg>
+                ) : (
+                  stepNum
+                )}
+              </div>
+              <span
+                className={`text-xs font-medium ${isActive ? "text-slate-800" : "text-slate-400"}`}
+              >
+                {label}
+              </span>
+            </div>
+          );
+        })}
+      </nav>
+
+      {/* Step 1: Select synthesis type */}
+      {step === 1 && (
+        <div className="space-y-3" data-testid="wizard-step-type">
+          <p className="text-sm text-slate-600">
+            Choose the type of synthesis to create.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {SYNTHESIS_TYPES.map((t) => (
+              <Card
+                key={t.value}
+                className={`p-4 ${synthesisType === t.value ? "border-indigo-500 ring-1 ring-indigo-500" : ""}`}
+                onClick={() => setSynthesisType(t.value)}
+              >
+                <div className="flex items-start gap-2">
+                  <input
+                    type="radio"
+                    name="synthesis-type"
+                    checked={synthesisType === t.value}
+                    onChange={() => setSynthesisType(t.value)}
+                    className="mt-0.5 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <div>
+                    <span className="text-sm font-medium text-slate-800">
+                      {t.label}
+                    </span>
+                    <p className="mt-0.5 text-xs text-slate-500">
+                      {t.description}
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Step 2: Select articles */}
+      {step === 2 && (
+        <div className="space-y-3" data-testid="wizard-step-articles">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-slate-600">
+              Select at least 2 articles to synthesize.
+            </p>
+            <Badge tone={selectedIds.length >= 2 ? "success" : "neutral"}>
+              {selectedIds.length} selected
+            </Badge>
+          </div>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search articles..."
+            className="block w-full rounded-lg border border-slate-300 px-4 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+            data-testid="article-search-input"
+          />
+          <div className="max-h-64 space-y-1 overflow-y-auto rounded-lg border border-slate-200 bg-white p-3">
+            {articlesLoading ? (
+              <div className="flex items-center gap-2 py-4 text-sm text-slate-500">
+                <Spinner size={14} /> Loading articles...
+              </div>
+            ) : filteredArticles.length > 0 ? (
+              filteredArticles.map((article) => (
+                <label
+                  key={article.id}
+                  className={`flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-slate-50 ${
+                    selectedIds.includes(article.id) ? "bg-indigo-50" : ""
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(article.id)}
+                    onChange={() => toggleArticle(article.id)}
+                    className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span className="truncate text-slate-700">
+                    {article.title}
+                  </span>
+                  <span className="ml-auto shrink-0 text-xs text-slate-400">
+                    {article.page_type}
+                  </span>
+                </label>
+              ))
+            ) : (
+              <p className="py-4 text-center text-sm text-slate-400">
+                {articles && articles.length === 0
+                  ? "No source articles found. Ingest some sources first."
+                  : "No articles match your search."}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Step 3: Guidance */}
+      {step === 3 && (
+        <div className="space-y-3" data-testid="wizard-step-guidance">
+          <p className="text-sm text-slate-600">
+            Optionally provide guidance to focus the synthesis. Leave blank for a
+            general synthesis.
+          </p>
+          <textarea
+            value={guidance}
+            onChange={(e) => setGuidance(e.target.value)}
+            placeholder='e.g. "Focus on methodology differences" or "Highlight areas of disagreement"'
+            rows={4}
+            className="block w-full rounded-lg border border-slate-300 px-4 py-2.5 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+            data-testid="guidance-input"
+          />
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+            <h4 className="text-xs font-medium text-slate-600">Summary</h4>
+            <ul className="mt-1 space-y-0.5 text-xs text-slate-500">
+              <li>
+                Type:{" "}
+                <span className="font-medium text-slate-700">
+                  {SYNTHESIS_TYPES.find((t) => t.value === synthesisType)
+                    ?.label ?? ""}
+                </span>
+              </li>
+              <li>
+                Articles:{" "}
+                <span className="font-medium text-slate-700">
+                  {selectedIds.length} selected
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* Step 4: Review draft */}
+      {step === 4 && (
+        <div className="space-y-4" data-testid="wizard-step-review">
+          {previewMutation.isPending ? (
+            <div className="flex items-center gap-2 py-8 text-sm text-slate-500">
+              <Spinner size={16} /> Generating synthesis preview...
+            </div>
+          ) : previewMutation.isError ? (
+            <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
+              {(previewMutation.error as Error)?.message ||
+                "Failed to generate preview."}
+            </div>
+          ) : preview ? (
+            <>
+              <div>
+                <h3 className="text-base font-semibold text-slate-800">
+                  {preview.title}
+                </h3>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {preview.themes.map((theme) => (
+                    <Badge key={theme} tone="brand">
+                      {theme}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              <div className="max-h-72 overflow-y-auto rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                <pre className="whitespace-pre-wrap font-sans">
+                  {preview.draft_markdown}
+                </pre>
+              </div>
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-slate-700">
+                  Refinement feedback (optional)
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={feedback}
+                    onChange={(e) => setFeedback(e.target.value)}
+                    placeholder="e.g. Add more detail on methodology..."
+                    className="block flex-1 rounded-lg border border-slate-300 px-4 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                    disabled={refineMutation.isPending}
+                    data-testid="refine-input"
+                  />
+                  <Button
+                    variant="secondary"
+                    onClick={handleRefine}
+                    disabled={
+                      !feedback.trim() || refineMutation.isPending
+                    }
+                  >
+                    {refineMutation.isPending ? (
+                      <Spinner size={14} />
+                    ) : null}
+                    Refine
+                  </Button>
+                </div>
+                {refineMutation.isError && (
+                  <p className="text-xs text-rose-600">
+                    {(refineMutation.error as Error)?.message ||
+                      "Refinement failed."}
+                  </p>
+                )}
+              </div>
+            </>
+          ) : null}
+        </div>
+      )}
+
+      {/* Error for preview generation shown in step 3 context */}
+      {step === 3 && previewMutation.isError && (
+        <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
+          {(previewMutation.error as Error)?.message ||
+            "Failed to generate preview."}
+        </div>
+      )}
+
+      {/* Navigation buttons */}
+      <div className="flex items-center justify-between border-t border-slate-200 pt-4">
+        <div>
+          {step > 1 && step < 4 && (
+            <Button
+              variant="ghost"
+              onClick={() => setStep((step - 1) as WizardStep)}
+            >
+              Back
+            </Button>
+          )}
+          {step === 4 && !confirmMutation.isPending && (
+            <Button variant="ghost" onClick={() => setStep(3)}>
+              Back
+            </Button>
+          )}
+          {onCancel && step === 1 && (
+            <Button variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {step < 3 && (
+            <Button
+              variant="primary"
+              disabled={!canAdvance()}
+              onClick={() => setStep((step + 1) as WizardStep)}
+            >
+              Next
+            </Button>
+          )}
+          {step === 3 && (
+            <Button
+              variant="primary"
+              disabled={previewMutation.isPending}
+              onClick={handlePreview}
+            >
+              {previewMutation.isPending ? (
+                <Spinner size={14} />
+              ) : null}
+              Generate Preview
+            </Button>
+          )}
+          {step === 4 && preview && (
+            <Button
+              variant="primary"
+              disabled={confirmMutation.isPending}
+              onClick={handleConfirm}
+              data-testid="confirm-synthesis-btn"
+            >
+              {confirmMutation.isPending ? (
+                <Spinner size={14} />
+              ) : null}
+              {confirmMutation.isPending ? "Creating..." : "Confirm & Create"}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {confirmMutation.isError && (
+        <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
+          {(confirmMutation.error as Error)?.message ||
+            "Failed to create synthesis."}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -16,6 +16,7 @@ import { editArticle } from "../../api/wiki";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 import { PageTypeIndicator } from "./PageTypeIndicator";
 import { Badge } from "../shared/Badge";
+import { ExportDropdown } from "./ExportDropdown";
 import { ShareButton } from "./ShareButton";
 import { TagSelector } from "./TagSelector";
 
@@ -175,6 +176,7 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
             {article.title}
           </h1>
           <div className="flex items-center gap-2">
+            <ExportDropdown slug={article.slug} articleContent={article.content} />
             <ShareButton articleId={article.id} />
             {!isEditing ? (
               <button

--- a/apps/web/src/components/wiki/ExportDropdown.tsx
+++ b/apps/web/src/components/wiki/ExportDropdown.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useState } from "react";
+import { getBaseUrl } from "../../api/client";
+
+interface ExportDropdownProps {
+  slug: string;
+  articleContent?: string | null;
+}
+
+export function ExportDropdown({ slug, articleContent }: ExportDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleDownload = useCallback(
+    (format: "markdown" | "json") => {
+      const baseUrl = getBaseUrl() || window.location.origin;
+      const url = `${baseUrl}/api/wiki/articles/${encodeURIComponent(slug)}/export?format=${format}`;
+      window.open(url, "_blank");
+      setIsOpen(false);
+    },
+    [slug],
+  );
+
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!articleContent) return;
+    try {
+      await navigator.clipboard.writeText(articleContent);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = articleContent;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [articleContent]);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        data-testid="export-button"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+          />
+        </svg>
+        Export
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full z-50 mt-2 w-56 rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+          <button
+            onClick={() => handleDownload("markdown")}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50"
+            data-testid="export-markdown"
+          >
+            <svg
+              className="h-4 w-4 text-slate-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+              />
+            </svg>
+            Download as Markdown
+          </button>
+          <button
+            onClick={() => handleDownload("json")}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50"
+            data-testid="export-json"
+          >
+            <svg
+              className="h-4 w-4 text-slate-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+              />
+            </svg>
+            Download as JSON
+          </button>
+          <div className="my-1 border-t border-slate-100" />
+          <button
+            onClick={handleCopyMarkdown}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50"
+            data-testid="export-copy-markdown"
+          >
+            <svg
+              className="h-4 w-4 text-slate-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+              />
+            </svg>
+            {copied ? "Copied!" : "Copy as Markdown"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/ShareButton.tsx
+++ b/apps/web/src/components/wiki/ShareButton.tsx
@@ -8,6 +8,13 @@ import {
 } from "../../api/sharing";
 import type { ShareLink } from "../../api/sharing";
 
+const EXPIRY_OPTIONS: { label: string; value: number | null }[] = [
+  { label: "1 day", value: 1 },
+  { label: "7 days", value: 7 },
+  { label: "30 days", value: 30 },
+  { label: "Never", value: null },
+];
+
 interface ShareButtonProps {
   articleId: string;
 }
@@ -15,6 +22,7 @@ interface ShareButtonProps {
 export function ShareButton({ articleId }: ShareButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [expiryDays, setExpiryDays] = useState<number | null>(7);
   const queryClient = useQueryClient();
 
   const { data: links = [] } = useQuery({
@@ -24,7 +32,11 @@ export function ShareButton({ articleId }: ShareButtonProps) {
   });
 
   const createMutation = useMutation({
-    mutationFn: () => createShareLink({ article_id: articleId }),
+    mutationFn: () =>
+      createShareLink({
+        article_id: articleId,
+        expires_in_days: expiryDays,
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["share-links", articleId] });
     },
@@ -138,6 +150,29 @@ export function ShareButton({ articleId }: ShareButtonProps) {
               No active share links for this article.
             </p>
           )}
+
+          <div className="mb-3">
+            <label className="mb-1 block text-xs font-medium text-slate-600">
+              Link expiry
+            </label>
+            <div className="flex gap-1">
+              {EXPIRY_OPTIONS.map((opt) => (
+                <button
+                  key={opt.label}
+                  type="button"
+                  onClick={() => setExpiryDays(opt.value)}
+                  className={`rounded-md px-2 py-1 text-xs font-medium transition ${
+                    expiryDays === opt.value
+                      ? "bg-brand-100 text-brand-700 ring-1 ring-brand-300"
+                      : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                  }`}
+                  data-testid={`expiry-option-${opt.label.toLowerCase().replace(/\s/g, "-")}`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
 
           <button
             onClick={() => createMutation.mutate()}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@ considered, and the consequences.
 | [026](adr-026-byok-api-key-encryption.md) | BYOK API Key Encryption at Rest | Accepted |
 | [026](adr-026-multi-replica-gateway.md) | Multi-Replica Gateway — Horizontal Scaling | Unknown |
 | [026](adr-026-onboarding-wizard.md) | First-Run Onboarding Wizard | Accepted |
+| [027](adr-027-mcp-auth-personal-access-tokens.md) | MCP Authentication — OAuth 2.1 + Personal Access Tokens | Unknown |
 
 ## ADR Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,6 @@ considered, and the consequences.
 | [026](adr-026-byok-api-key-encryption.md) | BYOK API Key Encryption at Rest | Accepted |
 | [026](adr-026-multi-replica-gateway.md) | Multi-Replica Gateway — Horizontal Scaling | Unknown |
 | [026](adr-026-onboarding-wizard.md) | First-Run Onboarding Wizard | Accepted |
-| [027](adr-027-mcp-auth-personal-access-tokens.md) | MCP Authentication — OAuth 2.1 + Personal Access Tokens | Unknown |
 
 ## ADR Format
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2732,6 +2732,44 @@ paths:
           description: Article not found
         '422':
           description: Invalid export format
+    get:
+      tags:
+      - Export
+      summary: Download Article
+      description: "Download a single article as a markdown file or structured JSON.\n\
+        \n- **markdown**: Returns the article content as a downloadable ``.md`` file\n\
+        \  with a ``Content-Disposition: attachment`` header.\n- **json**: Returns\
+        \ structured JSON with article metadata, content,\n  sources, and concepts."
+      operationId: download_article_api_wiki_articles__id_or_slug__export_get
+      parameters:
+      - name: id_or_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Id Or Slug
+      - name: format
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/ArticleDownloadFormat'
+          description: 'Download format: markdown or json'
+        description: 'Download format: markdown or json'
+      responses:
+        '200':
+          description: Downloadable article file (markdown or JSON)
+          content:
+            application/json:
+              schema: {}
+            text/markdown: {}
+        '404':
+          description: Article not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/wiki/export/wiki:
     post:
       tags:
@@ -3913,6 +3951,13 @@ components:
       - article_title
       title: ApproveDraftResponse
       description: Response after approving a compilation draft.
+    ArticleDownloadFormat:
+      type: string
+      enum:
+      - markdown
+      - json
+      title: ArticleDownloadFormat
+      description: Supported single-article download formats (GET endpoint).
     ArticleEditRequest:
       properties:
         content:

--- a/src/wikimind/api/routes/export.py
+++ b/src/wikimind/api/routes/export.py
@@ -1,20 +1,34 @@
 """Export wiki articles as PDF HTML, LinkedIn drafts, or Marp slide decks.
 
 Also supports full-wiki export to Obsidian-flavored markdown or plain
-markdown + JSON metadata for portability.
+markdown + JSON metadata for portability, and single-article download
+as markdown or structured JSON.
 """
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, Response, StreamingResponse
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.api.deps import get_current_user_id
 from wikimind.database import get_session
-from wikimind.models import Article, ExportFormat, ExportResponse, WikiExportFormat
+from wikimind.models import (
+    Article,
+    ArticleDownloadFormat,
+    ArticleDownloadResponse,
+    ExportFormat,
+    ExportResponse,
+    WikiExportFormat,
+)
 from wikimind.services.export import ExportService
 from wikimind.services.factories import get_export_service, get_wiki_export_service
+from wikimind.services.wiki import (
+    _fetch_concept_names_from_join,
+    _fetch_source_ids_from_join,
+    _fetch_sources,
+    _to_source_response,
+)
 from wikimind.services.wiki_export import WikiExportService
 from wikimind.storage import read_article_content
 
@@ -95,6 +109,66 @@ async def export_article(
         content=text,
         article_id=article.id,
         article_title=article.title,
+    )
+
+
+@router.get(
+    "/articles/{id_or_slug}/export",
+    response_model=None,
+    responses={
+        200: {
+            "description": "Downloadable article file (markdown or JSON)",
+            "content": {
+                "text/markdown": {},
+                "application/json": {},
+            },
+        },
+        404: {"description": "Article not found"},
+    },
+)
+async def download_article(
+    id_or_slug: str,
+    format: ArticleDownloadFormat = Query(..., description="Download format: markdown or json"),
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> Response | ArticleDownloadResponse:
+    """Download a single article as a markdown file or structured JSON.
+
+    - **markdown**: Returns the article content as a downloadable ``.md`` file
+      with a ``Content-Disposition: attachment`` header.
+    - **json**: Returns structured JSON with article metadata, content,
+      sources, and concepts.
+    """
+    article = await _resolve_article(id_or_slug, session, user_id)
+    content = await read_article_content(article.file_path, user_id=user_id)
+
+    if not content:
+        raise HTTPException(status_code=404, detail="Article content not found on disk")
+
+    if format == ArticleDownloadFormat.MARKDOWN:
+        filename = f"{article.slug}.md"
+        return Response(
+            content=content,
+            media_type="text/markdown",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    # JSON format — include metadata, content, sources, and concepts
+    source_ids = await _fetch_source_ids_from_join(session, article.id)
+    sources = await _fetch_sources(session, source_ids)
+    concepts = await _fetch_concept_names_from_join(session, article.id)
+
+    return ArticleDownloadResponse(
+        id=article.id,
+        slug=article.slug,
+        title=article.title,
+        summary=article.summary,
+        content=content,
+        page_type=article.page_type,
+        concepts=concepts,
+        sources=[_to_source_response(s) for s in sources],
+        created_at=article.created_at,
+        updated_at=article.updated_at,
     )
 
 

--- a/src/wikimind/api/routes/synthesis.py
+++ b/src/wikimind/api/routes/synthesis.py
@@ -20,6 +20,7 @@ from wikimind.models import (
     SynthesisRefineRequest,
     SynthesisRefineResponse,
     SynthesisResponse,
+    SynthesisSuggestion,
 )
 from wikimind.services.factories import get_wiki_service
 from wikimind.services.wiki import WikiService
@@ -227,3 +228,23 @@ async def list_synthesis_pages(
         offset=offset,
         user_id=user_id,
     )
+
+
+@router.get(
+    "/synthesis/suggestions",
+    response_model=list[SynthesisSuggestion],
+)
+async def get_synthesis_suggestions(
+    limit: int = Query(default=10, ge=1, le=50),
+    session: AsyncSession = Depends(get_session),
+    service: WikiService = Depends(get_wiki_service),
+    user_id: str = Depends(get_current_user_id),
+) -> list[SynthesisSuggestion]:
+    """Return auto-detected synthesis opportunities.
+
+    Identifies clusters of articles that would benefit from synthesis:
+    - Articles sharing 3+ concepts
+    - Articles with contradictions between them
+    - Articles on the same topic from different sources
+    """
+    return await service.get_synthesis_suggestions(session, user_id, limit=limit)

--- a/src/wikimind/api/routes/synthesis.py
+++ b/src/wikimind/api/routes/synthesis.py
@@ -11,6 +11,12 @@ from wikimind.models import (
     ArticleSummaryResponse,
     CreateSynthesisRequest,
     PageType,
+    SynthesisConfirmRequest,
+    SynthesisConfirmResponse,
+    SynthesisPreviewRequest,
+    SynthesisPreviewResponse,
+    SynthesisRefineRequest,
+    SynthesisRefineResponse,
     SynthesisResponse,
 )
 from wikimind.services.factories import get_wiki_service
@@ -19,6 +25,134 @@ from wikimind.services.wiki import WikiService
 log = structlog.get_logger()
 
 router = APIRouter()
+
+
+@router.post(
+    "/synthesis/preview",
+    response_model=SynthesisPreviewResponse,
+    responses={
+        422: {"description": "Not enough articles or synthesis failed"},
+    },
+)
+async def preview_synthesis(
+    body: SynthesisPreviewRequest,
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> SynthesisPreviewResponse:
+    """Generate a synthesis draft without saving it.
+
+    Returns draft content, suggested title, and key themes for user review.
+    The draft can be refined with feedback or confirmed to save.
+    """
+    compiler = SynthesisCompiler(user_id)
+    result = await compiler.preview(
+        session=session,
+        article_ids=body.article_ids,
+        synthesis_type=body.synthesis_type,
+        guidance=body.guidance,
+    )
+
+    if result is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Could not generate synthesis preview (need at least 2 articles).",
+        )
+
+    return SynthesisPreviewResponse(
+        draft_content=result.article_body,
+        suggested_title=result.title,
+        summary=result.summary,
+        themes=result.themes,
+        article_ids=result.source_article_ids,
+        source_count=len(result.source_article_ids),
+    )
+
+
+@router.post(
+    "/synthesis/refine",
+    response_model=SynthesisRefineResponse,
+    responses={
+        422: {"description": "Refinement failed"},
+    },
+)
+async def refine_synthesis(
+    body: SynthesisRefineRequest,
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> SynthesisRefineResponse:
+    """Refine a synthesis draft with user feedback.
+
+    Takes a previous draft and user guidance, regenerates the synthesis
+    incorporating the feedback. Can be called multiple times for iterative
+    refinement before confirming.
+    """
+    compiler = SynthesisCompiler(user_id)
+    result = await compiler.refine(
+        session=session,
+        article_ids=body.article_ids,
+        previous_draft=body.draft_content,
+        guidance=body.guidance,
+    )
+
+    if result is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Could not refine synthesis (need at least 2 articles).",
+        )
+
+    return SynthesisRefineResponse(
+        draft_content=result.article_body,
+        suggested_title=result.title,
+        summary=result.summary,
+        themes=result.themes,
+        article_ids=result.source_article_ids,
+        source_count=len(result.source_article_ids),
+    )
+
+
+@router.post(
+    "/synthesis/confirm",
+    response_model=SynthesisConfirmResponse,
+    status_code=201,
+    responses={
+        422: {"description": "Could not save synthesis"},
+    },
+)
+async def confirm_synthesis(
+    body: SynthesisConfirmRequest,
+    session: AsyncSession = Depends(get_session),
+    user_id: str = Depends(get_current_user_id),
+) -> SynthesisConfirmResponse:
+    """Save a confirmed synthesis draft as a real wiki article.
+
+    Takes the final draft content and title from a preview/refine cycle
+    and persists it as a synthesis article in the wiki.
+    """
+    compiler = SynthesisCompiler(user_id)
+    article = await compiler.confirm(
+        session=session,
+        title=body.title,
+        draft_content=body.draft_content,
+        article_ids=body.article_ids,
+    )
+
+    if article is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Could not save synthesis (need at least 2 valid articles).",
+        )
+
+    return SynthesisConfirmResponse(
+        id=article.id,
+        slug=article.slug,
+        title=article.title,
+        summary=article.summary or "",
+        themes=[],
+        source_count=len(body.article_ids),
+        source_article_ids=body.article_ids,
+        created_at=article.created_at,
+        page_type=PageType.SYNTHESIS,
+    )
 
 
 @router.post(

--- a/src/wikimind/api/routes/synthesis.py
+++ b/src/wikimind/api/routes/synthesis.py
@@ -1,5 +1,7 @@
 """Synthesis page endpoints — cross-cutting analysis across multiple sources."""
 
+import json
+
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -142,14 +144,17 @@ async def confirm_synthesis(
             detail="Could not save synthesis (need at least 2 valid articles).",
         )
 
+    persisted_source_ids = json.loads(article.source_ids or "[]")
+    persisted_concepts = json.loads(article.concept_ids or "[]")
+
     return SynthesisConfirmResponse(
         id=article.id,
         slug=article.slug,
         title=article.title,
         summary=article.summary or "",
-        themes=[],
-        source_count=len(body.article_ids),
-        source_article_ids=body.article_ids,
+        themes=persisted_concepts,
+        source_count=len(persisted_source_ids),
+        source_article_ids=persisted_source_ids,
         created_at=article.created_at,
         page_type=PageType.SYNTHESIS,
     )

--- a/src/wikimind/engine/synthesis_compiler.py
+++ b/src/wikimind/engine/synthesis_compiler.py
@@ -274,12 +274,21 @@ class SynthesisCompiler(BaseCompiler):
         if len(draft_content) > 200:
             summary += "..."
 
+        # Extract concepts from source articles (union of all source concepts)
+        concepts: list[str] = []
+        seen: set[str] = set()
+        for a in articles:
+            for c in json.loads(a.concept_ids or "[]"):
+                if c not in seen:
+                    seen.add(c)
+                    concepts.append(c)
+
         article = Article(
             slug=slug,
             title=title,
             file_path="",
             summary=summary,
-            concept_ids=json.dumps([]),
+            concept_ids=json.dumps(concepts),
             source_ids=json.dumps(source_ids),
             provider=self._last_provider_used,
             page_type=PageType.SYNTHESIS,
@@ -297,6 +306,16 @@ class SynthesisCompiler(BaseCompiler):
 
         article.file_path = relative_path
         session.add(article)
+        await session.commit()
+
+        # Populate concept join table
+        for concept_name in concepts:
+            session.add(
+                ArticleConcept(
+                    article_id=article.id,
+                    concept_name=concept_name,
+                )
+            )
         await session.commit()
 
         # Update full-text search index

--- a/src/wikimind/engine/synthesis_compiler.py
+++ b/src/wikimind/engine/synthesis_compiler.py
@@ -117,6 +117,208 @@ async def _build_synthesis_material(
 class SynthesisCompiler(BaseCompiler):
     """Compile synthesis pages from multiple wiki articles."""
 
+    async def preview(
+        self,
+        session: AsyncSession,
+        article_ids: list[str],
+        synthesis_type: str | None = None,
+        guidance: str | None = None,
+    ) -> SynthesisCompilationResult | None:
+        """Generate a synthesis draft without persisting it.
+
+        Returns a SynthesisCompilationResult for preview, or None if
+        synthesis could not be performed (e.g. articles not found).
+        """
+        articles = await _find_relevant_articles(
+            guidance or "synthesis",
+            session,
+            self.user_id,
+            article_ids=article_ids,
+        )
+        if len(articles) < 2:
+            log.warning(
+                "Not enough articles for synthesis preview",
+                found=len(articles),
+            )
+            return None
+
+        source_material = await _build_synthesis_material(
+            articles,
+            self.user_id,
+        )
+
+        prompt_parts = [
+            f"Number of source articles: {len(articles)}\n\n",
+            f"{source_material}\n\n",
+            "Synthesize a cross-cutting analysis page from these sources.",
+        ]
+        if synthesis_type:
+            prompt_parts.insert(0, f"Synthesis type: {synthesis_type}\n")
+        if guidance:
+            prompt_parts.insert(0, f"User guidance: {guidance}\n")
+
+        prompt = "".join(prompt_parts)
+
+        await session.commit()
+
+        response = await self._call_llm(
+            system=SYNTHESIS_SYSTEM_PROMPT,
+            user_content=prompt,
+        )
+        if response is None:
+            return None
+
+        data = self._parse_json_response(response)
+        if data is None:
+            return None
+        try:
+            data["query"] = guidance or "synthesis preview"
+            data["source_article_ids"] = [a.id for a in articles]
+            return SynthesisCompilationResult(**data)
+        except (KeyError, ValueError, TypeError):
+            log.warning(
+                "Synthesis preview response validation failed",
+                exc_info=True,
+            )
+            return None
+
+    async def refine(
+        self,
+        session: AsyncSession,
+        article_ids: list[str],
+        previous_draft: str,
+        guidance: str,
+    ) -> SynthesisCompilationResult | None:
+        """Regenerate a synthesis draft incorporating user feedback.
+
+        Returns a refined SynthesisCompilationResult, or None on failure.
+        """
+        articles = await _find_relevant_articles(
+            guidance,
+            session,
+            self.user_id,
+            article_ids=article_ids,
+        )
+        if len(articles) < 2:
+            log.warning(
+                "Not enough articles for synthesis refine",
+                found=len(articles),
+            )
+            return None
+
+        source_material = await _build_synthesis_material(
+            articles,
+            self.user_id,
+        )
+
+        prompt = (
+            f"Previous draft (needs revision):\n{previous_draft}\n\n"
+            f"User feedback: {guidance}\n\n"
+            f"Source articles ({len(articles)}):\n{source_material}\n\n"
+            "Revise the synthesis based on the user's feedback. "
+            "Produce a complete new synthesis (not just the changes)."
+        )
+
+        await session.commit()
+
+        response = await self._call_llm(
+            system=SYNTHESIS_SYSTEM_PROMPT,
+            user_content=prompt,
+        )
+        if response is None:
+            return None
+
+        data = self._parse_json_response(response)
+        if data is None:
+            return None
+        try:
+            data["query"] = guidance
+            data["source_article_ids"] = [a.id for a in articles]
+            return SynthesisCompilationResult(**data)
+        except (KeyError, ValueError, TypeError):
+            log.warning(
+                "Synthesis refine response validation failed",
+                exc_info=True,
+            )
+            return None
+
+    async def confirm(
+        self,
+        session: AsyncSession,
+        title: str,
+        draft_content: str,
+        article_ids: list[str],
+    ) -> Article | None:
+        """Save a confirmed draft as a real synthesis article.
+
+        Returns the persisted Article, or None if articles not found.
+        """
+        articles = await _find_relevant_articles(
+            "confirm",
+            session,
+            self.user_id,
+            article_ids=article_ids,
+        )
+        if len(articles) < 2:
+            log.warning(
+                "Not enough articles for synthesis confirm",
+                found=len(articles),
+            )
+            return None
+
+        slug = await self._generate_unique_slug(title, session, prefix="synthesis-", max_length=70)
+        source_ids = [a.id for a in articles]
+
+        # Extract a summary from the first ~200 chars of draft content
+        summary = draft_content[:200].strip()
+        if len(draft_content) > 200:
+            summary += "..."
+
+        article = Article(
+            slug=slug,
+            title=title,
+            file_path="",
+            summary=summary,
+            concept_ids=json.dumps([]),
+            source_ids=json.dumps(source_ids),
+            provider=self._last_provider_used,
+            page_type=PageType.SYNTHESIS,
+            confidence=ConfidenceLevel.INFERRED,
+            user_id=self.user_id,
+        )
+        session.add(article)
+        await session.commit()
+        await session.refresh(article)
+
+        # Write the markdown file
+        relative_path = f"synthesis/{slug}.md"
+        storage = get_wiki_storage(self.user_id)
+        await storage.write(relative_path, draft_content)
+
+        article.file_path = relative_path
+        session.add(article)
+        await session.commit()
+
+        # Update full-text search index
+        await self._index_article(session, article.id, article.title, relative_path)
+
+        # Create SYNTHESIZES backlinks to all source articles
+        await self._create_synthesizes_links(
+            article.id,
+            source_ids,
+            session,
+            user_id=self.user_id,
+            context="Synthesis page analyzes this source article",
+        )
+
+        log.info(
+            "Synthesis draft confirmed and saved",
+            slug=slug,
+            title=title,
+            source_count=len(articles),
+        )
+        return article
+
     async def synthesize(
         self,
         query: str,

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -1448,6 +1448,15 @@ class SynthesisConfirmResponse(BaseModel):
     page_type: PageType = PageType.SYNTHESIS
 
 
+class SynthesisSuggestion(BaseModel):
+    """A suggestion for a synthesis opportunity across related articles."""
+
+    article_ids: list[str]
+    article_titles: list[str]
+    reason: str
+    suggested_type: str  # "shared_concepts" | "contradiction" | "same_topic_different_sources"
+
+
 class RecompileResponse(BaseModel):
     """Response after scheduling an article recompile."""
 

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -1388,6 +1388,66 @@ class SynthesisResponse(BaseModel):
     page_type: PageType = PageType.SYNTHESIS
 
 
+class SynthesisPreviewRequest(BaseModel):
+    """Request to generate a synthesis draft without saving it."""
+
+    article_ids: list[str] = Field(min_length=2)
+    synthesis_type: str | None = None  # Optional synthesis style hint
+    guidance: str | None = None  # Optional user direction for focus
+
+
+class SynthesisPreviewResponse(BaseModel):
+    """Draft synthesis content returned for preview (not yet persisted)."""
+
+    draft_content: str  # Full markdown draft
+    suggested_title: str
+    summary: str
+    themes: list[str]
+    article_ids: list[str]
+    source_count: int
+
+
+class SynthesisRefineRequest(BaseModel):
+    """Request to refine a previous synthesis draft with user feedback."""
+
+    draft_content: str  # The previous draft to refine
+    article_ids: list[str] = Field(min_length=2)
+    guidance: str  # User feedback/direction for refinement
+
+
+class SynthesisRefineResponse(BaseModel):
+    """Refined draft synthesis content."""
+
+    draft_content: str
+    suggested_title: str
+    summary: str
+    themes: list[str]
+    article_ids: list[str]
+    source_count: int
+
+
+class SynthesisConfirmRequest(BaseModel):
+    """Request to save a confirmed synthesis draft as a real article."""
+
+    title: str = Field(min_length=1)
+    draft_content: str
+    article_ids: list[str] = Field(min_length=2)
+
+
+class SynthesisConfirmResponse(BaseModel):
+    """Response after confirming and saving a synthesis article."""
+
+    id: str
+    slug: str
+    title: str
+    summary: str
+    themes: list[str]
+    source_count: int
+    source_article_ids: list[str]
+    created_at: datetime
+    page_type: PageType = PageType.SYNTHESIS
+
+
 class RecompileResponse(BaseModel):
     """Response after scheduling an article recompile."""
 

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -15,6 +15,7 @@ from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
 from wikimind.models.enums import (
+    ArticleDownloadFormat,
     CaptureKind,
     CaptureStatus,
     ClaimConceptRole,
@@ -40,6 +41,7 @@ from wikimind.storage import find_original_sibling, get_raw_storage
 
 # Re-export enums so that `from wikimind.models import PageType` etc. still work.
 __all__ = [
+    "ArticleDownloadFormat",
     "CaptureKind",
     "CaptureStatus",
     "ClaimConceptRole",
@@ -1830,6 +1832,21 @@ class ExportResponse(BaseModel):
     content: str
     article_id: str
     article_title: str
+
+
+class ArticleDownloadResponse(BaseModel):
+    """Structured JSON export of a single article with metadata."""
+
+    id: str
+    slug: str
+    title: str
+    summary: str | None
+    content: str
+    page_type: PageType
+    concepts: list[str] = []
+    sources: list[SourceResponse] = []
+    created_at: datetime
+    updated_at: datetime
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/models/enums.py
+++ b/src/wikimind/models/enums.py
@@ -217,6 +217,13 @@ class ExportFormat(StrEnum):
     SLIDES = "slides"
 
 
+class ArticleDownloadFormat(StrEnum):
+    """Supported single-article download formats (GET endpoint)."""
+
+    MARKDOWN = "markdown"
+    JSON = "json"
+
+
 class WikiExportFormat(StrEnum):
     """Supported full-wiki export formats."""
 

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -59,6 +59,7 @@ from wikimind.models import (
     ResolveContradictionResponse,
     Source,
     SourceResponse,
+    SynthesisSuggestion,
     WikiHealthReport,
     WikilinkMatch,
 )
@@ -1398,6 +1399,183 @@ class WikiService:
         await compiler.schedule_recompile(article_id, effective_mode, job.id, user_id=user_id)
 
         return RecompileResponse(status="scheduled", job_id=job.id)
+
+    async def get_synthesis_suggestions(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        limit: int = 10,
+    ) -> list["SynthesisSuggestion"]:
+        """Find clusters of related articles that would benefit from synthesis.
+
+        Detects three types of synthesis opportunities:
+        1. Articles sharing 3+ concepts (shared knowledge that could be unified)
+        2. Articles with active contradictions between them
+        3. Articles from different sources on the same topic (same concept, different source_ids)
+
+        Args:
+            session: Async database session.
+            user_id: User scope.
+            limit: Maximum number of suggestions to return.
+
+        Returns:
+            List of :class:`SynthesisSuggestion` records.
+        """
+        suggestions: list[SynthesisSuggestion] = []
+        seen_pairs: set[frozenset[str]] = set()
+
+        concept_to_articles, article_concepts = await self._build_concept_maps(session, user_id)
+
+        self._find_shared_concept_suggestions(article_concepts, suggestions, seen_pairs)
+        await self._find_contradiction_suggestions(session, user_id, suggestions, seen_pairs)
+        await self._find_different_source_suggestions(session, concept_to_articles, suggestions, seen_pairs)
+
+        await self._resolve_suggestion_titles(session, suggestions)
+        return suggestions[:limit]
+
+    async def _build_concept_maps(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+        """Build concept-to-articles and article-to-concepts mappings."""
+        ac_stmt = (
+            select(ArticleConcept.article_id, ArticleConcept.concept_name)
+            .join(Article, Article.id == ArticleConcept.article_id)  # type: ignore[arg-type]
+            .where(Article.user_id == user_id, Article.page_type != PageType.SYNTHESIS)
+        )
+        ac_result = await session.execute(ac_stmt)
+        ac_rows = ac_result.all()
+
+        concept_to_articles: dict[str, set[str]] = {}
+        article_concepts: dict[str, set[str]] = {}
+        for article_id, concept_name in ac_rows:
+            concept_to_articles.setdefault(concept_name, set()).add(article_id)
+            article_concepts.setdefault(article_id, set()).add(concept_name)
+        return concept_to_articles, article_concepts
+
+    @staticmethod
+    def _find_shared_concept_suggestions(
+        article_concepts: dict[str, set[str]],
+        suggestions: list["SynthesisSuggestion"],
+        seen_pairs: set[frozenset[str]],
+    ) -> None:
+        """Find article pairs sharing 3+ concepts."""
+        article_ids_list = list(article_concepts.keys())
+        for i in range(len(article_ids_list)):
+            for j in range(i + 1, len(article_ids_list)):
+                aid_a = article_ids_list[i]
+                aid_b = article_ids_list[j]
+                shared = article_concepts[aid_a] & article_concepts[aid_b]
+                if len(shared) >= 3:
+                    pair_key = frozenset([aid_a, aid_b])
+                    if pair_key not in seen_pairs:
+                        seen_pairs.add(pair_key)
+                        suggestions.append(
+                            SynthesisSuggestion(
+                                article_ids=[aid_a, aid_b],
+                                article_titles=[],
+                                reason=f"Share {len(shared)} concepts: " + ", ".join(sorted(shared)[:5]),
+                                suggested_type="shared_concepts",
+                            )
+                        )
+
+    async def _find_contradiction_suggestions(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        suggestions: list["SynthesisSuggestion"],
+        seen_pairs: set[frozenset[str]],
+    ) -> None:
+        """Find article pairs with active contradictions."""
+        ctr_stmt = select(Contradiction).where(
+            Contradiction.user_id == user_id,
+            Contradiction.status == ContradictionStatus.ACTIVE,
+        )
+        ctr_result = await session.execute(ctr_stmt)
+        contradictions = ctr_result.scalars().all()
+
+        contradiction_pairs: dict[frozenset[str], int] = {}
+        for ctr in contradictions:
+            pair_key = frozenset([ctr.article_a_id, ctr.article_b_id])
+            contradiction_pairs[pair_key] = contradiction_pairs.get(pair_key, 0) + 1
+
+        for pair_key, count in contradiction_pairs.items():
+            if pair_key not in seen_pairs:
+                seen_pairs.add(pair_key)
+                suggestions.append(
+                    SynthesisSuggestion(
+                        article_ids=list(pair_key),
+                        article_titles=[],
+                        reason=f"{count} active contradiction(s) between these articles",
+                        suggested_type="contradiction",
+                    )
+                )
+
+    async def _find_different_source_suggestions(
+        self,
+        session: AsyncSession,
+        concept_to_articles: dict[str, set[str]],
+        suggestions: list["SynthesisSuggestion"],
+        seen_pairs: set[frozenset[str]],
+    ) -> None:
+        """Find article pairs on the same topic from different sources."""
+        for concept_name, aids in concept_to_articles.items():
+            if len(aids) < 2:
+                continue
+            aids_list = list(aids)
+            for i in range(len(aids_list)):
+                for j in range(i + 1, len(aids_list)):
+                    aid_a = aids_list[i]
+                    aid_b = aids_list[j]
+                    pair_key = frozenset([aid_a, aid_b])
+                    if pair_key in seen_pairs:
+                        continue
+                    has_diff = await self._has_different_sources(session, aid_a, aid_b)
+                    if has_diff:
+                        seen_pairs.add(pair_key)
+                        suggestions.append(
+                            SynthesisSuggestion(
+                                article_ids=[aid_a, aid_b],
+                                article_titles=[],
+                                reason=f"Same topic ({concept_name}) from different sources",
+                                suggested_type="same_topic_different_sources",
+                            )
+                        )
+
+    @staticmethod
+    async def _has_different_sources(
+        session: AsyncSession,
+        aid_a: str,
+        aid_b: str,
+    ) -> bool:
+        """Check whether two articles were compiled from non-overlapping sources."""
+        src_a_result = await session.execute(select(ArticleSource.source_id).where(ArticleSource.article_id == aid_a))
+        src_b_result = await session.execute(select(ArticleSource.source_id).where(ArticleSource.article_id == aid_b))
+        sources_a = set(src_a_result.scalars().all())
+        sources_b = set(src_b_result.scalars().all())
+        return bool(sources_a and sources_b and not sources_a & sources_b)
+
+    @staticmethod
+    async def _resolve_suggestion_titles(
+        session: AsyncSession,
+        suggestions: list["SynthesisSuggestion"],
+    ) -> None:
+        """Resolve article titles for all suggestions in bulk."""
+        all_article_ids: set[str] = set()
+        for s in suggestions:
+            all_article_ids.update(s.article_ids)
+
+        if not all_article_ids:
+            return
+
+        title_stmt = select(Article.id, Article.title).where(
+            Article.id.in_(list(all_article_ids))  # type: ignore[attr-defined]
+        )
+        title_result = await session.execute(title_stmt)
+        titles_map = {row[0]: row[1] for row in title_result.all()}
+        for s in suggestions:
+            s.article_titles = [titles_map.get(aid, "Unknown") for aid in s.article_ids]
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -339,3 +339,62 @@ class TestExportRoute:
             f"/api/wiki/articles/{article.slug}/export?format=docx",
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Single-article download endpoint (GET)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestArticleDownloadRoute:
+    async def test_download_markdown_returns_md_file(self, client, db_session, tmp_path):
+        article = await _seed_article(db_session, tmp_path)
+        resp = await client.get(
+            f"/api/wiki/articles/{article.slug}/export?format=markdown",
+        )
+        assert resp.status_code == 200
+        assert "text/markdown" in resp.headers["content-type"]
+        assert "attachment" in resp.headers["content-disposition"]
+        assert "test-export.md" in resp.headers["content-disposition"]
+        assert "# Test Export Article" in resp.text
+
+    async def test_download_markdown_by_id(self, client, db_session, tmp_path):
+        article = await _seed_article(db_session, tmp_path)
+        resp = await client.get(
+            f"/api/wiki/articles/{article.id}/export?format=markdown",
+        )
+        assert resp.status_code == 200
+        assert "text/markdown" in resp.headers["content-type"]
+        assert "test-export.md" in resp.headers["content-disposition"]
+
+    async def test_download_json_returns_structured_data(self, client, db_session, tmp_path):
+        article = await _seed_article(db_session, tmp_path)
+        resp = await client.get(
+            f"/api/wiki/articles/{article.slug}/export?format=json",
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == article.id
+        assert data["slug"] == "test-export"
+        assert data["title"] == "Test Export Article"
+        assert data["summary"] == "An article about AI agents."
+        assert "# Test Export Article" in data["content"]
+        assert data["page_type"] == "source"
+        assert isinstance(data["concepts"], list)
+        assert isinstance(data["sources"], list)
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    async def test_download_article_not_found(self, client):
+        resp = await client.get(
+            "/api/wiki/articles/nonexistent-slug/export?format=markdown",
+        )
+        assert resp.status_code == 404
+
+    async def test_download_invalid_format(self, client, db_session, tmp_path):
+        article = await _seed_article(db_session, tmp_path)
+        resp = await client.get(
+            f"/api/wiki/articles/{article.slug}/export?format=docx",
+        )
+        assert resp.status_code == 422

--- a/tests/unit/test_synthesis.py
+++ b/tests/unit/test_synthesis.py
@@ -1,4 +1,4 @@
-"""Tests for synthesis page creation and listing."""
+"""Tests for synthesis page creation, listing, and preview/refine/confirm workflow."""
 
 from __future__ import annotations
 
@@ -249,3 +249,327 @@ def test_synthesis_compilation_result_model() -> None:
     assert result.page_type == PageType.SYNTHESIS
     assert len(result.themes) == 2
     assert len(result.source_article_ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit: SynthesisCompiler.preview
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_not_enough_articles(
+    db_session: AsyncSession,
+) -> None:
+    """Preview returns None when fewer than 2 articles are found."""
+    compiler = SynthesisCompiler(TEST_USER_ID)
+    result = await compiler.preview(
+        session=db_session,
+        article_ids=["nonexistent-id"],
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_preview_success(
+    db_session: AsyncSession,
+    two_articles: list[Article],
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Preview returns a SynthesisCompilationResult without saving anything."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path / "wikimind"))
+
+    from wikimind.config import get_settings
+
+    get_settings.cache_clear()
+
+    mock_response = CompletionResponse(
+        content=MOCK_SYNTHESIS_JSON,
+        provider_used=Provider.MOCK,
+        model_used="mock-1",
+        input_tokens=100,
+        output_tokens=200,
+        cost_usd=0.01,
+        latency_ms=500,
+    )
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    mock_router.parse_json_response = MagicMock(
+        return_value=json.loads(MOCK_SYNTHESIS_JSON),
+    )
+
+    with patch(
+        "wikimind.engine.base_compiler.get_llm_router",
+        return_value=mock_router,
+    ):
+        compiler = SynthesisCompiler(TEST_USER_ID)
+        ids = [a.id for a in two_articles]
+        result = await compiler.preview(
+            session=db_session,
+            article_ids=ids,
+            guidance="Compare transformer architectures",
+        )
+
+    assert result is not None
+    assert result.title == "Transformer Architecture Evolution"
+    assert result.themes == ["Self-attention", "Pre-training"]
+    assert len(result.source_article_ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit: SynthesisCompiler.refine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refine_not_enough_articles(
+    db_session: AsyncSession,
+) -> None:
+    """Refine returns None when fewer than 2 articles are found."""
+    compiler = SynthesisCompiler(TEST_USER_ID)
+    result = await compiler.refine(
+        session=db_session,
+        article_ids=["nonexistent-id"],
+        previous_draft="Some draft content",
+        guidance="Focus more on attention mechanisms",
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_refine_success(
+    db_session: AsyncSession,
+    two_articles: list[Article],
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Refine returns a refined SynthesisCompilationResult."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path / "wikimind"))
+
+    from wikimind.config import get_settings
+
+    get_settings.cache_clear()
+
+    mock_response = CompletionResponse(
+        content=MOCK_SYNTHESIS_JSON,
+        provider_used=Provider.MOCK,
+        model_used="mock-1",
+        input_tokens=100,
+        output_tokens=200,
+        cost_usd=0.01,
+        latency_ms=500,
+    )
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    mock_router.parse_json_response = MagicMock(
+        return_value=json.loads(MOCK_SYNTHESIS_JSON),
+    )
+
+    with patch(
+        "wikimind.engine.base_compiler.get_llm_router",
+        return_value=mock_router,
+    ):
+        compiler = SynthesisCompiler(TEST_USER_ID)
+        ids = [a.id for a in two_articles]
+        result = await compiler.refine(
+            session=db_session,
+            article_ids=ids,
+            previous_draft="## Old draft\n\nSome content here",
+            guidance="Focus more on attention mechanisms",
+        )
+
+    assert result is not None
+    assert result.title == "Transformer Architecture Evolution"
+    assert result.themes == ["Self-attention", "Pre-training"]
+
+
+# ---------------------------------------------------------------------------
+# Unit: SynthesisCompiler.confirm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confirm_not_enough_articles(
+    db_session: AsyncSession,
+) -> None:
+    """Confirm returns None when fewer than 2 articles are found."""
+    compiler = SynthesisCompiler(TEST_USER_ID)
+    result = await compiler.confirm(
+        session=db_session,
+        title="My Synthesis",
+        draft_content="## Draft\n\nContent",
+        article_ids=["nonexistent-id"],
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_success(
+    db_session: AsyncSession,
+    two_articles: list[Article],
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Confirm saves the draft as a synthesis article."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path / "wikimind"))
+
+    from wikimind.config import get_settings
+
+    get_settings.cache_clear()
+
+    with patch(
+        "wikimind.engine.base_compiler.get_llm_router",
+        return_value=MagicMock(),
+    ):
+        compiler = SynthesisCompiler(TEST_USER_ID)
+        ids = [a.id for a in two_articles]
+        article = await compiler.confirm(
+            session=db_session,
+            title="Transformer Architecture Evolution",
+            draft_content="## Themes\n\nBoth papers use attention...",
+            article_ids=ids,
+        )
+
+    assert article is not None
+    assert article.page_type == PageType.SYNTHESIS
+    assert article.slug.startswith("synthesis-")
+    assert article.title == "Transformer Architecture Evolution"
+    assert article.file_path == f"synthesis/{article.slug}.md"
+
+
+# ---------------------------------------------------------------------------
+# API: POST /api/wiki/synthesis/preview
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_api_not_enough_articles(client: AsyncClient) -> None:
+    """POST /api/wiki/synthesis/preview returns 422 when articles don't exist."""
+    resp = await client.post(
+        "/api/wiki/synthesis/preview",
+        json={"article_ids": ["fake-id-1", "fake-id-2"]},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_preview_api_validation_too_few_ids(client: AsyncClient) -> None:
+    """POST /api/wiki/synthesis/preview rejects fewer than 2 article_ids."""
+    resp = await client.post(
+        "/api/wiki/synthesis/preview",
+        json={"article_ids": ["only-one"]},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# API: POST /api/wiki/synthesis/refine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refine_api_not_enough_articles(client: AsyncClient) -> None:
+    """POST /api/wiki/synthesis/refine returns 422 when articles don't exist."""
+    resp = await client.post(
+        "/api/wiki/synthesis/refine",
+        json={
+            "draft_content": "## Draft\n\nContent",
+            "article_ids": ["fake-id-1", "fake-id-2"],
+            "guidance": "More focus on attention",
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# API: POST /api/wiki/synthesis/confirm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confirm_api_not_enough_articles(client: AsyncClient) -> None:
+    """POST /api/wiki/synthesis/confirm returns 422 when articles don't exist."""
+    resp = await client.post(
+        "/api/wiki/synthesis/confirm",
+        json={
+            "title": "My Synthesis",
+            "draft_content": "## Draft\n\nContent",
+            "article_ids": ["fake-id-1", "fake-id-2"],
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Integration: full preview → refine → confirm flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_refine_confirm_flow(
+    db_session: AsyncSession,
+    two_articles: list[Article],
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Full preview → refine → confirm creates a persisted synthesis article."""
+    monkeypatch.setenv("WIKIMIND_DATA_DIR", str(tmp_path / "wikimind"))
+
+    from wikimind.config import get_settings
+
+    get_settings.cache_clear()
+
+    mock_response = CompletionResponse(
+        content=MOCK_SYNTHESIS_JSON,
+        provider_used=Provider.MOCK,
+        model_used="mock-1",
+        input_tokens=100,
+        output_tokens=200,
+        cost_usd=0.01,
+        latency_ms=500,
+    )
+    mock_router = MagicMock()
+    mock_router.complete = AsyncMock(return_value=mock_response)
+    mock_router.parse_json_response = MagicMock(
+        return_value=json.loads(MOCK_SYNTHESIS_JSON),
+    )
+
+    ids = [a.id for a in two_articles]
+
+    with patch(
+        "wikimind.engine.base_compiler.get_llm_router",
+        return_value=mock_router,
+    ):
+        compiler = SynthesisCompiler(TEST_USER_ID)
+
+        # Step 1: Preview
+        preview_result = await compiler.preview(
+            session=db_session,
+            article_ids=ids,
+            guidance="Compare transformer architectures",
+        )
+        assert preview_result is not None
+        assert preview_result.article_body
+
+        # Step 2: Refine
+        refined = await compiler.refine(
+            session=db_session,
+            article_ids=ids,
+            previous_draft=preview_result.article_body,
+            guidance="Focus more on attention mechanisms",
+        )
+        assert refined is not None
+        assert refined.article_body
+
+        # Step 3: Confirm
+        article = await compiler.confirm(
+            session=db_session,
+            title=refined.title,
+            draft_content=refined.article_body,
+            article_ids=ids,
+        )
+
+    assert article is not None
+    assert article.page_type == PageType.SYNTHESIS
+    assert article.title == "Transformer Architecture Evolution"
+    assert article.slug.startswith("synthesis-")

--- a/tests/unit/test_synthesis_suggestions.py
+++ b/tests/unit/test_synthesis_suggestions.py
@@ -1,0 +1,301 @@
+"""Tests for synthesis suggestion auto-detection (issue #415)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.conftest import TEST_USER_ID
+from wikimind.models import (
+    Article,
+    ArticleConcept,
+    ArticleSource,
+    Contradiction,
+    ContradictionStatus,
+    PageType,
+    Source,
+    SourceType,
+)
+from wikimind.services.wiki import WikiService
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def articles_with_shared_concepts(db_session: AsyncSession) -> list[Article]:
+    """Create articles sharing 3+ concepts."""
+    a1 = Article(
+        slug="article-transformers",
+        title="Transformer Architecture",
+        file_path="wiki/transformers.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    a2 = Article(
+        slug="article-attention",
+        title="Attention Mechanisms Deep Dive",
+        file_path="wiki/attention.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(a1)
+    db_session.add(a2)
+    await db_session.flush()
+
+    # Both share 3 concepts: "transformers", "attention", "deep-learning"
+    shared_concepts = ["transformers", "attention", "deep-learning"]
+    for concept_name in shared_concepts:
+        db_session.add(ArticleConcept(article_id=a1.id, concept_name=concept_name))
+        db_session.add(ArticleConcept(article_id=a2.id, concept_name=concept_name))
+    # Article 1 also has a unique concept
+    db_session.add(ArticleConcept(article_id=a1.id, concept_name="architecture"))
+
+    await db_session.commit()
+    await db_session.refresh(a1)
+    await db_session.refresh(a2)
+    return [a1, a2]
+
+
+@pytest.fixture
+async def articles_with_contradictions(db_session: AsyncSession) -> list[Article]:
+    """Create articles with an active contradiction between them."""
+    a1 = Article(
+        slug="article-scaling-laws",
+        title="Scaling Laws for Neural Models",
+        file_path="wiki/scaling.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    a2 = Article(
+        slug="article-efficiency",
+        title="Efficient Training Techniques",
+        file_path="wiki/efficiency.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(a1)
+    db_session.add(a2)
+    await db_session.flush()
+
+    ctr = Contradiction(
+        claim_a="Larger models always perform better",
+        claim_b="Smaller models can match large model performance with better training",
+        article_a_id=a1.id,
+        article_b_id=a2.id,
+        status=ContradictionStatus.ACTIVE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(ctr)
+    await db_session.commit()
+    await db_session.refresh(a1)
+    await db_session.refresh(a2)
+    return [a1, a2]
+
+
+@pytest.fixture
+async def articles_same_topic_different_sources(db_session: AsyncSession) -> list[Article]:
+    """Create articles on the same topic compiled from different sources."""
+    s1 = Source(
+        source_type=SourceType.URL,
+        title="Source Paper A",
+        user_id=TEST_USER_ID,
+    )
+    s2 = Source(
+        source_type=SourceType.URL,
+        title="Source Paper B",
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(s1)
+    db_session.add(s2)
+    await db_session.flush()
+
+    a1 = Article(
+        slug="article-rlhf-paper-a",
+        title="RLHF from Paper A",
+        file_path="wiki/rlhf-a.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    a2 = Article(
+        slug="article-rlhf-paper-b",
+        title="RLHF from Paper B",
+        file_path="wiki/rlhf-b.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(a1)
+    db_session.add(a2)
+    await db_session.flush()
+
+    # Link articles to different sources
+    db_session.add(ArticleSource(article_id=a1.id, source_id=s1.id))
+    db_session.add(ArticleSource(article_id=a2.id, source_id=s2.id))
+
+    # Both share the concept "rlhf"
+    db_session.add(ArticleConcept(article_id=a1.id, concept_name="rlhf"))
+    db_session.add(ArticleConcept(article_id=a2.id, concept_name="rlhf"))
+
+    await db_session.commit()
+    await db_session.refresh(a1)
+    await db_session.refresh(a2)
+    return [a1, a2]
+
+
+# ---------------------------------------------------------------------------
+# Unit: WikiService.get_synthesis_suggestions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suggestions_shared_concepts(
+    db_session: AsyncSession,
+    articles_with_shared_concepts: list[Article],
+) -> None:
+    """Articles sharing 3+ concepts are suggested for synthesis."""
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID)
+
+    assert len(suggestions) >= 1
+    shared = [s for s in suggestions if s.suggested_type == "shared_concepts"]
+    assert len(shared) == 1
+    assert set(shared[0].article_ids) == {a.id for a in articles_with_shared_concepts}
+    assert "3 concepts" in shared[0].reason
+
+
+@pytest.mark.asyncio
+async def test_suggestions_contradictions(
+    db_session: AsyncSession,
+    articles_with_contradictions: list[Article],
+) -> None:
+    """Articles with active contradictions are suggested for synthesis."""
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID)
+
+    assert len(suggestions) >= 1
+    contradiction_suggestions = [s for s in suggestions if s.suggested_type == "contradiction"]
+    assert len(contradiction_suggestions) == 1
+    assert set(contradiction_suggestions[0].article_ids) == {a.id for a in articles_with_contradictions}
+    assert "contradiction" in contradiction_suggestions[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_suggestions_same_topic_different_sources(
+    db_session: AsyncSession,
+    articles_same_topic_different_sources: list[Article],
+) -> None:
+    """Articles on the same topic from different sources are suggested."""
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID)
+
+    assert len(suggestions) >= 1
+    diff_source = [s for s in suggestions if s.suggested_type == "same_topic_different_sources"]
+    assert len(diff_source) == 1
+    assert set(diff_source[0].article_ids) == {a.id for a in articles_same_topic_different_sources}
+    assert "rlhf" in diff_source[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_suggestions_empty_wiki(db_session: AsyncSession) -> None:
+    """Returns empty list when wiki has no articles."""
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID)
+    assert suggestions == []
+
+
+@pytest.mark.asyncio
+async def test_suggestions_excludes_synthesis_pages(db_session: AsyncSession) -> None:
+    """Synthesis pages themselves are not suggested for synthesis."""
+    a1 = Article(
+        slug="synth-page",
+        title="Existing Synthesis",
+        file_path="wiki/synth.md",
+        page_type=PageType.SYNTHESIS,
+        user_id=TEST_USER_ID,
+    )
+    a2 = Article(
+        slug="source-page",
+        title="Source Article",
+        file_path="wiki/source.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(a1)
+    db_session.add(a2)
+    await db_session.flush()
+
+    # Add shared concepts to synth + source — should not trigger suggestion
+    for concept in ["a", "b", "c"]:
+        db_session.add(ArticleConcept(article_id=a1.id, concept_name=concept))
+        db_session.add(ArticleConcept(article_id=a2.id, concept_name=concept))
+    await db_session.commit()
+
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID)
+    # Should not include the synthesis page in any suggestion
+    for s in suggestions:
+        assert a1.id not in s.article_ids
+
+
+@pytest.mark.asyncio
+async def test_suggestions_respects_limit(
+    db_session: AsyncSession,
+    articles_with_shared_concepts: list[Article],
+    articles_with_contradictions: list[Article],
+) -> None:
+    """Respects the limit parameter."""
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID, limit=1)
+    assert len(suggestions) <= 1
+
+
+@pytest.mark.asyncio
+async def test_suggestions_includes_article_titles(
+    db_session: AsyncSession,
+    articles_with_shared_concepts: list[Article],
+) -> None:
+    """Suggestions include resolved article titles."""
+    service = WikiService()
+    suggestions = await service.get_synthesis_suggestions(db_session, TEST_USER_ID)
+
+    assert len(suggestions) >= 1
+    for s in suggestions:
+        assert len(s.article_titles) == len(s.article_ids)
+        for title in s.article_titles:
+            assert title != "Unknown"
+            assert len(title) > 0
+
+
+# ---------------------------------------------------------------------------
+# API: GET /api/wiki/synthesis/suggestions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suggestions_api_empty(client: AsyncClient) -> None:
+    """GET /api/wiki/synthesis/suggestions returns empty list initially."""
+    resp = await client.get("/api/wiki/synthesis/suggestions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_suggestions_api_returns_suggestions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/wiki/synthesis/suggestions returns suggestions when articles exist."""
+    # Create articles with shared concepts via the client's session
+    # Note: the client fixture uses its own session, so we use the API
+    # This test primarily verifies the endpoint wiring
+    resp = await client.get("/api/wiki/synthesis/suggestions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)


### PR DESCRIPTION
## Summary

- Restores actual feature code from PRs #754, #751, #752, #755, #757, #759, #761 that were squash-merged as empty commits
- Root cause: empty "chore: trigger CI" commits were pushed to PR branches from detached HEAD, then rebasing only carried the empty commits — the squash merges contained zero file changes
- This PR cherry-picks the original feature commits (still in reflog) and resolves merge conflicts

## Features restored

| PR | Feature | Files |
|---|---|---|
| #754 | Single-article markdown/JSON export API | 5 |
| #751 | Export dropdown UI component | 2 |
| #752 | Share expiry UI and management page | 4 |
| #755 | Synthesis type selection with prompts | 6 |
| #757 | Synthesis preview/refine/confirm workflow | 4+2 |
| #759 | Auto-detection of synthesis opportunities | 6 |
| #761 | Multi-step synthesis creation wizard | 3 |

## Test plan
- [ ] `make verify` passes
- [ ] Export API returns markdown/JSON for articles
- [ ] Share links include `expires_at` field
- [ ] Synthesis routes include preview/refine/confirm/suggestions endpoints
- [ ] Frontend build passes (`cd apps/web && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)