### PR TITLE
fix(ci): stabilize CI/CD pipeline — pin images, guard create_all, configurable pools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -309,6 +309,11 @@
 #
 # Verbose SQL query logging — dev only, very noisy
 # WIKIMIND_DATABASE__ECHO=false
+#
+# Connection pool tuning (Postgres only). Lower values for small Fly.io
+# instances or PgBouncer setups; raise for high-concurrency workloads.
+# WIKIMIND_DATABASE__POOL_SIZE=5
+# WIKIMIND_DATABASE__MAX_OVERFLOW=10
 
 # ----------------------------------------------------------------------------
 # Rate Limiting (issue #704)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 #
 #   - chains after the Docker workflow (build → scan → GHCR publish)
 #   - deploys staging first, smoke-tests it, then promotes to prod
-#   - auto-provisions apps, volumes, Postgres, and secrets
+#   - validates that apps, volumes, Postgres exist (never creates them)
 #   - fails loudly on real errors; suppresses only idempotent ones
 #
 # ---------------------------------------------------------------
@@ -48,21 +48,21 @@
 #        • creates GitHub issue for visibility
 #
 # ---------------------------------------------------------------
-# Auto-provisioning (both environments)
+# Infrastructure validation (both environments)
 # ---------------------------------------------------------------
 #
 #   Resource          │ Behavior
 #   ──────────────────┼─────────────────────────────────────────
-#   Fly app           │ Created if missing
-#   Volume            │ Created if missing (1 GB)
-#   Postgres cluster  │ Created if missing (⚠️ WARNING emitted)
-#   Postgres attach   │ Idempotent; real errors fail the job
+#   Fly app           │ Must exist; deploy fails with setup instructions if missing
+#   Volume            │ Must exist; created as part of initial app setup
+#   Postgres cluster  │ Must exist; deploy fails with setup instructions if missing
 #   Secrets           │ Staged (--stage) from GitHub secrets
-#   Docling sidecar   │ App created if missing, deployed
+#   Docling sidecar   │ Must exist; deploy fails with setup instructions if missing
 #
-#   Why ⚠️ on Postgres create: a new cluster has empty data.
-#   If the old cluster was deleted, you've lost data. The warning
-#   ensures operators notice and investigate.
+#   Infrastructure is NEVER created at deploy time. All resources
+#   must be provisioned manually before the first deploy. This
+#   prevents accidental creation of empty databases or duplicate
+#   apps during CI/CD runs.
 #
 # ---------------------------------------------------------------
 # Required GitHub repository secrets
@@ -175,31 +175,22 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
-      # 1️⃣  Ensure staging infrastructure exists
-      - name: 🏗️  Ensure staging app exists
+      # 1️⃣  Validate staging infrastructure exists (never create at deploy time)
+      - name: 🏗️  Validate staging infrastructure
         run: |
           if ! flyctl status --app wikimind-staging 2>/dev/null; then
-            echo "Creating staging app..."
-            flyctl apps create wikimind-staging --org personal
-            flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
+            echo "::error::Staging app 'wikimind-staging' does not exist. Create it manually:"
+            echo "::error::  fly apps create wikimind-staging --org personal"
+            echo "::error::  fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes"
+            exit 1
           fi
 
-          # Staging Postgres — separate from production
           if ! flyctl status --app wikimind-staging-db 2>/dev/null; then
-            echo "::warning::Creating NEW staging Postgres cluster"
-            flyctl postgres create --name wikimind-staging-db --org personal --region ord \
-              --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
+            echo "::error::Staging Postgres 'wikimind-staging-db' does not exist. Create it manually:"
+            echo "::error::  fly postgres create --name wikimind-staging-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1"
+            echo "::error::  fly postgres attach wikimind-staging-db --app wikimind-staging"
+            exit 1
           fi
-
-          # Attach — idempotent; only suppress "already attached" errors
-          output=$(flyctl postgres attach wikimind-staging-db --app wikimind-staging 2>&1) || {
-            if echo "$output" | grep -qi "already attached\|already exists\|already contains"; then
-              echo "Postgres already attached to staging"
-            else
-              echo "::error::Postgres attach failed: $output"
-              exit 1
-            fi
-          }
 
           # Redis — URL is set manually via `fly secrets set`. Just verify it exists.
           REDIS_CHECK=$(flyctl secrets list --app wikimind-staging 2>/dev/null | grep -c "WIKIMIND_REDIS_URL" || echo "0")
@@ -231,7 +222,11 @@ jobs:
       # 3️⃣  Deploy sidecar + app
       - name: 🧠  Deploy staging docling-serve sidecar
         run: |
-          flyctl status --app wikimind-staging-docling 2>/dev/null || flyctl apps create wikimind-staging-docling --org personal
+          if ! flyctl status --app wikimind-staging-docling 2>/dev/null; then
+            echo "::error::Staging docling app 'wikimind-staging-docling' does not exist. Create it manually:"
+            echo "::error::  fly apps create wikimind-staging-docling --org personal"
+            exit 1
+          fi
           flyctl deploy --config fly.docling.toml --app wikimind-staging-docling --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -379,28 +374,21 @@ jobs:
       - name: 🪁  Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
-      - name: 🏗️  Ensure production app exists
+      - name: 🏗️  Validate production infrastructure
         run: |
           if ! flyctl status --app wikimind 2>/dev/null; then
-            echo "Creating production app..."
-            flyctl apps create wikimind --org personal
-            flyctl volumes create wikimind_data --region ord --size 1 --app wikimind --yes
+            echo "::error::Production app 'wikimind' does not exist. Create it manually:"
+            echo "::error::  fly apps create wikimind --org personal"
+            echo "::error::  fly volumes create wikimind_data --region ord --size 1 --app wikimind --yes"
+            exit 1
           fi
 
           if ! flyctl status --app wikimind-db 2>/dev/null; then
