### PR TITLE
fix(ci): add schema-aware rollback policy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -553,6 +553,17 @@ jobs:
   # -----------------------------------------------------------
   # 5️⃣  Rollback production (if verify fails)
   # -----------------------------------------------------------
+  # Schema safety: this rollback redeploys the previous image, which
+  # runs `alembic upgrade head` from its own migration set. This is
+  # safe because our additive-only migration policy (enforced by the
+  # migration-safety workflow) guarantees that forward-applied schema
+  # changes are backward-compatible — the old code can still work
+  # with extra columns/tables it doesn't know about.
+  #
+  # If a migration were destructive (DROP TABLE/COLUMN), the rolled-
+  # back image would crash on missing schema objects. That's why
+  # destructive migrations are blocked in CI. See #589.
+  # -----------------------------------------------------------
   rollback-production:
     name: rollback production
     runs-on: ubuntu-latest

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -1,0 +1,57 @@
+# ===============================================================
+# Migration Safety — Additive-Only Policy Enforcement
+# ===============================================================
+#
+#   - scans Alembic migration upgrade() functions for destructive ops
+#   - blocks DROP TABLE, DROP COLUMN, ALTER COLUMN type changes
+#   - ensures rollback to a previous image won't break on schema mismatch
+#   - destructive changes must use a two-phase deploy strategy
+#   - lines with `# rollback-safe: <reason>` are exempted
+#   - triggers on changes to alembic/ or this workflow
+# ---------------------------------------------------------------
+
+name: Migration Safety
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "alembic/**"
+      - "scripts/check_migration_safety.py"
+      - ".github/workflows/migration-safety.yml"
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - "alembic/**"
+      - "scripts/check_migration_safety.py"
+      - ".github/workflows/migration-safety.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  migration-safety:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Additive-only migration check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Check migration safety
+        run: python scripts/check_migration_safety.py

--- a/alembic/versions/0010_add_concept_layer_tables.py
+++ b/alembic/versions/0010_add_concept_layer_tables.py
@@ -225,7 +225,7 @@ def upgrade() -> None:
         if has_new and has_old:
             # Only ``compilationschema`` can still reach this path. The
             # concept-layer collision is handled above to respect FK ordering.
-            op.drop_table(new_name)
+            op.drop_table(new_name)  # rollback-safe: drops empty duplicate before rename
             op.rename_table(old_name, new_name)
         elif has_new:
             # Scenario 4: already migrated — nothing to do.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ considered, and the consequences.
 | [026](adr-026-multi-replica-gateway.md) | Multi-Replica Gateway — Horizontal Scaling | Unknown |
 | [026](adr-026-onboarding-wizard.md) | First-Run Onboarding Wizard | Accepted |
 | [027](adr-027-mcp-auth-personal-access-tokens.md) | MCP Authentication — OAuth 2.1 + Personal Access Tokens | Unknown |
+| [028](adr-028-additive-only-migrations.md) | Additive-Only Migration Policy for Schema-Safe Rollback | Accepted |
 
 ## ADR Format
 

--- a/docs/adr/adr-028-additive-only-migrations.md
+++ b/docs/adr/adr-028-additive-only-migrations.md
@@ -1,0 +1,59 @@
+# ADR-028: Additive-Only Migration Policy for Schema-Safe Rollback
+
+## Status
+
+Accepted
+
+## Context
+
+The deploy pipeline rolls back production by redeploying the previous Docker image
+when post-deploy verification fails. Each image runs `alembic upgrade head` on
+startup via `release_command` in `fly.toml`. This means:
+
+1. A deploy applies forward migrations (new columns, tables).
+2. On rollback, the old image runs its own `alembic upgrade head` — a no-op since
+   its migration set is a subset of what's already applied.
+3. The old code runs against a database that may have extra columns/tables it
+   doesn't know about — which is fine.
+
+The problem: if a migration drops a column or table, the rolled-back image expects
+schema objects that no longer exist, causing runtime crashes.
+
+Three options were evaluated:
+
+| Option | Approach | Tradeoff |
+|--------|----------|----------|
+| 1 | Additive-only migrations, enforced by CI | Simple, safe, prevents the problem |
+| 2 | Alembic downgrade step in rollback job | Fragile, downgrade() rarely tested in production |
+| 3 | Manual approval gate for schema changes | Adds friction, no automation |
+
+## Decision
+
+**Option 1: Additive-only migrations with CI enforcement.**
+
+All Alembic migration `upgrade()` functions must be backward-compatible. The
+`migration-safety` CI workflow runs `scripts/check_migration_safety.py` which
+uses AST analysis to detect destructive operations:
+
+- `op.drop_table()`
+- `op.drop_column()`
+- `op.alter_column(..., type_=...)` (column type changes)
+- Raw SQL containing `DROP TABLE` or `DROP COLUMN`
+
+Safe operations are allowed: `DROP INDEX`, `DROP CONSTRAINT`, `CREATE TABLE`,
+`ADD COLUMN`, `CREATE INDEX`, data-only changes.
+
+Lines annotated with `# rollback-safe: <reason>` are exempted for rare cases
+where a destructive operation is genuinely safe (e.g., dropping an empty
+duplicate table during a rename).
+
+For genuine destructive changes, use a two-phase deploy:
+1. Deploy code that stops using the column/table.
+2. Separate PR to drop the column/table from the schema.
+
+## Consequences
+
+- Rollback is always schema-safe — the old image can work with extra schema objects.
+- Developers must plan destructive schema changes as two-phase deploys.
+- The CI check catches mistakes before merge, not after production breakage.
+- Legacy migration 0010 has one exempted `drop_table` (table rename collision repair).

