### PR TITLE
feat: promote CompiledClaim reads to DB table with backfill migration (#466)

### DIFF
--- a/alembic/versions/0019_backfill_compiled_claims_from_markdown.py
+++ b/alembic/versions/0019_backfill_compiled_claims_from_markdown.py
@@ -1,0 +1,170 @@
+"""Backfill compiled_claim rows from article markdown key-claims sections.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-19
+
+Articles compiled before the ``compiledclaim`` table existed (migration 0010)
+have key claims only in their markdown ``## Key Claims`` section.  This data
+migration parses those claims and inserts ``compiledclaim`` rows so that all
+claim consumers (linter, search, concept clustering) can query a single
+authoritative source.
+
+The migration is idempotent: articles that already have ``compiledclaim`` rows
+are skipped.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0019"
+down_revision: str = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(conn: sa.engine.Connection, table: str) -> bool:
+    inspector = sa_inspect(conn)
+    return table in inspector.get_table_names()
+
+
+def _parse_claims_from_markdown(content: str) -> list[str]:
+    """Parse bullet-point claims from a ``## Key Claims`` markdown section."""
+    lines = content.split("\n")
+    claims: list[str] = []
+    in_claims_section = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.lower().startswith("## key claims") or stripped.lower().startswith(
+            "## key_claims"
+        ):
+            in_claims_section = True
+            continue
+        if in_claims_section:
+            if stripped.startswith("## "):
+                break
+            if stripped.startswith(("- ", "* ")):
+                claims.append(stripped[2:].strip())
+
+    return claims
+
+
+def upgrade() -> None:
+    """Backfill compiledclaim rows from article markdown files.
+
+    Uses raw SQL to avoid importing the ORM models (which may change
+    after this migration is written).  Reads wiki file content via the
+    storage layer only if the article has no existing compiledclaim rows.
+    """
+    conn = op.get_bind()
+
+    if not _table_exists(conn, "compiledclaim"):
+        # Table doesn't exist yet — nothing to backfill.
+        return
+
+    if not _table_exists(conn, "article"):
+        return
+
+    # Find articles that have NO compiledclaim rows yet.
+    articles_without_claims = conn.execute(
+        sa.text(
+            """
+            SELECT a.id, a.user_id, a.file_path, a.created_at
+            FROM article a
+            LEFT JOIN compiledclaim cc ON cc.article_id = a.id
+            WHERE cc.id IS NULL
+              AND a.file_path IS NOT NULL
+            """
+        )
+    ).fetchall()
+
+    if not articles_without_claims:
+        return
+
+    # We need the storage layer to resolve file paths.  Import lazily
+    # because Alembic migrations should minimise app-level imports.
+    try:
+        from wikimind.storage import get_wiki_storage  # noqa: PLC0415
+    except ImportError:
+        # If the app code is not importable (e.g. running bare Alembic),
+        # skip the data migration — it will be retried on next deploy.
+        return
+
+    now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+
+    rows_to_insert: list[dict] = []
+
+    for article_id, user_id, file_path, created_at in articles_without_claims:
+        try:
+            storage = get_wiki_storage(user_id)
+            # Read file synchronously — the async storage.read() just wraps
+            # Path.read_text via asyncio.to_thread, so call it directly.
+            resolved = storage.resolve_path(file_path)
+            content = resolved.read_text(encoding="utf-8")
+        except (FileNotFoundError, ValueError):
+            continue
+
+        claims = _parse_claims_from_markdown(content)
+        article_created = created_at or now
+
+        for claim_text in claims:
+            if not claim_text:
+                continue
+            rows_to_insert.append(
+                {
+                    "id": str(uuid.uuid4()),
+                    "article_id": article_id,
+                    "user_id": user_id,
+                    "text": claim_text,
+                    "subjects": "[]",
+                    "predicate": None,
+                    "confidence_level": "sourced",
+                    "confidence_score": 0.5,
+                    "source_ids": "[]",
+                    "last_reinforced_at": article_created,
+                    "quote": None,
+                    "embedding": None,
+                    "embedding_version": None,
+                    "cluster_assignment_reconciled": False,
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+    if rows_to_insert:
+        compiled_claim_table = sa.table(
+            "compiledclaim",
+            sa.column("id", sa.String),
+            sa.column("article_id", sa.String),
+            sa.column("user_id", sa.String),
+            sa.column("text", sa.String),
+            sa.column("subjects", sa.String),
+            sa.column("predicate", sa.String),
+            sa.column("confidence_level", sa.String),
+            sa.column("confidence_score", sa.Float),
+            sa.column("source_ids", sa.String),
+            sa.column("last_reinforced_at", sa.DateTime),
+            sa.column("quote", sa.String),
+            sa.column("embedding", sa.LargeBinary),
+            sa.column("embedding_version", sa.String),
+            sa.column("cluster_assignment_reconciled", sa.Boolean),
+            sa.column("created_at", sa.DateTime),
+            sa.column("updated_at", sa.DateTime),
+        )
+        op.bulk_insert(compiled_claim_table, rows_to_insert)
+
+
+def downgrade() -> None:
+    """No-op — we do not delete backfilled claims on downgrade.
+
+    The claims are valid data regardless of migration direction.
+    """

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -31,6 +31,7 @@ from wikimind.models import (
     Article,
     ArticleConcept,
     Backlink,
+    CompiledClaim,
     CompletionRequest,
     Concept,
     ContradictionFinding,
@@ -63,8 +64,25 @@ def _content_hash(article_a_id: str, article_b_id: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-async def _extract_claims(article: Article) -> list[str]:
-    """Extract key claims from an article's markdown file."""
+async def _extract_claims_from_db(
+    article: Article,
+    session: AsyncSession,
+) -> list[str]:
+    """Extract key claims from the CompiledClaim table.
+
+    Returns an empty list if no persisted claims exist for this article,
+    signalling the caller to fall back to markdown extraction.
+    """
+    result = await session.execute(select(CompiledClaim).where(CompiledClaim.article_id == article.id))
+    return [claim.text for claim in result.scalars().all()]
+
+
+async def _extract_claims_from_markdown(article: Article) -> list[str]:
+    """Extract key claims by parsing the article's markdown file.
+
+    This is the legacy extraction path used as a fallback when no
+    ``CompiledClaim`` rows exist for an article (pre-migration data).
+    """
     try:
         storage = get_wiki_storage(article.user_id)
         content = await storage.read(article.file_path)
@@ -95,6 +113,23 @@ async def _extract_claims(article: Article) -> list[str]:
                     break
 
     return claims
+
+
+async def _extract_claims(
+    article: Article,
+    session: AsyncSession | None = None,
+) -> list[str]:
+    """Extract key claims for an article, preferring the DB table.
+
+    Reads from the ``CompiledClaim`` table first.  Falls back to parsing
+    the article's markdown ``## Key Claims`` section when no DB rows exist
+    (backward compatibility for pre-migration articles).
+    """
+    if session is not None:
+        db_claims = await _extract_claims_from_db(article, session)
+        if db_claims:
+            return db_claims
+    return await _extract_claims_from_markdown(article)
 
 
 async def _get_articles_for_concept(
@@ -597,8 +632,8 @@ async def detect_contradictions(
                     continue
 
             # Collect claims for uncached pair
-            claims_a = await _extract_claims(article_a)
-            claims_b = await _extract_claims(article_b)
+            claims_a = await _extract_claims(article_a, session)
+            claims_b = await _extract_claims(article_b, session)
             if claims_a and claims_b:
                 uncached_pairs.append((article_a, article_b, claims_a, claims_b))
             else:
@@ -640,8 +675,8 @@ async def _compare_article_pair(
 ) -> list[ContradictionFinding]:
     """Compare a single article pair via LLM and return any findings."""
     cfg = settings.linter
-    claims_a = await _extract_claims(article_a)
-    claims_b = await _extract_claims(article_b)
+    claims_a = await _extract_claims(article_a, session)
+    claims_b = await _extract_claims(article_b, session)
 
     if not claims_a or not claims_b:
         return []


### PR DESCRIPTION
## Summary

- **Linter claim extraction now reads from the `CompiledClaim` table first**, falling back to markdown parsing for articles compiled before the table existed. This makes the linter's contradiction detector consistent with the compiler's write path (which already persists `CompiledClaim` rows).
- **Added Alembic migration 0019** to backfill `CompiledClaim` rows from article markdown `## Key Claims` sections for pre-existing articles that were compiled before migration 0010 created the table.
- **Added 3 tests** covering DB-first extraction, markdown fallback, and no-session fallback.

## Problem

The `CompiledClaim` table was already created (migration 0010) and the compiler was already writing claims to it, but the linter's contradiction detector was still parsing claims from markdown files. This meant the linter ignored any claim metadata (subjects, confidence, source_ids) stored in the DB and could miss claims for articles without a `## Key Claims` markdown section.

## Changes

| File | Change |
|------|--------|
| `src/wikimind/engine/linter/contradictions.py` | Split `_extract_claims` into `_extract_claims_from_db` + `_extract_claims_from_markdown`, with DB-first preference |
| `alembic/versions/0019_backfill_compiled_claims_from_markdown.py` | Data migration: parse claims from markdown files and insert `compiledclaim` rows for articles with no DB claims |
| `tests/unit/test_concept_layer_schema.py` | 3 new tests for the claim extraction fallback chain |
| `docs/openapi.yaml` | Regenerated (was already out of sync on main) |

## Test plan

- [x] `make lint` passes
- [x] `make format` passes
- [x] `make typecheck` (mypy) passes
- [x] 1903 tests pass (unit + integration), 0 failures
- [x] New tests verify DB-first, markdown-fallback, and no-session paths

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)