### PR TITLE
fix: respect COMPOSE_CMD variable in docker-* targets

### DIFF
--- a/.env.make.example
+++ b/.env.make.example
@@ -1,3 +1,6 @@
 # .env.make — Build-time variables for the Makefile.
 # Copy to .env.make and customize. This file is gitignored.
 COMPOSE_CMD=docker compose
+
+# For Podman users:
+# COMPOSE_CMD=podman compose

--- a/Makefile
+++ b/Makefile
@@ -344,24 +344,24 @@ extension-package: extension-build ## Build extension and create submission-read
 
 .PHONY: docker-build
 docker-build: ## Build the dev image used by docker-compose
-	docker compose build
+	$(COMPOSE_CMD) build
 
 .PHONY: docker-up
 docker-up: ## Start the dev stack in the background (uses cached image)
-	docker compose up -d
+	$(COMPOSE_CMD) up -d
 
 .PHONY: docker-up-build
 docker-up-build: ## Rebuild the image and start the dev stack in the background
-	docker compose up -d --build
+	$(COMPOSE_CMD) up -d --build
 
 .PHONY: docker-logs
 docker-logs: ## Tail logs from all dev stack services
-	docker compose logs -f
+	$(COMPOSE_CMD) logs -f
 
 .PHONY: docker-down
 docker-down: ## Stop and remove the dev stack
-	docker compose down --remove-orphans
-	docker compose rm -f 2>/dev/null || true
+	$(COMPOSE_CMD) down --remove-orphans
+	$(COMPOSE_CMD) rm -f 2>/dev/null || true
 
 ##@ 🔄 PRODUCTION PARITY
 


### PR DESCRIPTION
## Summary

- Fixed `docker-*` Makefile targets to respect the `COMPOSE_CMD` variable
- Added Podman usage example to `.env.make.example`
- Makes Podman support consistent across all compose-based targets

## Doc Impact

- [x] README updated (N/A — no user-facing changes, internal dev workflow only)
- [x] ADR added or updated (N/A — no architectural decision)
- [x] OpenAPI regenerated (N/A — no API changes)
- [x] CLAUDE.md updated (N/A — no convention changes)
- [x] `.env.make.example` updated with Podman example

## Test Plan

- [x] Verified `make docker-up` works with `COMPOSE_CMD=podman compose`
- [x] Verified `make docker-down` works with `COMPOSE_CMD=podman compose`
- [x] Verified existing Docker users unaffected (default still `docker compose`)

## Context

The `deploy-*` and `parity-*` targets already used `$(COMPOSE_CMD)`, but the `docker-*` targets were hardcoded to `docker compose`. This inconsistency prevented Podman users from using the local development workflow.