### PR TITLE
fix(infra): remove invalid [[services]] block from fly.redis.toml

### DIFF
--- a/fly.redis.toml
+++ b/fly.redis.toml
@@ -5,18 +5,20 @@
 # Replaces the managed Upstash Redis instance (~$141/mo) with a single
 # always-on shared-cpu-1x machine backed by a persistent volume.
 #
-# Redis is a TCP service (not HTTP), so there is no [http_service] block.
-# Apps on the same org are reachable over Fly's private 6PN network
-# without any public service mapping. The machine is kept always-on
-# (auto_stop_machines = "off", min_machines_running = 1) because it is a
-# persistent store and the ARQ worker polls it constantly.
+# Redis is reached purely over Fly's private 6PN network at
+# wikimind-redis.internal:6379, so this app defines NO services at all
+# (no [http_service], no [[services]]). A [[services]] block would require
+# a public [[services.ports]] entry — which Fly now hard-fails on — and we
+# do not want Redis publicly routable. With no service, the Fly proxy never
+# auto-stops the machine, so the single deployed machine simply stays up
+# continuously, which is exactly what a persistent queue store needs.
 #
 # Eviction policy is intentionally "noeviction" (NOT allkeys-lru): under
 # memory pressure Redis must refuse writes rather than silently evict
 # queued ARQ jobs. Persistence (--appendonly yes) keeps the queue across
 # machine restarts.
 #
-# First-time setup:
+# First-time setup (CI does this idempotently; manual fallback):
 #   fly apps create wikimind-redis
 #   fly volumes create wikimind_redis_data --region ord --size 1 --app wikimind-redis --yes
 #
@@ -35,21 +37,6 @@ primary_region = "ord"
 # (see header) and persistence is enabled with --appendonly yes.
 [processes]
   app = "redis-server --maxmemory 256mb --maxmemory-policy noeviction --appendonly yes"
-
-# Internal-only TCP service. No public ports are exposed; this block exists
-# to pin the machine always-on (no auto-stop) so the worker can always
-# reach the queue. Reachable on the 6PN network at wikimind-redis.internal:6379.
-[[services]]
-  internal_port = 6379
-  protocol = "tcp"
-  auto_stop_machines = "off"
-  auto_start_machines = false
-  min_machines_running = 1
-
-  [[services.tcp_checks]]
-    interval = "30s"
-    timeout = "5s"
-    grace_period = "30s"
 
 [mounts]
   source = "wikimind_redis_data"


### PR DESCRIPTION
## Problem

The production deploy triggered by merging #822 **failed** at the `🧱 Deploy self-hosted Redis` step — `fly.redis.toml` is invalid config and Fly rejected it:

```
Service has no processes set but app has 1 processes defined
WARNING: Service must expose at least one port. Add a [[services.ports]] section
Validation for services without ports will hard fail after February 15, 2024.
✘ invalid app configuration
Error: App configuration is not valid
```

Because this step runs on **every** production deploy, all prod deploys are currently blocked until this is fixed. (Production itself is healthy and unaffected — the step fails before the main app is touched; prod is still serving on Upstash.)

## Root cause

The original `fly.redis.toml` included a `[[services]]` block solely to set `auto_stop_machines = "off"` / `min_machines_running = 1`. But a `[[services]]` block:
1. requires a `processes` mapping when the app defines named processes, and
2. must expose at least one public port via `[[services.ports]]` (Fly hard-fails otherwise).

Redis must **not** be publicly routable, so a service block is the wrong construct entirely.

## Fix

Remove the `[[services]]` block. An internal-only app is reachable over Fly's private 6PN network at `wikimind-redis.internal:6379` with no service mapping at all. With no service, the Fly proxy never auto-stops the machine, so the single deployed machine simply runs continuously — which is exactly what a persistent queue store needs.

Remaining config: `[build]` (image), `[processes]` (the `redis-server` command with `noeviction` + AOF), `[mounts]`, `[[vm]]`.

**Validated with `fly config validate --config fly.redis.toml --app wikimind-redis` → `✓ Configuration is valid`** (this time actually checked against Fly, not assumed).

## After merge

The `wikimind-redis` app + `wikimind_redis_data` volume were already created by the idempotent CI step on the failed run, so the next production deploy reuses them and just deploys the corrected config. Then the manual cutover (`fly secrets set WIKIMIND_REDIS_URL=…`) proceeds as planned. Closes the deploy-failure alert #824 once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)