### PR TITLE
feat(admin): add per-user details to admin dashboard (#772)

### DIFF
--- a/apps/web/src/api/admin.ts
+++ b/apps/web/src/api/admin.ts
@@ -57,6 +57,44 @@ export function retryStuckSource(sourceId: string): Promise<AdminActionResult> {
   );
 }
 
+// ----- Admin Users -----
+
+export interface AdminUserSummary {
+  id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+  article_count: number;
+  source_count: number;
+  total_cost_usd: number;
+  last_active_at: string | null;
+}
+
+export interface RecentSourceEntry {
+  id: string;
+  title: string | null;
+  source_type: string;
+  status: string;
+  ingested_at: string;
+}
+
+export interface AdminUserDetail extends AdminUserSummary {
+  articles_by_type: Record<string, number>;
+  sources_by_status: Record<string, number>;
+  cost_by_provider: Record<string, number>;
+  recent_sources: RecentSourceEntry[];
+}
+
+export function getAdminUsers(): Promise<AdminUserSummary[]> {
+  return apiFetch<AdminUserSummary[]>("/api/admin/users");
+}
+
+export function getAdminUserDetail(userId: string): Promise<AdminUserDetail> {
+  return apiFetch<AdminUserDetail>(
+    `/api/admin/users/${encodeURIComponent(userId)}`,
+  );
+}
+
 // ----- LLM Traces -----
 
 export interface LLMTrace {

--- a/apps/web/src/components/admin/AdminDashboard.tsx
+++ b/apps/web/src/components/admin/AdminDashboard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "../shared/Card";
 import { Badge } from "../shared/Badge";
@@ -6,9 +7,13 @@ import { Button } from "../shared/Button";
 import { Spinner } from "../shared/Spinner";
 import {
   getAdminStats,
+  getAdminUsers,
+  getAdminUserDetail,
   retryStuckSource,
   type SystemStats,
   type StuckSource,
+  type AdminUserSummary,
+  type AdminUserDetail,
 } from "../../api/admin";
 import { TraceViewer } from "./TraceViewer";
 
@@ -256,6 +261,235 @@ function OperationalHealthSection({ stats }: { stats: SystemStats }) {
 }
 
 // ---------------------------------------------------------------------------
+// Users section
+// ---------------------------------------------------------------------------
+
+type SortField = "email" | "article_count" | "source_count" | "total_cost_usd";
+
+function UserDetailPanel({ userId }: { userId: string }) {
+  const { data: detail, isLoading } = useQuery({
+    queryKey: ["admin-user-detail", userId],
+    queryFn: () => getAdminUserDetail(userId),
+  });
+
+  if (isLoading) return <Spinner size={20} />;
+  if (!detail) return null;
+
+  return (
+    <div className="mt-3 grid gap-4 sm:grid-cols-3">
+      <Card className="p-3">
+        <h4 className="mb-2 text-xs font-semibold text-slate-500">Articles by Type</h4>
+        {Object.keys(detail.articles_by_type).length === 0 ? (
+          <p className="text-xs text-slate-400">No articles</p>
+        ) : (
+          <ul className="space-y-1 text-xs text-slate-600">
+            {Object.entries(detail.articles_by_type).map(([k, v]) => (
+              <li key={k} className="flex justify-between">
+                <span>{k}</span>
+                <span className="font-medium tabular-nums">{v}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      <Card className="p-3">
+        <h4 className="mb-2 text-xs font-semibold text-slate-500">Sources by Status</h4>
+        {Object.keys(detail.sources_by_status).length === 0 ? (
+          <p className="text-xs text-slate-400">No sources</p>
+        ) : (
+          <ul className="space-y-1 text-xs text-slate-600">
+            {Object.entries(detail.sources_by_status).map(([k, v]) => (
+              <li key={k} className="flex justify-between">
+                <span>{k}</span>
+                <span className="font-medium tabular-nums">{v}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      <Card className="p-3">
+        <h4 className="mb-2 text-xs font-semibold text-slate-500">Cost by Provider</h4>
+        {Object.keys(detail.cost_by_provider).length === 0 ? (
+          <p className="text-xs text-slate-400">No cost data</p>
+        ) : (
+          <ul className="space-y-1 text-xs text-slate-600">
+            {Object.entries(detail.cost_by_provider).map(([k, v]) => (
+              <li key={k} className="flex justify-between">
+                <span>{k}</span>
+                <span className="font-medium tabular-nums">${v.toFixed(4)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      {detail.recent_sources.length > 0 && (
+        <div className="sm:col-span-3">
+          <Card className="p-3">
+            <h4 className="mb-2 text-xs font-semibold text-slate-500">
+              Recent Sources (last 10)
+            </h4>
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="text-slate-400">
+                  <th className="pb-1 pr-3 font-medium">Title</th>
+                  <th className="pb-1 pr-3 font-medium">Type</th>
+                  <th className="pb-1 pr-3 font-medium">Status</th>
+                  <th className="pb-1 font-medium">Ingested</th>
+                </tr>
+              </thead>
+              <tbody>
+                {detail.recent_sources.map((s) => (
+                  <tr key={s.id} className="border-t border-slate-100">
+                    <td className="py-1.5 pr-3 text-slate-700">
+                      {s.title || s.id.slice(0, 8)}
+                    </td>
+                    <td className="py-1.5 pr-3">
+                      <Badge tone="neutral">{s.source_type}</Badge>
+                    </td>
+                    <td className="py-1.5 pr-3">
+                      <Badge tone={STATUS_BADGE_TONE[s.status] ?? "neutral"}>
+                        {s.status}
+                      </Badge>
+                    </td>
+                    <td className="py-1.5 text-slate-500">
+                      {new Date(s.ingested_at).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UsersSection() {
+  const { data: users, isLoading } = useQuery({
+    queryKey: ["admin-users"],
+    queryFn: getAdminUsers,
+    refetchInterval: 30_000,
+  });
+
+  const [expandedUserId, setExpandedUserId] = useState<string | null>(null);
+  const [sortField, setSortField] = useState<SortField>("email");
+  const [sortAsc, setSortAsc] = useState(true);
+
+  if (isLoading) return <Spinner size={24} />;
+  if (!users || users.length === 0) {
+    return (
+      <p className="text-xs text-slate-400">No users found.</p>
+    );
+  }
+
+  const sorted = [...users].sort((a, b) => {
+    const av = a[sortField];
+    const bv = b[sortField];
+    if (typeof av === "string" && typeof bv === "string") {
+      return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+    }
+    return sortAsc
+      ? (av as number) - (bv as number)
+      : (bv as number) - (av as number);
+  });
+
+  function handleSort(field: SortField) {
+    if (sortField === field) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortField(field);
+      setSortAsc(true);
+    }
+  }
+
+  const arrow = (field: SortField) =>
+    sortField === field ? (sortAsc ? " \u2191" : " \u2193") : "";
+
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold text-slate-700">Users</h2>
+      <Card className="overflow-x-auto p-4">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="text-xs text-slate-400">
+              <th
+                className="cursor-pointer pb-2 pr-3 font-medium"
+                onClick={() => handleSort("email")}
+              >
+                Email{arrow("email")}
+              </th>
+              <th className="pb-2 pr-3 font-medium">Name</th>
+              <th
+                className="cursor-pointer pb-2 pr-3 font-medium text-right"
+                onClick={() => handleSort("article_count")}
+              >
+                Articles{arrow("article_count")}
+              </th>
+              <th
+                className="cursor-pointer pb-2 pr-3 font-medium text-right"
+                onClick={() => handleSort("source_count")}
+              >
+                Sources{arrow("source_count")}
+              </th>
+              <th
+                className="cursor-pointer pb-2 pr-3 font-medium text-right"
+                onClick={() => handleSort("total_cost_usd")}
+              >
+                Cost (USD){arrow("total_cost_usd")}
+              </th>
+              <th className="pb-2 font-medium">Last Active</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((user) => (
+              <tr key={user.id}>
+                <td colSpan={6} className="p-0">
+                  <div
+                    className="flex cursor-pointer items-center border-t border-slate-100 hover:bg-slate-50"
+                    onClick={() =>
+                      setExpandedUserId(
+                        expandedUserId === user.id ? null : user.id,
+                      )
+                    }
+                  >
+                    <span className="flex-1 py-2 pr-3 text-sm text-slate-700">
+                      {user.email}
+                    </span>
+                    <span className="w-32 py-2 pr-3 text-sm text-slate-600 truncate">
+                      {user.name || "\u2014"}
+                    </span>
+                    <span className="w-20 py-2 pr-3 text-right text-sm tabular-nums text-slate-700">
+                      {user.article_count}
+                    </span>
+                    <span className="w-20 py-2 pr-3 text-right text-sm tabular-nums text-slate-700">
+                      {user.source_count}
+                    </span>
+                    <span className="w-24 py-2 pr-3 text-right text-sm tabular-nums text-slate-700">
+                      ${user.total_cost_usd.toFixed(4)}
+                    </span>
+                    <span className="w-40 py-2 text-sm text-slate-500">
+                      {user.last_active_at
+                        ? new Date(user.last_active_at).toLocaleString()
+                        : "Never"}
+                    </span>
+                  </div>
+                  {expandedUserId === user.id && (
+                    <div className="px-3 pb-3">
+                      <UserDetailPanel userId={user.id} />
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main dashboard
 // ---------------------------------------------------------------------------
 
@@ -289,6 +523,7 @@ export function AdminDashboard() {
         <OverviewSection stats={stats} />
         <ContentBreakdownSection stats={stats} />
         <OperationalHealthSection stats={stats} />
+        <UsersSection />
         <section>
           <h2 className="mb-3 text-lg font-semibold text-slate-700">LLM Traces</h2>
           <TraceViewer />

--- a/apps/web/src/components/admin/AdminDashboard.tsx
+++ b/apps/web/src/components/admin/AdminDashboard.tsx
@@ -12,8 +12,6 @@ import {
   retryStuckSource,
   type SystemStats,
   type StuckSource,
-  type AdminUserSummary,
-  type AdminUserDetail,
 } from "../../api/admin";
 import { TraceViewer } from "./TraceViewer";
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2653,6 +2653,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DoclingStatusResponse'
+  /api/admin/users:
+    get:
+      tags:
+      - Admin
+      summary: List Users
+      description: List all users with summary metrics (admin only).
+      operationId: list_users_api_admin_users_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/AdminUserSummary'
+                type: array
+                title: Response List Users Api Admin Users Get
+  /api/admin/users/{user_id}:
+    get:
+      tags:
+      - Admin
+      summary: Get User Detail
+      description: Full stats breakdown for a single user (admin only).
+      operationId: get_user_detail_api_admin_users__user_id__get
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserDetail'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/admin/traces:
     get:
       tags:
@@ -3088,6 +3132,89 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/synthesis/preview:
+    post:
+      tags:
+      - Synthesis
+      summary: Preview Synthesis
+      description: 'Generate a synthesis draft without saving it.
+
+
+        Returns draft content, suggested title, and key themes for user review.
+
+        The draft can be refined with feedback or confirmed to save.'
+      operationId: preview_synthesis_api_wiki_synthesis_preview_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SynthesisPreviewRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynthesisPreviewResponse'
+        '422':
+          description: Not enough articles or synthesis failed
+  /api/wiki/synthesis/refine:
+    post:
+      tags:
+      - Synthesis
+      summary: Refine Synthesis
+      description: 'Refine a synthesis draft with user feedback.
+
+
+        Takes a previous draft and user guidance, regenerates the synthesis
+
+        incorporating the feedback. Can be called multiple times for iterative
+
+        refinement before confirming.'
+      operationId: refine_synthesis_api_wiki_synthesis_refine_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SynthesisRefineRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynthesisRefineResponse'
+        '422':
+          description: Refinement failed
+  /api/wiki/synthesis/confirm:
+    post:
+      tags:
+      - Synthesis
+      summary: Confirm Synthesis
+      description: 'Save a confirmed synthesis draft as a real wiki article.
+
+
+        Takes the final draft content and title from a preview/refine cycle
+
+        and persists it as a synthesis article in the wiki.'
+      operationId: confirm_synthesis_api_wiki_synthesis_confirm_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SynthesisConfirmRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynthesisConfirmResponse'
+        '422':
+          description: Could not save synthesis
   /api/wiki/synthesize:
     post:
       tags:
@@ -3153,6 +3280,49 @@ paths:
                 items:
                   $ref: '#/components/schemas/ArticleSummaryResponse'
                 title: Response List Synthesis Pages Api Wiki Synthesis Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/synthesis/suggestions:
+    get:
+      tags:
+      - Synthesis
+      summary: Get Synthesis Suggestions
+      description: 'Return auto-detected synthesis opportunities.
+
+
+        Identifies clusters of articles that would benefit from synthesis:
+
+        - Articles sharing 3+ concepts
+
+        - Articles with contradictions between them
+
+        - Articles on the same topic from different sources'
+      operationId: get_synthesis_suggestions_api_wiki_synthesis_suggestions_get
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 50
+          minimum: 1
+          default: 10
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SynthesisSuggestion'
+                title: Response Get Synthesis Suggestions Api Wiki Synthesis Suggestions
+                  Get
         '422':
           description: Validation Error
           content:
@@ -3633,7 +3803,7 @@ paths:
       tags:
       - Auth
       summary: Authorize
-      description: 'OAuth 2.1 authorization endpoint.
+      description: 'Handle OAuth 2.1 authorization request.
 
 
         Validates the authorization request parameters, stores them, and
@@ -3835,6 +4005,118 @@ paths:
               schema: {}
 components:
   schemas:
+    AdminUserDetail:
+      properties:
+        id:
+          type: string
+          title: Id
+        email:
+          type: string
+          title: Email
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+        avatar_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Avatar Url
+        article_count:
+          type: integer
+          title: Article Count
+          default: 0
+        source_count:
+          type: integer
+          title: Source Count
+          default: 0
+        total_cost_usd:
+          type: number
+          title: Total Cost Usd
+          default: 0.0
+        last_active_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Active At
+        articles_by_type:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Articles By Type
+          default: {}
+        sources_by_status:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Sources By Status
+          default: {}
+        cost_by_provider:
+          additionalProperties:
+            type: number
+          type: object
+          title: Cost By Provider
+          default: {}
+        recent_sources:
+          items:
+            $ref: '#/components/schemas/RecentSourceEntry'
+          type: array
+          title: Recent Sources
+          default: []
+      type: object
+      required:
+      - id
+      - email
+      - name
+      - avatar_url
+      title: AdminUserDetail
+      description: Full per-user detail for the admin user detail endpoint.
+    AdminUserSummary:
+      properties:
+        id:
+          type: string
+          title: Id
+        email:
+          type: string
+          title: Email
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+        avatar_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Avatar Url
+        article_count:
+          type: integer
+          title: Article Count
+          default: 0
+        source_count:
+          type: integer
+          title: Source Count
+          default: 0
+        total_cost_usd:
+          type: number
+          title: Total Cost Usd
+          default: 0.0
+        last_active_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Active At
+      type: object
+      required:
+      - id
+      - email
+      - name
+      - avatar_url
+      title: AdminUserSummary
+      description: Summary metrics for a single user in the admin users list.
     AllSettingsResponse:
       properties:
         data_dir:
@@ -6416,6 +6698,35 @@ components:
       - status
       title: RebuildConceptsResponse
       description: Response after triggering taxonomy rebuild.
+    RecentSourceEntry:
+      properties:
+        id:
+          type: string
+          title: Id
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        source_type:
+          type: string
+          title: Source Type
+        status:
+          type: string
+          title: Status
+        ingested_at:
+          type: string
+          format: date-time
+          title: Ingested At
+      type: object
+      required:
+      - id
+      - title
+      - source_type
+      - status
+      - ingested_at
+      title: RecentSourceEntry
+      description: A recently ingested source entry for the admin user detail view.
     RecompileResponse:
       properties:
         status:
@@ -7203,6 +7514,186 @@ components:
       - bucket
       title: SyncSettingsResponse
       description: Cloud sync configuration section.
+    SynthesisConfirmRequest:
+      properties:
+        title:
+          type: string
+          minLength: 1
+          title: Title
+        draft_content:
+          type: string
+          title: Draft Content
+        article_ids:
+          items:
+            type: string
+          type: array
+          minItems: 2
+          title: Article Ids
+      type: object
+      required:
+      - title
+      - draft_content
+      - article_ids
+      title: SynthesisConfirmRequest
+      description: Request to save a confirmed synthesis draft as a real article.
+    SynthesisConfirmResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+        summary:
+          type: string
+          title: Summary
+        themes:
+          items:
+            type: string
+          type: array
+          title: Themes
+        source_count:
+          type: integer
+          title: Source Count
+        source_article_ids:
+          items:
+            type: string
+          type: array
+          title: Source Article Ids
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        page_type:
+          $ref: '#/components/schemas/PageType'
+          default: synthesis
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      - summary
+      - themes
+      - source_count
+      - source_article_ids
+      - created_at
+      title: SynthesisConfirmResponse
+      description: Response after confirming and saving a synthesis article.
+    SynthesisPreviewRequest:
+      properties:
+        article_ids:
+          items:
+            type: string
+          type: array
+          minItems: 2
+          title: Article Ids
+        synthesis_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Synthesis Type
+        guidance:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Guidance
+      type: object
+      required:
+      - article_ids
+      title: SynthesisPreviewRequest
+      description: Request to generate a synthesis draft without saving it.
+    SynthesisPreviewResponse:
+      properties:
+        draft_content:
+          type: string
+          title: Draft Content
+        suggested_title:
+          type: string
+          title: Suggested Title
+        summary:
+          type: string
+          title: Summary
+        themes:
+          items:
+            type: string
+          type: array
+          title: Themes
+        article_ids:
+          items:
+            type: string
+          type: array
+          title: Article Ids
+        source_count:
+          type: integer
+          title: Source Count
+      type: object
+      required:
+      - draft_content
+      - suggested_title
+      - summary
+      - themes
+      - article_ids
+      - source_count
+      title: SynthesisPreviewResponse
+      description: Draft synthesis content returned for preview (not yet persisted).
+    SynthesisRefineRequest:
+      properties:
+        draft_content:
+          type: string
+          title: Draft Content
+        article_ids:
+          items:
+            type: string
+          type: array
+          minItems: 2
+          title: Article Ids
+        guidance:
+          type: string
+          title: Guidance
+      type: object
+      required:
+      - draft_content
+      - article_ids
+      - guidance
+      title: SynthesisRefineRequest
+      description: Request to refine a previous synthesis draft with user feedback.
+    SynthesisRefineResponse:
+      properties:
+        draft_content:
+          type: string
+          title: Draft Content
+        suggested_title:
+          type: string
+          title: Suggested Title
+        summary:
+          type: string
+          title: Summary
+        themes:
+          items:
+            type: string
+          type: array
+          title: Themes
+        article_ids:
+          items:
+            type: string
+          type: array
+          title: Article Ids
+        source_count:
+          type: integer
+          title: Source Count
+      type: object
+      required:
+      - draft_content
+      - suggested_title
+      - summary
+      - themes
+      - article_ids
+      - source_count
+      title: SynthesisRefineResponse
+      description: Refined draft synthesis content.
     SynthesisResponse:
       properties:
         id:
@@ -7253,6 +7744,32 @@ components:
       - created_at
       title: SynthesisResponse
       description: Response after creating a synthesis page.
+    SynthesisSuggestion:
+      properties:
+        article_ids:
+          items:
+            type: string
+          type: array
+          title: Article Ids
+        article_titles:
+          items:
+            type: string
+          type: array
+          title: Article Titles
+        reason:
+          type: string
+          title: Reason
+        suggested_type:
+          type: string
+          title: Suggested Type
+      type: object
+      required:
+      - article_ids
+      - article_titles
+      - reason
+      - suggested_type
+      title: SynthesisSuggestion
+      description: A suggestion for a synthesis opportunity across related articles.
     TagArticleRequest:
       properties:
         tag_id:

--- a/src/wikimind/api/routes/admin.py
+++ b/src/wikimind/api/routes/admin.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlmodel import select
@@ -15,7 +15,13 @@ from sqlmodel import select
 from wikimind.api.deps import require_admin
 from wikimind.config import get_settings
 from wikimind.database import get_session
-from wikimind.models import LLMTrace, LLMTraceListResponse, LLMTraceResponse
+from wikimind.models import (
+    AdminUserDetail,
+    AdminUserSummary,
+    LLMTrace,
+    LLMTraceListResponse,
+    LLMTraceResponse,
+)
 from wikimind.services.admin import AdminService  # noqa: TC001 — needed at runtime for Depends()
 from wikimind.services.factories import get_admin_service
 
@@ -125,6 +131,30 @@ async def get_docling_status(
     except (httpx.HTTPError, OSError) as exc:
         log.warning("docling-status: sidecar unreachable", url=url, error=str(exc))
         return DoclingStatusResponse(status="disconnected", url=url)
+
+
+@router.get("/users", response_model=list[AdminUserSummary])
+async def list_users(
+    session: AsyncSession = Depends(get_session),
+    service: AdminService = Depends(get_admin_service),
+    _admin_user_id: str = Depends(require_admin),
+):
+    """List all users with summary metrics (admin only)."""
+    return await service.list_users(session)
+
+
+@router.get("/users/{user_id}", response_model=AdminUserDetail)
+async def get_user_detail(
+    user_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: AdminService = Depends(get_admin_service),
+    _admin_user_id: str = Depends(require_admin),
+):
+    """Full stats breakdown for a single user (admin only)."""
+    detail = await service.get_user_detail(session, user_id=user_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return detail
 
 
 @router.get("/traces", response_model=LLMTraceListResponse)

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -2417,3 +2417,48 @@ class MCPTokenRevokeResponse(BaseModel):
     """Response after revoking an MCP token."""
 
     status: str
+
+
+# ---------------------------------------------------------------------------
+# Admin per-user detail response models (issue #772)
+# ---------------------------------------------------------------------------
+
+
+class AdminUserSummary(BaseModel):
+    """Summary metrics for a single user in the admin users list."""
+
+    id: str
+    email: str
+    name: str | None
+    avatar_url: str | None
+    article_count: int = 0
+    source_count: int = 0
+    total_cost_usd: float = 0.0
+    last_active_at: datetime | None = None
+
+
+class RecentSourceEntry(BaseModel):
+    """A recently ingested source entry for the admin user detail view."""
+
+    id: str
+    title: str | None
+    source_type: str
+    status: str
+    ingested_at: datetime
+
+
+class AdminUserDetail(BaseModel):
+    """Full per-user detail for the admin user detail endpoint."""
+
+    id: str
+    email: str
+    name: str | None
+    avatar_url: str | None
+    article_count: int = 0
+    source_count: int = 0
+    total_cost_usd: float = 0.0
+    last_active_at: datetime | None = None
+    articles_by_type: dict[str, int] = {}
+    sources_by_status: dict[str, int] = {}
+    cost_by_provider: dict[str, float] = {}
+    recent_sources: list[RecentSourceEntry] = []

--- a/src/wikimind/services/admin.py
+++ b/src/wikimind/services/admin.py
@@ -12,17 +12,21 @@ from wikimind.config import get_settings
 from wikimind.jobs.background import get_background_compiler
 from wikimind.models import (
     AdminActionResult,
+    AdminUserDetail,
+    AdminUserSummary,
     Article,
     Backlink,
     CompiledClaim,
     Concept,
     Conversation,
+    CostLog,
     EligibleConcept,
     IngestStatus,
     Job,
     JobStatus,
     JobType,
     OrphanArticle,
+    RecentSourceEntry,
     Source,
     StuckSource,
     SystemStats,
@@ -400,3 +404,147 @@ class AdminService:
             AdminActionResult with action result.
         """
         return AdminActionResult(action="reindex", status="scheduled")
+
+    async def list_users(
+        self,
+        session: AsyncSession,
+    ) -> list[AdminUserSummary]:
+        """List all users with summary metrics (article/source counts, cost).
+
+        Args:
+            session: Async database session.
+
+        Returns:
+            List of AdminUserSummary for each user.
+        """
+        result = await session.exec(select(User))
+        users = list(result.all())
+
+        summaries: list[AdminUserSummary] = []
+        for user in users:
+            # Article count
+            art_stmt = select(func.count()).select_from(Article).where(Article.user_id == user.id)
+            art_result = await session.execute(art_stmt)
+            article_count = art_result.scalar() or 0
+
+            # Source count
+            src_stmt = select(func.count()).select_from(Source).where(Source.user_id == user.id)
+            src_result = await session.execute(src_stmt)
+            source_count = src_result.scalar() or 0
+
+            # Total cost
+            cost_stmt = select(func.coalesce(func.sum(CostLog.cost_usd), 0.0)).where(CostLog.user_id == user.id)
+            cost_result = await session.execute(cost_stmt)
+            total_cost_usd = float(cost_result.scalar() or 0.0)
+
+            # Last active: most recent source ingested_at
+            active_stmt = select(func.max(Source.ingested_at)).where(Source.user_id == user.id)
+            active_result = await session.execute(active_stmt)
+            last_active_at = active_result.scalar()
+
+            summaries.append(
+                AdminUserSummary(
+                    id=user.id,
+                    email=user.email,
+                    name=user.name,
+                    avatar_url=user.avatar_url,
+                    article_count=article_count,
+                    source_count=source_count,
+                    total_cost_usd=total_cost_usd,
+                    last_active_at=last_active_at,
+                )
+            )
+
+        return summaries
+
+    async def get_user_detail(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> AdminUserDetail | None:
+        """Get detailed stats for a single user.
+
+        Args:
+            session: Async database session.
+            user_id: The user UUID to look up.
+
+        Returns:
+            AdminUserDetail with full breakdown, or None if user not found.
+        """
+        result = await session.exec(select(User).where(User.id == user_id))
+        user = result.one_or_none()
+        if user is None:
+            return None
+
+        # Article count
+        art_count_stmt = select(func.count()).select_from(Article).where(Article.user_id == user_id)
+        art_count_result = await session.execute(art_count_stmt)
+        article_count = art_count_result.scalar() or 0
+
+        # Source count
+        src_count_stmt = select(func.count()).select_from(Source).where(Source.user_id == user_id)
+        src_count_result = await session.execute(src_count_stmt)
+        source_count = src_count_result.scalar() or 0
+
+        # Total cost
+        cost_stmt = select(func.coalesce(func.sum(CostLog.cost_usd), 0.0)).where(CostLog.user_id == user_id)
+        cost_result = await session.execute(cost_stmt)
+        total_cost_usd = float(cost_result.scalar() or 0.0)
+
+        # Last active
+        active_stmt = select(func.max(Source.ingested_at)).where(Source.user_id == user_id)
+        active_result = await session.execute(active_stmt)
+        last_active_at = active_result.scalar()
+
+        # Articles by page_type
+        abt_stmt = select(Article.page_type, func.count()).where(Article.user_id == user_id).group_by(Article.page_type)
+        abt_result = await session.execute(abt_stmt)
+        articles_by_type = {row[0]: row[1] for row in abt_result.all()}
+
+        # Sources by status
+        sbs_stmt = select(Source.status, func.count()).where(Source.user_id == user_id).group_by(Source.status)
+        sbs_result = await session.execute(sbs_stmt)
+        sources_by_status = {row[0]: row[1] for row in sbs_result.all()}
+
+        # Cost by provider
+        cbp_stmt = (
+            select(CostLog.provider, func.sum(CostLog.cost_usd))
+            .where(CostLog.user_id == user_id)
+            .group_by(CostLog.provider)
+        )
+        cbp_result = await session.execute(cbp_stmt)
+        cost_by_provider = {row[0]: float(row[1]) for row in cbp_result.all()}
+
+        # Recent sources (last 10)
+        recent_stmt = (
+            select(Source)
+            .where(Source.user_id == user_id)
+            .order_by(Source.ingested_at.desc())  # type: ignore[attr-defined]
+            .limit(10)
+        )
+        recent_result = await session.exec(recent_stmt)
+        recent_sources = [
+            RecentSourceEntry(
+                id=s.id,
+                title=s.title,
+                source_type=s.source_type,
+                status=s.status,
+                ingested_at=s.ingested_at,
+            )
+            for s in recent_result.all()
+        ]
+
+        return AdminUserDetail(
+            id=user.id,
+            email=user.email,
+            name=user.name,
+            avatar_url=user.avatar_url,
+            article_count=article_count,
+            source_count=source_count,
+            total_cost_usd=total_cost_usd,
+            last_active_at=last_active_at,
+            articles_by_type=articles_by_type,
+            sources_by_status=sources_by_status,
+            cost_by_provider=cost_by_provider,
+            recent_sources=recent_sources,
+        )

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -74,3 +74,49 @@ async def test_require_admin_rejects_unknown_user(db_session: AsyncSession) -> N
     with pytest.raises(Exception) as exc_info:
         await require_admin(user_id="nonexistent-user", session=db_session)
     assert exc_info.value.status_code == 403  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Per-user admin endpoints (issue #772)
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_users_list(client: AsyncClient) -> None:
+    """GET /api/admin/users returns a list of user summaries."""
+    resp = await client.get("/api/admin/users")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    # The test fixture seeds a single admin user
+    assert len(data) >= 1
+    first = data[0]
+    assert "id" in first
+    assert "email" in first
+    assert "article_count" in first
+    assert "source_count" in first
+    assert "total_cost_usd" in first
+
+
+async def test_admin_user_detail(client: AsyncClient) -> None:
+    """GET /api/admin/users/{user_id} returns detailed stats."""
+    # First get the users list to find the test user's ID
+    resp = await client.get("/api/admin/users")
+    assert resp.status_code == 200
+    users = resp.json()
+    assert len(users) >= 1
+    user_id = users[0]["id"]
+
+    resp = await client.get(f"/api/admin/users/{user_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == user_id
+    assert "articles_by_type" in data
+    assert "sources_by_status" in data
+    assert "cost_by_provider" in data
+    assert "recent_sources" in data
+
+
+async def test_admin_user_detail_not_found(client: AsyncClient) -> None:
+    """GET /api/admin/users/{user_id} returns 404 for unknown user."""
+    resp = await client.get("/api/admin/users/nonexistent-user-id")
+    assert resp.status_code == 404

--- a/tests/unit/test_admin_service.py
+++ b/tests/unit/test_admin_service.py
@@ -6,7 +6,18 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 from tests.conftest import TEST_USER_ID
-from wikimind.models import Article, Concept, IngestStatus, PageType, Source, SourceType, User
+from wikimind.models import (
+    Article,
+    Concept,
+    CostLog,
+    IngestStatus,
+    PageType,
+    Provider,
+    Source,
+    SourceType,
+    TaskType,
+    User,
+)
 from wikimind.services import admin as admin_mod
 from wikimind.services import factories as services_mod
 from wikimind.services.admin import AdminService
@@ -192,3 +203,154 @@ async def test_retry_stuck_source_rejects_zombie(db_session: AsyncSession) -> No
     result = await service.retry_stuck_source(db_session, str(source.id), TEST_USER_ID)
     assert result.action == "retry_stuck"
     assert result.status == "not_retryable"
+
+
+# ---------------------------------------------------------------------------
+# Per-user detail tests (issue #772)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_users_empty(db_session: AsyncSession) -> None:
+    """list_users returns empty list when no users exist."""
+    service = AdminService()
+    users = await service.list_users(db_session)
+    assert users == []
+
+
+async def test_list_users_with_data(db_session: AsyncSession) -> None:
+    """list_users returns summaries with correct counts."""
+    user = User(
+        id=TEST_USER_ID,
+        email="admin@test.com",
+        auth_provider="google",
+        auth_provider_id="123",
+        is_admin=True,
+    )
+    db_session.add(user)
+    for i in range(3):
+        db_session.add(Source(source_type=SourceType.TEXT, title=f"src-{i}", user_id=TEST_USER_ID))
+    for i in range(2):
+        db_session.add(
+            Article(
+                slug=f"art-{i}",
+                title=f"Article {i}",
+                file_path=f"wiki/art-{i}.md",
+                page_type=PageType.SOURCE,
+                user_id=TEST_USER_ID,
+            )
+        )
+    db_session.add(
+        CostLog(
+            user_id=TEST_USER_ID,
+            provider=Provider.ANTHROPIC,
+            model="claude-3",
+            task_type=TaskType.COMPILE,
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.005,
+            latency_ms=200,
+        )
+    )
+    await db_session.commit()
+
+    service = AdminService()
+    users = await service.list_users(db_session)
+    assert len(users) == 1
+    assert users[0].email == "admin@test.com"
+    assert users[0].article_count == 2
+    assert users[0].source_count == 3
+    assert users[0].total_cost_usd == 0.005
+    assert users[0].last_active_at is not None
+
+
+async def test_get_user_detail_not_found(db_session: AsyncSession) -> None:
+    """get_user_detail returns None for unknown user."""
+    service = AdminService()
+    result = await service.get_user_detail(db_session, "nonexistent-id")
+    assert result is None
+
+
+async def test_get_user_detail_with_data(db_session: AsyncSession) -> None:
+    """get_user_detail returns full breakdown."""
+    user = User(
+        id=TEST_USER_ID,
+        email="detail@test.com",
+        name="Detail User",
+        auth_provider="google",
+        auth_provider_id="456",
+        is_admin=True,
+    )
+    db_session.add(user)
+    db_session.add(
+        Source(
+            source_type=SourceType.URL,
+            title="url-src",
+            user_id=TEST_USER_ID,
+            status=IngestStatus.COMPILED,
+        )
+    )
+    db_session.add(
+        Source(
+            source_type=SourceType.PDF,
+            title="pdf-src",
+            user_id=TEST_USER_ID,
+            status=IngestStatus.PENDING,
+        )
+    )
+    db_session.add(
+        Article(
+            slug="art-source",
+            title="Source Art",
+            file_path="wiki/art-source.md",
+            page_type=PageType.SOURCE,
+            user_id=TEST_USER_ID,
+        )
+    )
+    db_session.add(
+        Article(
+            slug="art-concept",
+            title="Concept Art",
+            file_path="wiki/art-concept.md",
+            page_type=PageType.CONCEPT,
+            user_id=TEST_USER_ID,
+        )
+    )
+    db_session.add(
+        CostLog(
+            user_id=TEST_USER_ID,
+            provider=Provider.ANTHROPIC,
+            model="claude-3",
+            task_type=TaskType.COMPILE,
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.01,
+            latency_ms=200,
+        )
+    )
+    db_session.add(
+        CostLog(
+            user_id=TEST_USER_ID,
+            provider=Provider.OPENAI,
+            model="gpt-4",
+            task_type=TaskType.QA,
+            input_tokens=200,
+            output_tokens=100,
+            cost_usd=0.02,
+            latency_ms=300,
+        )
+    )
+    await db_session.commit()
+
+    service = AdminService()
+    detail = await service.get_user_detail(db_session, TEST_USER_ID)
+    assert detail is not None
+    assert detail.email == "detail@test.com"
+    assert detail.article_count == 2
+    assert detail.source_count == 2
+    assert abs(detail.total_cost_usd - 0.03) < 0.001
+    assert detail.articles_by_type.get("source") == 1
+    assert detail.articles_by_type.get("concept") == 1
+    assert detail.sources_by_status.get("compiled") == 1
+    assert detail.sources_by_status.get("pending") == 1
+    assert len(detail.cost_by_provider) == 2
+    assert len(detail.recent_sources) == 2


### PR DESCRIPTION
## Summary

- Adds per-user visibility to the admin dashboard with user list and detail views
- Two new API endpoints: `GET /api/admin/users` and `GET /api/admin/users/{user_id}`
- Frontend: sortable users table + expandable detail panel with stats breakdown

## Changes

**Backend:**
- `AdminService.list_users()` — queries all users with article/source counts, total cost, last activity
- `AdminService.get_user_detail()` — full breakdown: articles by type, sources by status, cost by provider, recent sources
- Response models: `AdminUserSummary`, `AdminUserDetail`, `RecentSourceEntry`

**Frontend:**
- `UsersSection` — sortable table (email, articles, sources, cost)
- `UserDetailPanel` — expandable detail with stats and recent activity

**Tests:**
- 4 service tests + 3 route tests covering list, detail, and 404

## Test plan

- [x] `make verify` passes
- [x] 25 admin tests pass
- [ ] Admin dashboard shows "Users" section with user list
- [ ] Clicking a user row expands detail panel

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)