### PR TITLE
feat(engine): add per-claim confidence persistence (#465)

### DIFF
--- a/src/wikimind/engine/compiler.py
+++ b/src/wikimind/engine/compiler.py
@@ -433,6 +433,8 @@ class Compiler(BaseCompiler):
             meta += f"\nAuthor: {doc.author}"
         if doc.published_date:
             meta += f"\nPublished: {doc.published_date}"
+        if doc.raw_source_id:
+            meta += f"\nSource ID: {doc.raw_source_id}"
 
         return f"""{meta}
 

--- a/src/wikimind/engine/prompts.py
+++ b/src/wikimind/engine/prompts.py
@@ -38,6 +38,8 @@ Output schema:
     {
       "claim": "Specific, falsifiable claim from the source",
       "confidence": "sourced|inferred|opinion",
+      "subjects": ["canonical-subject-name"],
+      "source_ids": ["<source_id from metadata>"],
       "quote": "Optional direct quote under 15 words if the exact wording matters"
     }
   ],
@@ -53,6 +55,8 @@ Rules:
 - page_type is always "source" for source compilations
 - Every claim must be attributable to the source
 - Mark LLM inferences as confidence=inferred explicitly
+- For each claim, set "subjects" to a list of 1-3 canonical entity/concept names the claim is about (e.g. ["neural networks", "image classification"]). Reuse existing concept names when possible.
+- For each claim, set "source_ids" to the list of source UUIDs that support it. Use the source_id provided in the metadata.
 - Suggest backlinks only to concepts genuinely related
 - For backlink_suggestions, use relation_type "references" (mentions related topic), "extends" (builds on/adds to claims), or "supersedes" (newer source replaces older claims)
 - Open questions should drive future research

--- a/tests/integration/test_confidence_integration.py
+++ b/tests/integration/test_confidence_integration.py
@@ -255,12 +255,14 @@ async def test_persist_claims_stores_source_ids_and_subjects(
     from sqlmodel import select
 
     claims = (
-        await db_session.execute(
-            select(CompiledClaim)
-            .where(CompiledClaim.article_id == article.id)
-            .order_by(CompiledClaim.text)
+        (
+            await db_session.execute(
+                select(CompiledClaim).where(CompiledClaim.article_id == article.id).order_by(CompiledClaim.text)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     assert len(claims) == 2
 

--- a/tests/integration/test_confidence_integration.py
+++ b/tests/integration/test_confidence_integration.py
@@ -1,23 +1,34 @@
-"""Integration tests for article-level confidence scoring (issue #422).
+"""Integration tests for article-level confidence scoring (issue #422, #465).
 
 These tests exercise the compiler helper that recomputes
 ``Article.confidence_score`` from the live source set + contradiction
 backlinks and verify that the wiki service decays the score for stale
 articles. They use the in-memory SQLite engine from conftest, not the
 LLM, so they are hermetic and fast.
+
+Issue #465 adds per-claim confidence persistence: claims get individual
+``confidence_score`` values, and the article's score is the aggregate
+(weighted mean) of its claims.
 """
 
 from __future__ import annotations
 
+import json
+import math
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from wikimind._datetime import utcnow_naive
 from wikimind.engine.compiler import Compiler
+from wikimind.engine.confidence import compute_claim_confidence
 from wikimind.models import (
     Article,
     ArticleSource,
     Backlink,
+    CompilationResult,
+    CompiledClaim,
+    CompiledClaimDTO,
+    ConfidenceLevel,
     PageType,
     RelationType,
     Source,
@@ -148,3 +159,124 @@ async def test_effective_confidence_decays_for_year_old_article(
     # Sanity: with the documented multiplier (1 - 1*0.3) = 0.7, the effective
     # value should be in the right ballpark.
     assert effective < 0.8 * 0.75
+
+
+# ---------------------------------------------------------------------------
+# Per-claim confidence → article aggregation (issue #465)
+# ---------------------------------------------------------------------------
+
+
+async def test_article_confidence_aggregated_from_claims(
+    db_session: AsyncSession,
+) -> None:
+    """Article confidence_score should be the mean of its claim scores when claims exist."""
+    article = Article(
+        slug="claim-agg",
+        title="Claim Aggregation",
+        file_path="claim-agg.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(article)
+    await db_session.commit()
+
+    src = await _add_source(db_session, "claim-source")
+    await _link_source(db_session, article.id, src.id)
+
+    # Insert two claims with known confidence scores.
+    claim1 = CompiledClaim(
+        article_id=article.id,
+        user_id=TEST_USER_ID,
+        text="Claim with high confidence.",
+        confidence_level="sourced",
+        confidence_score=compute_claim_confidence("sourced", source_count=2),
+        source_ids=json.dumps([src.id]),
+    )
+    claim2 = CompiledClaim(
+        article_id=article.id,
+        user_id=TEST_USER_ID,
+        text="Claim with lower confidence.",
+        confidence_level="inferred",
+        confidence_score=compute_claim_confidence("inferred", source_count=0),
+        source_ids="[]",
+    )
+    db_session.add_all([claim1, claim2])
+    await db_session.commit()
+
+    compiler = Compiler(user_id=TEST_USER_ID)
+    await compiler._refresh_confidence_score(article, db_session)
+
+    # Expected: mean of (0.9, 0.3) = 0.6
+    expected = (claim1.confidence_score + claim2.confidence_score) / 2
+    assert math.isclose(article.confidence_score, expected, abs_tol=1e-9)
+
+
+async def test_persist_claims_stores_source_ids_and_subjects(
+    db_session: AsyncSession,
+) -> None:
+    """_persist_claims should store source_ids and subjects from CompiledClaimDTO."""
+    article = Article(
+        slug="persist-claims",
+        title="Persist Claims",
+        file_path="persist-claims.md",
+        page_type=PageType.SOURCE,
+        user_id=TEST_USER_ID,
+    )
+    db_session.add(article)
+    await db_session.commit()
+
+    src = await _add_source(db_session, "src-for-claims")
+
+    result = CompilationResult(
+        title="Persist Claims",
+        summary="Test article.",
+        key_claims=[
+            CompiledClaimDTO(
+                claim="ML models need data.",
+                confidence=ConfidenceLevel.SOURCED,
+                subjects=["machine learning", "data"],
+                source_ids=[src.id],
+            ),
+            CompiledClaimDTO(
+                claim="This is inferred.",
+                confidence=ConfidenceLevel.INFERRED,
+                subjects=["inference"],
+            ),
+        ],
+        concepts=["ml"],
+        backlink_suggestions=[],
+        open_questions=[],
+        article_body="Body text here.",
+    )
+
+    compiler = Compiler(user_id=TEST_USER_ID)
+    await compiler._persist_claims(article.id, result, src, db_session)
+
+    from sqlmodel import select
+
+    claims = (
+        await db_session.execute(
+            select(CompiledClaim)
+            .where(CompiledClaim.article_id == article.id)
+            .order_by(CompiledClaim.text)
+        )
+    ).scalars().all()
+
+    assert len(claims) == 2
+
+    # First claim (alphabetical): "ML models need data."
+    ml_claim = claims[0]
+    assert ml_claim.text == "ML models need data."
+    assert json.loads(ml_claim.source_ids) == [src.id]
+    assert json.loads(ml_claim.subjects) == ["machine learning", "data"]
+    # sourced + 1 source: 0.8 + 0.2 * 0.25 = 0.85
+    assert math.isclose(ml_claim.confidence_score, 0.85, abs_tol=1e-9)
+
+    # Second claim: "This is inferred."
+    inf_claim = claims[1]
+    assert inf_claim.text == "This is inferred."
+    # No source_ids on DTO, falls back to [src.id]
+    assert json.loads(inf_claim.source_ids) == [src.id]
+    assert json.loads(inf_claim.subjects) == ["inference"]
+    # inferred + 1 source: 0.3 + 0.2 * 0.25 = 0.35
+    assert math.isclose(inf_claim.confidence_score, 0.35, abs_tol=1e-9)

--- a/tests/unit/test_engine_compiler.py
+++ b/tests/unit/test_engine_compiler.py
@@ -160,6 +160,13 @@ def test_build_user_prompt_includes_metadata() -> None:
     assert "Author" in p
 
 
+def test_build_user_prompt_includes_source_id() -> None:
+    c = _make_compiler()
+    doc = _doc()
+    p = c._build_user_prompt(doc)
+    assert f"Source ID: {doc.raw_source_id}" in p
+
+
 def test_merge_chunk_results() -> None:
     c = _make_compiler()
     r1 = _result(concepts=["a", "b"])


### PR DESCRIPTION
## Summary

- Update the compiler prompt to request `subjects` and `source_ids` per claim, enabling per-claim source attribution from LLM output
- Pass source UUID in user prompt metadata so the LLM can reference it in claim source_ids
- Add integration tests verifying claim-level confidence aggregates correctly into article-level confidence

## Context

PR #800 shipped Phase 1 of issue #465 (article-level confidence with persistence). This PR advances the issue by closing the gap between the LLM prompt and the existing `CompiledClaim` table schema — the table already had `subjects`, `source_ids`, and `confidence_score` fields, but the compiler prompt never asked the LLM to populate them. Now it does.

**What was already in place (from PR #800 and #784):**
- `CompiledClaim` table with `confidence_score`, `source_ids`, `last_reinforced_at`, `subjects`
- `compute_claim_confidence()` and `aggregate_claim_confidence()` pure functions
- `_persist_claims()` storing claims with per-claim confidence scores
- `_refresh_confidence_score()` aggregating claim scores to article level
- `GET /wiki/articles/{id}/claims` endpoint and service layer
- Full DTOs, migrations, and unit tests

**What this PR adds:**
- Compiler prompt schema now includes `subjects` and `source_ids` fields per claim
- Prompt rules instruct the LLM to set subjects (1-3 canonical entity names) and source_ids (UUIDs from metadata)
- `_build_user_prompt` passes `Source ID: <uuid>` in metadata block
- Integration test: article confidence is the mean of its claim scores
- Integration test: `_persist_claims` correctly stores subjects and source_ids from DTOs
- Unit test: `_build_user_prompt` includes source ID in output

**Not included (deferred to future PRs):**
- Concept identity / embedding clustering
- Cross-article claim deduplication

## Test plan

- [x] All existing unit tests pass (35 compiler tests, 24 claim confidence tests, 30 citation tests)
- [x] All existing integration tests pass (3 confidence integration tests)
- [x] New unit test: `test_build_user_prompt_includes_source_id` verifies source ID in prompt
- [x] New integration test: `test_article_confidence_aggregated_from_claims` verifies claim-to-article aggregation
- [x] New integration test: `test_persist_claims_stores_source_ids_and_subjects` verifies claim persistence
- [x] `ruff check` passes with no errors
- [x] `mypy` passes (4 pre-existing errors in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)