### PR TITLE
fix: extract shared slug generation and fix unbounded loop (#712)

### DIFF
--- a/src/wikimind/engine/base_compiler.py
+++ b/src/wikimind/engine/base_compiler.py
@@ -11,14 +11,11 @@ import json
 from typing import TYPE_CHECKING
 
 import structlog
-from slugify import slugify
-from sqlmodel import select
 
 from wikimind.config import get_settings
 from wikimind.database import _dialect_insert
 from wikimind.engine.llm_router import get_llm_router
 from wikimind.models import (
-    Article,
     Backlink,
     CompletionRequest,
     CompletionResponse,
@@ -27,6 +24,7 @@ from wikimind.models import (
     TaskType,
 )
 from wikimind.services.search import index_article as fts_index_article
+from wikimind.slug import generate_unique_slug
 from wikimind.storage import get_wiki_storage
 
 if TYPE_CHECKING:
@@ -120,6 +118,9 @@ class BaseCompiler:
     ) -> str:
         """Generate a URL-safe slug from a title, avoiding collisions.
 
+        Delegates to :func:`wikimind.slug.generate_unique_slug` so all
+        compiler variants share the same bounded, per-user slug logic.
+
         Args:
             title: The title to slugify.
             session: Async database session for collision checks.
@@ -129,18 +130,13 @@ class BaseCompiler:
         Raises:
             ValueError: If no unique slug is found within max attempts.
         """
-        max_attempts = self.settings.compiler.slug_max_attempts
-        base = f"{prefix}{slugify(title, max_length=max_length)}"
-        candidate = base
-        suffix = 2
-        for _ in range(max_attempts):
-            existing = (await session.exec(select(Article).where(Article.slug == candidate))).first()
-            if existing is None:
-                return candidate
-            candidate = f"{base}-{suffix}"
-            suffix += 1
-        msg = f"Could not generate unique slug for {title!r} after {max_attempts} attempts"
-        raise ValueError(msg)
+        return await generate_unique_slug(
+            title,
+            session,
+            user_id=self.user_id,
+            prefix=prefix,
+            max_length=max_length,
+        )
 
     async def _index_article(
         self,

--- a/src/wikimind/services/crystallization.py
+++ b/src/wikimind/services/crystallization.py
@@ -9,7 +9,6 @@ import json
 from datetime import datetime
 
 import structlog
-from slugify import slugify
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -26,6 +25,7 @@ from wikimind.models import (
     Query,
     TaskType,
 )
+from wikimind.slug import generate_unique_slug
 from wikimind.storage import get_wiki_storage
 
 log = structlog.get_logger()
@@ -63,33 +63,6 @@ def _format_conversation(queries: list[Query]) -> str:
         lines.append(f"Assistant: {q.answer}")
         lines.append("")
     return "\n".join(lines)
-
-
-async def _generate_unique_slug(title: str, user_id: str, session: AsyncSession) -> str:
-    """Generate a URL-safe slug, appending a suffix to avoid collisions.
-
-    Slugs are unique per-user, so the collision check filters by ``user_id``.
-    """
-    base = slugify(title, max_length=80)
-    candidate = base
-    suffix = 2
-    while True:
-        existing = (
-            (
-                await session.execute(
-                    select(Article).where(
-                        Article.slug == candidate,
-                        Article.user_id == user_id,
-                    )
-                )
-            )
-            .scalars()
-            .first()
-        )
-        if existing is None:
-            return candidate
-        candidate = f"{base}-{suffix}"
-        suffix += 1
 
 
 def _build_markdown(
@@ -262,7 +235,7 @@ Distill this conversation into a structured wiki article following the JSON sche
     article_body = data.get("article_body", "")
 
     now = utcnow_naive()
-    slug = await _generate_unique_slug(title, user_id, session)
+    slug = await generate_unique_slug(title, session, user_id=user_id)
     content = _build_markdown(
         title,
         slug,

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -17,7 +17,6 @@ import re
 
 import structlog
 from fastapi import HTTPException
-from slugify import slugify
 from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
@@ -64,6 +63,7 @@ from wikimind.models import (
     WikilinkMatch,
 )
 from wikimind.services.embedding import _SEARCH_AVAILABLE
+from wikimind.slug import generate_unique_slug
 from wikimind.storage import get_wiki_storage, read_article_content
 
 log = structlog.get_logger()
@@ -1031,29 +1031,10 @@ class WikiService:
     ) -> str:
         """Generate a URL-safe slug from a title, avoiding collisions per user.
 
-        Tries the base slug first; if it already exists for this user,
-        appends ``-2``, ``-3``, etc. until a unique value is found.
+        Delegates to :func:`wikimind.slug.generate_unique_slug` so every
+        call site shares the same bounded, per-user slug logic.
         """
-        base = slugify(title, max_length=80)
-        candidate = base
-        suffix = 2
-        while True:
-            existing = (
-                (
-                    await session.execute(
-                        select(Article).where(
-                            Article.slug == candidate,
-                            Article.user_id == user_id,
-                        )
-                    )
-                )
-                .scalars()
-                .first()
-            )
-            if existing is None:
-                return candidate
-            candidate = f"{base}-{suffix}"
-            suffix += 1
+        return await generate_unique_slug(title, session, user_id=user_id)
 
     async def create_stub_article(
         self,

--- a/src/wikimind/slug.py
+++ b/src/wikimind/slug.py
@@ -1,0 +1,72 @@
+"""Shared slug generation for wiki articles.
+
+Centralizes the ``title -> unique slug`` logic that was previously
+duplicated across compiler, wiki service, synthesis compiler, and
+crystallization modules.  All call sites now delegate here so the
+max-attempts cap and per-user scoping are consistent everywhere.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from slugify import slugify
+from sqlmodel import select
+
+from wikimind.config import get_settings
+from wikimind.models import Article
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+async def generate_unique_slug(
+    title: str,
+    session: AsyncSession,
+    *,
+    user_id: str,
+    prefix: str = "",
+    max_length: int = 80,
+    max_attempts: int | None = None,
+) -> str:
+    """Generate a URL-safe slug from *title*, avoiding per-user collisions.
+
+    Tries the base slug first; if it already exists for this user,
+    appends ``-2``, ``-3``, etc. until a unique value is found or the
+    attempt limit is reached.
+
+    Args:
+        title: The title to slugify.
+        session: Async database session for collision checks.
+        user_id: Owner user ID -- slugs are unique per user.
+        prefix: Optional prefix (e.g. ``"synthesis-"``) prepended to the slug.
+        max_length: Maximum slug length before prefix.
+        max_attempts: Cap on collision retries.  Defaults to
+            ``settings.compiler.slug_max_attempts`` when ``None``.
+
+    Returns:
+        A unique slug string.
+
+    Raises:
+        ValueError: If no unique slug is found within *max_attempts*.
+    """
+    if max_attempts is None:
+        max_attempts = get_settings().compiler.slug_max_attempts
+    base = f"{prefix}{slugify(title, max_length=max_length)}"
+    candidate = base
+    suffix = 2
+    for _ in range(max_attempts):
+        existing = (
+            await session.exec(
+                select(Article).where(
+                    Article.slug == candidate,
+                    Article.user_id == user_id,
+                )
+            )
+        ).first()
+        if existing is None:
+            return candidate
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    msg = f"Could not generate unique slug for {title!r} after {max_attempts} attempts"
+    raise ValueError(msg)


### PR DESCRIPTION
## Summary

- **Problem**: `_generate_unique_slug` was duplicated 4 times across the codebase with inconsistent behavior. Two copies (`wiki.py` and `crystallization.py`) used unbounded `while True` loops that could spin forever on slug collisions. The `BaseCompiler` version did not scope collision checks to `user_id`.
- **Solution**: Extract a single `generate_unique_slug()` function into `src/wikimind/slug.py` that combines the correct behavior from all variants: per-user collision scoping + bounded `max_attempts` cap (defaults to `settings.compiler.slug_max_attempts`).
- **Changes**:
  - New `src/wikimind/slug.py` with the shared `generate_unique_slug()` function
  - `BaseCompiler._generate_unique_slug` now delegates to the shared function (adds user_id scoping it was missing)
  - `WikiService._generate_unique_slug` now delegates to the shared function (fixes unbounded loop)
  - `crystallization._generate_unique_slug` removed entirely, call site updated to use shared function (fixes unbounded loop)

## Test plan

- [x] All 1915 existing tests pass (5 pre-existing smoke test failures unrelated to this change)
- [x] `make lint` passes
- [x] `make format` passes
- [x] `make typecheck` passes
- [x] Existing slug generation tests (`test_generate_unique_slug*`) continue to pass, including the max-attempts overflow test

🤖 Generated with [Claude Code](https://claude.com/claude-code)