### PR TITLE
chore(infra): scale prod web to zero when idle

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -2,15 +2,18 @@
 # External Uptime Monitor
 # ===============================================================
 #
-# Pings production and staging health endpoints from GitHub Actions
-# (outside Fly.io network) every 15 minutes. Creates an issue on
-# failure.
+# Pings the production health endpoint from GitHub Actions
+# (outside Fly.io network) once a day. Creates an issue on failure.
+#
+# Daily, not every 15 minutes: production scales to zero when idle
+# (fly.toml min_machines_running = 0) and each ping wakes the machine,
+# so a frequent monitor would keep it running around the clock.
 
 name: Uptime Monitor
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "0 14 * * *"
   workflow_dispatch:
 
 permissions:
@@ -33,18 +36,6 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           if [ "$status" != "ok" ]; then
             echo "::warning::Production health: $status"
-          fi
-
-      - name: Check staging health
-        id: staging
-        continue-on-error: true
-        run: |
-          status=$(curl -sf --max-time 10 https://wikimind-staging.fly.dev/health \
-            | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" \
-            2>/dev/null || echo "unreachable")
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-          if [ "$status" != "ok" ]; then
-            echo "::warning::Staging health: $status"
           fi
 
       - name: Alert on production failure

--- a/fly.toml
+++ b/fly.toml
@@ -26,7 +26,9 @@ primary_region = "ord"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 1
+  # Scale to zero when idle — personal deployment, cold starts are acceptable.
+  # The proxy starts a machine on the first incoming request.
+  min_machines_running = 0
   processes = ["web"]
 
   [http_service.concurrency]


### PR DESCRIPTION
## Problem

The June 2026 Fly invoice came to ~$61/mo for a personal project with no uptime requirement. One contributor: the prod `web` machine runs 24/7 because `fly.toml` pins `min_machines_running = 1` — and even if it didn't, the uptime monitor curls `/health` every 15 minutes, which auto-starts a stopped machine ~96×/day and keeps it billing around the clock.

## Solution

Let the prod web machine sleep when idle (Phase 2 of the cost-reduction plan):

- `fly.toml`: `min_machines_running = 0`. The Fly proxy stops the machine after idle and cold-starts it on the first request (`auto_start_machines = true` already set). Cold starts are an accepted trade-off.
- `uptime.yml`: daily ping instead of every 15 minutes, so the monitor stays a smoke check without defeating auto-stop. Removed the staging health step — it only emitted a log warning (no alerting was wired to it), and the staging stack is slated for teardown in Phase 1 of the same effort.

## Changes

- `fly.toml` — `min_machines_running` 1 → 0 under `[http_service]`
- `.github/workflows/uptime.yml` — cron `*/15 * * * *` → `0 14 * * *`; staging check step removed

## Notes

- This only affects the `web` process. The `worker` and `wikimind-redis` machines have no HTTP service, so the proxy never stops them — they stay 24/7 until Phase 3 (folding worker+redis into the web machine) lands separately.
- Deploy with `fly deploy -a wikimind` after merge (CI does this on merge to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)