### PR TITLE
feat(infra): self-host Redis on Fly.io to replace managed Upstash (#821)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@
 #   wikimind-staging-db │ (Postgres cluster) │ Staging database
 #   wikimind-db         │ (Postgres cluster) │ Production database
 #   wikimind-staging-redis │ (Upstash Redis)  │ Staging queue
-#   wikimind-redis         │ (Upstash Redis)  │ Production queue
+#   wikimind-redis         │ fly.redis.toml   │ Self-hosted Redis queue (production)
 #
 # ---------------------------------------------------------------
 
@@ -444,6 +444,18 @@ jobs:
           JWT_SECRET_KEY: ${{ secrets.WIKIMIND_AUTH__JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
+
+      - name: 🧱  Deploy self-hosted Redis
+        run: |
+          if ! flyctl status --app wikimind-redis 2>/dev/null; then
+            echo "::error::Production Redis app 'wikimind-redis' does not exist. Create it manually:"
+            echo "::error::  fly apps create wikimind-redis --org personal"
+            echo "::error::  fly volumes create wikimind_redis_data --region ord --size 1 --app wikimind-redis --yes"
+            exit 1
+          fi
+          flyctl deploy --app wikimind-redis --config fly.redis.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🧠  Deploy docling-serve sidecar
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -446,13 +446,27 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
       - name: 🧱  Deploy self-hosted Redis
+        # Idempotent: creates the app + persistent volume on first run, then
+        # deploys. Requires FLY_API_TOKEN to have org scope (the same token
+        # already deploys the separate wikimind-docling app, so it does).
         run: |
-          if ! flyctl status --app wikimind-redis 2>/dev/null; then
-            echo "::error::Production Redis app 'wikimind-redis' does not exist. Create it manually:"
-            echo "::error::  fly apps create wikimind-redis --org personal"
-            echo "::error::  fly volumes create wikimind_redis_data --region ord --size 1 --app wikimind-redis --yes"
-            exit 1
+          # 1. Create the app if absent.
+          if flyctl apps list --json | python3 -c "import sys,json; sys.exit(0 if 'wikimind-redis' in [a['Name'] for a in json.load(sys.stdin)] else 1)" 2>/dev/null; then
+            echo "Redis app 'wikimind-redis' already exists."
+          else
+            echo "Creating Redis app 'wikimind-redis'."
+            flyctl apps create wikimind-redis --org personal
           fi
+          # 2. Create the persistent volume if absent. Required before deploy —
+          #    flyctl deploy attaches the volume named in [mounts] but never
+          #    creates it. Guarded by name so we never make a duplicate.
+          if flyctl volumes list --app wikimind-redis --json | python3 -c "import sys,json; sys.exit(0 if 'wikimind_redis_data' in [v['Name'] for v in json.load(sys.stdin)] else 1)" 2>/dev/null; then
+            echo "Redis volume 'wikimind_redis_data' already exists."
+          else
+            echo "Creating Redis volume 'wikimind_redis_data'."
+            flyctl volumes create wikimind_redis_data --region ord --size 1 --app wikimind-redis --yes
+          fi
+          # 3. Deploy.
           flyctl deploy --app wikimind-redis --config fly.redis.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.redis.toml
+++ b/fly.redis.toml
@@ -1,0 +1,61 @@
+# fly.redis.toml — Fly.io config for the self-hosted Redis queue/cache.
+#
+# This runs on the Fly internal network (no public routing). The main
+# wikimind app reaches it at redis://wikimind-redis.internal:6379.
+# Replaces the managed Upstash Redis instance (~$141/mo) with a single
+# always-on shared-cpu-1x machine backed by a persistent volume.
+#
+# Redis is a TCP service (not HTTP), so there is no [http_service] block.
+# Apps on the same org are reachable over Fly's private 6PN network
+# without any public service mapping. The machine is kept always-on
+# (auto_stop_machines = "off", min_machines_running = 1) because it is a
+# persistent store and the ARQ worker polls it constantly.
+#
+# Eviction policy is intentionally "noeviction" (NOT allkeys-lru): under
+# memory pressure Redis must refuse writes rather than silently evict
+# queued ARQ jobs. Persistence (--appendonly yes) keeps the queue across
+# machine restarts.
+#
+# First-time setup:
+#   fly apps create wikimind-redis
+#   fly volumes create wikimind_redis_data --region ord --size 1 --app wikimind-redis --yes
+#
+# Deploy (done automatically by CI):
+#   fly deploy --app wikimind-redis --config fly.redis.toml
+
+app = "wikimind-redis"
+primary_region = "ord"
+
+[build]
+  image = "redis:7-alpine"
+
+# The redis:7-alpine entrypoint (docker-entrypoint.sh) passes its arguments
+# straight to redis-server, so this mirrors the docker-compose.prod.yml
+# command — except --maxmemory-policy is "noeviction" instead of allkeys-lru
+# (see header) and persistence is enabled with --appendonly yes.
+[processes]
+  app = "redis-server --maxmemory 256mb --maxmemory-policy noeviction --appendonly yes"
+
+# Internal-only TCP service. No public ports are exposed; this block exists
+# to pin the machine always-on (no auto-stop) so the worker can always
+# reach the queue. Reachable on the 6PN network at wikimind-redis.internal:6379.
+[[services]]
+  internal_port = 6379
+  protocol = "tcp"
+  auto_stop_machines = "off"
+  auto_start_machines = false
+  min_machines_running = 1
+
+  [[services.tcp_checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "30s"
+
+[mounts]
+  source = "wikimind_redis_data"
+  destination = "/data"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/scripts/fly-setup.sh
+++ b/scripts/fly-setup.sh
@@ -28,6 +28,10 @@ REGION="ord"
 VOLUME_NAME="wikimind_data"
 VOLUME_SIZE_GB=1
 PG_NAME="wikimind-db"
+REDIS_APP_NAME="wikimind-redis"
+REDIS_VOLUME_NAME="wikimind_redis_data"
+REDIS_VOLUME_SIZE_GB=1
+REDIS_URL="redis://wikimind-redis.internal:6379/0"
 
 # ---------------------------------------------------------------
 # Helpers
@@ -119,7 +123,34 @@ else
     info "Already attached"
 fi
 
-# 4. Configure secrets
+# 4. Create self-hosted Redis app + volume
+step "Redis app: ${REDIS_APP_NAME}"
+if flyctl apps list --json | python3 -c "import sys,json; apps=[a['Name'] for a in json.load(sys.stdin)]; sys.exit(0 if '${REDIS_APP_NAME}' in apps else 1)" 2>/dev/null; then
+    info "Already exists"
+else
+    flyctl apps create "$REDIS_APP_NAME" --json
+    info "Created"
+fi
+
+step "Redis volume: ${REDIS_VOLUME_NAME} (${REDIS_VOLUME_SIZE_GB} GB in ${REGION})"
+if flyctl volumes list --app "$REDIS_APP_NAME" --json | python3 -c "import sys,json; vols=[v['Name'] for v in json.load(sys.stdin)]; sys.exit(0 if '${REDIS_VOLUME_NAME}' in vols else 1)" 2>/dev/null; then
+    info "Already exists"
+else
+    flyctl volumes create "$REDIS_VOLUME_NAME" \
+        --app "$REDIS_APP_NAME" \
+        --region "$REGION" \
+        --size "$REDIS_VOLUME_SIZE_GB" \
+        --yes
+    info "Created"
+fi
+
+# Deploy the Redis app, then point the main app at it via WIKIMIND_REDIS_URL.
+# (Deploy of fly.redis.toml itself is handled by CI / run manually — see PR runbook.)
+step "Staging WIKIMIND_REDIS_URL on ${APP_NAME}"
+flyctl secrets set "WIKIMIND_REDIS_URL=${REDIS_URL}" --app "$APP_NAME" --stage
+info "Staged WIKIMIND_REDIS_URL=${REDIS_URL}"
+
+# 5. Configure secrets
 step "Secrets"
 
 # LLM provider key
@@ -154,7 +185,7 @@ step "Deploying staged secrets"
 flyctl secrets deploy --app "$APP_NAME"
 info "All secrets deployed"
 
-# 5. Generate deploy token
+# 6. Generate deploy token
 step "Deploy token for CI"
 echo "  Add this token as FLY_API_TOKEN in GitHub repo secrets:"
 echo "  GitHub → Settings → Secrets and variables → Actions → New repository secret"
@@ -162,7 +193,7 @@ echo ""
 flyctl tokens create deploy --app "$APP_NAME" -x 999999h
 echo ""
 
-# 6. Summary
+# 7. Summary
 step "Setup complete!"
 echo ""
 echo "  Next steps:"


### PR DESCRIPTION
## Problem

Our production Redis is a managed Upstash instance costing roughly **$141/month** — by far the most expensive line item in the WikiMind infrastructure bill. Redis here is just an internal queue/cache for ARQ background jobs; it never needs public exposure, multi-region replication, or the managed tier's premium SLA. We are paying managed-database prices for what is effectively a single-node in-memory store on the private network.

## Solution

Self-host Redis as a dedicated **internal-only Fly.io app** (`wikimind-redis`) running the stock `redis:7-alpine` image on a single always-on `shared-cpu-1x` (256MB) machine backed by a small persistent volume. It lives on Fly's private 6PN network and is reachable at `redis://wikimind-redis.internal:6379` — no public routing, no TLS overhead. This mirrors the existing `wikimind-docling` sidecar pattern (separate app, internal-only, deployed by CI).

The application code already reads `WIKIMIND_REDIS_URL` from settings, so **this is an infra/config-only change** — no Python was touched. Cutover is overwriting one existing secret value on the main app (the secret is already present, pointed at Upstash).

**Scope:** this PR self-hosts **production** Redis only. Staging continues to use its managed `wikimind-staging-redis` instance ($5.90/mo) for now — migrating staging can be a fast follow-up if desired.

### Design choices that matter for queue safety
- **Eviction policy is `noeviction`, not `allkeys-lru`.** Under memory pressure Redis must *refuse new writes* rather than silently evict queued ARQ jobs (which would drop background work without a trace). `--maxmemory 256mb` is retained from the docker-compose definition.
- **AOF persistence enabled (`--appendonly yes`)** so the job queue survives machine restarts/redeploys.
- **Always-on:** `auto_stop_machines = "off"` / `min_machines_running = 1` on the service, since it is a persistent store the worker polls continuously. It must never auto-stop.

## Changes

- **`fly.redis.toml`** (new) — internal-only app config: `redis:7-alpine`, `noeviction` + AOF (via the `[processes]` command), persistent `/data` volume (`wikimind_redis_data`), `shared-cpu-1x`/256MB in `ord`, and a `[[services]]` block (TCP, port 6379, `tcp_checks`) used only to pin the machine always-on. No `[http_service]` (Redis is TCP, not HTTP); no public ports.
- **`scripts/fly-setup.sh`** — the first-time, full-environment bootstrap script. Now also creates the `wikimind-redis` app + `wikimind_redis_data` volume and stages `WIKIMIND_REDIS_URL=redis://wikimind-redis.internal:6379/0` on the main app (for standing up a brand-new environment).
- **`.github/workflows/deploy.yml`** — adds a `🧱 Deploy self-hosted Redis` step to the **production** job that **idempotently creates the app + volume if absent**, then deploys `fly.redis.toml` (before docling and the main app). Re-runs never create duplicates (guarded by name checks matching `fly-setup.sh`). The staging job is unchanged apart from still requiring its `WIKIMIND_REDIS_URL` secret to exist. Header table updated.

## Migration: merge → cut over → clean up

CI now provisions and deploys the Redis app for you, so **merging this PR is safe and does the provisioning automatically** — no pre-merge manual steps.

Verified current state on Fly: **both `wikimind` and `wikimind-staging` already have `WIKIMIND_REDIS_URL` set and deployed**, pointed at their Upstash instances. So CI's "secret exists" pre-flight already passes, and the cutover is *overwriting* that value, not setting it for the first time.

**1. Merge the PR.** On the next production deploy, CI creates the `wikimind-redis` app + `wikimind_redis_data` volume (if they don't exist yet), deploys `fly.redis.toml`, and brings the instance up. Production is **still running on Upstash** at this point — the main app's `WIKIMIND_REDIS_URL` value is untouched, so the new instance comes up idle alongside the old one. No traffic has moved.

**2. Cut over** — overwrite the existing secret value to point at the self-hosted instance (triggers an automatic main-app redeploy onto the new Redis):
```bash
fly secrets set WIKIMIND_REDIS_URL='redis://wikimind-redis.internal:6379/0' --app wikimind
```
`verify-production` confirms health (`background_mode == "arq"`, `/health/deep`), with auto-rollback on failure. Optional manual sanity check first:
```bash
fly ssh console --app wikimind -C "redis-cli -h wikimind-redis.internal ping"   # expect: PONG
```

**3. Clean up (later)** — decommission the Upstash instance to stop the bill, **only after** production is confirmed healthy on self-hosted Redis. Keep Upstash running until then.

After that, no recurring manual steps: every later change to `fly.redis.toml` redeploys automatically with the rest of the stack.

> **Token scope note:** auto-create assumes `FLY_API_TOKEN` has org scope. It already deploys the separate `wikimind-docling` app from this same workflow, which confirms it does. If app creation ever 403s, run `fly apps create wikimind-redis --org personal` + `fly volumes create wikimind_redis_data --region ord --size 1 --app wikimind-redis --yes` once by hand and re-run the deploy.

## Verification run in this PR

- `make check-doc-sync` (with `pathspec`) — **6 doc-sync rules passed against 3 changed files**.
- `make check-docs` — the only failure is pre-existing OpenAPI drift in `docs/openapi.yaml` (already modified on the branch before this work; no `src/wikimind/api/routes/` changes were made here).
- `ruff check scripts/` — **All checks passed** (no Python changed).
- `bash -n scripts/fly-setup.sh` — shell syntax OK.
- `fly.redis.toml` parsed with `tomllib`; `deploy.yml` parsed with `yaml.safe_load` — both valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)