### PR TITLE
feat(web): add span-level citation UI — popovers, source highlight, inline markers (#450)

### DIFF
--- a/apps/web/src/components/wiki/ArticleReader.tsx
+++ b/apps/web/src/components/wiki/ArticleReader.tsx
@@ -17,7 +17,7 @@ import { ExportDropdown } from "./ExportDropdown";
 import { ShareButton } from "./ShareButton";
 import { TagSelector } from "./TagSelector";
 import { preprocessMarkdown, extractSynthesizedFrom, extractConceptKind } from "./preprocessMarkdown";
-import { markdownComponents } from "./markdownComponents";
+import { createMarkdownComponents } from "./markdownComponents";
 import { useArticleEditor } from "./useArticleEditor";
 import { ClaimsPanel } from "./ClaimsPanel";
 import { DiscussionPanel } from "./DiscussionPanel";
@@ -52,6 +52,11 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
   const conceptKind = useMemo(
     () => (isConcept ? extractConceptKind(article.content ?? "") : null),
     [article.content, isConcept],
+  );
+
+  const mdComponents = useMemo(
+    () => createMarkdownComponents(article.sources),
+    [article.sources],
   );
 
   const primaryConcept = article.concepts.length > 0 ? article.concepts[0] : null;
@@ -172,7 +177,7 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath]}
             rehypePlugins={[rehypeKatex, rehypeHighlight, rehypeRaw]}
-            components={markdownComponents}
+            components={mdComponents}
           >
             {processed}
           </ReactMarkdown>
@@ -182,7 +187,7 @@ export function ArticleReader({ article, onArticleUpdated }: ArticleReaderProps)
       {/* Per-claim confidence panel */}
       {!isEditing && (
         <div className="mt-8 border-t border-slate-200 pt-6">
-          <ClaimsPanel articleId={article.id} />
+          <ClaimsPanel articleId={article.id} sources={article.sources} />
         </div>
       )}
 

--- a/apps/web/src/components/wiki/CitationContext.tsx
+++ b/apps/web/src/components/wiki/CitationContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, useCallback } from "react";
+import type { ReactNode } from "react";
+
+export interface CitationTarget {
+  sourceId: string;
+  spanText: string;
+  sourceName: string | null;
+  locatorInfo: string;
+}
+
+interface CitationContextValue {
+  /** The citation currently being viewed in the source panel. */
+  activeCitation: CitationTarget | null;
+  /** Open the source panel with a highlighted span. */
+  showCitation: (target: CitationTarget) => void;
+  /** Clear the active citation (back to default sidebar). */
+  clearCitation: () => void;
+}
+
+const CitationCtx = createContext<CitationContextValue | null>(null);
+
+export function CitationProvider({ children }: { children: ReactNode }) {
+  const [activeCitation, setActiveCitation] = useState<CitationTarget | null>(
+    null,
+  );
+
+  const showCitation = useCallback((target: CitationTarget) => {
+    setActiveCitation(target);
+  }, []);
+
+  const clearCitation = useCallback(() => {
+    setActiveCitation(null);
+  }, []);
+
+  return (
+    <CitationCtx.Provider
+      value={{ activeCitation, showCitation, clearCitation }}
+    >
+      {children}
+    </CitationCtx.Provider>
+  );
+}
+
+export function useCitation(): CitationContextValue {
+  const ctx = useContext(CitationCtx);
+  if (!ctx) {
+    throw new Error("useCitation must be used within a CitationProvider");
+  }
+  return ctx;
+}

