### PR TITLE
refactor(frontend): decompose AskView and ArticleReader monolith components (#710)

### DIFF
--- a/apps/web/src/components/ask/AskView.tsx
+++ b/apps/web/src/components/ask/AskView.tsx
@@ -1,24 +1,16 @@
-import { useParams, useNavigate } from "react-router-dom";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState, useRef } from "react";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import {
-  askQuestion,
-  askQuestionStream,
   getConversation,
   listConversations,
-  fileBackConversation,
-  fileBackSelection,
-  exportConversation,
-  forkConversation,
-  type AskRequest,
-  type ConversationDetail,
-  type TurnSelection,
 } from "../../api/query";
-import { useWebSocketStore } from "../../store/websocket";
-import { SelectionProvider, useSelection } from "../../store/selection";
+import { SelectionProvider } from "../../store/selection";
 import { ConversationHistory } from "./ConversationHistory";
 import { ConversationThread } from "./ConversationThread";
 import { QueryInput } from "./QueryInput";
+import { useAskStream } from "./useAskStream";
+import { useFileBack } from "./useFileBack";
+import { useExportConversation } from "./useExportConversation";
 
 export function AskView() {
   return (
@@ -30,15 +22,6 @@ export function AskView() {
 
 function AskViewInner() {
   const { conversationId } = useParams<{ conversationId?: string }>();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const pushToast = useWebSocketStore((s) => s.pushToast);
-  const [pendingError, setPendingError] = useState<string | null>(null);
-
-  // Streaming state
-  const [pendingQuestion, setPendingQuestion] = useState<string | null>(null);
-  const [isStreaming, setIsStreaming] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
 
   // Load the current conversation's full thread (only if we have an id)
   const conversationDetail = useQuery({
@@ -53,224 +36,22 @@ function AskViewInner() {
     queryFn: () => listConversations(50),
   });
 
-  // Non-streaming fallback mutation (used when streaming fails to connect)
-  const askFallback = useMutation({
-    mutationFn: (req: AskRequest) => askQuestion(req),
-    onSuccess: (response) => {
-      setPendingError(null);
-      setPendingQuestion(null);
-      const newId = response.conversation.id;
-      if (!conversationId) {
-        navigate(`/ask/${newId}`, { replace: true });
-      }
-      queryClient.setQueryData<ConversationDetail>(
-        ["conversation", newId],
-        (old) => ({
-          conversation: response.conversation,
-          queries: [...(old?.queries ?? []), response.query],
-        }),
-      );
-      queryClient.invalidateQueries({ queryKey: ["conversations"] });
-    },
-    onError: (err: Error) => {
-      setPendingQuestion(null);
-      setPendingError(err.message || "Failed to ask question");
-    },
+  const {
+    pendingQuestion,
+    pendingError,
+    isStreaming,
+    isBusy,
+    handleSubmit,
+    handleFork,
+  } = useAskStream({ conversationId });
+
+  const { handleSave, isSaving, handleSaveSelection, isSavingSelection } =
+    useFileBack({ conversationId });
+
+  const { handleExport, isExporting } = useExportConversation({
+    conversationId,
+    conversationTitle: conversationDetail.data?.conversation.title,
   });
-
-  // Fork mutation
-  const fork = useMutation({
-    mutationFn: ({ id, turnIndex, newQuestion }: { id: string; turnIndex: number; newQuestion: string }) =>
-      forkConversation(id, { turn_index: turnIndex, new_question: newQuestion }),
-    onSuccess: (response) => {
-      setPendingQuestion(null);
-      setPendingError(null);
-      const newId = response.conversation.id;
-      navigate(`/ask/${newId}`, { replace: true });
-      queryClient.setQueryData<ConversationDetail>(
-        ["conversation", newId],
-        {
-          conversation: response.conversation,
-          queries: [response.query],
-        },
-      );
-      queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      // Invalidate parent to update fork_count
-      if (conversationId) {
-        queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] });
-      }
-      pushToast({
-        kind: "success",
-        title: "Created branch",
-        detail: `Forked at turn ${response.query.turn_index + 1}`,
-      });
-    },
-    onError: (err: Error) => {
-      setPendingQuestion(null);
-      setPendingError(err.message || "Failed to create branch");
-    },
-  });
-
-  const handleFork = useCallback(
-    (turnIndex: number, newQuestion: string) => {
-      if (!conversationId) return;
-      setPendingQuestion(newQuestion);
-      fork.mutate({ id: conversationId, turnIndex, newQuestion });
-    },
-    [conversationId, fork],
-  );
-
-  const selection = useSelection();
-
-  // File-back mutation (whole conversation)
-  const fileBack = useMutation({
-    mutationFn: (id: string) => fileBackConversation(id),
-    onSuccess: (response) => {
-      queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] });
-      queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      pushToast({
-        kind: "success",
-        title: response.was_update ? "Updated wiki article" : "Saved thread to wiki",
-        detail: response.article.title,
-      });
-    },
-    onError: (err: Error) => {
-      pushToast({
-        kind: "error",
-        title: "Failed to save thread",
-        detail: err.message,
-      });
-    },
-  });
-
-  // File-back selection mutation (partial / multi-thread)
-  const fileBackSel = useMutation({
-    mutationFn: (selections: TurnSelection[]) =>
-      fileBackSelection({ selections }),
-    onSuccess: (response) => {
-      selection.clear();
-      queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] });
-      queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      pushToast({
-        kind: "success",
-        title: "Saved selected turns to wiki",
-        detail: response.article.title,
-      });
-    },
-    onError: (err: Error) => {
-      pushToast({
-        kind: "error",
-        title: "Failed to save selection",
-        detail: err.message,
-      });
-    },
-  });
-
-  const handleSubmit = useCallback(async (question: string) => {
-    const req: AskRequest = { question, conversation_id: conversationId };
-
-    setPendingError(null);
-    setPendingQuestion(question);
-    setIsStreaming(true);
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    try {
-      for await (const event of askQuestionStream(req, controller.signal)) {
-        switch (event.type) {
-          case "chunk":
-            break;
-          case "done": {
-            const response = event.response;
-            const newId = response.conversation.id;
-            if (!conversationId) {
-              navigate(`/ask/${newId}`, { replace: true });
-            }
-            queryClient.setQueryData<ConversationDetail>(
-              ["conversation", newId],
-              (old) => ({
-                conversation: response.conversation,
-                queries: [...(old?.queries ?? []), response.query],
-              }),
-            );
-            queryClient.invalidateQueries({ queryKey: ["conversations"] });
-            queryClient.invalidateQueries({ queryKey: ["conversation", newId] });
-            setPendingQuestion(null);
-            break;
-          }
-          case "error":
-            setPendingError(event.message);
-            setPendingQuestion(null);
-            break;
-        }
-      }
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      setPendingError(null);
-      askFallback.mutate(req);
-    } finally {
-      setIsStreaming(false);
-      abortRef.current = null;
-    }
-  }, [conversationId, navigate, queryClient, askFallback]);
-
-  const handleSave = () => {
-    if (conversationId) fileBack.mutate(conversationId);
-  };
-
-  const handleSaveSelection = () => {
-    if (selection.count === 0) return;
-    // Group selections by conversation_id
-    const byConv = new Map<string, number[]>();
-    for (const item of selection.items) {
-      const indices = byConv.get(item.conversationId) ?? [];
-      indices.push(item.turnIndex);
-      byConv.set(item.conversationId, indices);
-    }
-    const selections: TurnSelection[] = Array.from(byConv.entries()).map(
-      ([conversation_id, turn_indices]) => ({
-        conversation_id,
-        turn_indices: turn_indices.sort((a, b) => a - b),
-      }),
-    );
-    fileBackSel.mutate(selections);
-  };
-
-  const [isExporting, setIsExporting] = useState(false);
-  const handleExport = async () => {
-    if (!conversationId) return;
-    setIsExporting(true);
-    try {
-      const markdown = await exportConversation(conversationId);
-      const blob = new Blob([markdown], { type: "text/markdown" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      const rawTitle =
-        conversationDetail.data?.conversation.title ?? "conversation";
-      const safeName = rawTitle
-        .replace(/[^a-zA-Z0-9_ -]/g, "")
-        .replace(/ +/g, " ")
-        .trim()
-        || "conversation";
-      a.download = safeName + ".md";
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    } catch {
-      pushToast({
-        kind: "error",
-        title: "Failed to export conversation",
-        detail: "Could not download the markdown file.",
-      });
-    } finally {
-      setIsExporting(false);
-    }
-  };
-
-  const isBusy = isStreaming || askFallback.isPending || fork.isPending;
 
   return (
     <div className="flex h-full">
@@ -288,12 +69,12 @@ function AskViewInner() {
             pendingQuestion={pendingQuestion}
             isStreaming={isStreaming}
             onSave={handleSave}
-            isSaving={fileBack.isPending}
+            isSaving={isSaving}
             onExport={handleExport}
             isExporting={isExporting}
             onFork={handleFork}
             onSaveSelection={handleSaveSelection}
-            isSavingSelection={fileBackSel.isPending}
+            isSavingSelection={isSavingSelection}
           />
           {pendingError && (
             <div className="mt-4 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">

--- a/apps/web/src/components/ask/useAskStream.ts
+++ b/apps/web/src/components/ask/useAskStream.ts
@@ -1,0 +1,164 @@
+import { useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  askQuestion,
+  askQuestionStream,
+  forkConversation,
+  type AskRequest,
+  type ConversationDetail,
+} from "../../api/query";
+import { useWebSocketStore } from "../../store/websocket";
+
+interface UseAskStreamOptions {
+  conversationId: string | undefined;
+}
+
+export function useAskStream({ conversationId }: UseAskStreamOptions) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const pushToast = useWebSocketStore((s) => s.pushToast);
+
+  const [pendingQuestion, setPendingQuestion] = useState<string | null>(null);
+  const [pendingError, setPendingError] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Non-streaming fallback mutation (used when streaming fails to connect)
+  const askFallback = useMutation({
+    mutationFn: (req: AskRequest) => askQuestion(req),
+    onSuccess: (response) => {
+      setPendingError(null);
+      setPendingQuestion(null);
+      const newId = response.conversation.id;
+      if (!conversationId) {
+        navigate(`/ask/${newId}`, { replace: true });
+      }
+      queryClient.setQueryData<ConversationDetail>(
+        ["conversation", newId],
+        (old) => ({
+          conversation: response.conversation,
+          queries: [...(old?.queries ?? []), response.query],
+        }),
+      );
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+    onError: (err: Error) => {
+      setPendingQuestion(null);
+      setPendingError(err.message || "Failed to ask question");
+    },
+  });
+
+  // Fork mutation
+  const fork = useMutation({
+    mutationFn: ({
+      id,
+      turnIndex,
+      newQuestion,
+    }: {
+      id: string;
+      turnIndex: number;
+      newQuestion: string;
+    }) => forkConversation(id, { turn_index: turnIndex, new_question: newQuestion }),
+    onSuccess: (response) => {
+      setPendingQuestion(null);
+      setPendingError(null);
+      const newId = response.conversation.id;
+      navigate(`/ask/${newId}`, { replace: true });
+      queryClient.setQueryData<ConversationDetail>(["conversation", newId], {
+        conversation: response.conversation,
+        queries: [response.query],
+      });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      // Invalidate parent to update fork_count
+      if (conversationId) {
+        queryClient.invalidateQueries({
+          queryKey: ["conversation", conversationId],
+        });
+      }
+      pushToast({
+        kind: "success",
+        title: "Created branch",
+        detail: `Forked at turn ${response.query.turn_index + 1}`,
+      });
+    },
+    onError: (err: Error) => {
+      setPendingQuestion(null);
+      setPendingError(err.message || "Failed to create branch");
+    },
+  });
+
+  const handleSubmit = useCallback(
+    async (question: string) => {
+      const req: AskRequest = { question, conversation_id: conversationId };
+
+      setPendingError(null);
+      setPendingQuestion(question);
+      setIsStreaming(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        for await (const event of askQuestionStream(req, controller.signal)) {
+          switch (event.type) {
+            case "chunk":
+              break;
+            case "done": {
+              const response = event.response;
+              const newId = response.conversation.id;
+              if (!conversationId) {
+                navigate(`/ask/${newId}`, { replace: true });
+              }
+              queryClient.setQueryData<ConversationDetail>(
+                ["conversation", newId],
+                (old) => ({
+                  conversation: response.conversation,
+                  queries: [...(old?.queries ?? []), response.query],
+                }),
+              );
+              queryClient.invalidateQueries({ queryKey: ["conversations"] });
+              queryClient.invalidateQueries({
+                queryKey: ["conversation", newId],
+              });
+              setPendingQuestion(null);
+              break;
+            }
+            case "error":
+              setPendingError(event.message);
+              setPendingQuestion(null);
+              break;
+          }
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setPendingError(null);
+        askFallback.mutate(req);
+      } finally {
+        setIsStreaming(false);
+        abortRef.current = null;
+      }
+    },
+    [conversationId, navigate, queryClient, askFallback],
+  );
+
+  const handleFork = useCallback(
+    (turnIndex: number, newQuestion: string) => {
+      if (!conversationId) return;
+      setPendingQuestion(newQuestion);
+      fork.mutate({ id: conversationId, turnIndex, newQuestion });
+    },
+    [conversationId, fork],
+  );
+
+  const isBusy = isStreaming || askFallback.isPending || fork.isPending;
+
+  return {
+    pendingQuestion,
+    pendingError,
+    isStreaming,
+    isBusy,
+    handleSubmit,
+    handleFork,
+  };
+}

--- a/apps/web/src/components/ask/useExportConversation.ts
+++ b/apps/web/src/components/ask/useExportConversation.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from "react";
+import { exportConversation } from "../../api/query";
+import { useWebSocketStore } from "../../store/websocket";
+
+interface UseExportConversationOptions {
+  conversationId: string | undefined;
+  conversationTitle: string | undefined;
+}
+
+export function useExportConversation({
+  conversationId,
+  conversationTitle,
+}: UseExportConversationOptions) {
+  const pushToast = useWebSocketStore((s) => s.pushToast);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    if (!conversationId) return;
+    setIsExporting(true);
+    try {
+      const markdown = await exportConversation(conversationId);
+      const blob = new Blob([markdown], { type: "text/markdown" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      const rawTitle = conversationTitle ?? "conversation";
+      const safeName =
+        rawTitle
+          .replace(/[^a-zA-Z0-9_ -]/g, "")
+          .replace(/ +/g, " ")
+          .trim() || "conversation";
+      a.download = safeName + ".md";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      pushToast({
+        kind: "error",
+        title: "Failed to export conversation",
+        detail: "Could not download the markdown file.",
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  }, [conversationId, conversationTitle, pushToast]);
+
+  return { handleExport, isExporting };
+}

--- a/apps/web/src/components/ask/useFileBack.ts
+++ b/apps/web/src/components/ask/useFileBack.ts
@@ -1,0 +1,95 @@
+import { useCallback } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  fileBackConversation,
+  fileBackSelection,
+  type TurnSelection,
+} from "../../api/query";
+import { useWebSocketStore } from "../../store/websocket";
+import { useSelection } from "../../store/selection";
+
+interface UseFileBackOptions {
+  conversationId: string | undefined;
+}
+
+export function useFileBack({ conversationId }: UseFileBackOptions) {
+  const queryClient = useQueryClient();
+  const pushToast = useWebSocketStore((s) => s.pushToast);
+  const selection = useSelection();
+
+  // File-back mutation (whole conversation)
+  const fileBack = useMutation({
+    mutationFn: (id: string) => fileBackConversation(id),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({
+        queryKey: ["conversation", conversationId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      pushToast({
+        kind: "success",
+        title: response.was_update ? "Updated wiki article" : "Saved thread to wiki",
+        detail: response.article.title,
+      });
+    },
+    onError: (err: Error) => {
+      pushToast({
+        kind: "error",
+        title: "Failed to save thread",
+        detail: err.message,
+      });
+    },
+  });
+
+  // File-back selection mutation (partial / multi-thread)
+  const fileBackSel = useMutation({
+    mutationFn: (selections: TurnSelection[]) => fileBackSelection({ selections }),
+    onSuccess: (response) => {
+      selection.clear();
+      queryClient.invalidateQueries({
+        queryKey: ["conversation", conversationId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      pushToast({
+        kind: "success",
+        title: "Saved selected turns to wiki",
+        detail: response.article.title,
+      });
+    },
+    onError: (err: Error) => {
+      pushToast({
+        kind: "error",
+        title: "Failed to save selection",
+        detail: err.message,
+      });
+    },
+  });
+
+  const handleSave = useCallback(() => {
+    if (conversationId) fileBack.mutate(conversationId);
+  }, [conversationId, fileBack]);
+
+  const handleSaveSelection = useCallback(() => {
+    if (selection.count === 0) return;
+    // Group selections by conversation_id
+    const byConv = new Map<string, number[]>();
+    for (const item of selection.items) {
+      const indices = byConv.get(item.conversationId) ?? [];
+      indices.push(item.turnIndex);
+      byConv.set(item.conversationId, indices);
+    }
+    const selections: TurnSelection[] = Array.from(byConv.entries()).map(
+      ([conversation_id, turn_indices]) => ({
+        conversation_id,
+        turn_indices: turn_indices.sort((a, b) => a - b),
+      }),
+    );
+    fileBackSel.mutate(selections);
+  }, [selection, fileBackSel]);
+
+  return {
+    handleSave,
+    isSaving: fileBack.isPending,
+    handleSaveSelection,
+    isSavingSelection: fileBackSel.isPending,
+  };
+}

--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -9,87 +9,33 @@ import rehypeHighlight from "rehype-highlight";
 import "katex/dist/katex.min.css";
 import "highlight.js/styles/github.css";
 import type { ArticleResponse, ConfidenceLevel } from "../../types/api";
-import { getBaseUrl } from "../../api/client";
-import { slugify } from "../../utils/slugify";
 import { Breadcrumbs } from "./Breadcrumbs";
-import { editArticle } from "../../api/wiki";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 import { PageTypeIndicator } from "./PageTypeIndicator";
 import { Badge } from "../shared/Badge";
 import { ExportDropdown } from "./ExportDropdown";
 import { ShareButton } from "./ShareButton";
 import { TagSelector } from "./TagSelector";
+import { preprocessMarkdown, extractSynthesizedFrom, extractConceptKind } from "./preprocessMarkdown";
+import { markdownComponents } from "./markdownComponents";
+import { useArticleEditor } from "./useArticleEditor";
 
 interface ArticleReaderProps {
   article: ArticleResponse;
   onArticleUpdated?: (article: ArticleResponse) => void;
 }
 
-const CONFIDENCE_TAG_REGEX = /\[(sourced|mixed|inferred|opinion)\]/gi;
-const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
-const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-const BROKEN_IMAGE_REGEX = /!\[[^\]]*\]\((?!\/|https?:\/\/)[^)]+\)\n*/g;
-
-function childrenToText(children: React.ReactNode): string {
-  if (typeof children === "string") return children;
-  if (Array.isArray(children)) return children.map(childrenToText).join("");
-  if (
-    children &&
-    typeof children === "object" &&
-    "props" in children &&
-    children.props?.children
-  ) {
-    return childrenToText(children.props.children);
-  }
-  return "";
-}
-
-function preprocessMarkdown(content: string): string {
-  return content
-    .replace(FRONTMATTER_REGEX, "")
-    .replace(BROKEN_IMAGE_REGEX, "")
-    .replace(WIKILINK_REGEX, (_, target: string) => {
-      const safe = escapeHtml(target.trim());
-      return `<span class="wikilink-unresolved" title="Article not yet in wiki">${safe}</span>`;
-    });
-}
-
-/** Extract synthesized_from article IDs from concept page frontmatter. */
-function extractSynthesizedFrom(content: string): string[] {
-  const match = content.match(FRONTMATTER_REGEX);
-  if (!match) return [];
-  const fm = match[0];
-  const synMatch = fm.match(/synthesized_from:\s*\n((?:\s*-\s*.+\n)*)/);
-  if (!synMatch) return [];
-  return synMatch[1]
-    .split("\n")
-    .map((line) => line.replace(/^\s*-\s*/, "").trim())
-    .filter(Boolean);
-}
-
-/** Extract concept_kind from concept page frontmatter. */
-function extractConceptKind(content: string): string | null {
-  const match = content.match(FRONTMATTER_REGEX);
-  if (!match) return null;
-  const kindMatch = match[0].match(/concept_kind:\s*(.+)/);
-  return kindMatch ? kindMatch[1].trim() : null;
-}
-
 export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [editContent, setEditContent] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
+  const {
+    isEditing,
+    editContent,
+    setEditContent,
+    isSaving,
+    saveError,
+    handleEdit,
+    handleCancel,
+    handleSave,
+  } = useArticleEditor({ article, onArticleUpdated });
 
   const processed = useMemo(
     () => preprocessMarkdown(article.content ?? ""),
@@ -107,33 +53,6 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
   );
 
   const primaryConcept = article.concepts.length > 0 ? article.concepts[0] : null;
-
-  const handleEdit = useCallback(() => {
-    setEditContent(article.content ?? "");
-    setSaveError(null);
-    setIsEditing(true);
-  }, [article.content]);
-
-  const handleCancel = useCallback(() => {
-    setIsEditing(false);
-    setSaveError(null);
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    setIsSaving(true);
-    setSaveError(null);
-    try {
-      const updated = await editArticle(article.slug, { content: editContent });
-      setIsEditing(false);
-      onArticleUpdated?.(updated);
-    } catch (err) {
-      setSaveError(
-        err instanceof Error ? err.message : "Failed to save changes.",
-      );
-    } finally {
-      setIsSaving(false);
-    }
-  }, [article.slug, editContent, onArticleUpdated]);
 
   return (
     <article className="mx-auto max-w-3xl p-8">
@@ -248,116 +167,7 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath]}
             rehypePlugins={[rehypeKatex, rehypeHighlight, rehypeRaw]}
-            components={{
-              a: ({ node: _node, href, children }) => {
-                if (href && href.startsWith("/wiki/")) {
-                  return (
-                    <Link
-                      to={href}
-                      className="text-brand-700 underline decoration-dotted underline-offset-2 hover:text-brand-900"
-                    >
-                      {children}
-                    </Link>
-                  );
-                }
-                return (
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-brand-700 underline"
-                  >
-                    {children}
-                  </a>
-                );
-              },
-              img: ({ node: _node, src, alt, ...props }) => {
-                const resolvedSrc =
-                  src && src.startsWith("/images/")
-                    ? `${getBaseUrl()}${src}`
-                    : src && src.startsWith("/api/")
-                      ? `${getBaseUrl()}${src}`
-                      : src;
-                return (
-                  <figure className="my-6">
-                    <img
-                      src={resolvedSrc}
-                      alt={alt || ""}
-                      className="mx-auto max-w-full rounded-lg border border-slate-200 shadow-sm"
-                      loading="lazy"
-                      {...props}
-                    />
-                    {alt && alt !== "Figure" && (
-                      <figcaption className="mt-2 text-center text-sm italic text-slate-500">
-                        {alt}
-                      </figcaption>
-                    )}
-                  </figure>
-                );
-              },
-              pre: ({ children }) => (
-                <pre className="overflow-x-auto rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed">
-                  {children}
-                </pre>
-              ),
-              code: ({ node: _node, className, children, ...props }) => {
-                const isInline = !className;
-                if (isInline) {
-                  return (
-                    <code
-                      className="rounded bg-slate-100 px-1.5 py-0.5 text-sm font-medium text-slate-800"
-                      {...props}
-                    >
-                      {children}
-                    </code>
-                  );
-                }
-                return (
-                  <code className={className} {...props}>
-                    {children}
-                  </code>
-                );
-              },
-              table: ({ children }) => (
-                <div className="my-6 overflow-x-auto rounded-lg border border-slate-200">
-                  <table className="min-w-full divide-y divide-slate-200 text-sm">
-                    {children}
-                  </table>
-                </div>
-              ),
-              thead: ({ children }) => (
-                <thead className="bg-slate-50">
-                  {children}
-                </thead>
-              ),
-              th: ({ children }) => (
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-600">
-                  {children}
-                </th>
-              ),
-              td: ({ children }) => (
-                <td className="px-4 py-2.5 text-slate-700">
-                  {children}
-                </td>
-              ),
-              tr: ({ children }) => (
-                <tr className="border-b border-slate-100 last:border-b-0">
-                  {children}
-                </tr>
-              ),
-              h2: ({ children }) => {
-                const text = childrenToText(children);
-                return <h2 id={slugify(text)}>{children}</h2>;
-              },
-              h3: ({ children }) => {
-                const text = childrenToText(children);
-                return <h3 id={slugify(text)}>{children}</h3>;
-              },
-              li: ({ children }) => (
-                <li>{decorateConfidence(children)}</li>
-              ),
-              p: ({ children }) => <p>{decorateConfidence(children)}</p>,
-            }}
+            components={markdownComponents}
           >
             {processed}
           </ReactMarkdown>
@@ -365,42 +175,4 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
       )}
     </article>
   );
-}
-
-function decorateConfidence(children: React.ReactNode): React.ReactNode {
-  if (typeof children === "string") {
-    return splitConfidence(children);
-  }
-  if (Array.isArray(children)) {
-    return children.map((child, idx) => {
-      if (typeof child === "string") {
-        return <span key={idx}>{splitConfidence(child)}</span>;
-      }
-      return child;
-    });
-  }
-  return children;
-}
-
-function splitConfidence(text: string): React.ReactNode[] {
-  const parts: React.ReactNode[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-  CONFIDENCE_TAG_REGEX.lastIndex = 0;
-  while ((match = CONFIDENCE_TAG_REGEX.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push(text.slice(lastIndex, match.index));
-    }
-    const level = match[1].toLowerCase() as ConfidenceLevel;
-    parts.push(
-      <span key={`${match.index}-${level}`} className="ml-1 align-middle">
-        <ConfidenceBadge level={level} />
-      </span>,
-    );
-    lastIndex = match.index + match[0].length;
-  }
-  if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex));
-  }
-  return parts.length > 0 ? parts : [text];
 }

--- a/apps/web/src/components/wiki/markdownComponents.tsx
+++ b/apps/web/src/components/wiki/markdownComponents.tsx
@@ -1,0 +1,157 @@
+import type { Components } from "react-markdown";
+import { Link } from "react-router-dom";
+import type { ConfidenceLevel } from "../../types/api";
+import { getBaseUrl } from "../../api/client";
+import { slugify } from "../../utils/slugify";
+import { ConfidenceBadge } from "./ConfidenceBadge";
+
+const CONFIDENCE_TAG_REGEX = /\[(sourced|mixed|inferred|opinion)\]/gi;
+
+function childrenToText(children: React.ReactNode): string {
+  if (typeof children === "string") return children;
+  if (Array.isArray(children)) return children.map(childrenToText).join("");
+  if (
+    children &&
+    typeof children === "object" &&
+    "props" in children &&
+    children.props?.children
+  ) {
+    return childrenToText(children.props.children);
+  }
+  return "";
+}
+
+function decorateConfidence(children: React.ReactNode): React.ReactNode {
+  if (typeof children === "string") {
+    return splitConfidence(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, idx) => {
+      if (typeof child === "string") {
+        return <span key={idx}>{splitConfidence(child)}</span>;
+      }
+      return child;
+    });
+  }
+  return children;
+}
+
+function splitConfidence(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  CONFIDENCE_TAG_REGEX.lastIndex = 0;
+  while ((match = CONFIDENCE_TAG_REGEX.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    const level = match[1].toLowerCase() as ConfidenceLevel;
+    parts.push(
+      <span key={`${match.index}-${level}`} className="ml-1 align-middle">
+        <ConfidenceBadge level={level} />
+      </span>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+  return parts.length > 0 ? parts : [text];
+}
+
+export const markdownComponents: Components = {
+  a: ({ node: _node, href, children }) => {
+    if (href && href.startsWith("/wiki/")) {
+      return (
+        <Link
+          to={href}
+          className="text-brand-700 underline decoration-dotted underline-offset-2 hover:text-brand-900"
+        >
+          {children}
+        </Link>
+      );
+    }
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className="text-brand-700 underline"
+      >
+        {children}
+      </a>
+    );
+  },
+  img: ({ node: _node, src, alt, ...props }) => {
+    const resolvedSrc =
+      src && src.startsWith("/images/")
+        ? `${getBaseUrl()}${src}`
+        : src && src.startsWith("/api/")
+          ? `${getBaseUrl()}${src}`
+          : src;
+    return (
+      <figure className="my-6">
+        <img
+          src={resolvedSrc}
+          alt={alt || ""}
+          className="mx-auto max-w-full rounded-lg border border-slate-200 shadow-sm"
+          loading="lazy"
+          {...props}
+        />
+        {alt && alt !== "Figure" && (
+          <figcaption className="mt-2 text-center text-sm italic text-slate-500">
+            {alt}
+          </figcaption>
+        )}
+      </figure>
+    );
+  },
+  pre: ({ children }) => (
+    <pre className="overflow-x-auto rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed">
+      {children}
+    </pre>
+  ),
+  code: ({ node: _node, className, children, ...props }) => {
+    const isInline = !className;
+    if (isInline) {
+      return (
+        <code
+          className="rounded bg-slate-100 px-1.5 py-0.5 text-sm font-medium text-slate-800"
+          {...props}
+        >
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  },
+  table: ({ children }) => (
+    <div className="my-6 overflow-x-auto rounded-lg border border-slate-200">
+      <table className="min-w-full divide-y divide-slate-200 text-sm">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => <thead className="bg-slate-50">{children}</thead>,
+  th: ({ children }) => (
+    <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-600">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => <td className="px-4 py-2.5 text-slate-700">{children}</td>,
+  tr: ({ children }) => (
+    <tr className="border-b border-slate-100 last:border-b-0">{children}</tr>
+  ),
+  h2: ({ children }) => {
+    const text = childrenToText(children);
+    return <h2 id={slugify(text)}>{children}</h2>;
+  },
+  h3: ({ children }) => {
+    const text = childrenToText(children);
+    return <h3 id={slugify(text)}>{children}</h3>;
+  },
+  li: ({ children }) => <li>{decorateConfidence(children)}</li>,
+  p: ({ children }) => <p>{decorateConfidence(children)}</p>,
+};

--- a/apps/web/src/components/wiki/preprocessMarkdown.ts
+++ b/apps/web/src/components/wiki/preprocessMarkdown.ts
@@ -1,0 +1,43 @@
+const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
+const BROKEN_IMAGE_REGEX = /!\[[^\]]*\]\((?!\/|https?:\/\/)[^)]+\)\n*/g;
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function preprocessMarkdown(content: string): string {
+  return content
+    .replace(FRONTMATTER_REGEX, "")
+    .replace(BROKEN_IMAGE_REGEX, "")
+    .replace(WIKILINK_REGEX, (_, target: string) => {
+      const safe = escapeHtml(target.trim());
+      return `<span class="wikilink-unresolved" title="Article not yet in wiki">${safe}</span>`;
+    });
+}
+
+/** Extract synthesized_from article IDs from concept page frontmatter. */
+export function extractSynthesizedFrom(content: string): string[] {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return [];
+  const fm = match[0];
+  const synMatch = fm.match(/synthesized_from:\s*\n((?:\s*-\s*.+\n)*)/);
+  if (!synMatch) return [];
+  return synMatch[1]
+    .split("\n")
+    .map((line) => line.replace(/^\s*-\s*/, "").trim())
+    .filter(Boolean);
+}
+
+/** Extract concept_kind from concept page frontmatter. */
+export function extractConceptKind(content: string): string | null {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return null;
+  const kindMatch = match[0].match(/concept_kind:\s*(.+)/);
+  return kindMatch ? kindMatch[1].trim() : null;
+}

--- a/apps/web/src/components/wiki/useArticleEditor.ts
+++ b/apps/web/src/components/wiki/useArticleEditor.ts
@@ -1,0 +1,51 @@
+import { useCallback, useState } from "react";
+import type { ArticleResponse } from "../../types/api";
+import { editArticle } from "../../api/wiki";
+
+interface UseArticleEditorOptions {
+  article: ArticleResponse;
+  onArticleUpdated?: (article: ArticleResponse) => void;
+}
+
+export function useArticleEditor({ article, onArticleUpdated }: UseArticleEditorOptions) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const handleEdit = useCallback(() => {
+    setEditContent(article.content ?? "");
+    setSaveError(null);
+    setIsEditing(true);
+  }, [article.content]);
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false);
+    setSaveError(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await editArticle(article.slug, { content: editContent });
+      setIsEditing(false);
+      onArticleUpdated?.(updated);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save changes.");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [article.slug, editContent, onArticleUpdated]);
+
+  return {
+    isEditing,
+    editContent,
+    setEditContent,
+    isSaving,
+    saveError,
+    handleEdit,
+    handleCancel,
+    handleSave,
+  };
+}


### PR DESCRIPTION
## Summary

- **AskView** (310 → 90 lines): extracted `useAskStream` (streaming + fallback + fork), `useFileBack` (file-back mutations), and `useExportConversation` (markdown export) custom hooks
- **ArticleReader** (407 → 170 lines): extracted `markdownComponents.tsx` (13 custom ReactMarkdown renderers), `preprocessMarkdown.ts` (frontmatter/wikilink/image preprocessing), and `useArticleEditor` hook (inline edit state)
- Pure refactor — no behavior changes, all extracted files live alongside their original components

## Test plan

- [x] `npx tsc -b` passes (TypeScript type-check)
- [x] `npx vite build` succeeds (production bundle)
- [x] `make verify` backend checks pass (1956 tests, lint, format)
- [ ] Manual smoke test: AskView streaming, fork, file-back, export still work
- [ ] Manual smoke test: ArticleReader renders markdown, edit/save, confidence badges work

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)