### PR TITLE
feat(billing): add admin endpoint to update plan LLM model (#774)

### DIFF
--- a/apps/web/src/api/admin.ts
+++ b/apps/web/src/api/admin.ts
@@ -137,3 +137,29 @@ export interface DoclingStatusResponse {
 export function getDoclingStatus(): Promise<DoclingStatusResponse> {
   return apiFetch<DoclingStatusResponse>("/api/admin/docling-status");
 }
+
+// ----- Admin Plans -----
+
+export interface AdminPlan {
+  id: string;
+  name: string;
+  display_name: string;
+  llm_provider: string;
+  llm_model: string;
+  is_active: boolean;
+  updated_at: string;
+}
+
+export function getAdminPlans(): Promise<AdminPlan[]> {
+  return apiFetch<AdminPlan[]>("/api/admin/billing/plans");
+}
+
+export function updatePlanModel(
+  planId: string,
+  update: { llm_model?: string; llm_provider?: string },
+): Promise<AdminPlan> {
+  return apiFetch<AdminPlan>(
+    `/api/admin/billing/plans/${encodeURIComponent(planId)}`,
+    { method: "PATCH", body: update },
+  );
+}

--- a/apps/web/src/components/admin/AdminDashboard.tsx
+++ b/apps/web/src/components/admin/AdminDashboard.tsx
@@ -9,9 +9,12 @@ import {
   getAdminStats,
   getAdminUsers,
   getAdminUserDetail,
+  getAdminPlans,
+  updatePlanModel,
   retryStuckSource,
   type SystemStats,
   type StuckSource,
+  type AdminPlan,
 } from "../../api/admin";
 import { TraceViewer } from "./TraceViewer";
 
@@ -488,6 +491,132 @@ function UsersSection() {
 }
 
 // ---------------------------------------------------------------------------
+// Plans section
+// ---------------------------------------------------------------------------
+
+function PlanRow({ plan }: { plan: AdminPlan }) {
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [model, setModel] = useState(plan.llm_model);
+  const [provider, setProvider] = useState(plan.llm_provider);
+
+  const save = useMutation({
+    mutationFn: () =>
+      updatePlanModel(plan.id, { llm_model: model, llm_provider: provider }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-plans"] });
+      setEditing(false);
+    },
+  });
+
+  const handleCancel = () => {
+    setModel(plan.llm_model);
+    setProvider(plan.llm_provider);
+    setEditing(false);
+  };
+
+  return (
+    <tr className="border-t border-slate-100">
+      <td className="py-2 pr-3 text-sm font-medium text-slate-700">
+        {plan.display_name}
+      </td>
+      <td className="py-2 pr-3 text-sm text-slate-500">{plan.name}</td>
+      <td className="py-2 pr-3">
+        {editing ? (
+          <input
+            type="text"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+          />
+        ) : (
+          <span className="text-sm text-slate-700">{plan.llm_provider}</span>
+        )}
+      </td>
+      <td className="py-2 pr-3">
+        {editing ? (
+          <input
+            type="text"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+          />
+        ) : (
+          <span className="text-sm text-slate-700">{plan.llm_model}</span>
+        )}
+      </td>
+      <td className="py-2 pr-3">
+        <Badge tone={plan.is_active ? "success" : "neutral"}>
+          {plan.is_active ? "Active" : "Inactive"}
+        </Badge>
+      </td>
+      <td className="py-2">
+        {editing ? (
+          <div className="flex gap-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => save.mutate()}
+              disabled={
+                save.isPending ||
+                (model === plan.llm_model && provider === plan.llm_provider)
+              }
+            >
+              {save.isPending ? "Saving..." : "Save"}
+            </Button>
+            <Button variant="secondary" size="sm" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button variant="secondary" size="sm" onClick={() => setEditing(true)}>
+            Edit
+          </Button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function PlansSection() {
+  const { data: plans, isLoading } = useQuery({
+    queryKey: ["admin-plans"],
+    queryFn: getAdminPlans,
+    refetchInterval: 30_000,
+  });
+
+  if (isLoading) return <Spinner size={24} />;
+  if (!plans || plans.length === 0) {
+    return <p className="text-xs text-slate-400">No plans configured.</p>;
+  }
+
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold text-slate-700">Plans</h2>
+      <Card className="overflow-x-auto p-4">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="text-xs text-slate-400">
+              <th className="pb-2 pr-3 font-medium">Display Name</th>
+              <th className="pb-2 pr-3 font-medium">Slug</th>
+              <th className="pb-2 pr-3 font-medium">LLM Provider</th>
+              <th className="pb-2 pr-3 font-medium">LLM Model</th>
+              <th className="pb-2 pr-3 font-medium">Status</th>
+              <th className="pb-2 font-medium">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {plans.map((plan) => (
+              <PlanRow key={plan.id} plan={plan} />
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main dashboard
 // ---------------------------------------------------------------------------
 
@@ -521,6 +650,7 @@ export function AdminDashboard() {
         <OverviewSection stats={stats} />
         <ContentBreakdownSection stats={stats} />
         <OperationalHealthSection stats={stats} />
+        <PlansSection />
         <UsersSection />
         <section>
           <h2 className="mb-3 text-lg font-semibold text-slate-700">LLM Traces</h2>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -144,7 +144,11 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Source'
+                title: Response List Sources Api Ingest Sources Get
         '422':
           description: Validation Error
           content:
@@ -196,7 +200,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/DeleteConfirmation'
         '422':
           description: Validation Error
           content:
@@ -315,7 +320,14 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: string
+                title: Response List Source Images Api Ingest Sources  Source Id  Images
+                  Get
         '404':
           description: Source not found or no images available
         '422':
@@ -468,7 +480,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/CaptureIngestResponse'
         '422':
           description: Validation Error
           content:
@@ -502,7 +515,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/CaptureDiscardResponse'
         '422':
           description: Validation Error
           content:
@@ -1330,7 +1344,11 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Concept'
+                title: Response Get Concepts Api Wiki Concepts Get
         '422':
           description: Validation Error
           content:
@@ -1370,7 +1388,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ConceptDetailResponse'
         '404':
           description: Concept not found
         '422':
@@ -1765,7 +1784,11 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Query'
+                title: Response Query History Api Query History Get
         '422':
           description: Validation Error
           content:
@@ -1879,7 +1902,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/FileBackResult'
         '422':
           description: Validation Error
           content:
@@ -1905,7 +1929,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/FileBackResult'
         '422':
           description: Validation Error
           content:
@@ -2547,7 +2572,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/SystemStats'
   /api/admin/orphans:
     get:
       tags:
@@ -2560,7 +2586,11 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrphanArticle'
+                type: array
+                title: Response Get Orphans Api Admin Orphans Get
   /api/admin/concepts/eligible:
     get:
       tags:
@@ -2573,7 +2603,12 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                items:
+                  $ref: '#/components/schemas/EligibleConcept'
+                type: array
+                title: Response Get Eligible Concepts Api Admin Concepts Eligible
+                  Get
   /api/admin/stuck-sources:
     get:
       tags:
@@ -2586,7 +2621,11 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                items:
+                  $ref: '#/components/schemas/StuckSource'
+                type: array
+                title: Response Get Stuck Sources Api Admin Stuck Sources Get
   /api/admin/retry-stuck/{source_id}:
     post:
       tags:
@@ -2606,7 +2645,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/AdminActionResult'
         '422':
           description: Validation Error
           content:
@@ -2625,7 +2665,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/AdminActionResult'
   /api/admin/reindex:
     post:
       tags:
@@ -2638,7 +2679,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/AdminActionResult'
   /api/admin/docling-status:
     get:
       tags:
@@ -2747,7 +2789,13 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                items:
+                  additionalProperties: true
+                  type: object
+                type: array
+                title: Response Admin List Subscriptions Api Admin Billing Subscriptions
+                  Get
   /api/admin/billing/subscriptions/{user_id}:
     get:
       tags:
@@ -2767,7 +2815,13 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                title: Response Admin Get User Subscription Api Admin Billing Subscriptions  User
+                  Id  Get
         '422':
           description: Validation Error
           content:
@@ -2799,7 +2853,12 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Admin Override Plan Api Admin Billing Subscriptions  User
+                  Id  Override Post
         '422':
           description: Validation Error
           content:
@@ -2825,7 +2884,12 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Admin Sync Subscription Api Admin Billing Subscriptions  User
+                  Id  Sync Post
         '422':
           description: Validation Error
           content:
@@ -2854,7 +2918,13 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                title: Response Admin List Webhook Events Api Admin Billing Webhook
+                  Events Get
         '422':
           description: Validation Error
           content:
@@ -3639,6 +3709,90 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/billing/plans:
+    get:
+      tags:
+      - Billing
+      summary: List Plans
+      description: List all active billing plans (public, no auth required).
+      operationId: list_plans_api_billing_plans_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PlanResponse'
+                type: array
+                title: Response List Plans Api Billing Plans Get
+  /api/billing/usage:
+    get:
+      tags:
+      - Billing
+      summary: Get Usage
+      description: Get current resource usage vs plan limits.
+      operationId: get_usage_api_billing_usage_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageResponse'
+  /api/billing/checkout:
+    post:
+      tags:
+      - Billing
+      summary: Create Checkout
+      description: Create a Lemon Squeezy checkout session for plan upgrade.
+      operationId: create_checkout_api_billing_checkout_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckoutRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckoutResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/billing/portal:
+    get:
+      tags:
+      - Billing
+      summary: Get Portal
+      description: Get Lemon Squeezy customer portal URL for subscription management.
+      operationId: get_portal_api_billing_portal_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortalResponse'
+  /api/billing/webhook:
+    post:
+      tags:
+      - Billing
+      summary: Handle Webhook
+      description: Process Lemon Squeezy webhook with insert-first idempotency.
+      operationId: handle_webhook_api_billing_webhook_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
   /public/articles/{token}:
     get:
       tags:
@@ -4186,6 +4340,25 @@ paths:
               schema: {}
 components:
   schemas:
+    AdminActionResult:
+      properties:
+        action:
+          type: string
+          title: Action
+        status:
+          type: string
+          title: Status
+        job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Id
+      type: object
+      required:
+      - action
+      - status
+      title: AdminActionResult
+      description: Result of an admin action.
     AdminPlanResponse:
       properties:
         id:
@@ -4886,6 +5059,38 @@ components:
       - code_verifier
       - client_id
       title: Body_token_exchange_mcp_token_post
+    CaptureDiscardResponse:
+      properties:
+        capture_id:
+          type: string
+          title: Capture Id
+        status:
+          type: string
+          title: Status
+          default: discarded
+      type: object
+      required:
+      - capture_id
+      title: CaptureDiscardResponse
+      description: Response after discarding a capture.
+    CaptureIngestResponse:
+      properties:
+        capture_id:
+          type: string
+          title: Capture Id
+        source_id:
+          type: string
+          title: Source Id
+        status:
+          type: string
+          title: Status
+          default: ingested
+      type: object
+      required:
+      - capture_id
+      - source_id
+      title: CaptureIngestResponse
+      description: Response after promoting a capture to a full source.
     CaptureKind:
       type: string
       enum:
@@ -5016,6 +5221,26 @@ components:
       - discarded
       title: CaptureStatus
       description: Lifecycle status of a captured item.
+    CheckoutRequest:
+      properties:
+        plan_id:
+          type: string
+          title: Plan Id
+      type: object
+      required:
+      - plan_id
+      title: CheckoutRequest
+      description: Request body for creating a checkout session.
+    CheckoutResponse:
+      properties:
+        checkout_url:
+          type: string
+          title: Checkout Url
+      type: object
+      required:
+      - checkout_url
+      title: CheckoutResponse
+      description: Checkout URL response.
     CitationArticleRef:
       properties:
         slug:
@@ -5195,6 +5420,88 @@ components:
       - updated_at
       title: CompilationSchemaResponse
       description: API response for a compilation schema.
+    Concept:
+      properties:
+        id:
+          type: string
+          title: Id
+        user_id:
+          type: string
+          title: User Id
+        name:
+          type: string
+          title: Name
+        parent_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Parent Id
+        article_count:
+          type: integer
+          title: Article Count
+          default: 0
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        concept_kind:
+          type: string
+          title: Concept Kind
+          default: topic
+      type: object
+      required:
+      - user_id
+      - name
+      title: Concept
+      description: Auto-generated concept taxonomy node.
+    ConceptDetailResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        article_count:
+          type: integer
+          title: Article Count
+          default: 0
+        parent_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Parent Id
+        concept_kind:
+          type: string
+          title: Concept Kind
+          default: topic
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        articles:
+          items:
+            $ref: '#/components/schemas/ArticleSummaryResponse'
+          type: array
+          title: Articles
+          default: []
+      type: object
+      required:
+      - id
+      - name
+      - created_at
+      title: ConceptDetailResponse
+      description: Full concept with linked articles.
     ConfidenceLevel:
       type: string
       enum:
@@ -5845,6 +6152,28 @@ components:
       - url
       title: DoclingStatusResponse
       description: Response model for Docling sidecar health check.
+    EligibleConcept:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        article_count:
+          type: integer
+          title: Article Count
+        has_existing_page:
+          type: boolean
+          title: Has Existing Page
+          default: false
+      type: object
+      required:
+      - id
+      - name
+      - article_count
+      title: EligibleConcept
+      description: Concept eligible for concept-page generation.
     ExportFormat:
       type: string
       enum:
@@ -5924,6 +6253,37 @@ components:
       - query
       title: FacetResponse
       description: All facet groups for a search query.
+    FileBackArticleRef:
+      properties:
+        id:
+          type: string
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      title: FileBackArticleRef
+      description: Minimal article reference returned by file-back operations.
+    FileBackResult:
+      properties:
+        article:
+          $ref: '#/components/schemas/FileBackArticleRef'
+        was_update:
+          type: boolean
+          title: Was Update
+          default: false
+      type: object
+      required:
+      - article
+      title: FileBackResult
+      description: Result of filing a conversation or selection back to the wiki.
     FileBackSelectionRequest:
       properties:
         selections:
@@ -6689,6 +7049,28 @@ components:
       - step
       title: OnboardingStatusResponse
       description: Onboarding wizard progress.
+    OrphanArticle:
+      properties:
+        id:
+          type: string
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+        file_path:
+          type: string
+          title: File Path
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      - file_path
+      title: OrphanArticle
+      description: Article whose wiki file is missing from disk.
     OrphanFinding:
       properties:
         id:
@@ -6772,6 +7154,92 @@ components:
       - description
       title: PipelineStep
       description: A single step in the source processing pipeline.
+    PlanResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        display_name:
+          type: string
+          title: Display Name
+        price_cents:
+          type: integer
+          title: Price Cents
+        billing_interval:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Billing Interval
+        max_sources:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Sources
+        max_articles:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Articles
+        max_queries_per_day:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Queries Per Day
+        max_storage_bytes:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Storage Bytes
+        max_active_shares:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Active Shares
+        allowed_exports:
+          items:
+            type: string
+          type: array
+          title: Allowed Exports
+        mcp_enabled:
+          type: boolean
+          title: Mcp Enabled
+        byok_allowed:
+          type: boolean
+          title: Byok Allowed
+        sort_order:
+          type: integer
+          title: Sort Order
+      type: object
+      required:
+      - id
+      - name
+      - display_name
+      - price_cents
+      - billing_interval
+      - max_sources
+      - max_articles
+      - max_queries_per_day
+      - max_storage_bytes
+      - max_active_shares
+      - allowed_exports
+      - mcp_enabled
+      - byok_allowed
+      - sort_order
+      title: PlanResponse
+      description: Public billing plan details.
+    PortalResponse:
+      properties:
+        portal_url:
+          type: string
+          title: Portal Url
+      type: object
+      required:
+      - portal_url
+      title: PortalResponse
+      description: Customer portal URL response.
     ProviderDetail:
       properties:
         enabled:
@@ -6831,6 +7299,64 @@ components:
       - updated_at
       title: PublicArticleResponse
       description: Read-only public article content for share links.
+    Query:
+      properties:
+        id:
+          type: string
+          title: Id
+        user_id:
+          type: string
+          title: User Id
+        question:
+          type: string
+          title: Question
+        answer:
+          type: string
+          title: Answer
+        confidence:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Confidence
+        source_article_ids:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Article Ids
+        related_article_ids:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Related Article Ids
+        filed_back:
+          type: boolean
+          title: Filed Back
+          default: false
+        filed_article_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Filed Article Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        conversation_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Conversation Id
+        turn_index:
+          type: integer
+          title: Turn Index
+          default: 0
+      type: object
+      required:
+      - user_id
+      - question
+      - answer
+      title: Query
+      description: Q&A history entry.
     QueryRequest:
       properties:
         question:
@@ -7735,6 +8261,34 @@ components:
       - violation_type
       title: StructuralFinding
       description: A structural integrity violation detected by the backlink enforcer.
+    StuckSource:
+      properties:
+        id:
+          type: string
+          title: Id
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        source_type:
+          type: string
+          title: Source Type
+        ingested_at:
+          type: string
+          title: Ingested At
+        minutes_stuck:
+          type: integer
+          title: Minutes Stuck
+      type: object
+      required:
+      - id
+      - title
+      - source_type
+      - ingested_at
+      - minutes_stuck
+      title: StuckSource
+      description: Source stuck in processing for longer than the threshold.
     SyncSettingsResponse:
       properties:
         enabled:
@@ -8011,6 +8565,110 @@ components:
       - suggested_type
       title: SynthesisSuggestion
       description: A suggestion for a synthesis opportunity across related articles.
+    SystemStats:
+      properties:
+        total_users:
+          type: integer
+          title: Total Users
+          default: 0
+        total_sources:
+          type: integer
+          title: Total Sources
+          default: 0
+        total_articles:
+          type: integer
+          title: Total Articles
+          default: 0
+        total_compiled_claims:
+          type: integer
+          title: Total Compiled Claims
+          default: 0
+        article_count:
+          type: integer
+          title: Article Count
+          default: 0
+        source_count:
+          type: integer
+          title: Source Count
+          default: 0
+        concept_count:
+          type: integer
+          title: Concept Count
+          default: 0
+        backlink_count:
+          type: integer
+          title: Backlink Count
+          default: 0
+        orphan_count:
+          type: integer
+          title: Orphan Count
+          default: 0
+        conversation_count:
+          type: integer
+          title: Conversation Count
+          default: 0
+        articles_by_type:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Articles By Type
+          default: {}
+        articles_by_page_type:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Articles By Page Type
+          default: {}
+        articles_by_confidence:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Articles By Confidence
+          default: {}
+        sources_by_type:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Sources By Type
+          default: {}
+        sources_by_status:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Sources By Status
+          default: {}
+        sources_stuck_processing:
+          items:
+            $ref: '#/components/schemas/StuckSource'
+          type: array
+          title: Sources Stuck Processing
+          default: []
+        stuck_sources:
+          type: integer
+          title: Stuck Sources
+          default: 0
+        compilation_queue_depth:
+          type: integer
+          title: Compilation Queue Depth
+          default: 0
+        compilation_success_rate:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Compilation Success Rate
+        avg_compilation_time_ms:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Avg Compilation Time Ms
+        last_compilation_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Compilation At
+      type: object
+      title: SystemStats
+      description: Aggregate system-wide statistics (admin dashboard).
     TagArticleRequest:
       properties:
         tag_id:
@@ -8179,6 +8837,80 @@ components:
       type: object
       title: UpdateCompilationSchemaRequest
       description: Request to update a compilation schema.
+    UsageResponse:
+      properties:
+        plan_name:
+          type: string
+          title: Plan Name
+        plan_display_name:
+          type: string
+          title: Plan Display Name
+        sources:
+          type: integer
+          title: Sources
+        sources_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Sources Limit
+        articles:
+          type: integer
+          title: Articles
+        articles_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Articles Limit
+        storage_bytes:
+          type: integer
+          title: Storage Bytes
+        storage_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Storage Limit
+        queries_today:
+          type: integer
+          title: Queries Today
+        queries_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Queries Limit
+        active_shares:
+          type: integer
+          title: Active Shares
+        shares_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Shares Limit
+        llm_spend_cents_today:
+          type: integer
+          title: Llm Spend Cents Today
+        llm_spend_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Llm Spend Limit
+      type: object
+      required:
+      - plan_name
+      - plan_display_name
+      - sources
+      - sources_limit
+      - articles
+      - articles_limit
+      - storage_bytes
+      - storage_limit
+      - queries_today
+      - queries_limit
+      - active_shares
+      - shares_limit
+      - llm_spend_cents_today
+      - llm_spend_limit
+      title: UsageResponse
+      description: Current resource usage vs plan limits.
     UserProfileResponse:
       properties:
         id:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -144,11 +144,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Source'
-                title: Response List Sources Api Ingest Sources Get
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -200,8 +196,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteConfirmation'
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -320,14 +315,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  additionalProperties:
-                    type: string
-                title: Response List Source Images Api Ingest Sources  Source Id  Images
-                  Get
+              schema: {}
         '404':
           description: Source not found or no images available
         '422':
@@ -480,8 +468,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/CaptureIngestResponse'
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -515,8 +502,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/CaptureDiscardResponse'
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -1344,11 +1330,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Concept'
-                title: Response Get Concepts Api Wiki Concepts Get
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -1388,8 +1370,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/ConceptDetailResponse'
+              schema: {}
         '404':
           description: Concept not found
         '422':
@@ -1784,11 +1765,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Query'
-                title: Response Query History Api Query History Get
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -1902,8 +1879,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FileBackResult'
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -1929,8 +1905,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FileBackResult'
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -2572,8 +2547,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SystemStats'
+              schema: {}
   /api/admin/orphans:
     get:
       tags:
@@ -2586,11 +2560,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/OrphanArticle'
-                type: array
-                title: Response Get Orphans Api Admin Orphans Get
+              schema: {}
   /api/admin/concepts/eligible:
     get:
       tags:
@@ -2603,12 +2573,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/EligibleConcept'
-                type: array
-                title: Response Get Eligible Concepts Api Admin Concepts Eligible
-                  Get
+              schema: {}
   /api/admin/stuck-sources:
     get:
       tags:
@@ -2621,11 +2586,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/StuckSource'
-                type: array
-                title: Response Get Stuck Sources Api Admin Stuck Sources Get
+              schema: {}
   /api/admin/retry-stuck/{source_id}:
     post:
       tags:
@@ -2645,8 +2606,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/AdminActionResult'
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -2665,8 +2625,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/AdminActionResult'
+              schema: {}
   /api/admin/reindex:
     post:
       tags:
@@ -2679,8 +2638,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/AdminActionResult'
+              schema: {}
   /api/admin/docling-status:
     get:
       tags:
@@ -2789,13 +2747,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                items:
-                  additionalProperties: true
-                  type: object
-                type: array
-                title: Response Admin List Subscriptions Api Admin Billing Subscriptions
-                  Get
+              schema: {}
   /api/admin/billing/subscriptions/{user_id}:
     get:
       tags:
@@ -2815,13 +2767,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  additionalProperties: true
-                title: Response Admin Get User Subscription Api Admin Billing Subscriptions  User
-                  Id  Get
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -2853,12 +2799,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: string
-                title: Response Admin Override Plan Api Admin Billing Subscriptions  User
-                  Id  Override Post
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -2884,12 +2825,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: string
-                title: Response Admin Sync Subscription Api Admin Billing Subscriptions  User
-                  Id  Sync Post
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -2918,13 +2854,62 @@ paths:
           description: Successful Response
           content:
             application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
               schema:
-                type: array
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/admin/billing/plans:
+    get:
+      tags:
+      - Admin
+      summary: Admin List Plans
+      description: List all billing plans with their LLM model/provider (admin only).
+      operationId: admin_list_plans_api_admin_billing_plans_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
                 items:
-                  type: object
-                  additionalProperties: true
-                title: Response Admin List Webhook Events Api Admin Billing Webhook
-                  Events Get
+                  $ref: '#/components/schemas/AdminPlanResponse'
+                type: array
+                title: Response Admin List Plans Api Admin Billing Plans Get
+  /api/admin/billing/plans/{plan_id}:
+    patch:
+      tags:
+      - Admin
+      summary: Admin Update Plan Model
+      description: 'Update LLM model and/or provider on a billing plan (admin only).
+
+
+        Used when an LLM provider deprecates a model and all affected plans
+
+        need to be migrated to a replacement.'
+      operationId: admin_update_plan_model_api_admin_billing_plans__plan_id__patch
+      parameters:
+      - name: plan_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Plan Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminPlanUpdateRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPlanResponse'
         '422':
           description: Validation Error
           content:
@@ -4201,25 +4186,56 @@ paths:
               schema: {}
 components:
   schemas:
-    AdminActionResult:
+    AdminPlanResponse:
       properties:
-        action:
+        id:
           type: string
-          title: Action
-        status:
+          title: Id
+        name:
           type: string
-          title: Status
-        job_id:
+          title: Name
+        display_name:
+          type: string
+          title: Display Name
+        llm_provider:
+          type: string
+          title: Llm Provider
+        llm_model:
+          type: string
+          title: Llm Model
+        is_active:
+          type: boolean
+          title: Is Active
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - id
+      - name
+      - display_name
+      - llm_provider
+      - llm_model
+      - is_active
+      - updated_at
+      title: AdminPlanResponse
+      description: API response for a billing plan (admin view).
+    AdminPlanUpdateRequest:
+      properties:
+        llm_model:
           anyOf:
           - type: string
           - type: 'null'
-          title: Job Id
+          title: Llm Model
+        llm_provider:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Llm Provider
       type: object
-      required:
-      - action
-      - status
-      title: AdminActionResult
-      description: Result of an admin action.
+      title: AdminPlanUpdateRequest
+      description: Request to update LLM model/provider on a billing plan.
     AdminUserDetail:
       properties:
         id:
@@ -4870,38 +4886,6 @@ components:
       - code_verifier
       - client_id
       title: Body_token_exchange_mcp_token_post
-    CaptureDiscardResponse:
-      properties:
-        capture_id:
-          type: string
-          title: Capture Id
-        status:
-          type: string
-          title: Status
-          default: discarded
-      type: object
-      required:
-      - capture_id
-      title: CaptureDiscardResponse
-      description: Response after discarding a capture.
-    CaptureIngestResponse:
-      properties:
-        capture_id:
-          type: string
-          title: Capture Id
-        source_id:
-          type: string
-          title: Source Id
-        status:
-          type: string
-          title: Status
-          default: ingested
-      type: object
-      required:
-      - capture_id
-      - source_id
-      title: CaptureIngestResponse
-      description: Response after promoting a capture to a full source.
     CaptureKind:
       type: string
       enum:
@@ -5211,88 +5195,6 @@ components:
       - updated_at
       title: CompilationSchemaResponse
       description: API response for a compilation schema.
-    Concept:
-      properties:
-        id:
-          type: string
-          title: Id
-        user_id:
-          type: string
-          title: User Id
-        name:
-          type: string
-          title: Name
-        parent_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Parent Id
-        article_count:
-          type: integer
-          title: Article Count
-          default: 0
-        description:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Description
-        created_at:
-          type: string
-          format: date-time
-          title: Created At
-        concept_kind:
-          type: string
-          title: Concept Kind
-          default: topic
-      type: object
-      required:
-      - user_id
-      - name
-      title: Concept
-      description: Auto-generated concept taxonomy node.
-    ConceptDetailResponse:
-      properties:
-        id:
-          type: string
-          title: Id
-        name:
-          type: string
-          title: Name
-        description:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Description
-        article_count:
-          type: integer
-          title: Article Count
-          default: 0
-        parent_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Parent Id
-        concept_kind:
-          type: string
-          title: Concept Kind
-          default: topic
-        created_at:
-          type: string
-          format: date-time
-          title: Created At
-        articles:
-          items:
-            $ref: '#/components/schemas/ArticleSummaryResponse'
-          type: array
-          title: Articles
-          default: []
-      type: object
-      required:
-      - id
-      - name
-      - created_at
-      title: ConceptDetailResponse
-      description: Full concept with linked articles.
     ConfidenceLevel:
       type: string
       enum:
@@ -5943,28 +5845,6 @@ components:
       - url
       title: DoclingStatusResponse
       description: Response model for Docling sidecar health check.
-    EligibleConcept:
-      properties:
-        id:
-          type: string
-          title: Id
-        name:
-          type: string
-          title: Name
-        article_count:
-          type: integer
-          title: Article Count
-        has_existing_page:
-          type: boolean
-          title: Has Existing Page
-          default: false
-      type: object
-      required:
-      - id
-      - name
-      - article_count
-      title: EligibleConcept
-      description: Concept eligible for concept-page generation.
     ExportFormat:
       type: string
       enum:
@@ -6044,37 +5924,6 @@ components:
       - query
       title: FacetResponse
       description: All facet groups for a search query.
-    FileBackArticleRef:
-      properties:
-        id:
-          type: string
-          title: Id
-        slug:
-          type: string
-          title: Slug
-        title:
-          type: string
-          title: Title
-      type: object
-      required:
-      - id
-      - slug
-      - title
-      title: FileBackArticleRef
-      description: Minimal article reference returned by file-back operations.
-    FileBackResult:
-      properties:
-        article:
-          $ref: '#/components/schemas/FileBackArticleRef'
-        was_update:
-          type: boolean
-          title: Was Update
-          default: false
-      type: object
-      required:
-      - article
-      title: FileBackResult
-      description: Result of filing a conversation or selection back to the wiki.
     FileBackSelectionRequest:
       properties:
         selections:
@@ -6840,28 +6689,6 @@ components:
       - step
       title: OnboardingStatusResponse
       description: Onboarding wizard progress.
-    OrphanArticle:
-      properties:
-        id:
-          type: string
-          title: Id
-        slug:
-          type: string
-          title: Slug
-        title:
-          type: string
-          title: Title
-        file_path:
-          type: string
-          title: File Path
-      type: object
-      required:
-      - id
-      - slug
-      - title
-      - file_path
-      title: OrphanArticle
-      description: Article whose wiki file is missing from disk.
     OrphanFinding:
       properties:
         id:
@@ -7004,64 +6831,6 @@ components:
       - updated_at
       title: PublicArticleResponse
       description: Read-only public article content for share links.
-    Query:
-      properties:
-        id:
-          type: string
-          title: Id
-        user_id:
-          type: string
-          title: User Id
-        question:
-          type: string
-          title: Question
-        answer:
-          type: string
-          title: Answer
-        confidence:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Confidence
-        source_article_ids:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Source Article Ids
-        related_article_ids:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Related Article Ids
-        filed_back:
-          type: boolean
-          title: Filed Back
-          default: false
-        filed_article_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Filed Article Id
-        created_at:
-          type: string
-          format: date-time
-          title: Created At
-        conversation_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Conversation Id
-        turn_index:
-          type: integer
-          title: Turn Index
-          default: 0
-      type: object
-      required:
-      - user_id
-      - question
-      - answer
-      title: Query
-      description: Q&A history entry.
     QueryRequest:
       properties:
         question:
@@ -7966,34 +7735,6 @@ components:
       - violation_type
       title: StructuralFinding
       description: A structural integrity violation detected by the backlink enforcer.
-    StuckSource:
-      properties:
-        id:
-          type: string
-          title: Id
-        title:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Title
-        source_type:
-          type: string
-          title: Source Type
-        ingested_at:
-          type: string
-          title: Ingested At
-        minutes_stuck:
-          type: integer
-          title: Minutes Stuck
-      type: object
-      required:
-      - id
-      - title
-      - source_type
-      - ingested_at
-      - minutes_stuck
-      title: StuckSource
-      description: Source stuck in processing for longer than the threshold.
     SyncSettingsResponse:
       properties:
         enabled:
@@ -8270,110 +8011,6 @@ components:
       - suggested_type
       title: SynthesisSuggestion
       description: A suggestion for a synthesis opportunity across related articles.
-    SystemStats:
-      properties:
-        total_users:
-          type: integer
-          title: Total Users
-          default: 0
-        total_sources:
-          type: integer
-          title: Total Sources
-          default: 0
-        total_articles:
-          type: integer
-          title: Total Articles
-          default: 0
-        total_compiled_claims:
-          type: integer
-          title: Total Compiled Claims
-          default: 0
-        article_count:
-          type: integer
-          title: Article Count
-          default: 0
-        source_count:
-          type: integer
-          title: Source Count
-          default: 0
-        concept_count:
-          type: integer
-          title: Concept Count
-          default: 0
-        backlink_count:
-          type: integer
-          title: Backlink Count
-          default: 0
-        orphan_count:
-          type: integer
-          title: Orphan Count
-          default: 0
-        conversation_count:
-          type: integer
-          title: Conversation Count
-          default: 0
-        articles_by_type:
-          additionalProperties:
-            type: integer
-          type: object
-          title: Articles By Type
-          default: {}
-        articles_by_page_type:
-          additionalProperties:
-            type: integer
-          type: object
-          title: Articles By Page Type
-          default: {}
-        articles_by_confidence:
-          additionalProperties:
-            type: integer
-          type: object
-          title: Articles By Confidence
-          default: {}
-        sources_by_type:
-          additionalProperties:
-            type: integer
-          type: object
-          title: Sources By Type
-          default: {}
-        sources_by_status:
-          additionalProperties:
-            type: integer
-          type: object
-          title: Sources By Status
-          default: {}
-        sources_stuck_processing:
-          items:
-            $ref: '#/components/schemas/StuckSource'
-          type: array
-          title: Sources Stuck Processing
-          default: []
-        stuck_sources:
-          type: integer
-          title: Stuck Sources
-          default: 0
-        compilation_queue_depth:
-          type: integer
-          title: Compilation Queue Depth
-          default: 0
-        compilation_success_rate:
-          anyOf:
-          - type: number
-          - type: 'null'
-          title: Compilation Success Rate
-        avg_compilation_time_ms:
-          anyOf:
-          - type: number
-          - type: 'null'
-          title: Avg Compilation Time Ms
-        last_compilation_at:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Last Compilation At
-      type: object
-      title: SystemStats
-      description: Aggregate system-wide statistics (admin dashboard).
     TagArticleRequest:
       properties:
         tag_id:

--- a/src/wikimind/api/routes/admin.py
+++ b/src/wikimind/api/routes/admin.py
@@ -35,6 +35,7 @@ from wikimind.models import (
     User,
     WebhookEvent,
 )
+from wikimind.models.enums import Provider
 from wikimind.services.admin import AdminService  # noqa: TC001 — needed at runtime for Depends()
 from wikimind.services.billing import LemonSqueezyClient, apply_entitlement
 from wikimind.services.factories import get_admin_service
@@ -399,6 +400,20 @@ async def admin_update_plan_model(
         raise HTTPException(
             status_code=400,
             detail="At least one of llm_model or llm_provider must be provided",
+        )
+
+    if body.llm_provider is not None:
+        valid_providers = [p.value for p in Provider]
+        if body.llm_provider not in valid_providers:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid llm_provider '{body.llm_provider}'. Must be one of: {', '.join(valid_providers)}",
+            )
+
+    if body.llm_model is not None and not body.llm_model.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="llm_model must be a non-empty string",
         )
 
     old_model = plan.llm_model

--- a/src/wikimind/api/routes/admin.py
+++ b/src/wikimind/api/routes/admin.py
@@ -13,11 +13,14 @@ from pydantic import BaseModel
 from sqlalchemy import func
 from sqlmodel import select
 
+from wikimind._datetime import utcnow_naive
 from wikimind.api.deps import require_admin
 from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.models import (
     AdminActionResult,
+    AdminPlanResponse,
+    AdminPlanUpdateRequest,
     AdminUserDetail,
     AdminUserSummary,
     EligibleConcept,
@@ -349,3 +352,85 @@ async def admin_list_webhook_events(
         }
         for evt in events
     ]
+
+
+@router.get("/billing/plans", response_model=list[AdminPlanResponse])
+async def admin_list_plans(
+    session: AsyncSession = Depends(get_session),
+    _admin: str = Depends(require_admin),
+):
+    """List all billing plans with their LLM model/provider (admin only)."""
+    result = await session.exec(
+        select(Plan).order_by(Plan.sort_order)  # type: ignore[arg-type]
+    )
+    plans = result.all()
+    return [
+        AdminPlanResponse(
+            id=p.id,
+            name=p.name,
+            display_name=p.display_name,
+            llm_provider=p.llm_provider,
+            llm_model=p.llm_model,
+            is_active=p.is_active,
+            updated_at=p.updated_at,
+        )
+        for p in plans
+    ]
+
+
+@router.patch("/billing/plans/{plan_id}", response_model=AdminPlanResponse)
+async def admin_update_plan_model(
+    plan_id: str,
+    body: AdminPlanUpdateRequest,
+    session: AsyncSession = Depends(get_session),
+    admin_user_id: str = Depends(require_admin),
+):
+    """Update LLM model and/or provider on a billing plan (admin only).
+
+    Used when an LLM provider deprecates a model and all affected plans
+    need to be migrated to a replacement.
+    """
+    result = await session.exec(select(Plan).where(Plan.id == plan_id))
+    plan = result.one_or_none()
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    if body.llm_model is None and body.llm_provider is None:
+        raise HTTPException(
+            status_code=400,
+            detail="At least one of llm_model or llm_provider must be provided",
+        )
+
+    old_model = plan.llm_model
+    old_provider = plan.llm_provider
+
+    if body.llm_model is not None:
+        plan.llm_model = body.llm_model
+    if body.llm_provider is not None:
+        plan.llm_provider = body.llm_provider
+    plan.updated_at = utcnow_naive()
+
+    session.add(plan)
+    await session.commit()
+    await session.refresh(plan)
+
+    log.info(
+        "admin.plan_model_updated",
+        plan_id=plan.id,
+        plan_name=plan.name,
+        old_model=old_model,
+        new_model=plan.llm_model,
+        old_provider=old_provider,
+        new_provider=plan.llm_provider,
+        admin_user_id=admin_user_id,
+    )
+
+    return AdminPlanResponse(
+        id=plan.id,
+        name=plan.name,
+        display_name=plan.display_name,
+        llm_provider=plan.llm_provider,
+        llm_model=plan.llm_model,
+        is_active=plan.is_active,
+        updated_at=plan.updated_at,
+    )

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel
 # Re-export DTO request/response schemas (replaces pipeline.py + schemas.py)
 from wikimind.models.dto.admin import (
     AdminActionResult,
+    AdminPlanResponse,
+    AdminPlanUpdateRequest,
     AdminUserDetail,
     AdminUserSummary,
     EligibleConcept,
@@ -322,6 +324,8 @@ SavedSearchExecuteResponse.model_rebuild()
 __all__ = [
     # API schemas
     "AdminActionResult",
+    "AdminPlanResponse",
+    "AdminPlanUpdateRequest",
     "AdminUserDetail",
     "AdminUserSummary",
     # Pipeline models

--- a/src/wikimind/models/dto/admin.py
+++ b/src/wikimind/models/dto/admin.py
@@ -151,6 +151,30 @@ class AdminUserDetail(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Admin plan update request/response models (issue #774)
+# ---------------------------------------------------------------------------
+
+
+class AdminPlanUpdateRequest(BaseModel):
+    """Request to update LLM model/provider on a billing plan."""
+
+    llm_model: str | None = None
+    llm_provider: str | None = None
+
+
+class AdminPlanResponse(BaseModel):
+    """API response for a billing plan (admin view)."""
+
+    id: str
+    name: str
+    display_name: str
+    llm_provider: str
+    llm_model: str
+    is_active: bool
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
 # Wiki health reports
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_admin_billing.py
+++ b/tests/unit/test_admin_billing.py
@@ -1,5 +1,10 @@
 """Tests for admin billing endpoints."""
 
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.models import AdminPlanResponse, AdminPlanUpdateRequest, Plan
+
 
 class TestAdminBillingEndpoints:
     def test_admin_billing_imports(self):
@@ -15,3 +20,170 @@ class TestAdminBillingEndpoints:
         from wikimind.services.billing import apply_entitlement
 
         assert callable(apply_entitlement)
+
+
+class TestAdminPlanUpdateModels:
+    """Unit tests for plan update request/response Pydantic models."""
+
+    def test_update_request_both_fields(self):
+        req = AdminPlanUpdateRequest(llm_model="gpt-4o", llm_provider="openai")
+        assert req.llm_model == "gpt-4o"
+        assert req.llm_provider == "openai"
+
+    def test_update_request_model_only(self):
+        req = AdminPlanUpdateRequest(llm_model="gpt-4o")
+        assert req.llm_model == "gpt-4o"
+        assert req.llm_provider is None
+
+    def test_update_request_provider_only(self):
+        req = AdminPlanUpdateRequest(llm_provider="anthropic")
+        assert req.llm_model is None
+        assert req.llm_provider == "anthropic"
+
+    def test_update_request_empty_is_valid(self):
+        """Both fields None is valid at model level; the endpoint rejects it."""
+        req = AdminPlanUpdateRequest()
+        assert req.llm_model is None
+        assert req.llm_provider is None
+
+    def test_plan_response_shape(self):
+        from datetime import datetime
+
+        resp = AdminPlanResponse(
+            id="plan-1",
+            name="free",
+            display_name="Free",
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            is_active=True,
+            updated_at=datetime(2026, 1, 1),
+        )
+        assert resp.name == "free"
+        assert resp.llm_model == "gpt-4o-mini"
+
+
+class TestAdminPlanUpdateEndpoint:
+    """Integration tests for PATCH /api/admin/billing/plans/{plan_id}."""
+
+    @pytest.mark.asyncio
+    async def test_patch_plan_model(self, client, db_session: AsyncSession):
+        """Updating llm_model on a plan returns the updated value."""
+        plan = Plan(
+            name="test-plan",
+            display_name="Test Plan",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+        await db_session.refresh(plan)
+
+        resp = await client.patch(
+            f"/api/admin/billing/plans/{plan.id}",
+            json={"llm_model": "gpt-4o"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["llm_model"] == "gpt-4o"
+        assert data["llm_provider"] == "openai_compatible"
+
+    @pytest.mark.asyncio
+    async def test_patch_plan_provider(self, client, db_session: AsyncSession):
+        """Updating llm_provider on a plan returns the updated value."""
+        plan = Plan(
+            name="test-plan-prov",
+            display_name="Test Plan Provider",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+        await db_session.refresh(plan)
+
+        resp = await client.patch(
+            f"/api/admin/billing/plans/{plan.id}",
+            json={"llm_provider": "anthropic"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["llm_provider"] == "anthropic"
+        assert data["llm_model"] == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_patch_plan_both_fields(self, client, db_session: AsyncSession):
+        """Updating both fields at once."""
+        plan = Plan(
+            name="test-plan-both",
+            display_name="Test Both",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+        await db_session.refresh(plan)
+
+        resp = await client.patch(
+            f"/api/admin/billing/plans/{plan.id}",
+            json={"llm_model": "claude-sonnet-4-20250514", "llm_provider": "anthropic"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["llm_model"] == "claude-sonnet-4-20250514"
+        assert data["llm_provider"] == "anthropic"
+
+    @pytest.mark.asyncio
+    async def test_patch_plan_not_found(self, client):
+        """Returns 404 for a nonexistent plan."""
+        resp = await client.patch(
+            "/api/admin/billing/plans/nonexistent-id",
+            json={"llm_model": "gpt-4o"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_patch_plan_no_fields(self, client, db_session: AsyncSession):
+        """Returns 400 when neither field is provided."""
+        plan = Plan(
+            name="test-plan-empty",
+            display_name="Test Empty",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+        await db_session.refresh(plan)
+
+        resp = await client.patch(
+            f"/api/admin/billing/plans/{plan.id}",
+            json={},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_list_plans(self, client, db_session: AsyncSession):
+        """GET /api/admin/billing/plans returns all plans."""
+        plan = Plan(
+            name="test-list-plan",
+            display_name="Test List",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+
+        resp = await client.get("/api/admin/billing/plans")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        names = [p["name"] for p in data]
+        assert "test-list-plan" in names

--- a/tests/unit/test_admin_billing.py
+++ b/tests/unit/test_admin_billing.py
@@ -168,6 +168,50 @@ class TestAdminPlanUpdateEndpoint:
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_patch_plan_invalid_provider(self, client, db_session: AsyncSession):
+        """Returns 400 when llm_provider is not a valid Provider enum value."""
+        plan = Plan(
+            name="test-plan-bad-prov",
+            display_name="Test Bad Provider",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+        await db_session.refresh(plan)
+
+        resp = await client.patch(
+            f"/api/admin/billing/plans/{plan.id}",
+            json={"llm_provider": "not_a_real_provider"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid llm_provider" in resp.json()["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_patch_plan_empty_model(self, client, db_session: AsyncSession):
+        """Returns 400 when llm_model is an empty or whitespace-only string."""
+        plan = Plan(
+            name="test-plan-empty-model",
+            display_name="Test Empty Model",
+            price_cents=0,
+            llm_provider="openai_compatible",
+            llm_model="gpt-4o-mini",
+            allowed_exports=["markdown"],
+        )
+        db_session.add(plan)
+        await db_session.commit()
+        await db_session.refresh(plan)
+
+        resp = await client.patch(
+            f"/api/admin/billing/plans/{plan.id}",
+            json={"llm_model": "   "},
+        )
+        assert resp.status_code == 400
+        assert "non-empty" in resp.json()["error"]["message"]
+
+    @pytest.mark.asyncio
     async def test_list_plans(self, client, db_session: AsyncSession):
         """GET /api/admin/billing/plans returns all plans."""
         plan = Plan(


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/admin/billing/plans/{plan_id}` endpoint for admins to update `llm_model` and/or `llm_provider` on billing plans without manual SQL
- Adds `GET /api/admin/billing/plans` to list all plans with their LLM configuration
- Adds "Plans" section to the admin dashboard UI with inline editable model/provider fields
- Logs all plan model changes via structured logging (`admin.plan_model_updated`) for audit trail

## Test plan
- [x] `AdminPlanUpdateRequest` / `AdminPlanResponse` Pydantic model unit tests
- [x] PATCH endpoint: updates model only, provider only, both fields
- [x] PATCH endpoint: 404 for nonexistent plan, 400 when neither field provided
- [x] GET endpoint: lists all plans
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (all unit tests green; 5 pre-existing smoke test failures in Docker-only tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)