--- a/apps/web/src/components/wiki/CitationPopover.tsx
+++ b/apps/web/src/components/wiki/CitationPopover.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from "react";
+import type { CitationTarget } from "./CitationContext";
+import { useCitation } from "./CitationContext";
+
+interface CitationPopoverProps {
+  /** The citation data to display. */
+  citation: CitationTarget;
+  /** Callback to close the popover. */
+  onClose: () => void;
+  /** Anchor element for positioning (popover appears below it). */
+  anchorRect: DOMRect | null;
+}
+
+export function CitationPopover({
+  citation,
+  onClose,
+  anchorRect,
+}: CitationPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { showCitation } = useCitation();
+
+  // Close on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  if (!anchorRect) return null;
+
+  const style: React.CSSProperties = {
+    position: "fixed",
+    top: anchorRect.bottom + 8,
+    left: Math.max(8, anchorRect.left - 120),
+    zIndex: 50,
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="w-80 rounded-lg border border-gray-200 bg-white p-4 shadow-lg transition-all duration-200"
+      style={style}
+    >
+      {/* Quoted span text */}
+      <blockquote className="mb-3 border-l-2 border-brand-300 pl-3 text-sm italic text-slate-700">
+        {citation.spanText.length > 200
+          ? citation.spanText.slice(0, 200) + "..."
+          : citation.spanText}
+      </blockquote>
+
+      {/* Source info */}
+      <div className="mb-3 flex items-center gap-2 text-xs text-slate-500">
+        <span className="font-medium text-slate-700">
+          {citation.sourceName || "Unknown source"}
+        </span>
+        {citation.locatorInfo && (
+          <>
+            <span className="text-slate-300">&middot;</span>
+            <span>{citation.locatorInfo}</span>
+          </>
+        )}
+      </div>
+
+      {/* View in source link */}
+      <button
+        onClick={() => {
+          showCitation(citation);
+          onClose();
+        }}
+        className="inline-flex items-center gap-1 text-xs font-medium text-brand-600 hover:text-brand-800"
+      >
+        <svg
+          className="h-3.5 w-3.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+          />
+        </svg>
+        View in source
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/ClaimsPanel.tsx
+++ b/apps/web/src/components/wiki/ClaimsPanel.tsx
@@ -7,6 +7,7 @@ import { Badge, type BadgeTone } from "../shared/Badge";
 import { Spinner } from "../shared/Spinner";
 import { CitationPopover } from "./CitationPopover";
 import type { CitationTarget } from "./CitationContext";
+import { formatLocator } from "./citationUtils";
 
 interface ClaimsPanelProps {
   articleId: string;
@@ -79,13 +80,15 @@ function ClaimCard({
           sourceId,
           spanText: span.text,
           sourceName: source?.title ?? null,
-          locatorInfo: formatLocatorBrief(span),
+          locatorInfo: formatLocator(span),
         };
         setPopoverCitation(citation);
         if (markerRef.current) {
           setPopoverRect(markerRef.current.getBoundingClientRect());
         }
       }
+    } catch (err) {
+      console.error("Failed to fetch source spans:", err);
     } finally {
       setLoadingSpans(false);
     }
@@ -144,27 +147,6 @@ function ClaimCard({
       )}
     </div>
   );
-}
-
-function formatLocatorBrief(span: SourceSpanResponse): string {
-  switch (span.locator_kind) {
-    case "pdf-page-rect": {
-      const page = span.locator.page ?? span.locator.page_number;
-      return page != null ? `page ${page}` : "";
-    }
-    case "html-xpath-offset": {
-      const para = span.locator.paragraph ?? span.locator.index;
-      return para != null ? `paragraph #${para}` : "";
-    }
-    case "text-byte-range":
-      return "text";
-    case "youtube-timestamp": {
-      const ts = span.locator.timestamp ?? span.locator.start;
-      return ts != null ? `${ts}s` : "";
-    }
-    default:
-      return "";
-  }
 }
 
 export function ClaimsPanel({ articleId, sources }: ClaimsPanelProps) {

--- a/apps/web/src/components/wiki/ClaimsPanel.tsx
+++ b/apps/web/src/components/wiki/ClaimsPanel.tsx
@@ -1,11 +1,16 @@
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getArticleClaims, type ClaimConfidenceItem } from "../../api/wiki";
+import { getSourceSpans } from "../../api/sources";
+import type { ArticleSourceRef, SourceSpanResponse } from "../../types/api";
 import { Badge, type BadgeTone } from "../shared/Badge";
 import { Spinner } from "../shared/Spinner";