--- a/scripts/check_migration_safety.py
+++ b/scripts/check_migration_safety.py
@@ -1,0 +1,179 @@
+"""Check Alembic migrations for destructive operations in upgrade() functions.
+
+Policy: all auto-deployed migrations MUST be backward-compatible (additive only).
+This ensures that a rollback to the previous Docker image leaves the database in a
+state the old code can still work with.  Destructive schema changes (DROP TABLE,
+DROP COLUMN, ALTER COLUMN type changes) require a manual two-phase deploy:
+
+  Phase 1: Deploy code that no longer uses the column/table.
+  Phase 2: A separate PR removes the column/table from the schema.
+
+Allowed operations (additive / safe):
+  - CREATE TABLE, ADD COLUMN, CREATE INDEX
+  - ADD CONSTRAINT (non-destructive)
+  - DROP INDEX (indexes are not required for correctness, only performance)
+  - DROP CONSTRAINT (relaxing constraints is backward-compatible)
+  - Data-only migrations (INSERT, UPDATE)
+
+Forbidden operations in upgrade():
+  - op.drop_table(...)
+  - op.drop_column(...)
+  - op.alter_column(..., type_=...)   [column type change]
+  - Raw SQL containing DROP TABLE or DROP COLUMN
+
+Lines with a ``# rollback-safe: <reason>`` comment are exempted.
+
+Exit codes:
+  0 — all migrations are safe
+  1 — destructive operations found
+
+Usage:
+  python scripts/check_migration_safety.py                    # check all
+  python scripts/check_migration_safety.py alembic/versions/0023_*.py  # check specific
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+# Operations that are destructive and forbidden in upgrade() functions.
+FORBIDDEN_OPS = {"drop_table", "drop_column"}
+
+
+class _DestructiveOpVisitor(ast.NodeVisitor):
+    """AST visitor that finds destructive operations inside upgrade() functions."""
+
+    def __init__(self, filepath: str, source_lines: list[str]) -> None:
+        self.filepath = filepath
+        self.source_lines = source_lines
+        self.violations: list[str] = []
+        self._in_upgrade = False
+
+    def _is_exempted(self, lineno: int) -> bool:
+        """Return True if the line has a ``# rollback-safe:`` bypass comment."""
+        if lineno < 1 or lineno > len(self.source_lines):
+            return False
+        return "# rollback-safe:" in self.source_lines[lineno - 1]
+
+    def _check_forbidden_op(self, node: ast.Call) -> None:
+        """Flag op.drop_table / op.drop_column / batch_op.drop_column."""
+        if not isinstance(node.func, ast.Attribute):
+            return
+        if node.func.attr not in FORBIDDEN_OPS:
+            return
+        if self._is_exempted(node.lineno):
+            return
+        self.violations.append(
+            f"{self.filepath}:{node.lineno}: op.{node.func.attr}() is destructive and not rollback-safe"
+        )
+
+    def _check_alter_column_type(self, node: ast.Call) -> None:
+        """Flag op.alter_column(..., type_=...) — column type change."""
+        if not isinstance(node.func, ast.Attribute):
+            return
+        if node.func.attr != "alter_column" or self._is_exempted(node.lineno):
+            return
+        for kw in node.keywords:
+            if kw.arg == "type_":
+                self.violations.append(
+                    f"{self.filepath}:{node.lineno}: op.alter_column(type_=...) changes column type — not rollback-safe"
+                )
+                break
+
+    def _check_raw_sql(self, node: ast.Call) -> None:
+        """Flag op.execute('... DROP TABLE/COLUMN ...')."""
+        if not isinstance(node.func, ast.Attribute):
+            return
+        if node.func.attr != "execute" or self._is_exempted(node.lineno):
+            return
+        for arg in node.args:
+            if not (isinstance(arg, ast.Constant) and isinstance(arg.value, str)):
+                continue
+            sql_upper = arg.value.upper()
+            if "DROP TABLE" in sql_upper:
+                self.violations.append(
+                    f"{self.filepath}:{node.lineno}: raw SQL contains DROP TABLE — not rollback-safe"
+                )
+            if "DROP COLUMN" in sql_upper:
+                self.violations.append(
+                    f"{self.filepath}:{node.lineno}: raw SQL contains DROP COLUMN — not rollback-safe"
+                )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if node.name == "upgrade":
+            self._in_upgrade = True
+            self.generic_visit(node)
+            self._in_upgrade = False
+        else:
+            self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if not self._in_upgrade:
+            self.generic_visit(node)
+            return
+
+        self._check_forbidden_op(node)
+        self._check_alter_column_type(node)
+        self._check_raw_sql(node)
+
+        self.generic_visit(node)
+
+
+def check_file(filepath: Path) -> list[str]:
+    """Parse a migration file and return a list of violation messages."""
+    source = filepath.read_text()
+    source_lines = source.splitlines()
+    tree = ast.parse(source, filename=str(filepath))
+    visitor = _DestructiveOpVisitor(str(filepath), source_lines)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def main() -> int:
+    """Check migration files for destructive operations.
+
+    If positional arguments are provided, check only those files.
+    Otherwise, check all files in alembic/versions/.
+    """
+    if len(sys.argv) > 1:
+        files = [Path(p) for p in sys.argv[1:]]
+    else:
+        versions_dir = Path("alembic/versions")
+        if not versions_dir.exists():
+            print("alembic/versions/ not found — skipping migration safety check")
+            return 0
+        files = sorted(versions_dir.glob("*.py"))
+
+    all_violations: list[str] = []
+    for filepath in files:
+        if not filepath.exists():
+            continue
+        violations = check_file(filepath)
+        all_violations.extend(violations)
+
+    if all_violations:
+        print("MIGRATION SAFETY CHECK FAILED")
+        print("=" * 60)
+        print()
+        print("The following destructive operations were found in upgrade() functions:")
+        print()
+        for v in all_violations:
+            print(f"  {v}")
+        print()
+        print("Policy: migrations must be additive-only (backward-compatible)")
+        print("so that rollback to the previous image leaves the DB usable.")
+        print()
+        print("If you need to remove a column or table, use a two-phase deploy:")
+        print("  Phase 1: Deploy code that stops using the column/table")
+        print("  Phase 2: Separate PR to drop the column/table")
+        print()
+        print("To bypass this check (rare, requires justification):")
+        print("  Add '# rollback-safe: <reason>' comment on the op line")
+        return 1
+
+    print(f"Migration safety check passed ({len(files)} files checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_migration_safety.py
+++ b/tests/unit/test_migration_safety.py
@@ -1,0 +1,284 @@
+"""Tests for scripts/check_migration_safety.py."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.check_migration_safety import check_file
+
+
+def _write_migration(tmp_path: Path, code: str) -> Path:
+    """Write a migration file and return the path."""
+    p = tmp_path / "test_migration.py"
+    p.write_text(textwrap.dedent(code))
+    return p
+
+
+class TestCheckFile:
+    """Tests for the check_file function."""
+
+    def test_additive_migration_passes(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+            import sqlalchemy as sa
+
+            def upgrade():
+                op.create_table("foo", sa.Column("id", sa.String(), primary_key=True))
+                op.add_column("bar", sa.Column("name", sa.String()))
+
+            def downgrade():
+                op.drop_table("foo")
+                op.drop_column("bar", "name")
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_drop_table_in_upgrade_fails(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.drop_table("old_table")
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert "drop_table" in violations[0]
+        assert "not rollback-safe" in violations[0]
+
+    def test_drop_column_in_upgrade_fails(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.drop_column("users", "legacy_field")
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert "drop_column" in violations[0]
+
+    def test_alter_column_type_change_fails(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+            import sqlalchemy as sa
+
+            def upgrade():
+                op.alter_column("users", "age", type_=sa.BigInteger())
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert "alter_column" in violations[0]
+        assert "type" in violations[0].lower()
+
+    def test_alter_column_nullable_change_passes(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.alter_column("users", "name", nullable=True)
+
+            def downgrade():
+                pass
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_raw_sql_drop_table_fails(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.execute("DROP TABLE old_data")
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert "DROP TABLE" in violations[0]
+
+    def test_raw_sql_drop_column_fails(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.execute("ALTER TABLE users DROP COLUMN legacy")
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert "DROP COLUMN" in violations[0]
+
+    def test_drop_index_passes(self, tmp_path: Path) -> None:
+        """DROP INDEX is safe — indexes don't affect correctness."""
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.drop_index("ix_old_index", table_name="users")
+
+            def downgrade():
+                pass
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_drop_constraint_passes(self, tmp_path: Path) -> None:
+        """DROP CONSTRAINT is safe — relaxing constraints is backward-compatible."""
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.drop_constraint("uq_old_constraint", "users", type_="unique")
+
+            def downgrade():
+                pass
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_rollback_safe_comment_exempts(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                op.drop_table("dup")  # rollback-safe: drops empty duplicate before rename
+
+            def downgrade():
+                pass
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_destructive_in_downgrade_ignored(self, tmp_path: Path) -> None:
+        """Destructive ops in downgrade() are fine — downgrade is manual."""
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+            import sqlalchemy as sa
+
+            def upgrade():
+                op.create_table("foo", sa.Column("id", sa.String(), primary_key=True))
+
+            def downgrade():
+                op.drop_table("foo")
+                op.drop_column("bar", "name")
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_destructive_in_helper_function_ignored(self, tmp_path: Path) -> None:
+        """Destructive ops in helper functions (not upgrade) are not flagged.
+
+        Note: this is a known limitation — we only check the direct AST
+        of upgrade(), not called helper functions. Helper functions with
+        destructive ops called from upgrade() would need manual review.
+        """
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def _cleanup():
+                op.drop_table("old_table")
+
+            def upgrade():
+                _cleanup()
+
+            def downgrade():
+                pass
+            """,
+        )
+        assert check_file(p) == []
+
+    def test_multiple_violations_reported(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+            import sqlalchemy as sa
+
+            def upgrade():
+                op.drop_table("old_table")
+                op.drop_column("users", "legacy")
+                op.alter_column("users", "age", type_=sa.BigInteger())
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 3
+
+    def test_batch_op_drop_column_fails(self, tmp_path: Path) -> None:
+        p = _write_migration(
+            tmp_path,
+            """\
+            from alembic import op
+
+            def upgrade():
+                with op.batch_alter_table("users") as batch_op:
+                    batch_op.drop_column("legacy_field")
+
+            def downgrade():
+                pass
+            """,
+        )
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert "drop_column" in violations[0]
+
+
+class TestExistingMigrations:
+    """Verify all existing migrations pass the safety check."""
+
+    def test_all_existing_migrations_pass(self) -> None:
+        versions_dir = Path("alembic/versions")
+        if not versions_dir.exists():
+            pytest.skip("alembic/versions not found")
+
+        all_violations: list[str] = []
+        for filepath in sorted(versions_dir.glob("*.py")):
+            violations = check_file(filepath)
+            all_violations.extend(violations)
+
+        assert all_violations == [], "Existing migrations have unexempted destructive operations:\n" + "\n".join(
+            f"  {v}" for v in all_violations
+        )


### PR DESCRIPTION
## Problem

The rollback job in deploy.yml redeploys the previous Docker image but does nothing about forward-applied Alembic migrations. If a migration contains destructive operations (DROP TABLE, DROP COLUMN), the rolled-back image crashes because it expects schema objects that no longer exist.

## Solution

Enforce an **additive-only migration policy** via CI (Option 1 from #589). All Alembic `upgrade()` functions must be backward-compatible so that rollback to any previous image leaves the database in a usable state.

## Changes

- **`scripts/check_migration_safety.py`** -- AST-based analyzer that scans migration `upgrade()` functions for destructive operations (`op.drop_table`, `op.drop_column`, `op.alter_column(type_=...)`, raw SQL `DROP TABLE/COLUMN`). Supports `# rollback-safe: <reason>` bypass comments for exemptions.
- **`.github/workflows/migration-safety.yml`** -- CI workflow that runs the check on any PR touching `alembic/**`
- **`.github/workflows/deploy.yml`** -- Documents the schema safety invariant in the rollback job comments
- **`alembic/versions/0010_add_concept_layer_tables.py`** -- Adds `# rollback-safe:` exemption to the one existing destructive op (drops empty duplicate table during rename)
- **`docs/adr/adr-028-additive-only-migrations.md`** -- ADR documenting the decision, alternatives considered, and two-phase deploy strategy for destructive changes
- **`tests/unit/test_migration_safety.py`** -- 15 tests covering detection of all destructive patterns, bypass mechanism, and validation that all existing migrations pass

## Why Option 1 over Options 2 and 3

- **Option 2 (Alembic downgrade)**: `downgrade()` functions are rarely tested in production and are inherently fragile. Adding a downgrade step to the rollback job would add complexity and a new failure mode.
- **Option 3 (manual approval gate)**: Adds friction without automation. Developers would still need to manually verify schema compatibility.
- **Option 1 (additive-only + CI)**: Prevents the problem at the source. The CI check catches mistakes before merge. For genuine destructive changes, a two-phase deploy strategy is documented.

## Test plan

- [x] All 15 new unit tests pass
- [x] All 2065 existing unit tests still pass
- [x] `scripts/check_migration_safety.py` passes on all 25 existing migrations
- [x] Lint and format checks pass
- [ ] CI runs migration-safety workflow on this PR (validates workflow syntax)

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)