-            echo "::warning::Creating NEW Postgres cluster — database will be empty!"
-            flyctl postgres create --name wikimind-db --org personal --region ord \
-              --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1
+            echo "::error::Production Postgres 'wikimind-db' does not exist. Create it manually:"
+            echo "::error::  fly postgres create --name wikimind-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1"
+            echo "::error::  fly postgres attach wikimind-db --app wikimind"
+            exit 1
           fi
-
-          output=$(flyctl postgres attach wikimind-db --app wikimind 2>&1) || {
-            if echo "$output" | grep -qi "already attached\|already exists\|already contains"; then
-              echo "Postgres already attached to production"
-            else
-              echo "::error::Postgres attach failed: $output"
-              exit 1
-            fi
-          }
 
           # Redis — URL is set manually via `fly secrets set`. Just verify it exists.
           REDIS_CHECK=$(flyctl secrets list --app wikimind 2>/dev/null | grep -c "WIKIMIND_REDIS_URL" || echo "0")
@@ -430,7 +418,11 @@ jobs:
 
       - name: 🧠  Deploy docling-serve sidecar
         run: |
-          flyctl status --app wikimind-docling 2>/dev/null || flyctl apps create wikimind-docling --org personal
+          if ! flyctl status --app wikimind-docling 2>/dev/null; then
+            echo "::error::Production docling app 'wikimind-docling' does not exist. Create it manually:"
+            echo "::error::  fly apps create wikimind-docling --org personal"
+            exit 1
+          fi
           flyctl deploy --config fly.docling.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ on:
       - "fly.docling.toml"
       - "gunicorn.conf.py"
       - ".github/workflows/docker.yml"
+      - ".github/workflows/deploy.yml"
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
@@ -68,6 +69,7 @@ on:
       - "fly.docling.toml"
       - "gunicorn.conf.py"
       - ".github/workflows/docker.yml"
+      - ".github/workflows/deploy.yml"
   schedule:
     # Weekly rebuild against the latest base image — catches bit-rot.
     - cron: "0 9 * * 1"

--- a/fly.docling.toml
+++ b/fly.docling.toml
@@ -13,7 +13,7 @@ app = "wikimind-docling"
 primary_region = "ord"
 
 [build]
-  image = "quay.io/docling-project/docling-serve-cpu:latest"
+  image = "quay.io/docling-project/docling-serve-cpu:v1.19.0"
 
 [http_service]
   internal_port = 5001

--- a/src/wikimind/config.py
+++ b/src/wikimind/config.py
@@ -148,6 +148,8 @@ class DatabaseConfig(BaseModel):
     """Database configuration."""
 
     echo: bool = False
+    pool_size: int = 5
+    max_overflow: int = 10
 
 
 class ServerConfig(BaseModel):

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -79,11 +79,12 @@ def _create_engine_from_url(url: str):
         # one backend are invalid on another, causing
         # InvalidCachedStatementError.
         connect_args["statement_cache_size"] = 0
+        settings = get_settings()
         return create_async_engine(
             url,
             echo=False,
-            pool_size=10,
-            max_overflow=20,
+            pool_size=settings.database.pool_size,
+            max_overflow=settings.database.max_overflow,
             pool_pre_ping=True,
             connect_args=connect_args,
         )
@@ -249,12 +250,17 @@ async def init_db():
     it runs at most once, avoiding O(n) startup scans on subsequent boots.
     """
     engine = get_async_engine()
+    settings = get_settings()
 
-    # create_all is idempotent — safe on both SQLite and Postgres.
-    # Alembic handles schema evolution but create_all ensures
-    # internal tables (e.g. migrationhistory) exist on first boot.
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
+    # On SQLite (dev/test), create_all bootstraps tables from scratch.
+    # On Postgres (production), Alembic owns the schema exclusively —
+    # create_all would mask missing migrations by silently creating
+    # tables that Alembic doesn't know about.
+    if is_sqlite(settings.database_url):
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+    else:
+        log.info("skipping create_all — Alembic owns schema on Postgres")
 
     # Ensure the dev user row exists so FK constraints are satisfied
     # when running in dev mode with dev_auto_auth.


### PR DESCRIPTION
## Summary

Addresses #634 with five targeted, non-controversial fixes to stabilize the Fly.io CI/CD pipeline:

- **docker.yml trigger paths**: Add `deploy.yml` so deploy workflow changes trigger Docker rebuild without dummy commits
- **Pin docling image**: `fly.docling.toml` pinned from `:latest` to `:v1.19.0` to prevent surprise breakage
- **Validation-only deploy**: Replace infrastructure auto-creation (apps, volumes, Postgres, docling sidecars) with validation checks that fail with clear setup instructions
- **Guard `create_all()`**: Skip `SQLModel.metadata.create_all()` on Postgres — Alembic owns the schema; `create_all` could mask missing migrations
- **Configurable DB pools**: `pool_size` (default 5) and `max_overflow` (default 10) via `WIKIMIND_DATABASE__POOL_SIZE` / `WIKIMIND_DATABASE__MAX_OVERFLOW` — previous hardcoded 10/20 was too high for small Fly/PgBouncer

## Test plan

- [x] `make verify` passes (2088 tests pass, 4 skipped; lint/format clean; mypy clean on changed files)
- [ ] Manual: verify staging deploy still works with existing infrastructure
- [ ] Manual: confirm `create_all` is skipped in Fly.io logs (Postgres path)
- [ ] Verify pool settings are respected by setting `WIKIMIND_DATABASE__POOL_SIZE=3` in a test environment

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)