### PR TITLE
feat(ingest): add span-level citation extraction (Phase 1) (#450)

### DIFF
--- a/apps/web/src/api/sources.ts
+++ b/apps/web/src/api/sources.ts
@@ -9,6 +9,7 @@ import type {
   Source,
   SourceContentResponse,
   SourceDetailResponse,
+  SourceSpanResponse,
   TriggerCompileResponse,
 } from "../types/api";
 
@@ -91,5 +92,11 @@ export function rejectDraft(sourceId: string): Promise<RejectDraftResponse> {
   return apiFetch<RejectDraftResponse>(
     `/api/ingest/sources/${encodeURIComponent(sourceId)}/draft/reject`,
     { method: "POST" },
+  );
+}
+
+export function getSourceSpans(sourceId: string): Promise<SourceSpanResponse[]> {
+  return apiFetch<SourceSpanResponse[]>(
+    `/api/ingest/sources/${encodeURIComponent(sourceId)}/spans`,
   );
 }

--- a/apps/web/src/components/inbox/SourceDetailView.tsx
+++ b/apps/web/src/components/inbox/SourceDetailView.tsx
@@ -5,6 +5,7 @@ import { getBaseUrl } from "../../api/client";
 import { Badge, type BadgeTone } from "../shared/Badge";
 import { Card } from "../shared/Card";
 import { Spinner } from "../shared/Spinner";
+import { SourceSpansPanel } from "../viewers/SourceSpansPanel";
 import type { IngestStatus, PipelineStep, SourceType } from "../../types/api";
 
 const STATUS_TONE: Record<IngestStatus, BadgeTone> = {
@@ -250,6 +251,9 @@ export function SourceDetailView() {
               </div>
             </Card>
           ) : null}
+
+          {/* Source spans (extracted passages) */}
+          <SourceSpansPanel sourceId={source.id} />
 
           {/* Linked articles */}
           {source.linked_articles.length > 0 ? (

--- a/apps/web/src/components/viewers/SourceSpansPanel.tsx
+++ b/apps/web/src/components/viewers/SourceSpansPanel.tsx
@@ -1,0 +1,139 @@
+import { useMemo } from "react";
+import { useSourceSpans } from "../../hooks/useSources";
+import { Badge } from "../shared/Badge";
+import { Card } from "../shared/Card";
+import { Spinner } from "../shared/Spinner";
+import type { LocatorKind, SourceSpanResponse } from "../../types/api";
+
+const LOCATOR_LABEL: Record<LocatorKind, string> = {
+  "pdf-page-rect": "PDF Page",
+  "html-xpath-offset": "HTML",
+  "text-byte-range": "Bytes",
+  "youtube-timestamp": "YouTube",
+};
+
+function formatLocator(kind: LocatorKind, locator: Record<string, unknown>): string {
+  switch (kind) {
+    case "pdf-page-rect": {
+      const page = locator.page ?? locator.page_number;
+      return page != null ? `page ${page}` : "page ?";
+    }
+    case "html-xpath-offset": {
+      const para = locator.paragraph ?? locator.index;
+      return para != null ? `paragraph #${para}` : "xpath";
+    }
+    case "text-byte-range": {
+      const start = locator.start ?? locator.byte_start;
+      const end = locator.end ?? locator.byte_end;
+      if (start != null && end != null) return `bytes ${start}-${end}`;
+      if (start != null) return `byte ${start}`;
+      return "byte range";
+    }
+    case "youtube-timestamp": {
+      const ts = locator.timestamp ?? locator.start;
+      return ts != null ? `${ts}s` : "timestamp";
+    }
+    default:
+      return JSON.stringify(locator);
+  }
+}
+
+function SpanCard({ span }: { span: SourceSpanResponse }) {
+  const truncatedFingerprint = span.fingerprint.slice(0, 12);
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-white p-3">
+      <blockquote className="border-l-2 border-brand-300 pl-3 text-sm italic text-slate-700">
+        {span.text}
+      </blockquote>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <Badge tone="info">
+          {LOCATOR_LABEL[span.locator_kind]} &middot; {formatLocator(span.locator_kind, span.locator)}
+        </Badge>
+        <span className="font-mono text-xs text-slate-400" title={span.fingerprint}>
+          {truncatedFingerprint}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+interface SourceSpansPanelProps {
+  sourceId: string;
+}
+
+export function SourceSpansPanel({ sourceId }: SourceSpansPanelProps) {
+  const { data: spans, isLoading, isError } = useSourceSpans(sourceId);
+
+  const grouped = useMemo(() => {
+    if (!spans || spans.length === 0) return null;
+
+    const groups = new Map<LocatorKind, SourceSpanResponse[]>();
+    for (const span of spans) {
+      const existing = groups.get(span.locator_kind);
+      if (existing) {
+        existing.push(span);
+      } else {
+        groups.set(span.locator_kind, [span]);
+      }
+    }
+
+    return groups;
+  }, [spans]);
+
+  if (isLoading) {
+    return (
+      <Card className="p-5">
+        <div className="flex items-center gap-2">
+          <Spinner size={16} />
+          <span className="text-sm text-slate-500">Loading source spans...</span>
+        </div>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card className="p-5">
+        <p className="text-sm text-slate-500">Failed to load source spans.</p>
+      </Card>
+    );
+  }
+
+  if (!spans || spans.length === 0) {
+    return null;
+  }
+
+  const hasMultipleKinds = grouped != null && grouped.size > 1;
+
+  return (
+    <Card className="p-5">
+      <h2 className="mb-4 text-base font-semibold text-slate-900">
+        Extracted Passages ({spans.length})
+      </h2>
+
+      {hasMultipleKinds ? (
+        <div className="space-y-5">
+          {Array.from(grouped!.entries()).map(([kind, kindSpans]) => (
+            <div key={kind}>
+              <h3 className="mb-2 text-sm font-medium text-slate-600">
+                {LOCATOR_LABEL[kind]} ({kindSpans.length})
+              </h3>
+              <div className="space-y-2">
+                {kindSpans.map((span) => (
+                  <SpanCard key={span.id} span={span} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {spans.map((span) => (
+            <SpanCard key={span.id} span={span} />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/useSources.ts
+++ b/apps/web/src/hooks/useSources.ts
@@ -9,6 +9,7 @@ import {
   deleteSource,
   getDraft,
   getSourceDetail,
+  getSourceSpans,
   ingestPdf,
   ingestUrl,
   listSources,
@@ -16,7 +17,7 @@ import {
   retryCompile,
   type ListSourcesParams,
 } from "../api/sources";
-import type { Source, SourceDetailResponse } from "../types/api";
+import type { Source, SourceDetailResponse, SourceSpanResponse } from "../types/api";
 
 const SOURCES_KEY = ["sources"] as const;
 
@@ -82,6 +83,18 @@ export function useSourceDetail(
   return useQuery({
     queryKey: [...SOURCE_DETAIL_KEY, sourceId],
     queryFn: () => getSourceDetail(sourceId!),
+    enabled: !!sourceId,
+  });
+}
+
+const SOURCE_SPANS_KEY = ["source-spans"] as const;
+
+export function useSourceSpans(
+  sourceId: string | undefined,
+): UseQueryResult<SourceSpanResponse[]> {
+  return useQuery({
+    queryKey: [...SOURCE_SPANS_KEY, sourceId],
+    queryFn: () => getSourceSpans(sourceId!),
     enabled: !!sourceId,
   });
 }

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -95,6 +95,22 @@ export interface SourceDetailResponse {
   linked_articles: LinkedArticleSummary[];
 }
 
+export type LocatorKind =
+  | "pdf-page-rect"
+  | "html-xpath-offset"
+  | "text-byte-range"
+  | "youtube-timestamp";
+
+export interface SourceSpanResponse {
+  id: string;
+  source_id: string;
+  locator_kind: LocatorKind;
+  locator: Record<string, unknown>;
+  text: string;
+  fingerprint: string;
+  created_at: string;
+}
+
 export interface TagRef {
   id: string;
   name: string;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7333,7 +7333,7 @@ components:
       type: string
       enum:
       - pdf-page-rect
-      - html-xpath-offset
+      - html-paragraph-offset
       - text-byte-range
       - youtube-timestamp
       title: LocatorKind

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -265,6 +265,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/ingest/sources/{source_id}/spans:
+    get:
+      tags:
+      - Ingest
+      summary: List Source Spans
+      description: 'Return all source spans for a source document.
+
+
+        Each span anchors a verbatim text excerpt to a precise location in the
+
+        original source (PDF page, byte range, HTML paragraph).'
+      operationId: list_source_spans_api_ingest_sources__source_id__spans_get
+      parameters:
+      - name: source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Source Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SourceSpanResponse'
+                title: Response List Source Spans Api Ingest Sources  Source Id  Spans
+                  Get
+        '404':
+          description: Source not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/ingest/sources/{source_id}/original:
     get:
       tags:

--- a/src/wikimind/api/routes/ingest.py
+++ b/src/wikimind/api/routes/ingest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response, StreamingResponse
-from sqlmodel import select
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.requests import Request
 
@@ -32,6 +32,8 @@ from wikimind.models import (
     SourceDetailResponse,
     SourceImage,
     SourceImageEntry,
+    SourceSpan,
+    SourceSpanResponse,
 )
 from wikimind.services.factories import get_ingest_service
 from wikimind.services.ingest import IngestService
@@ -305,6 +307,45 @@ async def get_source_content(
 ) -> SourceContentResponse:
     """Return the raw text content of a source for side-by-side reading."""
     return await service.get_source_content(source_id, session, user_id=user_id)
+
+
+@router.get(
+    "/sources/{source_id}/spans",
+    response_model=list[SourceSpanResponse],
+    responses={404: {"description": "Source not found"}},
+)
+async def list_source_spans(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    service: IngestService = Depends(get_ingest_service),
+    user_id: str = Depends(get_current_user_id),
+) -> list[SourceSpanResponse]:
+    """Return all source spans for a source document.
+
+    Each span anchors a verbatim text excerpt to a precise location in the
+    original source (PDF page, byte range, HTML paragraph).
+    """
+    # Verify the source exists and belongs to the user
+    await service.get_source(source_id, session, user_id=user_id)
+
+    stmt = (
+        select(SourceSpan)
+        .where(SourceSpan.source_id == source_id, SourceSpan.user_id == user_id)
+        .order_by(col(SourceSpan.created_at))
+    )
+    spans = (await session.exec(stmt)).all()
+    return [
+        SourceSpanResponse(
+            id=span.id,
+            source_id=span.source_id,
+            locator_kind=span.locator_kind,
+            locator=span.locator,
+            text=span.text,
+            fingerprint=span.fingerprint,
+            created_at=span.created_at,
+        )
+        for span in spans
+    ]
 
 
 @router.delete("/sources/{source_id}")

--- a/src/wikimind/database.py
+++ b/src/wikimind/database.py
@@ -290,7 +290,7 @@ async def _add_missing_columns_sqlite(engine) -> None:
                     col_type = col.type.compile(dialect=sync_conn.dialect)
                     nullable = "" if col.nullable else " NOT NULL"
                     default = _column_default_sql(col, sync_conn.dialect)
-                    ddl = f"ALTER TABLE {table_name} ADD COLUMN {col.name} {col_type}{nullable}{default}"
+                    ddl = f'ALTER TABLE "{table_name}" ADD COLUMN "{col.name}" {col_type}{nullable}{default}'
                     sync_conn.execute(sa_text(ddl))
                     log.info(
                         "added missing column to existing table",

--- a/src/wikimind/ingest/adapters/pdf.py
+++ b/src/wikimind/ingest/adapters/pdf.py
@@ -31,6 +31,7 @@ import structlog
 from wikimind.api.routes.ws import emit_source_progress
 from wikimind.config import get_settings
 from wikimind.engine.llm_router import _LLM_PROVIDER_ERRORS, get_llm_router
+from wikimind.ingest.spans import extract_pdf_spans, persist_spans
 from wikimind.ingest.utils import (
     _check_source_dedup,
     chunk_text,
@@ -285,6 +286,19 @@ class PDFAdapter:
                     "PDF image extraction failed — continuing without images",
                     source_id=source.id,
                 )
+
+        # Source span extraction (issue #450): extract per-page paragraph
+        # spans for citation anchoring. Uses fitz per-page text for page-level
+        # locators; falls back to paragraph-only if page text is unavailable.
+        try:
+            page_texts = self._extract_per_page_text(file_bytes)
+            spans = extract_pdf_spans(clean_text, source.id, user_id, page_texts=page_texts)
+            await persist_spans(spans, session)
+        except Exception:
+            log.warning(
+                "PDF span extraction failed — continuing without spans",
+                source_id=source.id,
+            )
 
         token_count = estimate_tokens(clean_text)
         source.token_count = token_count

--- a/src/wikimind/ingest/adapters/text.py
+++ b/src/wikimind/ingest/adapters/text.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from wikimind.ingest.spans import extract_text_spans, persist_spans
 from wikimind.ingest.utils import (
     _check_source_dedup,
     chunk_text,
@@ -77,6 +78,10 @@ class TextAdapter:
             session.add(source)
             await session.commit()
             raise
+        # Extract and persist source spans for citation anchoring (issue #450)
+        spans = extract_text_spans(content, source.id, user_id)
+        await persist_spans(spans, session)
+
         session.add(source)
         await session.commit()
 

--- a/src/wikimind/ingest/adapters/url.py
+++ b/src/wikimind/ingest/adapters/url.py
@@ -14,6 +14,7 @@ import structlog
 import trafilatura
 
 from wikimind.config import get_settings
+from wikimind.ingest.spans import extract_url_spans, persist_spans
 from wikimind.ingest.utils import (
     _check_source_dedup,
     chunk_text,
@@ -111,6 +112,18 @@ class URLAdapter:
 
         # Normalize
         clean_text = downloaded
+
+        # Source span extraction (issue #450): extract paragraph-level spans
+        # for citation anchoring from the extracted text.
+        try:
+            spans = extract_url_spans(clean_text, source.id, user_id)
+            await persist_spans(spans, session)
+        except Exception:
+            log.warning(
+                "URL span extraction failed — continuing without spans",
+                source_id=source.id,
+            )
+
         token_count = estimate_tokens(clean_text)
         source.token_count = token_count
         session.add(source)

--- a/src/wikimind/ingest/spans.py
+++ b/src/wikimind/ingest/spans.py
@@ -99,32 +99,36 @@ def extract_text_spans(
     Returns:
         List of SourceSpan instances (not yet persisted).
     """
-    paragraphs = _split_paragraphs(text)
-    spans: list[SourceSpan] = []
-    text_bytes = text.encode("utf-8")
+    try:
+        paragraphs = _split_paragraphs(text)
+        spans: list[SourceSpan] = []
+        text_bytes = text.encode("utf-8")
 
-    search_start = 0
-    for para in paragraphs:
-        para_bytes = para.encode("utf-8")
-        byte_start = text_bytes.find(para_bytes, search_start)
-        if byte_start == -1:
-            continue
-        byte_end = byte_start + len(para_bytes)
-        search_start = byte_end
+        search_start = 0
+        for para in paragraphs:
+            para_bytes = para.encode("utf-8")
+            byte_start = text_bytes.find(para_bytes, search_start)
+            if byte_start == -1:
+                continue
+            byte_end = byte_start + len(para_bytes)
+            search_start = byte_end
 
-        spans.append(
-            SourceSpan(
-                id=str(uuid.uuid4()),
-                source_id=source_id,
-                user_id=user_id,
-                locator_kind=LocatorKind.TEXT_BYTE_RANGE,
-                locator={"start": byte_start, "end": byte_end},
-                text=para,
-                fingerprint=compute_fingerprint(para),
+            spans.append(
+                SourceSpan(
+                    id=str(uuid.uuid4()),
+                    source_id=source_id,
+                    user_id=user_id,
+                    locator_kind=LocatorKind.TEXT_BYTE_RANGE,
+                    locator={"start": byte_start, "end": byte_end},
+                    text=para,
+                    fingerprint=compute_fingerprint(para),
+                )
             )
-        )
 
-    return spans
+        return spans
+    except Exception:
+        log.warning("Failed to extract text spans", source_id=source_id, exc_info=True)
+        return []
 
 
 def extract_pdf_spans(
@@ -148,11 +152,27 @@ def extract_pdf_spans(
     Returns:
         List of SourceSpan instances (not yet persisted).
     """
-    spans: list[SourceSpan] = []
+    try:
+        spans: list[SourceSpan] = []
 
-    if page_texts:
-        for page_num, page_text in enumerate(page_texts):
-            paragraphs = _split_paragraphs(page_text)
+        if page_texts:
+            for page_num, page_text in enumerate(page_texts):
+                paragraphs = _split_paragraphs(page_text)
+                for para_idx, para in enumerate(paragraphs):
+                    spans.append(
+                        SourceSpan(
+                            id=str(uuid.uuid4()),
+                            source_id=source_id,
+                            user_id=user_id,
+                            locator_kind=LocatorKind.PDF_PAGE_RECT,
+                            locator={"page": page_num + 1, "paragraph": para_idx},
+                            text=para,
+                            fingerprint=compute_fingerprint(para),
+                        )
+                    )
+        else:
+            # Fallback: treat as plain paragraphs without page info
+            paragraphs = _split_paragraphs(text)
             for para_idx, para in enumerate(paragraphs):
                 spans.append(
                     SourceSpan(
@@ -160,28 +180,16 @@ def extract_pdf_spans(
                         source_id=source_id,
                         user_id=user_id,
                         locator_kind=LocatorKind.PDF_PAGE_RECT,
-                        locator={"page": page_num + 1, "paragraph": para_idx},
+                        locator={"page": 1, "paragraph": para_idx},
                         text=para,
                         fingerprint=compute_fingerprint(para),
                     )
                 )
-    else:
-        # Fallback: treat as plain paragraphs without page info
-        paragraphs = _split_paragraphs(text)
-        for para_idx, para in enumerate(paragraphs):
-            spans.append(
-                SourceSpan(
-                    id=str(uuid.uuid4()),
-                    source_id=source_id,
-                    user_id=user_id,
-                    locator_kind=LocatorKind.PDF_PAGE_RECT,
-                    locator={"page": 1, "paragraph": para_idx},
-                    text=para,
-                    fingerprint=compute_fingerprint(para),
-                )
-            )
 
-    return spans
+        return spans
+    except Exception:
+        log.warning("Failed to extract PDF spans", source_id=source_id, exc_info=True)
+        return []
 
 
 def extract_url_spans(
@@ -192,7 +200,8 @@ def extract_url_spans(
     """Extract paragraph-level spans from URL-extracted text.
 
     Splits on paragraph boundaries and records paragraph index as the
-    locator, using the html-xpath-offset kind.
+    locator. Uses HTML_PARAGRAPH_OFFSET since we store paragraph index
+    and character offset, not actual XPath selectors.
 
     Args:
         text: Extracted text content from the web page.
@@ -202,23 +211,27 @@ def extract_url_spans(
     Returns:
         List of SourceSpan instances (not yet persisted).
     """
-    paragraphs = _split_paragraphs(text)
-    spans: list[SourceSpan] = []
+    try:
+        paragraphs = _split_paragraphs(text)
+        spans: list[SourceSpan] = []
 
-    for para_idx, para in enumerate(paragraphs):
-        spans.append(
-            SourceSpan(
-                id=str(uuid.uuid4()),
-                source_id=source_id,
-                user_id=user_id,
-                locator_kind=LocatorKind.HTML_XPATH_OFFSET,
-                locator={"paragraph": para_idx, "offset": 0, "length": len(para)},
-                text=para,
-                fingerprint=compute_fingerprint(para),
+        for para_idx, para in enumerate(paragraphs):
+            spans.append(
+                SourceSpan(
+                    id=str(uuid.uuid4()),
+                    source_id=source_id,
+                    user_id=user_id,
+                    locator_kind=LocatorKind.HTML_PARAGRAPH_OFFSET,
+                    locator={"paragraph": para_idx, "offset": 0, "length": len(para)},
+                    text=para,
+                    fingerprint=compute_fingerprint(para),
+                )
             )
-        )
 
-    return spans
+        return spans
+    except Exception:
+        log.warning("Failed to extract URL spans", source_id=source_id, exc_info=True)
+        return []
 
 
 # ---------------------------------------------------------------------------

--- a/src/wikimind/ingest/spans.py
+++ b/src/wikimind/ingest/spans.py
@@ -1,0 +1,244 @@
+"""Span-level citation utilities for source paragraph anchoring.
+
+Provides text fingerprinting for re-anchoring and span extraction
+helpers used by ingest adapters to produce SourceSpan rows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+from typing import TYPE_CHECKING
+
+import structlog
+
+from wikimind.models.enums import LocatorKind
+from wikimind.models.tables.wiki import SourceSpan
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+log = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# Text fingerprinting
+# ---------------------------------------------------------------------------
+
+_PUNCTUATION_RE = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text for fingerprinting: lowercase, strip punctuation, collapse whitespace.
+
+    Args:
+        text: Raw verbatim text.
+
+    Returns:
+        Normalized string suitable for hashing.
+    """
+    lowered = text.lower()
+    no_punct = _PUNCTUATION_RE.sub("", lowered)
+    return " ".join(no_punct.split())
+
+
+def compute_fingerprint(text: str) -> str:
+    """Compute a SHA-256 fingerprint of normalized text.
+
+    Used for re-anchoring: if a source is re-ingested with minor formatting
+    changes, the fingerprint remains stable so existing claim-to-span links
+    can be preserved.
+
+    Args:
+        text: Raw verbatim text to fingerprint.
+
+    Returns:
+        Hex-encoded SHA-256 digest of the normalized text.
+    """
+    return hashlib.sha256(normalize_text(text).encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Paragraph splitting
+# ---------------------------------------------------------------------------
+
+
+def _split_paragraphs(text: str) -> list[str]:
+    """Split text into non-empty paragraphs on double-newline boundaries.
+
+    Args:
+        text: The full source text.
+
+    Returns:
+        List of paragraph strings with leading/trailing whitespace stripped.
+    """
+    raw = re.split(r"\n\n+", text)
+    return [p.strip() for p in raw if p.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Adapter-specific span extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_text_spans(
+    text: str,
+    source_id: str,
+    user_id: str,
+) -> list[SourceSpan]:
+    """Extract byte-range spans from plain text content.
+
+    Splits on paragraph boundaries and records the byte offset of each
+    paragraph in the UTF-8 encoding of the full text.
+
+    Args:
+        text: Full source text content.
+        source_id: Parent source UUID.
+        user_id: Owner user UUID.
+
+    Returns:
+        List of SourceSpan instances (not yet persisted).
+    """
+    paragraphs = _split_paragraphs(text)
+    spans: list[SourceSpan] = []
+    text_bytes = text.encode("utf-8")
+
+    search_start = 0
+    for para in paragraphs:
+        para_bytes = para.encode("utf-8")
+        byte_start = text_bytes.find(para_bytes, search_start)
+        if byte_start == -1:
+            continue
+        byte_end = byte_start + len(para_bytes)
+        search_start = byte_end
+
+        spans.append(
+            SourceSpan(
+                id=str(uuid.uuid4()),
+                source_id=source_id,
+                user_id=user_id,
+                locator_kind=LocatorKind.TEXT_BYTE_RANGE,
+                locator={"start": byte_start, "end": byte_end},
+                text=para,
+                fingerprint=compute_fingerprint(para),
+            )
+        )
+
+    return spans
+
+
+def extract_pdf_spans(
+    text: str,
+    source_id: str,
+    user_id: str,
+    page_texts: list[str] | None = None,
+) -> list[SourceSpan]:
+    """Extract page-level paragraph spans from PDF extracted text.
+
+    When per-page text is available (via fitz), each paragraph is anchored
+    to its page number. Otherwise falls back to paragraph-level spans
+    without page anchoring.
+
+    Args:
+        text: Full extracted text from the PDF.
+        source_id: Parent source UUID.
+        user_id: Owner user UUID.
+        page_texts: Optional list of per-page text strings from fitz.
+
+    Returns:
+        List of SourceSpan instances (not yet persisted).
+    """
+    spans: list[SourceSpan] = []
+
+    if page_texts:
+        for page_num, page_text in enumerate(page_texts):
+            paragraphs = _split_paragraphs(page_text)
+            for para_idx, para in enumerate(paragraphs):
+                spans.append(
+                    SourceSpan(
+                        id=str(uuid.uuid4()),
+                        source_id=source_id,
+                        user_id=user_id,
+                        locator_kind=LocatorKind.PDF_PAGE_RECT,
+                        locator={"page": page_num + 1, "paragraph": para_idx},
+                        text=para,
+                        fingerprint=compute_fingerprint(para),
+                    )
+                )
+    else:
+        # Fallback: treat as plain paragraphs without page info
+        paragraphs = _split_paragraphs(text)
+        for para_idx, para in enumerate(paragraphs):
+            spans.append(
+                SourceSpan(
+                    id=str(uuid.uuid4()),
+                    source_id=source_id,
+                    user_id=user_id,
+                    locator_kind=LocatorKind.PDF_PAGE_RECT,
+                    locator={"page": 1, "paragraph": para_idx},
+                    text=para,
+                    fingerprint=compute_fingerprint(para),
+                )
+            )
+
+    return spans
+
+
+def extract_url_spans(
+    text: str,
+    source_id: str,
+    user_id: str,
+) -> list[SourceSpan]:
+    """Extract paragraph-level spans from URL-extracted text.
+
+    Splits on paragraph boundaries and records paragraph index as the
+    locator, using the html-xpath-offset kind.
+
+    Args:
+        text: Extracted text content from the web page.
+        source_id: Parent source UUID.
+        user_id: Owner user UUID.
+
+    Returns:
+        List of SourceSpan instances (not yet persisted).
+    """
+    paragraphs = _split_paragraphs(text)
+    spans: list[SourceSpan] = []
+
+    for para_idx, para in enumerate(paragraphs):
+        spans.append(
+            SourceSpan(
+                id=str(uuid.uuid4()),
+                source_id=source_id,
+                user_id=user_id,
+                locator_kind=LocatorKind.HTML_XPATH_OFFSET,
+                locator={"paragraph": para_idx, "offset": 0, "length": len(para)},
+                text=para,
+                fingerprint=compute_fingerprint(para),
+            )
+        )
+
+    return spans
+
+
+# ---------------------------------------------------------------------------
+# Persistence helper
+# ---------------------------------------------------------------------------
+
+
+async def persist_spans(
+    spans: list[SourceSpan],
+    session: AsyncSession,
+) -> None:
+    """Persist a batch of SourceSpan instances to the database.
+
+    Args:
+        spans: List of SourceSpan instances to save.
+        session: Async database session.
+    """
+    if not spans:
+        return
+    for span in spans:
+        session.add(span)
+    await session.flush()
+    log.info("Persisted source spans", count=len(spans), source_id=spans[0].source_id)

--- a/src/wikimind/models/enums.py
+++ b/src/wikimind/models/enums.py
@@ -236,6 +236,6 @@ class LocatorKind(StrEnum):
     """Type of anchor locator for a source span (issue #450)."""
 
     PDF_PAGE_RECT = "pdf-page-rect"
-    HTML_XPATH_OFFSET = "html-xpath-offset"
+    HTML_PARAGRAPH_OFFSET = "html-paragraph-offset"
     TEXT_BYTE_RANGE = "text-byte-range"
     YOUTUBE_TIMESTAMP = "youtube-timestamp"

--- a/src/wikimind/models/tables/wiki.py
+++ b/src/wikimind/models/tables/wiki.py
@@ -24,7 +24,7 @@ class SourceSpan(SQLModel, table=True):
         sa_column=Column(String, ForeignKey("source.id", ondelete="CASCADE"), index=True),
     )
     user_id: str = Field(foreign_key="user.id", index=True)
-    locator_kind: LocatorKind  # "pdf-page-rect", "html-xpath-offset", etc.
+    locator_kind: LocatorKind  # "pdf-page-rect", "html-paragraph-offset", etc.
     locator: dict = Field(sa_column=Column(JSON, nullable=False))  # adapter-specific anchor
     text: str = Field(sa_type=Text)  # verbatim quoted text
     fingerprint: str = Field(index=True)  # SHA-256 of normalized text for re-anchoring

--- a/tests/unit/test_citations.py
+++ b/tests/unit/test_citations.py
@@ -80,7 +80,7 @@ class TestSourceSpanModel:
     async def test_locator_kinds(self, db_session: AsyncSession) -> None:
         """All LocatorKind values should be valid."""
         assert LocatorKind.PDF_PAGE_RECT == "pdf-page-rect"
-        assert LocatorKind.HTML_XPATH_OFFSET == "html-xpath-offset"
+        assert LocatorKind.HTML_PARAGRAPH_OFFSET == "html-paragraph-offset"
         assert LocatorKind.TEXT_BYTE_RANGE == "text-byte-range"
         assert LocatorKind.YOUTUBE_TIMESTAMP == "youtube-timestamp"
 
@@ -361,7 +361,7 @@ class TestCitationsEndpoint:
                 id=span_id,
                 source_id=source_id,
                 user_id=TEST_USER_ID,
-                locator_kind=LocatorKind.HTML_XPATH_OFFSET,
+                locator_kind=LocatorKind.HTML_PARAGRAPH_OFFSET,
                 locator={"xpath": "//p[3]", "offset": 0, "length": 23},
                 text=span_text,
                 fingerprint=_fingerprint(span_text),
@@ -397,4 +397,4 @@ class TestCitationsEndpoint:
         assert len(data["claims"]) == 1
         assert len(data["claims"][0]["source_spans"]) == 1
         assert data["claims"][0]["source_spans"][0]["id"] == span_id
-        assert data["claims"][0]["source_spans"][0]["locator_kind"] == "html-xpath-offset"
+        assert data["claims"][0]["source_spans"][0]["locator_kind"] == "html-paragraph-offset"

--- a/tests/unit/test_source_spans.py
+++ b/tests/unit/test_source_spans.py
@@ -176,7 +176,7 @@ class TestExtractUrlSpans:
         text = "First paragraph.\n\nSecond paragraph."
         spans = extract_url_spans(text, "src-1", "user-1")
         assert len(spans) == 2
-        assert spans[0].locator_kind == LocatorKind.HTML_XPATH_OFFSET
+        assert spans[0].locator_kind == LocatorKind.HTML_PARAGRAPH_OFFSET
         assert spans[0].locator["paragraph"] == 0
         assert spans[0].locator["length"] == len("First paragraph.")
         assert spans[1].locator["paragraph"] == 1

--- a/tests/unit/test_source_spans.py
+++ b/tests/unit/test_source_spans.py
@@ -1,0 +1,300 @@
+"""Tests for span-level citation extraction and fingerprinting (issue #450).
+
+Covers the fingerprint utility, span extraction functions for each adapter,
+the SourceSpan persistence, and the GET /api/sources/{id}/spans endpoint.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tests.conftest import TEST_USER_ID
+from wikimind.ingest.spans import (
+    compute_fingerprint,
+    extract_pdf_spans,
+    extract_text_spans,
+    extract_url_spans,
+    normalize_text,
+    persist_spans,
+)
+from wikimind.models import LocatorKind, Source, SourceSpan
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint utility tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeText:
+    """Verify text normalization for fingerprinting."""
+
+    def test_lowercases(self) -> None:
+        assert normalize_text("Hello World") == "hello world"
+
+    def test_strips_punctuation(self) -> None:
+        assert normalize_text("Hello, world!") == "hello world"
+
+    def test_collapses_whitespace(self) -> None:
+        assert normalize_text("hello   world\n\tfoo") == "hello world foo"
+
+    def test_strips_leading_trailing(self) -> None:
+        assert normalize_text("  hello  ") == "hello"
+
+    def test_empty_string(self) -> None:
+        assert normalize_text("") == ""
+
+    def test_unicode_preserved(self) -> None:
+        result = normalize_text("Café résumé")
+        assert "café" in result
+        assert "résumé" in result
+
+
+class TestComputeFingerprint:
+    """Verify fingerprint stability and uniqueness."""
+
+    def test_deterministic(self) -> None:
+        text = "Machine learning models require large datasets."
+        assert compute_fingerprint(text) == compute_fingerprint(text)
+
+    def test_case_insensitive(self) -> None:
+        assert compute_fingerprint("Hello World") == compute_fingerprint("hello world")
+
+    def test_whitespace_insensitive(self) -> None:
+        assert compute_fingerprint("hello   world") == compute_fingerprint("hello world")
+
+    def test_punctuation_insensitive(self) -> None:
+        assert compute_fingerprint("Hello, world!") == compute_fingerprint("Hello world")
+
+    def test_different_text_different_fingerprint(self) -> None:
+        assert compute_fingerprint("hello") != compute_fingerprint("goodbye")
+
+    def test_returns_hex_sha256(self) -> None:
+        fp = compute_fingerprint("test")
+        assert len(fp) == 64  # SHA-256 hex digest length
+        assert all(c in "0123456789abcdef" for c in fp)
+
+
+# ---------------------------------------------------------------------------
+# Text span extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextSpans:
+    """Verify byte-range span extraction from plain text."""
+
+    def test_single_paragraph(self) -> None:
+        text = "This is a single paragraph."
+        spans = extract_text_spans(text, "src-1", "user-1")
+        assert len(spans) == 1
+        assert spans[0].text == text
+        assert spans[0].locator_kind == LocatorKind.TEXT_BYTE_RANGE
+        assert spans[0].locator["start"] == 0
+        assert spans[0].locator["end"] == len(text.encode("utf-8"))
+
+    def test_multiple_paragraphs(self) -> None:
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        spans = extract_text_spans(text, "src-1", "user-1")
+        assert len(spans) == 3
+        assert spans[0].text == "First paragraph."
+        assert spans[1].text == "Second paragraph."
+        assert spans[2].text == "Third paragraph."
+
+    def test_byte_ranges_are_correct(self) -> None:
+        text = "First.\n\nSecond."
+        spans = extract_text_spans(text, "src-1", "user-1")
+        text_bytes = text.encode("utf-8")
+        for span in spans:
+            extracted = text_bytes[span.locator["start"] : span.locator["end"]]
+            assert extracted.decode("utf-8") == span.text
+
+    def test_empty_text(self) -> None:
+        spans = extract_text_spans("", "src-1", "user-1")
+        assert spans == []
+
+    def test_fingerprints_are_set(self) -> None:
+        text = "A paragraph."
+        spans = extract_text_spans(text, "src-1", "user-1")
+        assert spans[0].fingerprint == compute_fingerprint("A paragraph.")
+
+    def test_source_and_user_ids(self) -> None:
+        text = "Some text."
+        spans = extract_text_spans(text, "src-42", "user-99")
+        assert spans[0].source_id == "src-42"
+        assert spans[0].user_id == "user-99"
+
+
+# ---------------------------------------------------------------------------
+# PDF span extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPdfSpans:
+    """Verify PDF page-level span extraction."""
+
+    def test_with_page_texts(self) -> None:
+        page_texts = ["Page 1 paragraph 1.\n\nPage 1 paragraph 2.", "Page 2 content."]
+        spans = extract_pdf_spans("full text", "src-1", "user-1", page_texts=page_texts)
+        assert len(spans) == 3
+        assert spans[0].locator_kind == LocatorKind.PDF_PAGE_RECT
+        assert spans[0].locator["page"] == 1
+        assert spans[0].locator["paragraph"] == 0
+        assert spans[0].text == "Page 1 paragraph 1."
+        assert spans[1].locator["page"] == 1
+        assert spans[1].locator["paragraph"] == 1
+        assert spans[2].locator["page"] == 2
+        assert spans[2].locator["paragraph"] == 0
+
+    def test_without_page_texts(self) -> None:
+        text = "Paragraph 1.\n\nParagraph 2."
+        spans = extract_pdf_spans(text, "src-1", "user-1")
+        assert len(spans) == 2
+        # Falls back to page=1 for all paragraphs
+        assert spans[0].locator["page"] == 1
+        assert spans[1].locator["page"] == 1
+
+    def test_empty_pages(self) -> None:
+        spans = extract_pdf_spans("", "src-1", "user-1", page_texts=[""])
+        assert spans == []
+
+
+# ---------------------------------------------------------------------------
+# URL span extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractUrlSpans:
+    """Verify URL paragraph-level span extraction."""
+
+    def test_paragraphs(self) -> None:
+        text = "First paragraph.\n\nSecond paragraph."
+        spans = extract_url_spans(text, "src-1", "user-1")
+        assert len(spans) == 2
+        assert spans[0].locator_kind == LocatorKind.HTML_XPATH_OFFSET
+        assert spans[0].locator["paragraph"] == 0
+        assert spans[0].locator["length"] == len("First paragraph.")
+        assert spans[1].locator["paragraph"] == 1
+
+    def test_empty_text(self) -> None:
+        spans = extract_url_spans("", "src-1", "user-1")
+        assert spans == []
+
+
+# ---------------------------------------------------------------------------
+# Persistence tests
+# ---------------------------------------------------------------------------
+
+
+class TestPersistSpans:
+    """Verify spans are saved to the database."""
+
+    @pytest.mark.asyncio
+    async def test_persist_spans(self, db_session: AsyncSession) -> None:
+        source_id = _uid()
+        source = Source(
+            id=source_id,
+            user_id=TEST_USER_ID,
+            source_type="text",
+            title="Test Source",
+        )
+        db_session.add(source)
+        await db_session.flush()
+
+        spans = extract_text_spans("Hello world.\n\nGoodbye world.", source_id, TEST_USER_ID)
+        await persist_spans(spans, db_session)
+        await db_session.flush()
+
+        # Read back
+        from sqlmodel import select
+
+        stmt = select(SourceSpan).where(SourceSpan.source_id == source_id)
+        result = (await db_session.exec(stmt)).all()
+        assert len(result) == 2
+        assert {s.text for s in result} == {"Hello world.", "Goodbye world."}
+
+    @pytest.mark.asyncio
+    async def test_persist_empty_list(self, db_session: AsyncSession) -> None:
+        # Should be a no-op
+        await persist_spans([], db_session)
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceSpansEndpoint:
+    """Verify GET /api/sources/{id}/spans endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_spans_endpoint_not_found(self, client) -> None:
+        resp = await client.get("/api/ingest/sources/nonexistent/spans")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_spans_endpoint_empty(self, client, async_engine) -> None:
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+        source_id = _uid()
+        async with factory() as session:
+            source = Source(
+                id=source_id,
+                user_id=TEST_USER_ID,
+                source_type="text",
+                title="Empty Source",
+            )
+            session.add(source)
+            await session.commit()
+
+        resp = await client.get(f"/api/ingest/sources/{source_id}/spans")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_spans_endpoint_with_spans(self, client, async_engine) -> None:
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+
+        source_id = _uid()
+        span_id = _uid()
+        span_text = "A test paragraph."
+
+        async with factory() as session:
+            source = Source(
+                id=source_id,
+                user_id=TEST_USER_ID,
+                source_type="text",
+                title="Span Source",
+            )
+            session.add(source)
+            await session.flush()
+
+            span = SourceSpan(
+                id=span_id,
+                source_id=source_id,
+                user_id=TEST_USER_ID,
+                locator_kind=LocatorKind.TEXT_BYTE_RANGE,
+                locator={"start": 0, "end": 17},
+                text=span_text,
+                fingerprint=compute_fingerprint(span_text),
+            )
+            session.add(span)
+            await session.commit()
+
+        resp = await client.get(f"/api/ingest/sources/{source_id}/spans")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == span_id
+        assert data[0]["text"] == span_text
+        assert data[0]["locator_kind"] == "text-byte-range"
+        assert data[0]["locator"] == {"start": 0, "end": 17}
+        assert data[0]["fingerprint"] == compute_fingerprint(span_text)


### PR DESCRIPTION
## Summary

Phase 1 of span-level citations (issue #450): during ingest, each adapter now extracts paragraph-level source spans and persists them as `SourceSpan` rows anchored to precise locations in the original document.

- **Fingerprint utility** (`src/wikimind/ingest/spans.py`): normalizes text (lowercase, strip punctuation, collapse whitespace) and computes a SHA-256 hash for stable re-anchoring across minor reformatting
- **Adapter span extraction**: PDF adapter produces page+paragraph spans via fitz per-page text; text adapter produces byte-range spans; URL adapter produces paragraph-index spans
- **API endpoint**: `GET /api/ingest/sources/{id}/spans` returns all spans for a source document
- 28 new tests covering fingerprinting, span extraction for each adapter type, persistence, and the API endpoint

The SourceSpan table, Alembic migration (0019), LocatorKind enum, SourceSpanResponse DTO, and CitationService already existed in main. This PR adds the missing ingest-time span production and source-level retrieval.

## Test plan

- [x] `make verify` passes (lint, format, typecheck, tests, coverage, docs sync)
- [x] Unit tests for `normalize_text` and `compute_fingerprint` (determinism, case/whitespace/punctuation insensitivity)
- [x] Unit tests for `extract_text_spans`, `extract_pdf_spans`, `extract_url_spans` (correct locator types, byte ranges, page anchoring)
- [x] Integration test for `persist_spans` (DB round-trip)
- [x] API endpoint tests for `GET /api/ingest/sources/{id}/spans` (404, empty, with spans)
- [ ] Manual test: ingest a PDF and verify spans appear via the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)