### PR TITLE
feat: add SourceSpan model and citation API endpoint (#450)

### DIFF
--- a/alembic/versions/0019_add_source_span_table.py
+++ b/alembic/versions/0019_add_source_span_table.py
@@ -1,0 +1,88 @@
+"""Add source_span table and source_span_ids column on compiledclaim.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-19
+
+Adds the SourceSpan table for paragraph-level citation anchoring and a
+source_span_ids JSON column on CompiledClaim to link claims to their
+source spans. See issue #450.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0019"
+down_revision: str = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    existing = inspector.get_table_names()
+
+    # ── sourcespan ──────────────────────────────────────────────────────────
+    if "sourcespan" not in existing:
+        op.create_table(
+            "sourcespan",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column(
+                "source_id",
+                sa.String(),
+                sa.ForeignKey("source.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "user_id",
+                sa.String(),
+                sa.ForeignKey("user.id"),
+                nullable=False,
+            ),
+            sa.Column("locator_kind", sa.String(), nullable=False),
+            sa.Column("locator", sa.JSON(), nullable=False),
+            sa.Column("text", sa.Text(), nullable=False),
+            sa.Column("fingerprint", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+        )
+        op.create_index("ix_sourcespan_source_id", "sourcespan", ["source_id"])
+        op.create_index("ix_sourcespan_user_id", "sourcespan", ["user_id"])
+        op.create_index("ix_sourcespan_fingerprint", "sourcespan", ["fingerprint"])
+
+    # ── source_span_ids on compiledclaim ────────────────────────────────────
+    if "compiledclaim" in existing:
+        claim_columns = [c["name"] for c in inspector.get_columns("compiledclaim")]
+        if "source_span_ids" not in claim_columns:
+            op.add_column(
+                "compiledclaim",
+                sa.Column(
+                    "source_span_ids",
+                    sa.String(),
+                    nullable=False,
+                    server_default="[]",
+                ),
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    existing = inspector.get_table_names()
+
+    # Drop source_span_ids from compiledclaim
+    if "compiledclaim" in existing:
+        claim_columns = [c["name"] for c in inspector.get_columns("compiledclaim")]
+        if "source_span_ids" in claim_columns:
+            op.drop_column("compiledclaim", "source_span_ids")
+
+    # Drop sourcespan table
+    if "sourcespan" in existing:
+        op.drop_index("ix_sourcespan_fingerprint", table_name="sourcespan")
+        op.drop_index("ix_sourcespan_user_id", table_name="sourcespan")
+        op.drop_index("ix_sourcespan_source_id", table_name="sourcespan")
+        op.drop_table("sourcespan")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1599,6 +1599,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/wiki/articles/{id_or_slug}/citations:
+    get:
+      tags:
+      - Wiki
+      summary: Get Article Citations
+      description: 'Return claims for an article with their linked source spans.
+
+
+        Each claim includes the verbatim source spans that anchor it to
+
+        specific paragraphs in the original source documents.'
+      operationId: get_article_citations_api_wiki_articles__id_or_slug__citations_get
+      parameters:
+      - name: id_or_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Id Or Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleCitationsResponse'
+        '404':
+          description: Article not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/wiki/articles/{article_id}/tags:
     post:
       tags:
@@ -4647,6 +4681,26 @@ components:
       - article_title
       title: ApproveDraftResponse
       description: Response after approving a compilation draft.
+    ArticleCitationsResponse:
+      properties:
+        article_id:
+          type: string
+          title: Article Id
+        article_title:
+          type: string
+          title: Article Title
+        claims:
+          items:
+            $ref: '#/components/schemas/ClaimCitationResponse'
+          type: array
+          title: Claims
+          default: []
+      type: object
+      required:
+      - article_id
+      - article_title
+      title: ArticleCitationsResponse
+      description: All claims for an article with their source spans.
     ArticleDownloadFormat:
       type: string
       enum:
@@ -5279,6 +5333,40 @@ components:
       title: CitationResponse
       description: 'A single Q&A citation: an article plus the sources it was compiled
         from.'
+    ClaimCitationResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        text:
+          type: string
+          title: Text
+        confidence_level:
+          type: string
+          title: Confidence Level
+        confidence_score:
+          type: number
+          title: Confidence Score
+        source_ids:
+          items:
+            type: string
+          type: array
+          title: Source Ids
+          default: []
+        source_spans:
+          items:
+            $ref: '#/components/schemas/SourceSpanResponse'
+          type: array
+          title: Source Spans
+          default: []
+      type: object
+      required:
+      - id
+      - text
+      - confidence_level
+      - confidence_score
+      title: ClaimCitationResponse
+      description: A compiled claim with its linked source spans for citation display.
     CompilationDraftResponse:
       properties:
         id:
@@ -6898,6 +6986,15 @@ components:
       - error
       title: LintSeverity
       description: Severity level for a lint finding.
+    LocatorKind:
+      type: string
+      enum:
+      - pdf-page-rect
+      - html-xpath-offset
+      - text-byte-range
+      - youtube-timestamp
+      title: LocatorKind
+      description: 'Type of anchor locator for a source span (issue #450).'
     MCPTokenCreateRequest:
       properties:
         name:
@@ -8187,6 +8284,41 @@ components:
         Q&A responses so callers can trace claims back to their origin
 
         (URL, PDF filename, upload date, etc.).'
+    SourceSpanResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        source_id:
+          type: string
+          title: Source Id
+        locator_kind:
+          $ref: '#/components/schemas/LocatorKind'
+        locator:
+          additionalProperties: true
+          type: object
+          title: Locator
+        text:
+          type: string
+          title: Text
+        fingerprint:
+          type: string
+          title: Fingerprint
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - source_id
+      - locator_kind
+      - locator
+      - text
+      - fingerprint
+      - created_at
+      title: SourceSpanResponse
+      description: API response for a single source span anchor.
     SourceType:
       type: string
       enum:

--- a/src/wikimind/api/routes/wiki.py
+++ b/src/wikimind/api/routes/wiki.py
@@ -7,6 +7,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind.api.deps import get_current_user_id, require_plan
 from wikimind.database import get_session
 from wikimind.models import (
+    ArticleCitationsResponse,
     ArticleEditRequest,
     ArticleRelationshipsResponse,
     ArticleResponse,
@@ -37,8 +38,10 @@ from wikimind.models import (
     TagResponse,
     WikilinkMatch,
 )
+from wikimind.services.citation import CitationService
 from wikimind.services.contradiction import ContradictionService
 from wikimind.services.factories import (
+    get_citation_service,
     get_contradiction_service,
     get_linter_service,
     get_search_service,
@@ -484,6 +487,31 @@ async def recompile_article(
         mode=mode,
         force=force,
     )
+
+
+# ---------------------------------------------------------------------------
+# Citation endpoints (issue #450)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/articles/{id_or_slug}/citations",
+    response_model=ArticleCitationsResponse,
+    responses={404: {"description": "Article not found"}},
+)
+async def get_article_citations(
+    id_or_slug: str,
+    session: AsyncSession = Depends(get_session),
+    citation_service: CitationService = Depends(get_citation_service),
+    wiki_service: WikiService = Depends(get_wiki_service),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Return claims for an article with their linked source spans.
+
+    Each claim includes the verbatim source spans that anchor it to
+    specific paragraphs in the original source documents.
+    """
+    return await citation_service.get_article_citations(id_or_slug, session, user_id=user_id, wiki_service=wiki_service)
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -157,12 +157,14 @@ from wikimind.models.dto.tags import (
     TagArticleRequest,
 )
 from wikimind.models.dto.wiki import (
+    ArticleCitationsResponse,
     ArticleDownloadResponse,
     ArticleEditRequest,
     ArticleRelationshipsResponse,
     ArticleResponse,
     ArticleSummaryResponse,
     BacklinkEntry,
+    ClaimCitationResponse,
     ConceptDetailResponse,
     ConceptResponse,
     ContradictionResolutionOption,
@@ -188,6 +190,7 @@ from wikimind.models.dto.wiki import (
     SavedSearchExecuteResponse,
     SearchResponse,
     SearchResult,
+    SourceSpanResponse,
     WikilinkMatch,
 )
 
@@ -208,6 +211,7 @@ from wikimind.models.enums import (
     LintFindingKind,
     LintReportStatus,
     LintSeverity,
+    LocatorKind,
     PageType,
     Provider,
     RelationType,
@@ -254,6 +258,7 @@ from wikimind.models.tables import (  # noqa: F401
     ShareLink,
     Source,
     SourceImage,
+    SourceSpan,
     StorageUsage,
     StructuralFinding,
     Subscription,
@@ -336,6 +341,7 @@ __all__ = [
     "ApproveDraftResponse",
     # Tables
     "Article",
+    "ArticleCitationsResponse",
     "ArticleConcept",
     # Enums
     "ArticleDownloadFormat",
@@ -361,6 +367,7 @@ __all__ = [
     "CaptureStatus",
     "CitationArticleRef",
     "CitationResponse",
+    "ClaimCitationResponse",
     "ClaimConcept",
     "ClaimConceptRole",
     "ClusterStatus",
@@ -447,6 +454,7 @@ __all__ = [
     "LintSeverity",
     "LinterContradiction",
     "LinterResult",
+    "LocatorKind",
     "MCPAccessToken",
     "MCPTokenCreateRequest",
     "MCPTokenCreateResponse",
@@ -509,6 +517,8 @@ __all__ = [
     "SourceImage",
     "SourceImageEntry",
     "SourceResponse",
+    "SourceSpan",
+    "SourceSpanResponse",
     "SourceType",
     "StorageUsage",
     "StructuralFinding",

--- a/src/wikimind/models/dto/wiki.py
+++ b/src/wikimind/models/dto/wiki.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from wikimind.models.dto.common import TagResponse
 from wikimind.models.dto.ingest import ArticleSourceSummary, SourceResponse
 from wikimind.models.dto.tags import SavedSearchResponse
-from wikimind.models.enums import ConfidenceLevel, ContradictionStatus, PageType, RelationType
+from wikimind.models.enums import ConfidenceLevel, ContradictionStatus, LocatorKind, PageType, RelationType
 
 # ---------------------------------------------------------------------------
 # Backlink / relationship DTOs
@@ -389,3 +389,39 @@ class SavedSearchExecuteResponse(BaseModel):
 
     saved_search: SavedSearchResponse
     articles: list[ArticleSummaryResponse]
+
+
+# ---------------------------------------------------------------------------
+# Span-level citation response models (issue #450)
+# ---------------------------------------------------------------------------
+
+
+class SourceSpanResponse(BaseModel):
+    """API response for a single source span anchor."""
+
+    id: str
+    source_id: str
+    locator_kind: LocatorKind
+    locator: dict
+    text: str
+    fingerprint: str
+    created_at: datetime
+
+
+class ClaimCitationResponse(BaseModel):
+    """A compiled claim with its linked source spans for citation display."""
+
+    id: str
+    text: str
+    confidence_level: str
+    confidence_score: float
+    source_ids: list[str] = []
+    source_spans: list[SourceSpanResponse] = []
+
+
+class ArticleCitationsResponse(BaseModel):
+    """All claims for an article with their source spans."""
+
+    article_id: str
+    article_title: str
+    claims: list[ClaimCitationResponse] = []

--- a/src/wikimind/models/enums.py
+++ b/src/wikimind/models/enums.py
@@ -229,3 +229,12 @@ class WikiExportFormat(StrEnum):
 
     OBSIDIAN = "obsidian"
     MARKDOWN_JSON = "markdown_json"
+
+
+class LocatorKind(StrEnum):
+    """Type of anchor locator for a source span (issue #450)."""
+
+    PDF_PAGE_RECT = "pdf-page-rect"
+    HTML_XPATH_OFFSET = "html-xpath-offset"
+    TEXT_BYTE_RANGE = "text-byte-range"
+    YOUTUBE_TIMESTAMP = "youtube-timestamp"

--- a/src/wikimind/models/tables/__init__.py
+++ b/src/wikimind/models/tables/__init__.py
@@ -52,6 +52,7 @@ from wikimind.models.tables.wiki import (
     Concept,
     ConceptKindDef,
     ReinforcementEvent,
+    SourceSpan,
 )
 
 __all__ = [
@@ -91,6 +92,7 @@ __all__ = [
     "ShareLink",
     "Source",
     "SourceImage",
+    "SourceSpan",
     "StorageUsage",
     "StructuralFinding",
     "Subscription",

--- a/src/wikimind/models/tables/compilation.py
+++ b/src/wikimind/models/tables/compilation.py
@@ -51,6 +51,7 @@ class CompiledClaim(SQLModel, table=True):
     quote: str | None = None
     embedding: bytes | None = None  # raw float32 array; nullable until embedding runs
     embedding_version: str | None = None  # e.g. "bge-small-1.5"
+    source_span_ids: str = "[]"  # JSON list of SourceSpan UUIDs (issue #450)
     cluster_assignment_reconciled: bool = False
     created_at: datetime = Field(default_factory=utcnow_naive)
     updated_at: datetime = Field(default_factory=utcnow_naive)

--- a/src/wikimind/models/tables/wiki.py
+++ b/src/wikimind/models/tables/wiki.py
@@ -3,11 +3,32 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Column, String, UniqueConstraint
+from sqlalchemy import JSON, Column, ForeignKey, String, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 from wikimind._datetime import utcnow_naive
-from wikimind.models.enums import ConfidenceLevel, PageType, Provider, RelationType
+from wikimind.models.enums import ConfidenceLevel, LocatorKind, PageType, Provider, RelationType
+
+
+class SourceSpan(SQLModel, table=True):
+    """A locatable span within a source document (issue #450).
+
+    Anchors a verbatim text excerpt to a precise location in the original
+    source (PDF page rectangle, HTML XPath offset, byte range, or YouTube
+    timestamp). Claims link to spans via ``CompiledClaim.source_span_ids``
+    to provide paragraph-level citation provenance.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    source_id: str = Field(
+        sa_column=Column(String, ForeignKey("source.id", ondelete="CASCADE"), index=True),
+    )
+    user_id: str = Field(foreign_key="user.id", index=True)
+    locator_kind: LocatorKind  # "pdf-page-rect", "html-xpath-offset", etc.
+    locator: dict = Field(sa_column=Column(JSON, nullable=False))  # adapter-specific anchor
+    text: str = Field(sa_type=Text)  # verbatim quoted text
+    fingerprint: str = Field(index=True)  # SHA-256 of normalized text for re-anchoring
+    created_at: datetime = Field(default_factory=utcnow_naive)
 
 
 class Article(SQLModel, table=True):

--- a/src/wikimind/services/citation.py
+++ b/src/wikimind/services/citation.py
@@ -1,0 +1,124 @@
+"""Citation service — resolves compiled claims to their source spans.
+
+Provides the data layer for span-level citations: given an article,
+returns its compiled claims together with the source spans that anchor
+each claim to a precise location in the original source document.
+"""
+
+import json
+
+import structlog
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from wikimind.errors import NotFoundError
+from wikimind.models import (
+    Article,
+    ArticleCitationsResponse,
+    ClaimCitationResponse,
+    CompiledClaim,
+    SourceSpan,
+    SourceSpanResponse,
+)
+from wikimind.services.wiki import WikiService
+
+log = structlog.get_logger()
+
+
+class CitationService:
+    """Resolve compiled claims to their anchored source spans."""
+
+    async def get_article_citations(
+        self,
+        id_or_slug: str,
+        session: AsyncSession,
+        *,
+        user_id: str,
+        wiki_service: WikiService,
+    ) -> ArticleCitationsResponse:
+        """Return all claims for an article with their linked source spans.
+
+        Args:
+            id_or_slug: Article UUID or slug.
+            session: Async database session.
+            user_id: Owner scope.
+            wiki_service: WikiService for article resolution.
+
+        Returns:
+            ArticleCitationsResponse with claims and their source spans.
+
+        Raises:
+            NotFoundError: If the article does not exist for this user.
+        """
+        article_id = await wiki_service._resolve_article_id(id_or_slug, session, user_id)
+        if article_id is None:
+            msg = f"Article not found: {id_or_slug}"
+            raise NotFoundError(msg)
+
+        # Fetch article title
+        article_row = (
+            await session.execute(select(Article.title).where(Article.id == article_id, Article.user_id == user_id))
+        ).first()
+        article_title = article_row[0] if article_row else ""
+
+        # Fetch all claims for this article
+        claims_stmt = (
+            select(CompiledClaim)
+            .where(
+                CompiledClaim.article_id == article_id,
+                CompiledClaim.user_id == user_id,
+            )
+            .order_by(col(CompiledClaim.created_at))
+        )
+        claims = (await session.execute(claims_stmt)).scalars().all()
+
+        # Collect all span IDs across claims for a single batch query
+        all_span_ids: set[str] = set()
+        for claim in claims:
+            span_ids = json.loads(claim.source_span_ids) if claim.source_span_ids else []
+            all_span_ids.update(span_ids)
+
+        # Batch-fetch all referenced spans
+        spans_by_id: dict[str, SourceSpan] = {}
+        if all_span_ids:
+            spans_stmt = select(SourceSpan).where(
+                col(SourceSpan.id).in_(list(all_span_ids)),
+                SourceSpan.user_id == user_id,
+            )
+            spans = (await session.execute(spans_stmt)).scalars().all()
+            spans_by_id = {s.id: s for s in spans}
+
+        # Build response
+        claim_responses: list[ClaimCitationResponse] = []
+        for claim in claims:
+            span_ids = json.loads(claim.source_span_ids) if claim.source_span_ids else []
+            source_ids = json.loads(claim.source_ids) if claim.source_ids else []
+            span_responses = [
+                SourceSpanResponse(
+                    id=span.id,
+                    source_id=span.source_id,
+                    locator_kind=span.locator_kind,
+                    locator=span.locator,
+                    text=span.text,
+                    fingerprint=span.fingerprint,
+                    created_at=span.created_at,
+                )
+                for sid in span_ids
+                if (span := spans_by_id.get(sid)) is not None
+            ]
+            claim_responses.append(
+                ClaimCitationResponse(
+                    id=claim.id,
+                    text=claim.text,
+                    confidence_level=claim.confidence_level,
+                    confidence_score=claim.confidence_score,
+                    source_ids=source_ids,
+                    source_spans=span_responses,
+                )
+            )
+
+        return ArticleCitationsResponse(
+            article_id=article_id,
+            article_title=article_title,
+            claims=claim_responses,
+        )

--- a/src/wikimind/services/factories.py
+++ b/src/wikimind/services/factories.py
@@ -12,6 +12,7 @@ import structlog
 
 from wikimind.services.admin import AdminService
 from wikimind.services.capture import CaptureService
+from wikimind.services.citation import CitationService
 from wikimind.services.compilation_schema import CompilationSchemaService
 from wikimind.services.compiler import CompilerService
 from wikimind.services.contradiction import ContradictionService
@@ -56,6 +57,12 @@ def get_admin_service() -> AdminService:
 def get_capture_service() -> CaptureService:
     """Return a singleton CaptureService instance for FastAPI dependency injection."""
     return CaptureService()
+
+
+@functools.lru_cache(maxsize=1)
+def get_citation_service() -> CitationService:
+    """Return a singleton CitationService instance for FastAPI dependency injection."""
+    return CitationService()
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/unit/test_citations.py
+++ b/tests/unit/test_citations.py
@@ -1,0 +1,400 @@
+"""Tests for span-level citations (issue #450).
+
+Covers the SourceSpan model, the CompiledClaim.source_span_ids field,
+the CitationService, and the GET /api/wiki/articles/{id}/citations endpoint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tests.conftest import TEST_USER_ID
+from wikimind.models import (
+    Article,
+    CompiledClaim,
+    LocatorKind,
+    Source,
+    SourceSpan,
+)
+from wikimind.services.citation import CitationService
+from wikimind.services.wiki import WikiService
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _fingerprint(text: str) -> str:
+    normalized = " ".join(text.lower().split())
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceSpanModel:
+    """Verify SourceSpan can be persisted and read back."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_read_source_span(self, db_session: AsyncSession) -> None:
+        source_id = _uid()
+        source = Source(
+            id=source_id,
+            user_id=TEST_USER_ID,
+            source_type="url",
+            title="Test Source",
+        )
+        db_session.add(source)
+        await db_session.flush()
+
+        span_id = _uid()
+        text = "Machine learning models require large datasets."
+        span = SourceSpan(
+            id=span_id,
+            source_id=source_id,
+            user_id=TEST_USER_ID,
+            locator_kind=LocatorKind.TEXT_BYTE_RANGE,
+            locator={"start": 0, "end": 47},
+            text=text,
+            fingerprint=_fingerprint(text),
+        )
+        db_session.add(span)
+        await db_session.flush()
+        await db_session.refresh(span)
+
+        assert span.id == span_id
+        assert span.source_id == source_id
+        assert span.locator_kind == LocatorKind.TEXT_BYTE_RANGE
+        assert span.locator == {"start": 0, "end": 47}
+        assert span.text == text
+        assert span.fingerprint == _fingerprint(text)
+
+    @pytest.mark.asyncio
+    async def test_locator_kinds(self, db_session: AsyncSession) -> None:
+        """All LocatorKind values should be valid."""
+        assert LocatorKind.PDF_PAGE_RECT == "pdf-page-rect"
+        assert LocatorKind.HTML_XPATH_OFFSET == "html-xpath-offset"
+        assert LocatorKind.TEXT_BYTE_RANGE == "text-byte-range"
+        assert LocatorKind.YOUTUBE_TIMESTAMP == "youtube-timestamp"
+
+
+class TestCompiledClaimSourceSpanIds:
+    """Verify CompiledClaim.source_span_ids field."""
+
+    @pytest.mark.asyncio
+    async def test_default_empty_list(self, db_session: AsyncSession) -> None:
+        article_id = _uid()
+        article = Article(
+            id=article_id,
+            user_id=TEST_USER_ID,
+            slug="test-article",
+            title="Test Article",
+            file_path="wiki/test-article.md",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        claim = CompiledClaim(
+            id=_uid(),
+            article_id=article_id,
+            user_id=TEST_USER_ID,
+            text="Some claim.",
+            confidence_level="sourced",
+        )
+        db_session.add(claim)
+        await db_session.flush()
+        await db_session.refresh(claim)
+
+        assert claim.source_span_ids == "[]"
+        assert json.loads(claim.source_span_ids) == []
+
+    @pytest.mark.asyncio
+    async def test_stores_span_ids(self, db_session: AsyncSession) -> None:
+        article_id = _uid()
+        article = Article(
+            id=article_id,
+            user_id=TEST_USER_ID,
+            slug="test-article-2",
+            title="Test Article 2",
+            file_path="wiki/test-article-2.md",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        span_ids = [_uid(), _uid()]
+        claim = CompiledClaim(
+            id=_uid(),
+            article_id=article_id,
+            user_id=TEST_USER_ID,
+            text="Another claim.",
+            confidence_level="mixed",
+            source_span_ids=json.dumps(span_ids),
+        )
+        db_session.add(claim)
+        await db_session.flush()
+        await db_session.refresh(claim)
+
+        assert json.loads(claim.source_span_ids) == span_ids
+
+
+# ---------------------------------------------------------------------------
+# Service tests
+# ---------------------------------------------------------------------------
+
+
+class TestCitationService:
+    """Verify CitationService.get_article_citations."""
+
+    @pytest.mark.asyncio
+    async def test_article_not_found(self, db_session: AsyncSession) -> None:
+        service = CitationService()
+        wiki_service = WikiService()
+        with pytest.raises(Exception, match="Article not found"):
+            await service.get_article_citations(
+                "nonexistent",
+                db_session,
+                user_id=TEST_USER_ID,
+                wiki_service=wiki_service,
+            )
+
+    @pytest.mark.asyncio
+    async def test_article_with_no_claims(self, db_session: AsyncSession) -> None:
+        article_id = _uid()
+        article = Article(
+            id=article_id,
+            user_id=TEST_USER_ID,
+            slug="empty-article",
+            title="Empty Article",
+            file_path="wiki/empty-article.md",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        service = CitationService()
+        wiki_service = WikiService()
+        result = await service.get_article_citations(
+            article_id,
+            db_session,
+            user_id=TEST_USER_ID,
+            wiki_service=wiki_service,
+        )
+
+        assert result.article_id == article_id
+        assert result.article_title == "Empty Article"
+        assert result.claims == []
+
+    @pytest.mark.asyncio
+    async def test_claims_with_source_spans(self, db_session: AsyncSession) -> None:
+        # Create source
+        source_id = _uid()
+        source = Source(
+            id=source_id,
+            user_id=TEST_USER_ID,
+            source_type="pdf",
+            title="Research Paper",
+        )
+        db_session.add(source)
+        await db_session.flush()
+
+        # Create source spans
+        span_1_id = _uid()
+        span_1_text = "Neural networks improve accuracy."
+        span_1 = SourceSpan(
+            id=span_1_id,
+            source_id=source_id,
+            user_id=TEST_USER_ID,
+            locator_kind=LocatorKind.PDF_PAGE_RECT,
+            locator={"page": 3, "rect": [10, 20, 300, 40]},
+            text=span_1_text,
+            fingerprint=_fingerprint(span_1_text),
+        )
+
+        span_2_id = _uid()
+        span_2_text = "Training requires GPU resources."
+        span_2 = SourceSpan(
+            id=span_2_id,
+            source_id=source_id,
+            user_id=TEST_USER_ID,
+            locator_kind=LocatorKind.PDF_PAGE_RECT,
+            locator={"page": 5, "rect": [10, 50, 300, 70]},
+            text=span_2_text,
+            fingerprint=_fingerprint(span_2_text),
+        )
+        db_session.add_all([span_1, span_2])
+        await db_session.flush()
+
+        # Create article and claim
+        article_id = _uid()
+        article = Article(
+            id=article_id,
+            user_id=TEST_USER_ID,
+            slug="neural-nets",
+            title="Neural Networks",
+            file_path="wiki/neural-nets.md",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        claim = CompiledClaim(
+            id=_uid(),
+            article_id=article_id,
+            user_id=TEST_USER_ID,
+            text="Neural networks need GPUs and improve accuracy.",
+            confidence_level="sourced",
+            source_ids=json.dumps([source_id]),
+            source_span_ids=json.dumps([span_1_id, span_2_id]),
+        )
+        db_session.add(claim)
+        await db_session.flush()
+
+        service = CitationService()
+        wiki_service = WikiService()
+        result = await service.get_article_citations(
+            article_id,
+            db_session,
+            user_id=TEST_USER_ID,
+            wiki_service=wiki_service,
+        )
+
+        assert result.article_id == article_id
+        assert result.article_title == "Neural Networks"
+        assert len(result.claims) == 1
+
+        claim_resp = result.claims[0]
+        assert claim_resp.text == "Neural networks need GPUs and improve accuracy."
+        assert claim_resp.confidence_level == "sourced"
+        assert len(claim_resp.source_spans) == 2
+        assert {s.id for s in claim_resp.source_spans} == {span_1_id, span_2_id}
+
+    @pytest.mark.asyncio
+    async def test_resolve_by_slug(self, db_session: AsyncSession) -> None:
+        article_id = _uid()
+        article = Article(
+            id=article_id,
+            user_id=TEST_USER_ID,
+            slug="slug-resolve-test",
+            title="Slug Resolve Test",
+            file_path="wiki/slug-resolve-test.md",
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        service = CitationService()
+        wiki_service = WikiService()
+        result = await service.get_article_citations(
+            "slug-resolve-test",
+            db_session,
+            user_id=TEST_USER_ID,
+            wiki_service=wiki_service,
+        )
+
+        assert result.article_id == article_id
+        assert result.article_title == "Slug Resolve Test"
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestCitationsEndpoint:
+    """Verify GET /api/wiki/articles/{id}/citations endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_citations_endpoint_not_found(self, client) -> None:
+        resp = await client.get("/api/wiki/articles/nonexistent/citations")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_citations_endpoint_empty_article(self, client, async_engine) -> None:
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+        article_id = _uid()
+        async with factory() as session:
+            article = Article(
+                id=article_id,
+                user_id=TEST_USER_ID,
+                slug="endpoint-test",
+                title="Endpoint Test",
+                file_path="wiki/endpoint-test.md",
+            )
+            session.add(article)
+            await session.commit()
+
+        resp = await client.get(f"/api/wiki/articles/{article_id}/citations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["article_id"] == article_id
+        assert data["article_title"] == "Endpoint Test"
+        assert data["claims"] == []
+
+    @pytest.mark.asyncio
+    async def test_citations_endpoint_with_spans(self, client, async_engine) -> None:
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+
+        source_id = _uid()
+        span_id = _uid()
+        article_id = _uid()
+        span_text = "Important finding here."
+
+        async with factory() as session:
+            source = Source(
+                id=source_id,
+                user_id=TEST_USER_ID,
+                source_type="url",
+                title="Web Source",
+            )
+            session.add(source)
+            await session.flush()
+
+            span = SourceSpan(
+                id=span_id,
+                source_id=source_id,
+                user_id=TEST_USER_ID,
+                locator_kind=LocatorKind.HTML_XPATH_OFFSET,
+                locator={"xpath": "//p[3]", "offset": 0, "length": 23},
+                text=span_text,
+                fingerprint=_fingerprint(span_text),
+            )
+            session.add(span)
+
+            article = Article(
+                id=article_id,
+                user_id=TEST_USER_ID,
+                slug="span-endpoint-test",
+                title="Span Endpoint Test",
+                file_path="wiki/span-endpoint-test.md",
+            )
+            session.add(article)
+            await session.flush()
+
+            claim = CompiledClaim(
+                id=_uid(),
+                article_id=article_id,
+                user_id=TEST_USER_ID,
+                text="An important finding.",
+                confidence_level="sourced",
+                source_ids=json.dumps([source_id]),
+                source_span_ids=json.dumps([span_id]),
+            )
+            session.add(claim)
+            await session.commit()
+
+        resp = await client.get(f"/api/wiki/articles/{article_id}/citations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["article_id"] == article_id
+        assert len(data["claims"]) == 1
+        assert len(data["claims"][0]["source_spans"]) == 1
+        assert data["claims"][0]["source_spans"][0]["id"] == span_id
+        assert data["claims"][0]["source_spans"][0]["locator_kind"] == "html-xpath-offset"


### PR DESCRIPTION
## Summary

- Adds the **SourceSpan** SQLModel table that anchors a verbatim text excerpt to a precise location in the original source document (PDF page rect, HTML XPath offset, byte range, or YouTube timestamp)
- Adds `source_span_ids` JSON field to **CompiledClaim** so claims can link to one or more source spans
- Adds `GET /api/wiki/articles/{id}/citations` endpoint returning claims with their resolved source spans for paragraph-level citation provenance
- Includes Alembic migration 0019, CitationService, and 11 tests (model, service, and API layers)

## Test plan

- [x] All 11 new citation tests pass (`tests/unit/test_citations.py`)
- [x] All 1911 non-smoke tests pass (zero regressions)
- [x] `make lint` clean
- [x] `make format` clean
- [x] `make typecheck` (mypy) passes
- [x] `make pyright` (basedpyright) passes — 0 errors
- [x] Alembic migration 0019 creates sourcespan table and adds source_span_ids column

🤖 Generated with [Claude Code](https://claude.com/claude-code)