### PR TITLE
fix(security): resolve P0 code scanning alerts (#803)

### DIFF
--- a/src/wikimind/api/routes/ws.py
+++ b/src/wikimind/api/routes/ws.py
@@ -269,7 +269,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                 break
 
     except WebSocketDisconnect:
-        pass
+        pass  # Expected during normal client disconnect; cleanup in finally
     finally:
         manager.disconnect(websocket)
 

--- a/src/wikimind/engine/concept_compiler.py
+++ b/src/wikimind/engine/concept_compiler.py
@@ -71,7 +71,7 @@ async def _build_source_material(articles: list[Article], user_id: str) -> str:
                 fc = fc[:max_chars] + "\n[...truncated...]"
             section += f"\nContent:\n{fc}\n"
         except (OSError, ValueError):
-            pass
+            log.debug("skipped article content", article_id=article.id, reason="storage read failed")
         parts.append(section)
     return "\n---\n".join(parts)
 

--- a/src/wikimind/engine/linter/contradictions.py
+++ b/src/wikimind/engine/linter/contradictions.py
@@ -425,7 +425,7 @@ async def _collect_work(
         articles = list(article_result.scalars().all())
         pairs = list(itertools.combinations(articles, 2))
         if len(pairs) > cfg.max_contradiction_pairs_per_concept:
-            pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
+            pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)  # nosec B311 -- sampling for performance, not security
         all_work.append((None, "all-articles", pairs))
     else:
         for concept_obj in concepts:
@@ -435,7 +435,7 @@ async def _collect_work(
                 continue
             pairs = list(itertools.combinations(articles, 2))
             if len(pairs) > cfg.max_contradiction_pairs_per_concept:
-                pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)
+                pairs = random.sample(pairs, cfg.max_contradiction_pairs_per_concept)  # nosec B311 -- sampling for performance, not security
             all_work.append((cid, cname, pairs))
 
     return all_work

--- a/src/wikimind/engine/qa_agent.py
+++ b/src/wikimind/engine/qa_agent.py
@@ -171,9 +171,11 @@ def _format_external_tools_block(tools: list[ExternalToolInfo]) -> str:
 
     lines = [
         "",
-        "You also have access to external tools. If the wiki context is insufficient, "
-        "you MAY suggest calling one of these tools by including a 'tool_calls' array "
-        "in your response:",
+        (
+            "You also have access to external tools. If the wiki context is insufficient, "
+            "you MAY suggest calling one of these tools by including a 'tool_calls' array "
+            "in your response:"
+        ),
         "",
     ]
     for info in tools:

--- a/src/wikimind/ingest/adapters/rss.py
+++ b/src/wikimind/ingest/adapters/rss.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from typing import TYPE_CHECKING
-from xml.etree.ElementTree import ParseError
+from xml.etree.ElementTree import ParseError  # nosec B405 -- exception class only, parsing uses defusedxml
 
 import defusedxml.ElementTree as DefusedET
 import httpx
@@ -26,7 +26,7 @@ from wikimind.models import (
 )
 
 if TYPE_CHECKING:
-    from xml.etree.ElementTree import Element
+    from xml.etree.ElementTree import Element  # nosec B405 -- exception class only, parsing uses defusedxml
 
     from sqlmodel.ext.asyncio.session import AsyncSession
 


### PR DESCRIPTION
## Summary
- Fixes implicit string concatenation potential bug in `qa_agent.py` (wrapped in parens)
- Documents empty except blocks in `ws.py` and `concept_compiler.py` (added comment/logging)
- Suppresses false positive Bandit alerts for XML ParseError import and `random.sample()` usage

## Test plan
- [x] `make lint` passes
- [ ] Verify CodeQL alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)