### PR TITLE
chore(code-quality): resolve P1 code scanning alerts

### DIFF
--- a/src/wikimind/engine/linter/runner.py
+++ b/src/wikimind/engine/linter/runner.py
@@ -181,7 +181,7 @@ async def _queue_recompile_for_new_contradictions(
     # Lazy import to break circular dependency:
     # runner -> background -> worker -> runner
     # CodeQL: cyclic-import — unavoidable, see #649
-    from wikimind.jobs.background import get_background_compiler  # noqa: PLC0415
+    from wikimind.jobs.background import get_background_compiler  # noqa: PLC0415  # CodeQL[cyclic-import]
 
     # Collect unique article IDs that need recompilation
     article_ids_to_recompile: set[str] = set()

--- a/src/wikimind/ingest/service.py
+++ b/src/wikimind/ingest/service.py
@@ -2,10 +2,6 @@
 
 Adapters save the source and return immediately. Compilation is scheduled
 separately by the outer service layer (see ``wikimind.services.ingest``).
-
-Re-exports from sub-modules are provided at the bottom of this file so that
-existing imports like ``from wikimind.ingest.service import PDFAdapter``
-continue to work without changes.
 """
 
 from __future__ import annotations
@@ -164,52 +160,12 @@ class IngestService:
         return await self.text_adapter.ingest(content, title, session, user_id=user_id)
 
 
-# ---------------------------------------------------------------------------
-# Backward-compatible re-exports
-#
-# Many modules and tests import symbols directly from
-# ``wikimind.ingest.service``.  The re-exports below keep those imports
-# working without requiring callers to change.
-# ---------------------------------------------------------------------------
-
-# Re-export third-party modules that tests patch via ``ingest_mod.<lib>``
-import fitz  # noqa: E402, F401
-import trafilatura  # noqa: E402, F401
-from youtube_transcript_api import YouTubeTranscriptApi  # noqa: E402, F401
-
-from wikimind.api.routes.ws import emit_source_progress  # noqa: E402, F401
-from wikimind.engine.llm_router import get_llm_router  # noqa: E402, F401
-from wikimind.ingest.adapters.pdf import (  # noqa: E402
-    _convert_via_docling_serve,
-    _extract_pdf_metadata,
-    _first_markdown_heading,
-    _parse_pdf_date,
-)
-from wikimind.ingest.utils import (  # noqa: E402
-    _check_source_dedup,
-    chunk_text,
-    compute_hash,
-    estimate_tokens,
-    find_source_by_hash,
-    reconstruct_normalized_doc,
-)
-
 __all__ = [
     "IngestService",
     "PDFAdapter",
     "TextAdapter",
     "URLAdapter",
     "YouTubeAdapter",
-    "_check_source_dedup",
-    "_convert_via_docling_serve",
-    "_extract_pdf_metadata",
-    "_first_markdown_heading",
-    "_parse_pdf_date",
-    "chunk_text",
-    "compute_hash",
-    "estimate_tokens",
-    "find_source_by_hash",
     "is_youtube_url",
-    "reconstruct_normalized_doc",
     "validate_url_host",
 ]

--- a/src/wikimind/jobs/worker.py
+++ b/src/wikimind/jobs/worker.py
@@ -23,7 +23,6 @@ from arq.connections import RedisSettings
 from sqlalchemy import distinct
 from sqlmodel import select
 
-import wikimind.ingest.service as _ingest_service
 from wikimind._datetime import utcnow_naive
 from wikimind.api.routes.ws import (
     emit_article_recompiled,
@@ -37,6 +36,7 @@ from wikimind.database import get_session_factory
 from wikimind.engine.compiler import Compiler
 from wikimind.engine.concept_compiler import ConceptCompiler
 from wikimind.engine.linter.runner import run_lint  # CodeQL[cyclic-import]
+from wikimind.ingest.utils import chunk_text, estimate_tokens
 from wikimind.jobs.sweep import sweep_wikilinks
 from wikimind.models import (
     AmbientAdapterSetting,
@@ -93,8 +93,8 @@ async def _build_normalized_doc(source: Source) -> NormalizedDocument:
         title=source.title or "Untitled",
         author=source.author,
         published_date=source.published_date,
-        estimated_tokens=_ingest_service.estimate_tokens(content),
-        chunks=_ingest_service.chunk_text(content, source.id),
+        estimated_tokens=estimate_tokens(content),
+        chunks=chunk_text(content, source.id),
     )
 
 

--- a/src/wikimind/mcp/server.py
+++ b/src/wikimind/mcp/server.py
@@ -54,8 +54,7 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
-# Valid enum values for input validation
-_VALID_PAGE_TYPES = {"source", "concept", "synthesis", "answer"}
+# Valid enum values for input validation (used by tools_analysis)
 _VALID_INGEST_STATUSES = {"pending", "processing", "compiled", "failed"}
 _VALID_SYNTHESIS_TYPES = {"comparative", "chronological", "thematic", "gap_analysis"}
 

--- a/src/wikimind/services/citation.py
+++ b/src/wikimind/services/citation.py
@@ -5,11 +5,13 @@ returns its compiled claims together with the source spans that anchor
 each claim to a precise location in the original source document.
 """
 
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 import structlog
 from sqlmodel import col, select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from wikimind.errors import NotFoundError
 from wikimind.models import (
@@ -22,7 +24,11 @@ from wikimind.models import (
     SourceSpan,
     SourceSpanResponse,
 )
-from wikimind.services.wiki import WikiService
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from wikimind.services.wiki import WikiService
 
 log = structlog.get_logger()
 

--- a/src/wikimind/services/draft.py
+++ b/src/wikimind/services/draft.py
@@ -15,7 +15,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from wikimind._datetime import utcnow_naive
 from wikimind.engine.compiler import Compiler
 from wikimind.errors import NotFoundError
-from wikimind.ingest.service import chunk_text, estimate_tokens
+from wikimind.ingest.utils import chunk_text, estimate_tokens
 from wikimind.models import (
     ApproveDraftResponse,
     CompilationDraft,

--- a/src/wikimind/services/factories.py
+++ b/src/wikimind/services/factories.py
@@ -13,7 +13,7 @@ import structlog
 from wikimind.services.admin import AdminService
 from wikimind.services.ambient import AmbientService
 from wikimind.services.capture import CaptureService
-from wikimind.services.citation import CitationService
+from wikimind.services.citation import CitationService  # CodeQL[cyclic-import] — runtime DI
 from wikimind.services.compilation_schema import CompilationSchemaService
 from wikimind.services.compiler import CompilerService
 from wikimind.services.contradiction import ContradictionService
@@ -30,7 +30,7 @@ from wikimind.services.search import SearchService
 from wikimind.services.sharing import SharingService
 from wikimind.services.tags import TagService
 from wikimind.services.user import UserService
-from wikimind.services.wiki import WikiService
+from wikimind.services.wiki import WikiService  # CodeQL[cyclic-import] — runtime DI
 from wikimind.services.wiki_export import WikiExportService
 
 log = structlog.get_logger()

--- a/src/wikimind/services/wiki.py
+++ b/src/wikimind/services/wiki.py
@@ -26,7 +26,7 @@ from wikimind._datetime import utcnow_naive
 from wikimind.config import get_settings
 from wikimind.engine.confidence import apply_decay, compute_staleness
 from wikimind.errors import NotFoundError
-from wikimind.jobs.background import get_background_compiler
+from wikimind.jobs.background import get_background_compiler  # CodeQL[cyclic-import] — runtime call
 from wikimind.models import (
     Article,
     ArticleConcept,


### PR DESCRIPTION
## Summary

Resolves #804 — fixes 11 CodeQL P1 code scanning alerts across 4 categories.

- **Cyclic imports (service layer):** Move `WikiService` import in `citation.py` to `TYPE_CHECKING` block; add `CodeQL[cyclic-import]` suppression comments on intentional cycles in `factories.py` and `wiki.py`
- **Cyclic imports (job layer):** Add inline `CodeQL[cyclic-import]` suppression to `runner.py:184` lazy import (already managed); `worker.py` and `background.py` already had comments
- **Unused globals (MCP):** Remove unused `_VALID_PAGE_TYPES` from `server.py` (duplicate of `tools_discovery.py`'s copy; `_VALID_INGEST_STATUSES` and `_VALID_SYNTHESIS_TYPES` kept since `tools_analysis.py` imports them)
- **Dead re-exports (ingest):** Remove stale backward-compat re-export block from `ingest/service.py` (`fitz`, `trafilatura`, `YouTubeTranscriptApi`, `emit_source_progress`, `get_llm_router`, plus PDF adapter helpers); update `worker.py` and `draft.py` to import `chunk_text`/`estimate_tokens` directly from `wikimind.ingest.utils`

## Test plan

- [x] `ruff check` passes (0 errors)
- [x] `mypy` shows no new errors (4 pre-existing in unrelated files)
- [x] All 2181 unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)