### PR TITLE
test(db): add assertions for user-scoped concept backfill (#542)

### DIFF
--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -16,9 +16,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tests.conftest import TEST_USER_ID
 from wikimind.database import _backfill_concepts_from_articles
-from wikimind.models import Article, ConfidenceLevel, Query, Source, SourceType, User
+from wikimind.models import Article, Concept, ConfidenceLevel, Query, Source, SourceType, User
 
 POSTGRES_URL = os.environ.get("WIKIMIND_TEST_POSTGRES_URL")
+SECOND_USER_ID = "test-user-2"
 
 pytestmark = [
     pytest.mark.postgres,
@@ -112,16 +113,87 @@ class TestPostgresBasicOperations:
 
 class TestPostgresMigrationHelpers:
     async def test_backfill_concepts_on_postgres(self, pg_engine, pg_session):
-        """_backfill_concepts_from_articles works with named params on Postgres."""
-        article = Article(
-            slug="pg-backfill",
-            title="PG Backfill",
-            file_path="pg-backfill.md",
-            concept_ids=json.dumps(["new-concept"]),
-            confidence=ConfidenceLevel.SOURCED,
-            user_id=TEST_USER_ID,
+        """_backfill_concepts_from_articles creates user-scoped concepts."""
+        # Seed two articles for user 1 sharing concept "machine-learning"
+        pg_session.add(
+            Article(
+                slug="pg-backfill-1",
+                title="PG Backfill 1",
+                file_path="pg-backfill-1.md",
+                concept_ids=json.dumps(["Machine Learning", "new-concept"]),
+                confidence=ConfidenceLevel.SOURCED,
+                user_id=TEST_USER_ID,
+            )
         )
-        pg_session.add(article)
+        pg_session.add(
+            Article(
+                slug="pg-backfill-2",
+                title="PG Backfill 2",
+                file_path="pg-backfill-2.md",
+                concept_ids=json.dumps(["Machine Learning"]),
+                confidence=ConfidenceLevel.SOURCED,
+                user_id=TEST_USER_ID,
+            )
+        )
+
+        # Seed a second user with an overlapping concept name
+        pg_session.add(
+            User(
+                id=SECOND_USER_ID,
+                email=f"{SECOND_USER_ID}@test.local",
+                name="Second Test User",
+                auth_provider="jwt",
+                auth_provider_id=SECOND_USER_ID,
+            )
+        )
+        pg_session.add(
+            Article(
+                slug="pg-backfill-u2",
+                title="PG Backfill U2",
+                file_path="pg-backfill-u2.md",
+                concept_ids=json.dumps(["Machine Learning", "deep-learning"]),
+                confidence=ConfidenceLevel.SOURCED,
+                user_id=SECOND_USER_ID,
+            )
+        )
         await pg_session.commit()
 
         await _backfill_concepts_from_articles(pg_engine)
+
+        # ---- Assertions for user 1 ----
+        result = await pg_session.exec(select(Concept).where(Concept.user_id == TEST_USER_ID).order_by(Concept.name))
+        u1_concepts = result.all()
+        u1_by_name = {c.name: c for c in u1_concepts}
+
+        assert set(u1_by_name.keys()) == {"machine-learning", "new-concept"}
+
+        ml_u1 = u1_by_name["machine-learning"]
+        assert ml_u1.user_id == TEST_USER_ID
+        assert ml_u1.article_count == 2  # appears in both articles
+        assert ml_u1.concept_kind == "topic"
+
+        nc_u1 = u1_by_name["new-concept"]
+        assert nc_u1.user_id == TEST_USER_ID
+        assert nc_u1.article_count == 1
+        assert nc_u1.concept_kind == "topic"
+
+        # ---- Assertions for user 2 ----
+        result = await pg_session.exec(select(Concept).where(Concept.user_id == SECOND_USER_ID).order_by(Concept.name))
+        u2_concepts = result.all()
+        u2_by_name = {c.name: c for c in u2_concepts}
+
+        assert set(u2_by_name.keys()) == {"machine-learning", "deep-learning"}
+
+        ml_u2 = u2_by_name["machine-learning"]
+        assert ml_u2.user_id == SECOND_USER_ID
+        assert ml_u2.article_count == 1  # only one article for user 2
+        assert ml_u2.concept_kind == "topic"
+
+        dl_u2 = u2_by_name["deep-learning"]
+        assert dl_u2.user_id == SECOND_USER_ID
+        assert dl_u2.article_count == 1
+        assert dl_u2.concept_kind == "topic"
+
+        # ---- Cross-user partitioning ----
+        # "machine-learning" exists for both users but they are separate rows
+        assert ml_u1.id != ml_u2.id


### PR DESCRIPTION
## Summary
- The existing `test_backfill_concepts_on_postgres` test called `_backfill_concepts_from_articles()` but never asserted anything about the resulting `Concept` rows
- Added assertions verifying `user_id`, `article_count`, and `concept_kind` for each backfilled concept
- Added a second user with overlapping concept names ("Machine Learning") to test cross-user partitioning, verifying that same-name concepts for different users produce separate rows with independent counts

## Test plan
- [x] `ruff check` passes on the modified file
- [x] `ruff format --check` passes on the modified file
- [x] `mypy` shows no new errors (pre-existing errors in other files only)
- [x] Full test suite passes (2088 passed, 4 skipped — postgres tests skipped without `WIKIMIND_TEST_POSTGRES_URL`)

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)