### PR TITLE
fix(ci): use lowercase 'name' key in fly volume existence checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -460,7 +460,7 @@ jobs:
           # 2. Create the persistent volume if absent. Required before deploy —
           #    flyctl deploy attaches the volume named in [mounts] but never
           #    creates it. Guarded by name so we never make a duplicate.
-          if flyctl volumes list --app wikimind-redis --json | python3 -c "import sys,json; sys.exit(0 if 'wikimind_redis_data' in [v['Name'] for v in json.load(sys.stdin)] else 1)" 2>/dev/null; then
+          if flyctl volumes list --app wikimind-redis --json | python3 -c "import sys,json; sys.exit(0 if 'wikimind_redis_data' in [v['name'] for v in json.load(sys.stdin)] else 1)" 2>/dev/null; then
             echo "Redis volume 'wikimind_redis_data' already exists."
           else
             echo "Creating Redis volume 'wikimind_redis_data'."

--- a/scripts/fly-setup.sh
+++ b/scripts/fly-setup.sh
@@ -90,7 +90,7 @@ fi
 
 # 2. Create volume
 step "Volume: ${VOLUME_NAME} (${VOLUME_SIZE_GB} GB in ${REGION})"
-if flyctl volumes list --app "$APP_NAME" --json | python3 -c "import sys,json; vols=[v['Name'] for v in json.load(sys.stdin)]; sys.exit(0 if '${VOLUME_NAME}' in vols else 1)" 2>/dev/null; then
+if flyctl volumes list --app "$APP_NAME" --json | python3 -c "import sys,json; vols=[v['name'] for v in json.load(sys.stdin)]; sys.exit(0 if '${VOLUME_NAME}' in vols else 1)" 2>/dev/null; then
     info "Already exists"
 else
     flyctl volumes create "$VOLUME_NAME" \
@@ -133,7 +133,7 @@ else
 fi
 
 step "Redis volume: ${REDIS_VOLUME_NAME} (${REDIS_VOLUME_SIZE_GB} GB in ${REGION})"
-if flyctl volumes list --app "$REDIS_APP_NAME" --json | python3 -c "import sys,json; vols=[v['Name'] for v in json.load(sys.stdin)]; sys.exit(0 if '${REDIS_VOLUME_NAME}' in vols else 1)" 2>/dev/null; then
+if flyctl volumes list --app "$REDIS_APP_NAME" --json | python3 -c "import sys,json; vols=[v['name'] for v in json.load(sys.stdin)]; sys.exit(0 if '${REDIS_VOLUME_NAME}' in vols else 1)" 2>/dev/null; then
     info "Already exists"
 else
     flyctl volumes create "$REDIS_VOLUME_NAME" \


### PR DESCRIPTION
## Problem

The idempotent volume guards added for self-hosted Redis create a **duplicate, unattached volume on every deploy**. `flyctl volumes list --json` returns the volume name under `name` (lowercase), but the guards checked `v['Name']` (capital). That raises `KeyError` → the `python3 -c` exits non-zero → the guard concludes "volume missing" → runs `flyctl volumes create` again.

Confirmed in production: the #826 deploy left two `wikimind_redis_data` volumes — `vol_r7y0…` (attached) and `vol_42koj…` (orphan). Left unfixed, each future prod deploy would leak another.

Subtle detail: `flyctl apps list --json` uses **capital** `Name`, which is why the app-existence checks (`a['Name']`) work correctly. The casing genuinely differs between the two subcommands, so only the volume checks are wrong.

## Fix

`v['Name']` → `v['name']` in the volume guards:
- `.github/workflows/deploy.yml` — the `wikimind-redis` volume guard
- `scripts/fly-setup.sh` — both the `wikimind_data` and `wikimind_redis_data` guards

App-existence checks (`a['Name']`) are intentionally left unchanged.

Validated: `yaml.safe_load` (deploy.yml) and `bash -n` (fly-setup.sh) pass.

## Related cleanup (done outside this PR)
- The orphan `vol_42koj…` volume is being deleted manually.
- The Redis migration itself (#821) is complete — production is on self-hosted Redis and the Upstash instance has been destroyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)