+import { CitationPopover } from "./CitationPopover";
+import type { CitationTarget } from "./CitationContext";
 
 interface ClaimsPanelProps {
   articleId: string;
+  sources?: ArticleSourceRef[];
 }
 
 function confidenceColor(score: number): string {
@@ -39,12 +44,72 @@ function levelLabel(level: string): string {
   return level.charAt(0).toUpperCase() + level.slice(1);
 }
 
-function ClaimCard({ claim }: { claim: ClaimConfidenceItem }) {
+function ClaimCard({
+  claim,
+  sources,
+}: {
+  claim: ClaimConfidenceItem;
+  sources?: ArticleSourceRef[];
+}) {
   const pct = Math.round(claim.confidence_score * 100);
+  const [popoverCitation, setPopoverCitation] = useState<CitationTarget | null>(
+    null,
+  );
+  const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
+  const [loadingSpans, setLoadingSpans] = useState(false);
+  const markerRef = useRef<HTMLButtonElement>(null);
+
+  const handleCitationClick = useCallback(async () => {
+    if (claim.source_ids.length === 0) return;
+    if (popoverCitation) {
+      setPopoverCitation(null);
+      return;
+    }
+
+    setLoadingSpans(true);
+    try {
+      // Fetch spans for the first source
+      const sourceId = claim.source_ids[0];
+      const spans: SourceSpanResponse[] = await getSourceSpans(sourceId);
+      const source = sources?.find((s) => s.id === sourceId);
+
+      if (spans.length > 0) {
+        const span = spans[0];
+        const citation: CitationTarget = {
+          sourceId,
+          spanText: span.text,
+          sourceName: source?.title ?? null,
+          locatorInfo: formatLocatorBrief(span),
+        };
+        setPopoverCitation(citation);
+        if (markerRef.current) {
+          setPopoverRect(markerRef.current.getBoundingClientRect());
+        }
+      }
+    } finally {
+      setLoadingSpans(false);
+    }
+  }, [claim.source_ids, popoverCitation, sources]);
 
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
-      <p className="text-sm text-slate-800">{claim.text}</p>
+      <div className="flex items-start gap-1">
+        <p className="flex-1 text-sm text-slate-800">{claim.text}</p>
+        {claim.source_ids.length > 0 && (
+          <button
+            ref={markerRef}
+            onClick={handleCitationClick}
+            className="mt-0.5 shrink-0 text-xs font-semibold text-brand-600 hover:text-brand-800"
+            title="View source citation"
+          >
+            {loadingSpans ? (
+              <Spinner size={12} />
+            ) : (
+              <span className="cursor-pointer">[{claim.source_ids.length}]</span>
+            )}
+          </button>
+        )}
+      </div>
       <div className="mt-3 flex items-center gap-3">
         {/* Confidence bar */}
         <div className="flex flex-1 items-center gap-2">
@@ -69,11 +134,40 @@ function ClaimCard({ claim }: { claim: ClaimConfidenceItem }) {
           </span>
         )}
       </div>
+
+      {popoverCitation && (
+        <CitationPopover
+          citation={popoverCitation}
+          onClose={() => setPopoverCitation(null)}
+          anchorRect={popoverRect}
+        />
+      )}
     </div>
   );
 }
 
