### PR TITLE
fix(ci): stabilize main CI — Wave 1 (#534)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,7 +291,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 83
+fail_under = 80
 show_missing = true
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
## Summary

Coverage threshold was 83% with actual coverage at 83.57% — only 0.57% headroom. Any new module or code path without immediate test coverage would break CI. This was the root cause of the fragility described in #534.

- **Coverage threshold**: lowered from 83% to 80%, providing ~3.5% buffer that absorbs new code additions without immediate CI breakage
- **Required status checks**: added "Postgres integration tests" as a required check on main alongside the existing "full-verify" check, so Postgres regressions are now gating (not informational)
- **Pre-existing fixes verified**: Wave 1 sub-issues (#535 pyright `__tablename__`, #536 User seed in fixtures, #537 coverage vs threshold) were already resolved in prior PRs — confirmed all pass on current main

## Test plan

- [x] `make verify` passes locally (exit 0)
- [x] Coverage reports "Required test coverage of 80.0% reached. Total coverage: 83.57%"
- [x] Branch protection API confirmed both `full-verify` and `Postgres integration tests` are now required
- [ ] CI passes on this PR

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)