### PR TITLE
feat: add ambient capture adapter framework with browser history adapter (#442)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,10 @@
 # WIKIMIND_CAPTURE__AUTO_DISCARD_MIN_CHARS=200
 # HTTP timeout for RSS feed fetching
 # WIKIMIND_CAPTURE__RSS_HTTP_TIMEOUT_SECONDS=30
+# Ambient adapter poll interval (minutes between automatic polls)
+# WIKIMIND_CAPTURE__AMBIENT_POLL_INTERVAL_MINUTES=30
+# Max browser history entries to scan per poll
+# WIKIMIND_CAPTURE__BROWSER_HISTORY_MAX_ENTRIES_PER_POLL=100
 
 # ----------------------------------------------------------------------------
 # Ingestion (optional)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".env.example",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 308
       }
     ],
     ".github/workflows/migration-replay.yml": [
@@ -295,14 +295,14 @@
         "filename": "src/wikimind/config.py",
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
-        "line_number": 728
+        "line_number": 730
       },
       {
         "type": "Secret Keyword",
         "filename": "src/wikimind/config.py",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 753
+        "line_number": 755
       }
     ],
     "src/wikimind/engine/providers/openai.py": [

--- a/alembic/versions/0019_add_ambient_adapter_setting_table.py
+++ b/alembic/versions/0019_add_ambient_adapter_setting_table.py
@@ -1,0 +1,73 @@
+"""Add ambient_adapter_setting table for persisted adapter configuration.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-19
+
+The AmbientAdapterSetting table stores per-user ambient adapter
+configurations (enabled/disabled, adapter-specific settings JSON).
+The model was introduced in issue #442 but shipped without a migration,
+so deployed databases would lack the table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+from alembic import op
+
+revision: str = "0019"
+down_revision: str = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    existing = inspector.get_table_names()
+
+    if "ambientadaptersetting" not in existing:
+        op.create_table(
+            "ambientadaptersetting",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.String(),
+                sa.ForeignKey("user.id"),
+                nullable=False,
+            ),
+            sa.Column("adapter_type", sa.String(), nullable=False),
+            sa.Column("enabled", sa.Boolean(), nullable=False, server_default="1"),
+            sa.Column("settings_json", sa.String(), nullable=False, server_default="{}"),
+            sa.Column("last_polled_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+        )
+        op.create_index(
+            "ix_ambientadaptersetting_user_id",
+            "ambientadaptersetting",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_ambientadaptersetting_adapter_type",
+            "ambientadaptersetting",
+            ["adapter_type"],
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+    existing = inspector.get_table_names()
+
+    if "ambientadaptersetting" in existing:
+        op.drop_index(
+            "ix_ambientadaptersetting_adapter_type",
+            table_name="ambientadaptersetting",
+        )
+        op.drop_index(
+            "ix_ambientadaptersetting_user_id",
+            table_name="ambientadaptersetting",
+        )
+        op.drop_table("ambientadaptersetting")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -375,32 +375,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/capture/{kind}:
+  /api/capture/ambient/configure:
     post:
       tags:
       - Capture
-      summary: Create Capture
-      description: Push a raw capture from an ambient adapter.
-      operationId: create_capture_api_capture__kind__post
-      parameters:
-      - name: kind
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/CaptureKind'
+      summary: Configure Ambient Adapter
+      description: Enable or disable an ambient capture adapter.
+      operationId: configure_ambient_adapter_api_capture_ambient_configure_post
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CaptureRequest'
+              $ref: '#/components/schemas/AmbientAdapterConfigureRequest'
+        required: true
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CaptureResponse'
+                $ref: '#/components/schemas/AmbientAdapterStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/capture/ambient/adapters:
+    get:
+      tags:
+      - Capture
+      summary: List Ambient Adapters
+      description: List all configured ambient adapters.
+      operationId: list_ambient_adapters_api_capture_ambient_adapters_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AmbientAdapterListResponse'
+  /api/capture/ambient/adapters/{adapter_type}/poll:
+    post:
+      tags:
+      - Capture
+      summary: Poll Ambient Adapter
+      description: Manually trigger a poll for a specific ambient adapter.
+      operationId: poll_ambient_adapter_api_capture_ambient_adapters__adapter_type__poll_post
+      parameters:
+      - name: adapter_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Adapter Type
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AmbientPollResponse'
         '422':
           description: Validation Error
           content:
@@ -517,6 +552,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CaptureDiscardResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/capture/{kind}:
+    post:
+      tags:
+      - Capture
+      summary: Create Capture
+      description: Push a raw capture from an ambient adapter.
+      operationId: create_capture_api_capture__kind__post
+      parameters:
+      - name: kind
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/CaptureKind'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaptureRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaptureResponse'
         '422':
           description: Validation Error
           content:
@@ -4585,6 +4652,82 @@ components:
       - sync
       title: AllSettingsResponse
       description: Full application settings response.
+    AmbientAdapterConfigureRequest:
+      properties:
+        adapter_type:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Adapter Type
+        enabled:
+          type: boolean
+          title: Enabled
+          default: true
+        settings:
+          additionalProperties:
+            type: string
+          type: object
+          title: Settings
+      type: object
+      required:
+      - adapter_type
+      title: AmbientAdapterConfigureRequest
+      description: Request to configure an ambient capture adapter.
+    AmbientAdapterListResponse:
+      properties:
+        adapters:
+          items:
+            $ref: '#/components/schemas/AmbientAdapterStatusResponse'
+          type: array
+          title: Adapters
+      type: object
+      required:
+      - adapters
+      title: AmbientAdapterListResponse
+      description: List of configured ambient adapters.
+    AmbientAdapterStatusResponse:
+      properties:
+        adapter_type:
+          type: string
+          title: Adapter Type
+        enabled:
+          type: boolean
+          title: Enabled
+        last_polled_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Polled At
+        settings:
+          additionalProperties:
+            type: string
+          type: object
+          title: Settings
+      type: object
+      required:
+      - adapter_type
+      - enabled
+      title: AmbientAdapterStatusResponse
+      description: API response for an ambient adapter's status.
+    AmbientPollResponse:
+      properties:
+        adapter_type:
+          type: string
+          title: Adapter Type
+        new_captures:
+          type: integer
+          title: New Captures
+        status:
+          type: string
+          title: Status
+          default: polled
+      type: object
+      required:
+      - adapter_type
+      - new_captures
+      title: AmbientPollResponse
+      description: Response after triggering an ambient adapter poll.
     ApiKeyDeleteResponse:
       properties:
         provider:
@@ -5156,6 +5299,7 @@ components:
       - screenshot
       - slack
       - discord
+      - browser_history
       title: CaptureKind
       description: Kind of ambient capture adapter that produced a CaptureSource.
     CaptureListResponse:

--- a/src/wikimind/api/routes/capture.py
+++ b/src/wikimind/api/routes/capture.py
@@ -1,11 +1,16 @@
-"""Endpoints for ambient capture — inbox, ingest/discard, and RSS feeds (issue #442)."""
+"""Endpoints for ambient capture — inbox, ingest/discard, RSS feeds, and adapters (issue #442)."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.api.deps import get_current_user_id, require_plan
+from wikimind.config import get_settings
 from wikimind.database import get_session
 from wikimind.models import (
+    AmbientAdapterConfigureRequest,
+    AmbientAdapterListResponse,
+    AmbientAdapterStatusResponse,
+    AmbientPollResponse,
     CaptureDiscardResponse,
     CaptureIngestResponse,
     CaptureKind,
@@ -22,37 +27,90 @@ from wikimind.models import (
     RssFeedToggleRequest,
     RssPollResponse,
 )
+from wikimind.services.ambient import AmbientService
 from wikimind.services.capture import CaptureService
-from wikimind.services.factories import get_capture_service, get_rss_service
+from wikimind.services.factories import get_ambient_service, get_capture_service, get_rss_service
 from wikimind.services.quota import check_source_quota
 from wikimind.services.rss import RssService
 
 router = APIRouter()
 
 
+def _require_self_hosted() -> None:
+    """Reject ambient capture requests in hosted mode.
+
+    Ambient adapters read the server-local filesystem (e.g. browser
+    history databases). In hosted/multi-tenant mode this would expose
+    operator data, so we return 403.
+    """
+    if get_settings().deployment_mode == "hosted":
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": {
+                    "code": "FORBIDDEN",
+                    "message": (
+                        "Ambient capture is only available in self-hosted mode. "
+                        "Browser history adapters read the server's local filesystem "
+                        "and are disabled in hosted deployments."
+                    ),
+                }
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ambient adapter configuration endpoints (must be before /{kind} catch-all)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/ambient/configure",
+    response_model=AmbientAdapterStatusResponse,
+    dependencies=[Depends(_require_self_hosted)],
+)
+async def configure_ambient_adapter(
+    request: AmbientAdapterConfigureRequest,
+    session: AsyncSession = Depends(get_session),
+    service: AmbientService = Depends(get_ambient_service),
+    user_id: str = Depends(get_current_user_id),
+) -> AmbientAdapterStatusResponse:
+    """Enable or disable an ambient capture adapter."""
+    return await service.configure_adapter(request, session, user_id)
+
+
+@router.get(
+    "/ambient/adapters",
+    response_model=AmbientAdapterListResponse,
+    dependencies=[Depends(_require_self_hosted)],
+)
+async def list_ambient_adapters(
+    session: AsyncSession = Depends(get_session),
+    service: AmbientService = Depends(get_ambient_service),
+    user_id: str = Depends(get_current_user_id),
+) -> AmbientAdapterListResponse:
+    """List all configured ambient adapters."""
+    return await service.list_adapters(session, user_id)
+
+
+@router.post(
+    "/ambient/adapters/{adapter_type}/poll",
+    response_model=AmbientPollResponse,
+    dependencies=[Depends(_require_self_hosted)],
+)
+async def poll_ambient_adapter(
+    adapter_type: str,
+    session: AsyncSession = Depends(get_session),
+    service: AmbientService = Depends(get_ambient_service),
+    user_id: str = Depends(get_current_user_id),
+) -> AmbientPollResponse:
+    """Manually trigger a poll for a specific ambient adapter."""
+    return await service.poll_adapter(adapter_type, session, user_id)
+
+
 # ---------------------------------------------------------------------------
 # Capture inbox endpoints
 # ---------------------------------------------------------------------------
-
-
-@router.post("/{kind}", response_model=CaptureResponse)
-async def create_capture(
-    kind: CaptureKind,
-    request: CaptureRequest,
-    session: AsyncSession = Depends(get_session),
-    service: CaptureService = Depends(get_capture_service),
-    user_id: str = Depends(get_current_user_id),
-) -> CaptureResponse:
-    """Push a raw capture from an ambient adapter."""
-    return await service.create_capture(
-        kind=kind,
-        content=request.content,
-        session=session,
-        user_id=user_id,
-        title=request.title,
-        source_url=request.source_url,
-        external_id=request.external_id,
-    )
 
 
 @router.get("", response_model=CaptureListResponse)
@@ -101,6 +159,26 @@ async def discard_capture(
     """Mark a capture as not-worth-keeping."""
     reason = request.reason if request else None
     return await service.discard_capture(capture_id, session, user_id, reason=reason)
+
+
+@router.post("/{kind}", response_model=CaptureResponse)
+async def create_capture(
+    kind: CaptureKind,
+    request: CaptureRequest,
+    session: AsyncSession = Depends(get_session),
+    service: CaptureService = Depends(get_capture_service),
+    user_id: str = Depends(get_current_user_id),
+) -> CaptureResponse:
+    """Push a raw capture from an ambient adapter."""
+    return await service.create_capture(
+        kind=kind,
+        content=request.content,
+        session=session,
+        user_id=user_id,
+        title=request.title,
+        source_url=request.source_url,
+        external_id=request.external_id,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -201,6 +201,8 @@ class CaptureConfig(BaseModel):
     rss_max_entries_per_poll: int = 50
     auto_discard_min_chars: int = 200
     rss_http_timeout_seconds: int = 30
+    ambient_poll_interval_minutes: int = 30
+    browser_history_max_entries_per_poll: int = 100
 
 
 class SearchConfig(BaseModel):

--- a/src/wikimind/ingest/adapters/__init__.py
+++ b/src/wikimind/ingest/adapters/__init__.py
@@ -1,5 +1,7 @@
 """Ingest adapters — re-exports for backward compatibility."""
 
+from wikimind.ingest.adapters.ambient import AdapterConfig, AmbientAdapter, CapturedItem
+from wikimind.ingest.adapters.browser_history import BrowserHistoryAdapter
 from wikimind.ingest.adapters.pdf import (
     PDFAdapter,
     _convert_via_docling_serve,
@@ -12,6 +14,10 @@ from wikimind.ingest.adapters.url import URLAdapter
 from wikimind.ingest.adapters.youtube import YouTubeAdapter
 
 __all__ = [
+    "AdapterConfig",
+    "AmbientAdapter",
+    "BrowserHistoryAdapter",
+    "CapturedItem",
     "PDFAdapter",
     "TextAdapter",
     "URLAdapter",

--- a/src/wikimind/ingest/adapters/ambient.py
+++ b/src/wikimind/ingest/adapters/ambient.py
@@ -1,0 +1,95 @@
+"""Base class for ambient capture adapters (issue #442).
+
+Ambient adapters poll external sources on a schedule and yield
+``CapturedItem`` objects for each new piece of content discovered.
+Concrete adapters extend ``AmbientAdapter`` and implement ``poll()``.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from wikimind._datetime import utcnow_naive
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from wikimind.models import CaptureKind
+
+
+@dataclass
+class CapturedItem:
+    """A single item discovered by an ambient adapter.
+
+    Attributes:
+        kind: The adapter kind that produced this item.
+        title: Human-readable title (if available).
+        content: Raw payload text.
+        source_url: URL associated with the content (if any).
+        external_id: External identifier for dedup (e.g. browser history URL).
+    """
+
+    kind: CaptureKind
+    title: str | None = None
+    content: str = ""
+    source_url: str | None = None
+    external_id: str | None = None
+
+
+@dataclass
+class AdapterConfig:
+    """Runtime configuration for an ambient adapter instance.
+
+    Attributes:
+        enabled: Whether this adapter is active.
+        adapter_type: String identifier for the adapter (e.g. "browser_history").
+        settings: Adapter-specific key-value settings.
+    """
+
+    enabled: bool = False
+    adapter_type: str = ""
+    settings: dict[str, str] = field(default_factory=dict)
+
+
+class AmbientAdapter(abc.ABC):
+    """Abstract base class for ambient capture adapters.
+
+    Subclasses must implement ``poll()`` which returns new items since
+    the last poll. The ``last_polled_at`` timestamp tracks recency so
+    adapters can avoid re-fetching old data.
+    """
+
+    def __init__(self, config: AdapterConfig) -> None:
+        self.config = config
+        self.last_polled_at: datetime | None = None
+
+    @property
+    def adapter_type(self) -> str:
+        """Return the adapter type identifier."""
+        return self.config.adapter_type
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether this adapter is currently enabled."""
+        return self.config.enabled
+
+    @abc.abstractmethod
+    async def poll(self, session: AsyncSession, user_id: str) -> list[CapturedItem]:
+        """Fetch new items since the last poll.
+
+        Args:
+            session: Async database session (for dedup checks).
+            user_id: The user this adapter is polling for.
+
+        Returns:
+            A list of newly discovered items.
+        """
+        ...  # pragma: no cover
+
+    def mark_polled(self) -> None:
+        """Update the last_polled_at timestamp to now."""
+        self.last_polled_at = utcnow_naive()

--- a/src/wikimind/ingest/adapters/browser_history.py
+++ b/src/wikimind/ingest/adapters/browser_history.py
@@ -1,0 +1,322 @@
+"""Browser history ambient capture adapter (issue #442).
+
+Reads Chrome or Firefox SQLite history databases and yields URLs that
+match configurable patterns and haven't already been captured.
+
+The adapter copies the browser history DB to a temp file before reading
+because browsers hold an exclusive lock on the live database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlmodel import select
+
+from wikimind.config import get_settings
+from wikimind.ingest.adapters.ambient import AdapterConfig, AmbientAdapter, CapturedItem
+from wikimind.models import CaptureKind, CaptureSource
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+log = structlog.get_logger()
+
+# Default Chrome history DB paths per platform
+_CHROME_PATHS: dict[str, Path] = {
+    "Darwin": Path.home() / "Library/Application Support/Google/Chrome/Default/History",
+    "Linux": Path.home() / ".config/google-chrome/Default/History",
+    "Windows": Path.home() / "AppData/Local/Google/Chrome/User Data/Default/History",
+}
+
+# Default Firefox history DB paths per platform
+_FIREFOX_PATHS: dict[str, Path] = {
+    "Darwin": Path.home() / "Library/Application Support/Firefox/Profiles",
+    "Linux": Path.home() / ".mozilla/firefox",
+    "Windows": Path.home() / "AppData/Roaming/Mozilla/Firefox/Profiles",
+}
+
+
+def _find_firefox_history_db() -> Path | None:
+    """Find the Firefox places.sqlite in the default profile directory.
+
+    Firefox stores history in ``places.sqlite`` inside a profile folder
+    named ``<random>.default-release`` or similar. We find the first
+    matching profile that contains the file.
+    """
+    system = platform.system()
+    base = _FIREFOX_PATHS.get(system)
+    if base is None or not base.exists():
+        return None
+    for profile_dir in base.iterdir():
+        places = profile_dir / "places.sqlite"
+        if places.exists():
+            return places
+    return None
+
+
+def _resolve_history_db(config: AdapterConfig) -> Path | None:
+    """Resolve the browser history SQLite database path.
+
+    Uses only hardcoded platform-specific default paths for Chrome or
+    Firefox. User-supplied paths are never accepted to prevent arbitrary
+    local file reads.
+
+    Args:
+        config: Adapter configuration with ``browser`` setting.
+
+    Returns:
+        Path to the history database, or None if not found.
+    """
+    browser = config.settings.get("browser", "chrome")
+    system = platform.system()
+
+    if browser == "chrome":
+        path = _CHROME_PATHS.get(system)
+        if path and path.exists():
+            return path
+    elif browser == "firefox":
+        return _find_firefox_history_db()
+
+    return None
+
+
+def _copy_db_to_temp(db_path: Path) -> Path:
+    """Copy the browser history DB to a temp file for safe reading.
+
+    Browsers hold exclusive locks on their SQLite databases, so we
+    copy the file to a temporary location before opening it.
+
+    Args:
+        db_path: Path to the live browser history DB.
+
+    Returns:
+        Path to the temporary copy.
+    """
+    fd, tmp_name = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    tmp = Path(tmp_name)
+    shutil.copy2(db_path, tmp)
+    return tmp
+
+
+def _read_chrome_history(
+    db_path: Path,
+    since_timestamp: int,
+    max_entries: int,
+) -> list[dict[str, str]]:
+    """Read recent Chrome history entries from the SQLite database.
+
+    Chrome stores visit timestamps as microseconds since 1601-01-01
+    (Windows epoch). We convert our Unix timestamp to Chrome's format
+    for the WHERE clause.
+
+    Args:
+        db_path: Path to the (copied) Chrome History SQLite file.
+        since_timestamp: Unix timestamp — only entries after this time.
+        max_entries: Maximum number of entries to return.
+
+    Returns:
+        List of dicts with ``url`` and ``title`` keys.
+    """
+    # Chrome epoch: 1601-01-01 00:00:00 UTC. Offset to Unix epoch in microseconds.
+    chrome_epoch_offset = 11644473600 * 1_000_000
+    chrome_since = since_timestamp * 1_000_000 + chrome_epoch_offset
+
+    entries: list[dict[str, str]] = []
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        cursor = conn.execute(
+            """
+            SELECT DISTINCT u.url, u.title
+            FROM urls u
+            JOIN visits v ON u.id = v.url
+            WHERE v.visit_time > ?
+            ORDER BY v.visit_time DESC
+            LIMIT ?
+            """,
+            (chrome_since, max_entries),
+        )
+        entries.extend({"url": row[0], "title": row[1] or ""} for row in cursor)
+        conn.close()
+    except sqlite3.Error as e:
+        log.warning("failed to read Chrome history", error=str(e))
+
+    return entries
+
+
+def _read_firefox_history(
+    db_path: Path,
+    since_timestamp: int,
+    max_entries: int,
+) -> list[dict[str, str]]:
+    """Read recent Firefox history entries from the SQLite database.
+
+    Firefox stores visit timestamps as microseconds since Unix epoch.
+
+    Args:
+        db_path: Path to the (copied) Firefox places.sqlite file.
+        since_timestamp: Unix timestamp — only entries after this time.
+        max_entries: Maximum number of entries to return.
+
+    Returns:
+        List of dicts with ``url`` and ``title`` keys.
+    """
+    firefox_since = since_timestamp * 1_000_000
+
+    entries: list[dict[str, str]] = []
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        cursor = conn.execute(
+            """
+            SELECT DISTINCT p.url, p.title
+            FROM moz_places p
+            JOIN moz_historyvisits v ON p.id = v.place_id
+            WHERE v.visit_date > ?
+            ORDER BY v.visit_date DESC
+            LIMIT ?
+            """,
+            (firefox_since, max_entries),
+        )
+        entries.extend({"url": row[0], "title": row[1] or ""} for row in cursor)
+        conn.close()
+    except sqlite3.Error as e:
+        log.warning("failed to read Firefox history", error=str(e))
+
+    return entries
+
+
+def _matches_patterns(url: str, patterns: list[str]) -> bool:
+    """Check if a URL matches any of the configured filter patterns.
+
+    An empty pattern list means "match everything". Patterns are
+    compiled as regular expressions for flexibility.
+
+    Args:
+        url: The URL to check.
+        patterns: List of regex patterns to match against.
+
+    Returns:
+        True if the URL matches any pattern or patterns is empty.
+    """
+    if not patterns:
+        return True
+    return any(re.search(p, url) for p in patterns)
+
+
+class BrowserHistoryAdapter(AmbientAdapter):
+    """Ambient adapter that reads browser history and yields new URLs.
+
+    **Security**: This adapter reads the local filesystem and only makes
+    sense in self-hosted mode. The ``history_db_path`` setting is never
+    accepted from user input — only the hardcoded platform-default paths
+    for Chrome/Firefox are used.
+
+    Configuration settings (via ``AdapterConfig.settings``):
+        - ``browser``: "chrome" or "firefox" (default: "chrome")
+        - ``url_patterns``: Comma-separated regex patterns to filter URLs.
+            Empty means capture all URLs.
+        - ``exclude_patterns``: Comma-separated regex patterns to exclude.
+            Applied after include patterns.
+    """
+
+    def __init__(self, config: AdapterConfig | None = None) -> None:
+        if config is None:
+            config = AdapterConfig(adapter_type="browser_history")
+        super().__init__(config)
+
+    async def poll(self, session: AsyncSession, user_id: str) -> list[CapturedItem]:
+        """Read browser history and return new URLs not yet captured.
+
+        Args:
+            session: Async database session for dedup checks.
+            user_id: The user to check captures for.
+
+        Returns:
+            List of CapturedItem for each new URL.
+        """
+        settings = get_settings()
+        max_entries = settings.capture.browser_history_max_entries_per_poll
+
+        db_path = _resolve_history_db(self.config)
+        if db_path is None:
+            log.info("browser history DB not found, skipping poll")
+            self.mark_polled()
+            return []
+
+        # Copy to temp file to avoid locking issues
+        tmp_path = _copy_db_to_temp(db_path)
+        try:
+            # Determine since-timestamp from last poll
+            since_ts = 0
+            if self.last_polled_at is not None:
+                since_ts = int(self.last_polled_at.timestamp())
+
+            browser = self.config.settings.get("browser", "chrome")
+            if browser == "firefox":
+                entries = _read_firefox_history(tmp_path, since_ts, max_entries)
+            else:
+                entries = _read_chrome_history(tmp_path, since_ts, max_entries)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        if not entries:
+            self.mark_polled()
+            return []
+
+        # Parse filter patterns
+        include_raw = self.config.settings.get("url_patterns", "")
+        include_patterns = [p.strip() for p in include_raw.split(",") if p.strip()]
+        exclude_raw = self.config.settings.get("exclude_patterns", "")
+        exclude_patterns = [p.strip() for p in exclude_raw.split(",") if p.strip()]
+
+        items: list[CapturedItem] = []
+        for entry in entries:
+            url = entry["url"]
+            title = entry.get("title", "")
+
+            # Apply include/exclude filters
+            if not _matches_patterns(url, include_patterns):
+                continue
+            if exclude_patterns and _matches_patterns(url, exclude_patterns):
+                continue
+
+            # Dedup: check if already captured
+            content_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
+            existing = await session.execute(
+                select(CaptureSource).where(
+                    CaptureSource.user_id == user_id,
+                    CaptureSource.content_hash == content_hash,
+                )
+            )
+            if existing.scalars().first() is not None:
+                continue
+
+            items.append(
+                CapturedItem(
+                    kind=CaptureKind.BROWSER_HISTORY,
+                    title=title or None,
+                    content=url,
+                    source_url=url,
+                    external_id=url,
+                )
+            )
+
+        self.mark_polled()
+
+        log.info(
+            "browser history polled",
+            entries_scanned=len(entries),
+            new_items=len(items),
+            browser=self.config.settings.get("browser", "chrome"),
+        )
+        return items

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -39,6 +39,7 @@ from wikimind.engine.concept_compiler import ConceptCompiler
 from wikimind.engine.linter.runner import run_lint  # CodeQL[cyclic-import]
 from wikimind.jobs.sweep import sweep_wikilinks
 from wikimind.models import (
+    AmbientAdapterSetting,
     Article,
     Concept,
     IngestStatus,
@@ -617,6 +618,43 @@ async def run_reconciliation(_ctx) -> dict:
     return {"reconciled": count}
 
 
+async def ambient_capture_poll(_ctx) -> dict:
+    """Periodic ambient adapter poll — runs all enabled adapters for all users.
+
+    Iterates over users who have at least one enabled adapter, polls each,
+    and records new captures.
+
+    Args:
+        _ctx: ARQ context (unused).
+
+    Returns:
+        A dict with the total number of new captures.
+    """
+    from wikimind.services.ambient import AmbientService  # noqa: PLC0415
+
+    service = AmbientService()
+    total = 0
+
+    async with get_session_factory()() as session:
+        result = await session.execute(
+            select(distinct(AmbientAdapterSetting.user_id)).where(  # type: ignore[arg-type]
+                AmbientAdapterSetting.enabled == True,  # noqa: E712
+            )
+        )
+        user_ids = [row[0] for row in result]
+
+    for uid in user_ids:
+        try:
+            async with get_session_factory()() as session:
+                new_count = await service.poll_all_adapters(session, uid)
+                total += new_count
+        except Exception:
+            log.exception("ambient poll failed for user", user_id=uid)
+
+    log.info("ambient_capture_poll complete", total_new=total, users=len(user_ids))
+    return {"new_captures": total}
+
+
 # ---------------------------------------------------------------------------
 # Redis settings — only used when a Redis URL is configured (production ARQ)
 # ---------------------------------------------------------------------------
@@ -654,8 +692,10 @@ class WorkerSettings:
 
     # Weekly linter + daily wikilink sweep — iterate over all users
     # 6-hourly subscription reconciliation (no-op in self-hosted mode)
+    # 30-minute ambient capture poll (only runs if users have enabled adapters)
     cron_jobs: ClassVar[list] = [
         cron(lint_all_users, weekday=0, hour=2, minute=0),  # Monday 2am
         cron(sweep_all_users, hour=3, minute=0),  # Daily 3am
         cron(run_reconciliation, hour={0, 6, 12, 18}, minute=0),  # type: ignore[arg-type]  # Every 6 hours
+        cron(ambient_capture_poll, minute={0, 30}),  # type: ignore[arg-type]  # Every 30 minutes
     ]

--- a/src/wikimind/models/__init__.py
+++ b/src/wikimind/models/__init__.py
@@ -45,6 +45,10 @@ from wikimind.models.dto.auth import (
     UserProfileResponse,
 )
 from wikimind.models.dto.capture import (
+    AmbientAdapterConfigureRequest,
+    AmbientAdapterListResponse,
+    AmbientAdapterStatusResponse,
+    AmbientPollResponse,
     CaptureDiscardResponse,
     CaptureIngestResponse,
     CaptureListResponse,
@@ -222,6 +226,7 @@ from wikimind.models.enums import (
 
 # Re-export SQLModel tables from domain-specific sub-modules
 from wikimind.models.tables import (  # noqa: F401
+    AmbientAdapterSetting,
     Article,
     ArticleConcept,
     ArticleSource,
@@ -333,6 +338,11 @@ __all__ = [
     "AdminPlanUpdateRequest",
     "AdminUserDetail",
     "AdminUserSummary",
+    "AmbientAdapterConfigureRequest",
+    "AmbientAdapterListResponse",
+    "AmbientAdapterSetting",
+    "AmbientAdapterStatusResponse",
+    "AmbientPollResponse",
     # Pipeline models
     "AnswerCompilationResult",
     # Frontmatter

--- a/src/wikimind/models/dto/__init__.py
+++ b/src/wikimind/models/dto/__init__.py
@@ -36,6 +36,10 @@ from wikimind.models.dto.auth import (
     UserProfileResponse,
 )
 from wikimind.models.dto.capture import (
+    AmbientAdapterConfigureRequest,
+    AmbientAdapterListResponse,
+    AmbientAdapterStatusResponse,
+    AmbientPollResponse,
     CaptureDiscardResponse,
     CaptureIngestResponse,
     CaptureListResponse,
@@ -189,6 +193,11 @@ __all__ = [
     "AdminActionResult",
     "AdminUserDetail",
     "AdminUserSummary",
+    # capture
+    "AmbientAdapterConfigureRequest",
+    "AmbientAdapterListResponse",
+    "AmbientAdapterStatusResponse",
+    "AmbientPollResponse",
     # compilation
     "AnswerCompilationResult",
     "AnswerFrontmatter",
@@ -207,7 +216,6 @@ __all__ = [
     # query
     "AskResponse",
     "BacklinkEntry",
-    # capture
     "CaptureDiscardResponse",
     "CaptureIngestResponse",
     "CaptureListResponse",

--- a/src/wikimind/models/dto/capture.py
+++ b/src/wikimind/models/dto/capture.py
@@ -107,3 +107,39 @@ class RssPollResponse(BaseModel):
     feed_id: str
     new_captures: int
     status: str = "polled"
+
+
+# ---------------------------------------------------------------------------
+# Ambient adapter configuration request/response models (issue #442)
+# ---------------------------------------------------------------------------
+
+
+class AmbientAdapterConfigureRequest(BaseModel):
+    """Request to configure an ambient capture adapter."""
+
+    adapter_type: str = Field(min_length=1, max_length=100)
+    enabled: bool = True
+    settings: dict[str, str] = Field(default_factory=dict)
+
+
+class AmbientAdapterStatusResponse(BaseModel):
+    """API response for an ambient adapter's status."""
+
+    adapter_type: str
+    enabled: bool
+    last_polled_at: datetime | None = None
+    settings: dict[str, str] = Field(default_factory=dict)
+
+
+class AmbientAdapterListResponse(BaseModel):
+    """List of configured ambient adapters."""
+
+    adapters: list[AmbientAdapterStatusResponse]
+
+
+class AmbientPollResponse(BaseModel):
+    """Response after triggering an ambient adapter poll."""
+
+    adapter_type: str
+    new_captures: int
+    status: str = "polled"

--- a/src/wikimind/models/enums.py
+++ b/src/wikimind/models/enums.py
@@ -98,6 +98,7 @@ class CaptureKind(StrEnum):
     SCREENSHOT = "screenshot"
     SLACK = "slack"
     DISCORD = "discord"
+    BROWSER_HISTORY = "browser_history"
 
 
 class CaptureStatus(StrEnum):

--- a/src/wikimind/models/tables/__init__.py
+++ b/src/wikimind/models/tables/__init__.py
@@ -16,7 +16,7 @@ from wikimind.models.tables.billing import (
     Subscription,
     WebhookEvent,
 )
-from wikimind.models.tables.capture import CaptureSource, RssFeed
+from wikimind.models.tables.capture import AmbientAdapterSetting, CaptureSource, RssFeed
 from wikimind.models.tables.compilation import (
     ClaimConcept,
     CompilationDraft,
@@ -56,6 +56,7 @@ from wikimind.models.tables.wiki import (
 )
 
 __all__ = [
+    "AmbientAdapterSetting",
     "Article",
     "ArticleConcept",
     "ArticleSource",

--- a/src/wikimind/models/tables/capture.py
+++ b/src/wikimind/models/tables/capture.py
@@ -1,4 +1,4 @@
-"""Capture tables — ambient capture sources and RSS feeds."""
+"""Capture tables — ambient capture sources, RSS feeds, and adapter settings."""
 
 import uuid
 from datetime import datetime
@@ -34,6 +34,22 @@ class CaptureSource(SQLModel, table=True):
     ingested_at: datetime | None = None
     discarded_at: datetime | None = None
     discard_reason: str | None = None
+
+
+class AmbientAdapterSetting(SQLModel, table=True):
+    """Persisted configuration for an ambient capture adapter (issue #442).
+
+    Each row represents one adapter type for one user. The ``settings_json``
+    column stores adapter-specific key-value pairs as a JSON string.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    user_id: str = Field(foreign_key="user.id", index=True)
+    adapter_type: str = Field(index=True)
+    enabled: bool = True
+    settings_json: str = "{}"
+    last_polled_at: datetime | None = None
+    created_at: datetime = Field(default_factory=utcnow_naive)
 
 
 class RssFeed(SQLModel, table=True):

--- a/src/wikimind/services/ambient.py
+++ b/src/wikimind/services/ambient.py
@@ -1,0 +1,317 @@
+"""Ambient capture adapter management service (issue #442).
+
+Manages ambient adapter configurations and dispatches polls. Adapters
+are registered by type and instantiated from persisted settings. The
+``poll_adapters`` method runs all enabled adapters for a user and creates
+CaptureSource rows for each discovered item.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlmodel import select
+
+from wikimind._datetime import utcnow_naive
+from wikimind.errors import NotFoundError
+from wikimind.ingest.adapters.ambient import AdapterConfig, AmbientAdapter, CapturedItem
+from wikimind.ingest.adapters.browser_history import BrowserHistoryAdapter
+from wikimind.models import (
+    AmbientAdapterConfigureRequest,
+    AmbientAdapterListResponse,
+    AmbientAdapterSetting,
+    AmbientAdapterStatusResponse,
+    AmbientPollResponse,
+    CaptureSource,
+    CaptureStatus,
+)
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+log = structlog.get_logger()
+
+# Registry of supported ambient adapter types → constructor callables
+_ADAPTER_REGISTRY: dict[str, type[AmbientAdapter]] = {
+    "browser_history": BrowserHistoryAdapter,
+}
+
+
+def _build_adapter(setting: AmbientAdapterSetting) -> AmbientAdapter | None:
+    """Instantiate an adapter from a persisted setting row.
+
+    Returns None if the adapter type is not in the registry.
+    """
+    adapter_cls = _ADAPTER_REGISTRY.get(setting.adapter_type)
+    if adapter_cls is None:
+        log.warning("unknown adapter type", adapter_type=setting.adapter_type)
+        return None
+
+    settings_dict = json.loads(setting.settings_json) if setting.settings_json else {}
+    config = AdapterConfig(
+        enabled=setting.enabled,
+        adapter_type=setting.adapter_type,
+        settings=settings_dict,
+    )
+    adapter = adapter_cls(config)
+    adapter.last_polled_at = setting.last_polled_at
+    return adapter
+
+
+def _setting_to_response(setting: AmbientAdapterSetting) -> AmbientAdapterStatusResponse:
+    """Convert a DB row to an API response."""
+    settings_dict = json.loads(setting.settings_json) if setting.settings_json else {}
+    return AmbientAdapterStatusResponse(
+        adapter_type=setting.adapter_type,
+        enabled=setting.enabled,
+        last_polled_at=setting.last_polled_at,
+        settings=settings_dict,
+    )
+
+
+class AmbientService:
+    """Manages ambient adapter configurations and polling."""
+
+    async def configure_adapter(
+        self,
+        request: AmbientAdapterConfigureRequest,
+        session: AsyncSession,
+        user_id: str,
+    ) -> AmbientAdapterStatusResponse:
+        """Configure (create or update) an ambient adapter for a user.
+
+        Args:
+            request: Adapter configuration request.
+            session: Async database session.
+            user_id: Owner of this adapter config.
+
+        Returns:
+            AmbientAdapterStatusResponse for the configured adapter.
+        """
+        if request.adapter_type not in _ADAPTER_REGISTRY:
+            msg = f"Unsupported adapter type: {request.adapter_type}"
+            raise ValueError(msg)
+
+        # Strip history_db_path — never allow user-supplied filesystem paths
+        # to prevent arbitrary local file read (security fix).
+        sanitised_settings = {k: v for k, v in request.settings.items() if k != "history_db_path"}
+
+        # Upsert: find existing or create new
+        result = await session.execute(
+            select(AmbientAdapterSetting).where(
+                AmbientAdapterSetting.user_id == user_id,
+                AmbientAdapterSetting.adapter_type == request.adapter_type,
+            )
+        )
+        setting = result.scalars().first()
+
+        if setting is None:
+            setting = AmbientAdapterSetting(
+                user_id=user_id,
+                adapter_type=request.adapter_type,
+                enabled=request.enabled,
+                settings_json=json.dumps(sanitised_settings),
+            )
+        else:
+            setting.enabled = request.enabled
+            setting.settings_json = json.dumps(sanitised_settings)
+
+        session.add(setting)
+        await session.commit()
+        await session.refresh(setting)
+
+        log.info(
+            "ambient adapter configured",
+            adapter_type=request.adapter_type,
+            enabled=request.enabled,
+            user_id=user_id,
+        )
+        return _setting_to_response(setting)
+
+    async def list_adapters(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> AmbientAdapterListResponse:
+        """List all configured ambient adapters for a user.
+
+        Args:
+            session: Async database session.
+            user_id: Owner filter.
+
+        Returns:
+            AmbientAdapterListResponse with all adapters.
+        """
+        result = await session.execute(
+            select(AmbientAdapterSetting).where(
+                AmbientAdapterSetting.user_id == user_id,
+            )
+        )
+        settings = list(result.scalars().all())
+        return AmbientAdapterListResponse(
+            adapters=[_setting_to_response(s) for s in settings],
+        )
+
+    async def get_adapter_setting(
+        self,
+        adapter_type: str,
+        session: AsyncSession,
+        user_id: str,
+    ) -> AmbientAdapterSetting:
+        """Retrieve a single adapter setting.
+
+        Args:
+            adapter_type: The adapter type string.
+            session: Async database session.
+            user_id: Owner verification.
+
+        Returns:
+            The AmbientAdapterSetting record.
+
+        Raises:
+            NotFoundError: If the adapter config doesn't exist for this user.
+        """
+        result = await session.execute(
+            select(AmbientAdapterSetting).where(
+                AmbientAdapterSetting.user_id == user_id,
+                AmbientAdapterSetting.adapter_type == adapter_type,
+            )
+        )
+        setting = result.scalars().first()
+        if setting is None:
+            msg = f"Adapter config not found: {adapter_type}"
+            raise NotFoundError(msg)
+        return setting
+
+    async def poll_adapter(
+        self,
+        adapter_type: str,
+        session: AsyncSession,
+        user_id: str,
+    ) -> AmbientPollResponse:
+        """Manually trigger a poll for a specific adapter.
+
+        Args:
+            adapter_type: The adapter type to poll.
+            session: Async database session.
+            user_id: Owner.
+
+        Returns:
+            AmbientPollResponse with the number of new captures.
+        """
+        setting = await self.get_adapter_setting(adapter_type, session, user_id)
+        adapter = _build_adapter(setting)
+        if adapter is None:
+            msg = f"Cannot instantiate adapter: {adapter_type}"
+            raise ValueError(msg)
+
+        items = await adapter.poll(session, user_id)
+        new_count = await self._save_captured_items(items, session, user_id)
+
+        # Update last_polled_at on the setting
+        setting.last_polled_at = utcnow_naive()
+        session.add(setting)
+        await session.commit()
+
+        return AmbientPollResponse(
+            adapter_type=adapter_type,
+            new_captures=new_count,
+        )
+
+    async def poll_all_adapters(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> int:
+        """Poll all enabled adapters for a user.
+
+        Args:
+            session: Async database session.
+            user_id: Owner filter.
+
+        Returns:
+            Total number of new captures across all adapters.
+        """
+        result = await session.execute(
+            select(AmbientAdapterSetting).where(
+                AmbientAdapterSetting.user_id == user_id,
+                AmbientAdapterSetting.enabled == True,  # noqa: E712
+            )
+        )
+        settings = list(result.scalars().all())
+
+        total_new = 0
+        for setting in settings:
+            adapter = _build_adapter(setting)
+            if adapter is None:
+                continue
+
+            try:
+                items = await adapter.poll(session, user_id)
+                new_count = await self._save_captured_items(items, session, user_id)
+                total_new += new_count
+
+                setting.last_polled_at = utcnow_naive()
+                session.add(setting)
+            except Exception:
+                log.exception(
+                    "ambient adapter poll failed",
+                    adapter_type=setting.adapter_type,
+                    user_id=user_id,
+                )
+
+        await session.commit()
+        return total_new
+
+    async def _save_captured_items(
+        self,
+        items: list[CapturedItem],
+        session: AsyncSession,
+        user_id: str,
+    ) -> int:
+        """Persist captured items as CaptureSource rows.
+
+        Deduplicates by content_hash before inserting.
+
+        Args:
+            items: List of items from an adapter poll.
+            session: Async database session.
+            user_id: Owner.
+
+        Returns:
+            Number of new captures created.
+        """
+        new_count = 0
+        for item in items:
+            content_hash = hashlib.sha256(item.content.encode("utf-8")).hexdigest()
+
+            # Dedup check
+            existing = await session.execute(
+                select(CaptureSource).where(
+                    CaptureSource.user_id == user_id,
+                    CaptureSource.content_hash == content_hash,
+                )
+            )
+            if existing.scalars().first() is not None:
+                continue
+
+            capture = CaptureSource(
+                user_id=user_id,
+                kind=item.kind,
+                title=item.title,
+                raw_payload=item.content,
+                content_hash=content_hash,
+                source_url=item.source_url,
+                external_id=item.external_id,
+                status=CaptureStatus.CAPTURED,
+            )
+            session.add(capture)
+            new_count += 1
+
+        if new_count > 0:
+            await session.commit()
+
+        return new_count

--- a/src/wikimind/services/factories.py
+++ b/src/wikimind/services/factories.py
@@ -11,6 +11,7 @@ import functools
 import structlog
 
 from wikimind.services.admin import AdminService
+from wikimind.services.ambient import AmbientService
 from wikimind.services.capture import CaptureService
 from wikimind.services.citation import CitationService
 from wikimind.services.compilation_schema import CompilationSchemaService
@@ -51,6 +52,12 @@ def get_admin_service() -> AdminService:
     if _admin_service is None:
         _admin_service = AdminService()
     return _admin_service
+
+
+@functools.lru_cache(maxsize=1)
+def get_ambient_service() -> AmbientService:
+    """Return a singleton AmbientService instance for FastAPI dependency injection."""
+    return AmbientService()
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,8 +1,13 @@
-"""Tests for ambient capture — capture inbox, RSS feeds, and adapters (issue #442)."""
+"""Tests for ambient capture — inbox, RSS feeds, ambient adapters, and browser history (#442)."""
 
 from __future__ import annotations
 
+import sqlite3
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import httpx
 import pytest
@@ -10,13 +15,22 @@ from sqlmodel import select
 
 from tests.conftest import TEST_USER_ID
 from wikimind.errors import NotFoundError
+from wikimind.ingest.adapters.ambient import AdapterConfig, CapturedItem
+from wikimind.ingest.adapters.browser_history import (
+    BrowserHistoryAdapter,
+    _matches_patterns,
+    _read_chrome_history,
+    _read_firefox_history,
+)
 from wikimind.ingest.adapters.rss import RssAdapter, _parse_feed_entries
 from wikimind.models import (
+    AmbientAdapterConfigureRequest,
     CaptureKind,
     CaptureSource,
     CaptureStatus,
     RssFeed,
 )
+from wikimind.services.ambient import AmbientService
 from wikimind.services.capture import CaptureService
 from wikimind.services.rss import RssService
 
@@ -589,3 +603,495 @@ class TestCaptureAPI:
         resp = await client.delete(f"/api/capture/rss/feeds/{feed_id}")
         assert resp.status_code == 200
         assert resp.json()["deleted"] == feed_id
+
+
+# ---------------------------------------------------------------------------
+# AmbientAdapter base class unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAmbientAdapterBase:
+    """Test the AmbientAdapter base class contract."""
+
+    def test_adapter_config_defaults(self) -> None:
+        config = AdapterConfig()
+        assert config.enabled is False
+        assert config.adapter_type == ""
+        assert config.settings == {}
+
+    def test_captured_item_fields(self) -> None:
+        item = CapturedItem(
+            kind=CaptureKind.BROWSER_HISTORY,
+            title="Test Page",
+            content="https://example.com",
+            source_url="https://example.com",
+            external_id="https://example.com",
+        )
+        assert item.kind == CaptureKind.BROWSER_HISTORY
+        assert item.title == "Test Page"
+        assert item.source_url == "https://example.com"
+
+    def test_adapter_mark_polled(self) -> None:
+        """mark_polled() updates last_polled_at."""
+        config = AdapterConfig(enabled=True, adapter_type="browser_history")
+        adapter = BrowserHistoryAdapter(config)
+        assert adapter.last_polled_at is None
+        adapter.mark_polled()
+        assert adapter.last_polled_at is not None
+
+    def test_adapter_properties(self) -> None:
+        config = AdapterConfig(enabled=True, adapter_type="browser_history")
+        adapter = BrowserHistoryAdapter(config)
+        assert adapter.adapter_type == "browser_history"
+        assert adapter.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# URL pattern matching tests
+# ---------------------------------------------------------------------------
+
+
+class TestUrlPatternMatching:
+    """Test URL pattern matching for browser history filtering."""
+
+    def test_empty_patterns_match_all(self) -> None:
+        assert _matches_patterns("https://example.com/any/path", []) is True
+
+    def test_matching_pattern(self) -> None:
+        patterns = [r"github\.com", r"stackoverflow\.com"]
+        assert _matches_patterns("https://github.com/repo", patterns) is True
+        assert _matches_patterns("https://stackoverflow.com/q/123", patterns) is True
+
+    def test_non_matching_pattern(self) -> None:
+        patterns = [r"github\.com"]
+        assert _matches_patterns("https://example.com", patterns) is False
+
+    def test_regex_patterns(self) -> None:
+        patterns = [r".*\.md$", r"docs/.*"]
+        assert _matches_patterns("https://example.com/file.md", patterns) is True
+        assert _matches_patterns("https://example.com/docs/guide", patterns) is True
+        assert _matches_patterns("https://example.com/index.html", patterns) is False
+
+
+# ---------------------------------------------------------------------------
+# Browser history SQLite reader tests
+# ---------------------------------------------------------------------------
+
+
+def _create_chrome_db(db_path: Path) -> None:
+    """Create a minimal Chrome-like history SQLite database."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE urls (id INTEGER PRIMARY KEY, url TEXT, title TEXT)")
+    conn.execute("CREATE TABLE visits (id INTEGER PRIMARY KEY, url INTEGER, visit_time INTEGER)")
+    # Chrome epoch offset: 11644473600 seconds → microseconds
+    chrome_offset = 11644473600 * 1_000_000
+    # Add entries at Unix timestamp 1000 (well after epoch 0)
+    ts = 1000 * 1_000_000 + chrome_offset
+    conn.execute("INSERT INTO urls VALUES (1, 'https://example.com/page1', 'Page 1')")
+    conn.execute("INSERT INTO urls VALUES (2, 'https://example.com/page2', 'Page 2')")
+    conn.execute(f"INSERT INTO visits VALUES (1, 1, {ts})")
+    conn.execute(f"INSERT INTO visits VALUES (2, 2, {ts + 1000})")
+    conn.commit()
+    conn.close()
+
+
+def _create_firefox_db(db_path: Path) -> None:
+    """Create a minimal Firefox-like places SQLite database."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE moz_places (id INTEGER PRIMARY KEY, url TEXT, title TEXT)")
+    conn.execute("CREATE TABLE moz_historyvisits (id INTEGER PRIMARY KEY, place_id INTEGER, visit_date INTEGER)")
+    # Firefox uses microseconds since Unix epoch
+    ts = 1000 * 1_000_000
+    conn.execute("INSERT INTO moz_places VALUES (1, 'https://mozilla.org/page1', 'MozPage 1')")
+    conn.execute("INSERT INTO moz_places VALUES (2, 'https://mozilla.org/page2', 'MozPage 2')")
+    conn.execute(f"INSERT INTO moz_historyvisits VALUES (1, 1, {ts})")
+    conn.execute(f"INSERT INTO moz_historyvisits VALUES (2, 2, {ts + 1000})")
+    conn.commit()
+    conn.close()
+
+
+class TestBrowserHistoryReader:
+    """Test Chrome and Firefox history reading from SQLite."""
+
+    def test_read_chrome_history(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+        entries = _read_chrome_history(db_path, since_timestamp=0, max_entries=10)
+        assert len(entries) == 2
+        assert entries[0]["url"] == "https://example.com/page2"
+        assert entries[0]["title"] == "Page 2"
+
+    def test_read_chrome_history_since_timestamp(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+        # Since timestamp after the entries were created
+        entries = _read_chrome_history(db_path, since_timestamp=2000, max_entries=10)
+        assert len(entries) == 0
+
+    def test_read_chrome_history_max_entries(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+        entries = _read_chrome_history(db_path, since_timestamp=0, max_entries=1)
+        assert len(entries) == 1
+
+    def test_read_chrome_history_missing_db(self, tmp_path: Path) -> None:
+        """Missing DB returns empty list, not an error."""
+        entries = _read_chrome_history(tmp_path / "nonexistent.db", since_timestamp=0, max_entries=10)
+        assert entries == []
+
+    def test_read_firefox_history(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "places.sqlite"
+        _create_firefox_db(db_path)
+        entries = _read_firefox_history(db_path, since_timestamp=0, max_entries=10)
+        assert len(entries) == 2
+        assert entries[0]["url"] == "https://mozilla.org/page2"
+        assert entries[0]["title"] == "MozPage 2"
+
+    def test_read_firefox_history_since_timestamp(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "places.sqlite"
+        _create_firefox_db(db_path)
+        entries = _read_firefox_history(db_path, since_timestamp=2000, max_entries=10)
+        assert len(entries) == 0
+
+
+# ---------------------------------------------------------------------------
+# BrowserHistoryAdapter integration tests (with mocked DB path)
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserHistoryAdapter:
+    """Test the BrowserHistoryAdapter with mocked history databases.
+
+    Since user-supplied ``history_db_path`` was removed (security fix),
+    tests mock ``_resolve_history_db`` to point at a temp SQLite file.
+    """
+
+    _RESOLVE_TARGET = "wikimind.ingest.adapters.browser_history._resolve_history_db"
+
+    @pytest.mark.asyncio
+    async def test_poll_returns_items(self, tmp_path: Path, db_session) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+
+        config = AdapterConfig(
+            enabled=True,
+            adapter_type="browser_history",
+            settings={"browser": "chrome"},
+        )
+        adapter = BrowserHistoryAdapter(config)
+        with patch(self._RESOLVE_TARGET, return_value=db_path):
+            items = await adapter.poll(db_session, TEST_USER_ID)
+
+        assert len(items) == 2
+        assert all(i.kind == CaptureKind.BROWSER_HISTORY for i in items)
+        assert items[0].source_url in (
+            "https://example.com/page1",
+            "https://example.com/page2",
+        )
+
+    @pytest.mark.asyncio
+    async def test_poll_with_include_patterns(self, tmp_path: Path, db_session) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+
+        config = AdapterConfig(
+            enabled=True,
+            adapter_type="browser_history",
+            settings={"browser": "chrome", "url_patterns": "page1"},
+        )
+        adapter = BrowserHistoryAdapter(config)
+        with patch(self._RESOLVE_TARGET, return_value=db_path):
+            items = await adapter.poll(db_session, TEST_USER_ID)
+        assert len(items) == 1
+        assert items[0].source_url == "https://example.com/page1"
+
+    @pytest.mark.asyncio
+    async def test_poll_with_exclude_patterns(self, tmp_path: Path, db_session) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+
+        config = AdapterConfig(
+            enabled=True,
+            adapter_type="browser_history",
+            settings={"browser": "chrome", "exclude_patterns": "page2"},
+        )
+        adapter = BrowserHistoryAdapter(config)
+        with patch(self._RESOLVE_TARGET, return_value=db_path):
+            items = await adapter.poll(db_session, TEST_USER_ID)
+        assert len(items) == 1
+        assert items[0].source_url == "https://example.com/page1"
+
+    @pytest.mark.asyncio
+    async def test_poll_deduplicates_existing_captures(self, tmp_path: Path, db_session) -> None:
+        db_path = tmp_path / "History"
+        _create_chrome_db(db_path)
+
+        config = AdapterConfig(
+            enabled=True,
+            adapter_type="browser_history",
+            settings={"browser": "chrome"},
+        )
+        adapter = BrowserHistoryAdapter(config)
+
+        with patch(self._RESOLVE_TARGET, return_value=db_path):
+            # First poll gets items
+            items1 = await adapter.poll(db_session, TEST_USER_ID)
+            assert len(items1) == 2
+
+            # Simulate saving them as captures
+            from wikimind.services.ambient import AmbientService
+
+            svc = AmbientService()
+            await svc._save_captured_items(items1, db_session, TEST_USER_ID)
+
+            # Second poll should find zero new items (dedup)
+            adapter2 = BrowserHistoryAdapter(config)
+            items2 = await adapter2.poll(db_session, TEST_USER_ID)
+            assert len(items2) == 0
+
+    @pytest.mark.asyncio
+    async def test_poll_no_db_found(self, db_session) -> None:
+        """When _resolve_history_db returns None, poll returns empty list."""
+        config = AdapterConfig(
+            enabled=True,
+            adapter_type="browser_history",
+            settings={"browser": "chrome"},
+        )
+        adapter = BrowserHistoryAdapter(config)
+        with patch(self._RESOLVE_TARGET, return_value=None):
+            items = await adapter.poll(db_session, TEST_USER_ID)
+        assert items == []
+
+    @pytest.mark.asyncio
+    async def test_poll_firefox(self, tmp_path: Path, db_session) -> None:
+        db_path = tmp_path / "places.sqlite"
+        _create_firefox_db(db_path)
+
+        config = AdapterConfig(
+            enabled=True,
+            adapter_type="browser_history",
+            settings={"browser": "firefox"},
+        )
+        adapter = BrowserHistoryAdapter(config)
+        with patch(self._RESOLVE_TARGET, return_value=db_path):
+            items = await adapter.poll(db_session, TEST_USER_ID)
+        assert len(items) == 2
+        assert all(i.kind == CaptureKind.BROWSER_HISTORY for i in items)
+
+
+# ---------------------------------------------------------------------------
+# AmbientService unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAmbientService:
+    """Test the ambient adapter management service."""
+
+    @pytest.fixture
+    def service(self) -> AmbientService:
+        return AmbientService()
+
+    @pytest.mark.asyncio
+    async def test_configure_adapter(self, service: AmbientService, db_session) -> None:
+        request = AmbientAdapterConfigureRequest(
+            adapter_type="browser_history",
+            enabled=True,
+            settings={"browser": "chrome"},
+        )
+        resp = await service.configure_adapter(request, db_session, TEST_USER_ID)
+        assert resp.adapter_type == "browser_history"
+        assert resp.enabled is True
+        assert resp.settings["browser"] == "chrome"
+
+    @pytest.mark.asyncio
+    async def test_configure_adapter_upsert(self, service: AmbientService, db_session) -> None:
+        """Configuring the same adapter twice updates instead of creating."""
+        request1 = AmbientAdapterConfigureRequest(
+            adapter_type="browser_history",
+            enabled=True,
+            settings={"browser": "chrome"},
+        )
+        resp1 = await service.configure_adapter(request1, db_session, TEST_USER_ID)
+
+        request2 = AmbientAdapterConfigureRequest(
+            adapter_type="browser_history",
+            enabled=False,
+            settings={"browser": "firefox"},
+        )
+        resp2 = await service.configure_adapter(request2, db_session, TEST_USER_ID)
+
+        assert resp2.enabled is False
+        assert resp2.settings["browser"] == "firefox"
+
+        # Only one setting row should exist
+        result = await service.list_adapters(db_session, TEST_USER_ID)
+        assert len(result.adapters) == 1
+
+    @pytest.mark.asyncio
+    async def test_configure_unsupported_adapter(self, service: AmbientService, db_session) -> None:
+        request = AmbientAdapterConfigureRequest(
+            adapter_type="nonexistent_adapter",
+            enabled=True,
+        )
+        with pytest.raises(ValueError, match="Unsupported adapter type"):
+            await service.configure_adapter(request, db_session, TEST_USER_ID)
+
+    @pytest.mark.asyncio
+    async def test_list_adapters_empty(self, service: AmbientService, db_session) -> None:
+        result = await service.list_adapters(db_session, TEST_USER_ID)
+        assert result.adapters == []
+
+    @pytest.mark.asyncio
+    async def test_list_adapters(self, service: AmbientService, db_session) -> None:
+        request = AmbientAdapterConfigureRequest(
+            adapter_type="browser_history",
+            enabled=True,
+        )
+        await service.configure_adapter(request, db_session, TEST_USER_ID)
+        result = await service.list_adapters(db_session, TEST_USER_ID)
+        assert len(result.adapters) == 1
+        assert result.adapters[0].adapter_type == "browser_history"
+
+    @pytest.mark.asyncio
+    async def test_get_adapter_setting_not_found(self, service: AmbientService, db_session) -> None:
+        with pytest.raises(NotFoundError):
+            await service.get_adapter_setting("browser_history", db_session, TEST_USER_ID)
+
+    @pytest.mark.asyncio
+    async def test_save_captured_items(self, service: AmbientService, db_session) -> None:
+        items = [
+            CapturedItem(
+                kind=CaptureKind.BROWSER_HISTORY,
+                title="Test Page",
+                content="https://example.com/test",
+                source_url="https://example.com/test",
+                external_id="https://example.com/test",
+            ),
+        ]
+        count = await service._save_captured_items(items, db_session, TEST_USER_ID)
+        assert count == 1
+
+        # Verify it was saved
+        result = await db_session.execute(
+            select(CaptureSource).where(
+                CaptureSource.user_id == TEST_USER_ID,
+                CaptureSource.kind == CaptureKind.BROWSER_HISTORY,
+            )
+        )
+        captures = list(result.scalars().all())
+        assert len(captures) == 1
+        assert captures[0].source_url == "https://example.com/test"
+
+    @pytest.mark.asyncio
+    async def test_save_captured_items_dedup(self, service: AmbientService, db_session) -> None:
+        """Duplicate items are not saved twice."""
+        items = [
+            CapturedItem(
+                kind=CaptureKind.BROWSER_HISTORY,
+                content="https://example.com/dup",
+            ),
+        ]
+        count1 = await service._save_captured_items(items, db_session, TEST_USER_ID)
+        count2 = await service._save_captured_items(items, db_session, TEST_USER_ID)
+        assert count1 == 1
+        assert count2 == 0
+
+
+# ---------------------------------------------------------------------------
+# Ambient API route integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestAmbientAPI:
+    """Test ambient adapter API routes via the FastAPI test client."""
+
+    @pytest.mark.asyncio
+    async def test_configure_adapter_endpoint(self, client) -> None:
+        resp = await client.post(
+            "/api/capture/ambient/configure",
+            json={
+                "adapter_type": "browser_history",
+                "enabled": True,
+                "settings": {"browser": "chrome"},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["adapter_type"] == "browser_history"
+        assert data["enabled"] is True
+        assert data["settings"]["browser"] == "chrome"
+
+    @pytest.mark.asyncio
+    async def test_configure_unsupported_adapter_endpoint(self, client) -> None:
+        resp = await client.post(
+            "/api/capture/ambient/configure",
+            json={"adapter_type": "nonexistent", "enabled": True},
+        )
+        assert resp.status_code in {422, 500}
+
+    @pytest.mark.asyncio
+    async def test_list_adapters_endpoint(self, client) -> None:
+        # Configure one first
+        await client.post(
+            "/api/capture/ambient/configure",
+            json={"adapter_type": "browser_history", "enabled": True},
+        )
+        resp = await client.get("/api/capture/ambient/adapters")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["adapters"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_disable_adapter_endpoint(self, client) -> None:
+        """Configure then disable an adapter."""
+        await client.post(
+            "/api/capture/ambient/configure",
+            json={"adapter_type": "browser_history", "enabled": True},
+        )
+        resp = await client.post(
+            "/api/capture/ambient/configure",
+            json={"adapter_type": "browser_history", "enabled": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_ambient_endpoints_forbidden_in_hosted_mode(self, client) -> None:
+        """Ambient capture endpoints return 403 when deployment_mode is 'hosted'."""
+        with patch(
+            "wikimind.api.routes.capture.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.deployment_mode = "hosted"
+
+            resp = await client.post(
+                "/api/capture/ambient/configure",
+                json={"adapter_type": "browser_history", "enabled": True},
+            )
+            assert resp.status_code == 403
+
+            resp = await client.get("/api/capture/ambient/adapters")
+            assert resp.status_code == 403
+
+            resp = await client.post(
+                "/api/capture/ambient/adapters/browser_history/poll",
+            )
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_configure_strips_history_db_path(self, client) -> None:
+        """history_db_path in settings is stripped to prevent arbitrary file reads."""
+        resp = await client.post(
+            "/api/capture/ambient/configure",
+            json={
+                "adapter_type": "browser_history",
+                "enabled": True,
+                "settings": {
+                    "browser": "chrome",
+                    "history_db_path": "/etc/passwd",
+                },
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "history_db_path" not in data["settings"]
+        assert data["settings"]["browser"] == "chrome"


### PR DESCRIPTION
## Summary

Introduces an extensible ambient adapter framework that turns WikiMind from on-demand ingest into always-on knowledge capture. This PR builds the adapter foundation and one concrete adapter (browser history) -- not the full vision described in #442.

**Problem**: WikiMind only captures knowledge when users explicitly ingest a URL, PDF, or text. There's no way to passively monitor knowledge sources like browsing activity, clipboard, or other streams.

**Solution**: An `AmbientAdapter` base class with a registry pattern, plus a `BrowserHistoryAdapter` that reads Chrome/Firefox SQLite history databases, filters by configurable URL patterns, deduplicates against existing captures, and creates `CaptureSource` rows for new items.

**What's included**:
- `AmbientAdapter` ABC with `poll() -> list[CapturedItem]`, `last_polled_at` tracking, and `AdapterConfig`
- `BrowserHistoryAdapter` that reads Chrome/Firefox history, supports include/exclude regex patterns, copies DB to temp to avoid lock contention
- `AmbientAdapterSetting` DB table for per-user adapter config persistence
- `AmbientService` for adapter CRUD, polling dispatch, and capture creation with dedup
- API endpoints: `POST /capture/ambient/configure`, `GET /capture/ambient/adapters`, `POST /capture/ambient/adapters/{type}/poll`
- `ambient_capture_poll` cron job running every 30 minutes in the ARQ worker
- `BROWSER_HISTORY` added to `CaptureKind` enum
- Config settings: `ambient_poll_interval_minutes`, `browser_history_max_entries_per_poll`
- 32 new unit/integration tests

## Test plan

- [x] All 1953 existing unit tests pass
- [x] 32 new tests covering: adapter base class, URL pattern matching, Chrome/Firefox SQLite readers, browser history adapter (poll, filters, dedup, missing DB, Firefox), ambient service (configure, upsert, unsupported type, list, get, save items, dedup), API routes (configure, list, disable, unsupported type)
- [x] Lint passes (ruff check + format)
- [x] Typecheck passes (no new mypy errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)