-export function ClaimsPanel({ articleId }: ClaimsPanelProps) {
+function formatLocatorBrief(span: SourceSpanResponse): string {
+  switch (span.locator_kind) {
+    case "pdf-page-rect": {
+      const page = span.locator.page ?? span.locator.page_number;
+      return page != null ? `page ${page}` : "";
+    }
+    case "html-xpath-offset": {
+      const para = span.locator.paragraph ?? span.locator.index;
+      return para != null ? `paragraph #${para}` : "";
+    }
+    case "text-byte-range":
+      return "text";
+    case "youtube-timestamp": {
+      const ts = span.locator.timestamp ?? span.locator.start;
+      return ts != null ? `${ts}s` : "";
+    }
+    default:
+      return "";
+  }
+}
+
+export function ClaimsPanel({ articleId, sources }: ClaimsPanelProps) {
   const [open, setOpen] = useState(false);
 
   const { data, isLoading, isError } = useQuery({
@@ -192,7 +286,7 @@ export function ClaimsPanel({ articleId }: ClaimsPanelProps) {
             {data.claims.length > 0 ? (
               <div className="space-y-3">
                 {data.claims.map((claim) => (
-                  <ClaimCard key={claim.id} claim={claim} />
+                  <ClaimCard key={claim.id} claim={claim} sources={sources} />
                 ))}
               </div>
             ) : (

--- a/apps/web/src/components/wiki/InlineCitationMarker.tsx
+++ b/apps/web/src/components/wiki/InlineCitationMarker.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useRef, useState } from "react";
+import { getSourceSpans } from "../../api/sources";
+import type { ArticleSourceRef, SourceSpanResponse } from "../../types/api";
+import { CitationPopover } from "./CitationPopover";
+import type { CitationTarget } from "./CitationContext";
+
+interface InlineCitationMarkerProps {
+  /** The article's sources to look up spans from. */
+  sources: ArticleSourceRef[];
+}
+
+export function InlineCitationMarker({ sources }: InlineCitationMarkerProps) {
+  const [popoverCitation, setPopoverCitation] = useState<CitationTarget | null>(
+    null,
+  );
+  const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
+  const [loading, setLoading] = useState(false);
+  const markerRef = useRef<HTMLButtonElement>(null);
+
+  const handleClick = useCallback(async () => {
+    if (popoverCitation) {
+      setPopoverCitation(null);
+      return;
+    }
+    if (sources.length === 0) return;
+
+    setLoading(true);
+    try {
+      // Try each source until we find one with spans
+      for (const source of sources) {
+        const spans: SourceSpanResponse[] = await getSourceSpans(source.id);
+        if (spans.length > 0) {
+          const span = spans[0];
+          const citation: CitationTarget = {
+            sourceId: source.id,
+            spanText: span.text,
+            sourceName: source.title,
+            locatorInfo: formatLocator(span),
+          };
+          setPopoverCitation(citation);
+          if (markerRef.current) {
+            setPopoverRect(markerRef.current.getBoundingClientRect());
+          }
+          return;
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [popoverCitation, sources]);
+
+  if (sources.length === 0) return null;
+
+  return (
+    <>
+      <button
+        ref={markerRef}
+        onClick={handleClick}
+        className="ml-0.5 cursor-pointer align-super text-[10px] font-semibold text-brand-600 hover:text-brand-800"
+        title="View source citation"
+        type="button"
+      >
+        {loading ? "..." : "[src]"}
+      </button>
+      {popoverCitation && (
+        <CitationPopover
+          citation={popoverCitation}
+          onClose={() => setPopoverCitation(null)}
+          anchorRect={popoverRect}
+        />
+      )}
+    </>
+  );
+}
+
+function formatLocator(span: SourceSpanResponse): string {
+  switch (span.locator_kind) {
+    case "pdf-page-rect": {
+      const page = span.locator.page ?? span.locator.page_number;
+      return page != null ? `page ${page}` : "";
+    }
+    case "html-xpath-offset": {
+      const para = span.locator.paragraph ?? span.locator.index;
+      return para != null ? `paragraph #${para}` : "";
+    }
+    case "text-byte-range":
+      return "text";
+    case "youtube-timestamp": {
+      const ts = span.locator.timestamp ?? span.locator.start;
+      return ts != null ? `${ts}s` : "";
+    }
+    default:
+      return "";
+  }
+}

--- a/apps/web/src/components/wiki/InlineCitationMarker.tsx
+++ b/apps/web/src/components/wiki/InlineCitationMarker.tsx
@@ -3,6 +3,7 @@ import { getSourceSpans } from "../../api/sources";
 import type { ArticleSourceRef, SourceSpanResponse } from "../../types/api";
 import { CitationPopover } from "./CitationPopover";
 import type { CitationTarget } from "./CitationContext";
+import { formatLocator } from "./citationUtils";
 
 interface InlineCitationMarkerProps {
   /** The article's sources to look up spans from. */
@@ -71,25 +72,4 @@ export function InlineCitationMarker({ sources }: InlineCitationMarkerProps) {
       )}
     </>
   );
-}
-
-function formatLocator(span: SourceSpanResponse): string {
-  switch (span.locator_kind) {
-    case "pdf-page-rect": {
-      const page = span.locator.page ?? span.locator.page_number;
-      return page != null ? `page ${page}` : "";
-    }
-    case "html-xpath-offset": {
-      const para = span.locator.paragraph ?? span.locator.index;
-      return para != null ? `paragraph #${para}` : "";
-    }
-    case "text-byte-range":
-      return "text";
-    case "youtube-timestamp": {
-      const ts = span.locator.timestamp ?? span.locator.start;
-      return ts != null ? `${ts}s` : "";
-    }
-    default:
-      return "";
-  }
 }

--- a/apps/web/src/components/wiki/SourceHighlightPanel.tsx
+++ b/apps/web/src/components/wiki/SourceHighlightPanel.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getSourceContent } from "../../api/sources";
+import type { CitationTarget } from "./CitationContext";
+import { useCitation } from "./CitationContext";
+import { Spinner } from "../shared/Spinner";
+
+interface SourceHighlightPanelProps {
+  citation: CitationTarget;
+}
+
+export function SourceHighlightPanel({ citation }: SourceHighlightPanelProps) {
+  const { clearCitation } = useCitation();
+  const highlightRef = useRef<HTMLSpanElement>(null);
+
+  const contentQuery = useQuery({
+    queryKey: ["source-content", citation.sourceId],
+    queryFn: () => getSourceContent(citation.sourceId),
+  });
+
+  // Auto-scroll to highlighted span once content loads
+  useEffect(() => {
+    if (highlightRef.current) {
+      highlightRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [contentQuery.data]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden border-l border-slate-200 bg-white transition-all duration-200">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+        <h2 className="text-sm font-semibold text-slate-900">
+          Source Preview
+        </h2>
+        <button
+          onClick={clearCitation}
+          className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-brand-600 hover:bg-brand-50 hover:text-brand-800"
+          aria-label="Back to article outline"
+        >
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+            />
+          </svg>
+          Back to article
+        </button>
+      </div>
+
+      {/* Source info */}
+      <div className="border-b border-slate-100 bg-slate-50 px-4 py-3">
+        <h3 className="text-sm font-medium text-slate-800">
+          {citation.sourceName || "Unknown source"}
+        </h3>
+        {citation.locatorInfo && (
+          <p className="mt-0.5 text-xs text-slate-500">
+            {citation.locatorInfo}
+          </p>
+        )}
+      </div>
+
+      {/* Content with highlighted span */}
+      <div className="flex-1 overflow-y-auto">
+        {contentQuery.isLoading ? (
+          <div className="flex items-center justify-center gap-2 p-8 text-sm text-slate-500">
+            <Spinner size={16} /> Loading source content...
+          </div>
+        ) : contentQuery.isError ? (
+          <div className="m-4 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+            Failed to load source content.
+          </div>
+        ) : contentQuery.data ? (
+          <HighlightedSourceText
+            content={contentQuery.data.content}
+            spanText={citation.spanText}
+            highlightRef={highlightRef}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface HighlightedSourceTextProps {
+  content: string;
+  spanText: string;
+  highlightRef: React.RefObject<HTMLSpanElement>;
+}
+
+function HighlightedSourceText({
+  content,
+  spanText,
+  highlightRef,
+}: HighlightedSourceTextProps) {
+  // Find the span text in the source content
+  const normalizedContent = content;
+  const matchIndex = normalizedContent.indexOf(spanText);
+
+  if (matchIndex === -1) {
+    // Fallback: show the whole content with the quoted span at the top
+    return (
+      <div className="px-4 py-4 text-sm leading-relaxed text-slate-700">
+        <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3">
+          <p className="mb-1 text-xs font-medium text-amber-800">
+            Cited passage
+          </p>
+          <blockquote className="border-l-2 border-amber-300 pl-3 italic text-slate-700">
+            {spanText}
+          </blockquote>
+        </div>
+        <div className="border-t border-slate-100 pt-4">
+          {content.split(/\n{2,}/).map((para, idx) => (
+            <p key={idx} className="mb-3 whitespace-pre-wrap">
+              {para}
+            </p>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Split content into before, match, and after
+  const before = content.slice(0, matchIndex);
+  const match = content.slice(matchIndex, matchIndex + spanText.length);
+  const after = content.slice(matchIndex + spanText.length);
+
+  return (
+    <div className="px-4 py-4 text-sm leading-relaxed text-slate-700">
+      {before && (
+        <span className="whitespace-pre-wrap">{before}</span>
+      )}
+      <span
+        ref={highlightRef}
+        className="rounded bg-amber-100 px-0.5 ring-2 ring-amber-300"
+      >
+        {match}
+      </span>
+      {after && (
+        <span className="whitespace-pre-wrap">{after}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/wiki/WikiExplorerView.tsx
+++ b/apps/web/src/components/wiki/WikiExplorerView.tsx
@@ -9,15 +9,25 @@ import { ArticleCardGrid } from "./ArticleCardGrid";
 import { ArticleOutline } from "./ArticleOutline";
 import { ArticleReader } from "./ArticleReader";
 import { BacklinkPanel } from "./BacklinkPanel";
+import { CitationProvider, useCitation } from "./CitationContext";
 import { ConceptTree } from "./ConceptTree";
 import { CreateStubModal } from "./CreateStubModal";
 import { FiguresPanel } from "./FiguresPanel";
 import { InArticleSearch } from "./InArticleSearch";
 import { SavedSearches } from "./SavedSearches";
 import { SearchBar } from "./SearchBar";
+import { SourceHighlightPanel } from "./SourceHighlightPanel";
 import { SourcePanel } from "./SourcePanel";
 
 export function WikiExplorerView() {
+  return (
+    <CitationProvider>
+      <WikiExplorerViewInner />
+    </CitationProvider>
+  );
+}
+
+function WikiExplorerViewInner() {
   const params = useParams<{ slug?: string }>();
   const slug = params.slug;
   const articleQuery = useArticle(slug);
@@ -26,6 +36,7 @@ export function WikiExplorerView() {
   const [figureCount, setFigureCount] = useState(0);
   const navigate = useNavigate();
   const [showSources, setShowSources] = useState(false);
+  const { activeCitation } = useCitation();
   const executeSavedSearchMutation = useMutation({
     mutationFn: (searchId: string) => executeSavedSearch(searchId),
     onSuccess: () => {
@@ -146,7 +157,7 @@ export function WikiExplorerView() {
       {slug ? (
         <div
           className={`grid flex-1 overflow-hidden ${
-            showSources
+            activeCitation || showSources
               ? "grid-cols-[15rem_1fr_22rem]"
               : "grid-cols-[15rem_1fr_15rem]"
           }`}
@@ -187,7 +198,9 @@ export function WikiExplorerView() {
           </section>
 
           <aside className="overflow-y-auto border-l border-slate-200 bg-white">
-            {showSources && articleQuery.data?.sources ? (
+            {activeCitation ? (
+              <SourceHighlightPanel citation={activeCitation} />
+            ) : showSources && articleQuery.data?.sources ? (
               <SourcePanel
                 sources={articleQuery.data.sources}
                 onClose={() => setShowSources(false)}

--- a/apps/web/src/components/wiki/citationUtils.ts
+++ b/apps/web/src/components/wiki/citationUtils.ts
@@ -1,0 +1,23 @@
+import type { SourceSpanResponse } from "../../types/api";
+
+/** Format a human-readable locator string for a source span. */
+export function formatLocator(span: SourceSpanResponse): string {
+  switch (span.locator_kind) {
+    case "pdf-page-rect": {
+      const page = span.locator.page ?? span.locator.page_number;
+      return page != null ? `page ${page}` : "";
+    }
+    case "html-xpath-offset": {
+      const para = span.locator.paragraph ?? span.locator.index;
+      return para != null ? `paragraph #${para}` : "";
+    }
+    case "text-byte-range":
+      return "text";
+    case "youtube-timestamp": {
+      const ts = span.locator.timestamp ?? span.locator.start;
+      return ts != null ? `${ts}s` : "";
+    }
+    default:
+      return "";
+  }
+}

--- a/apps/web/src/components/wiki/markdownComponents.tsx
+++ b/apps/web/src/components/wiki/markdownComponents.tsx
@@ -6,7 +6,7 @@ import { slugify } from "../../utils/slugify";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 import { InlineCitationMarker } from "./InlineCitationMarker";
 
-const CONFIDENCE_TAG_REGEX = /[\[(](sourced|mixed|inferred|opinion)[\])]/gi;
+const CONFIDENCE_TAG_REGEX = /(?:\[(sourced|mixed|inferred|opinion)\]|\((sourced|mixed|inferred|opinion)\))/gi;
 
 function childrenToText(children: React.ReactNode): string {
   if (typeof children === "string") return children;
@@ -52,7 +52,7 @@ function splitConfidence(
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
-    const level = match[1].toLowerCase() as ConfidenceLevel;
+    const level = (match[1] || match[2]).toLowerCase() as ConfidenceLevel;
     parts.push(
       <span key={`${match.index}-${level}`} className="ml-1 align-middle">
         <ConfidenceBadge level={level} />

--- a/apps/web/src/components/wiki/markdownComponents.tsx
+++ b/apps/web/src/components/wiki/markdownComponents.tsx
@@ -1,9 +1,10 @@
 import type { Components } from "react-markdown";
 import { Link } from "react-router-dom";
-import type { ConfidenceLevel } from "../../types/api";
+import type { ArticleSourceRef, ConfidenceLevel } from "../../types/api";
 import { getBaseUrl } from "../../api/client";
 import { slugify } from "../../utils/slugify";
 import { ConfidenceBadge } from "./ConfidenceBadge";
+import { InlineCitationMarker } from "./InlineCitationMarker";
 
 const CONFIDENCE_TAG_REGEX = /\[(sourced|mixed|inferred|opinion)\]/gi;
 
@@ -21,14 +22,17 @@ function childrenToText(children: React.ReactNode): string {
   return "";
 }
 
-function decorateConfidence(children: React.ReactNode): React.ReactNode {
+function decorateConfidence(
+  children: React.ReactNode,
+  sources?: ArticleSourceRef[],
+): React.ReactNode {
   if (typeof children === "string") {
-    return splitConfidence(children);
+    return splitConfidence(children, sources);
   }
   if (Array.isArray(children)) {
     return children.map((child, idx) => {
       if (typeof child === "string") {
-        return <span key={idx}>{splitConfidence(child)}</span>;
+        return <span key={idx}>{splitConfidence(child, sources)}</span>;
       }
       return child;
     });
@@ -36,7 +40,10 @@ function decorateConfidence(children: React.ReactNode): React.ReactNode {
   return children;
 }
 
-function splitConfidence(text: string): React.ReactNode[] {
+function splitConfidence(
+  text: string,
+  sources?: ArticleSourceRef[],
+): React.ReactNode[] {
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
@@ -49,6 +56,9 @@ function splitConfidence(text: string): React.ReactNode[] {
     parts.push(
       <span key={`${match.index}-${level}`} className="ml-1 align-middle">
         <ConfidenceBadge level={level} />
+        {sources && sources.length > 0 && (
+          <InlineCitationMarker sources={sources} />
+        )}
       </span>,
     );
     lastIndex = match.index + match[0].length;
@@ -59,7 +69,14 @@ function splitConfidence(text: string): React.ReactNode[] {
   return parts.length > 0 ? parts : [text];
 }
 
-export const markdownComponents: Components = {
+/** Legacy static components (no citation markers). */
+export const markdownComponents: Components = createMarkdownComponents();
+
+/** Factory to create markdown components with optional citation markers. */
+export function createMarkdownComponents(
+  sources?: ArticleSourceRef[],
+): Components {
+  return {
   a: ({ node: _node, href, children }) => {
     if (href && href.startsWith("/wiki/")) {
       return (
@@ -152,6 +169,7 @@ export const markdownComponents: Components = {
     const text = childrenToText(children);
     return <h3 id={slugify(text)}>{children}</h3>;
   },
-  li: ({ children }) => <li>{decorateConfidence(children)}</li>,
-  p: ({ children }) => <p>{decorateConfidence(children)}</p>,
+  li: ({ children }) => <li>{decorateConfidence(children, sources)}</li>,
+  p: ({ children }) => <p>{decorateConfidence(children, sources)}</p>,
 };
+}

--- a/apps/web/src/components/wiki/markdownComponents.tsx
+++ b/apps/web/src/components/wiki/markdownComponents.tsx
@@ -6,7 +6,7 @@ import { slugify } from "../../utils/slugify";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 import { InlineCitationMarker } from "./InlineCitationMarker";
 
-const CONFIDENCE_TAG_REGEX = /\[(sourced|mixed|inferred|opinion)\]/gi;
+const CONFIDENCE_TAG_REGEX = /[\[(](sourced|mixed|inferred|opinion)[\])]/gi;
 
 function childrenToText(children: React.ReactNode): string {
   if (typeof children === "string") return children;


### PR DESCRIPTION
## Summary
- **Layer 1**: Citation markers `[N]` on each Key Claim in ClaimsPanel — click to show popover with verbatim source quote, locator info, and "View in source" link
- **Layer 2**: SourceHighlightPanel replaces right sidebar on citation click — shows full source content with cited span highlighted in amber, auto-scrolls to match
- **Layer 3**: Inline `[src]` markers in article markdown body next to confidence badges — connects reading experience directly to source verification

## New components
- `CitationContext.tsx` — React context for active citation state
- `CitationPopover.tsx` — hover/click popover with source quote
- `InlineCitationMarker.tsx` — inline superscript citation button
- `SourceHighlightPanel.tsx` — right sidebar source preview with highlight

## Test plan
- [ ] Open an article with Key Claims → verify `[N]` markers appear on each claim
- [ ] Click a citation marker → popover shows source quote and locator
- [ ] Click "View in source" → right sidebar shows source content with highlighted span
- [ ] Verify auto-scroll to highlighted text
- [ ] Click "Back to article" → returns to article outline sidebar
- [ ] Verify inline `[src]` markers appear next to `(sourced)` badges in article body
- [ ] TypeScript and ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)