### PR TITLE
chore(ci): make staging ephemeral — provision per deploy, destroy after

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,12 @@
 # ===============================================================
-# 🚀  Deploy to Fly.io — Staging-Gated Production Pipeline
+# 🚀  Deploy to Fly.io — Ephemeral-Staging Production Pipeline
 # ===============================================================
 #
 #   - chains after the Docker workflow (build → scan → GHCR publish)
-#   - deploys staging first, smoke-tests it, then promotes to prod
-#   - validates that apps, volumes, Postgres exist (never creates them)
-#   - fails loudly on real errors; suppresses only idempotent ones
+#   - creates a fresh staging stack, smoke-tests it, promotes to
+#     prod, then destroys staging — nothing staging-related runs
+#     (or bills) between deploys
+#   - production infrastructure is validated, never created
 #
 # ---------------------------------------------------------------
 # Pipeline
@@ -15,23 +16,23 @@
 #     │
 #     ▼
 #   1️⃣  deploy-staging
-#     │  • ensure app + volume exist
-#     │  • ensure Postgres cluster + attach
-#     │  • stage secrets (--stage, no restart)
-#     │  • deploy docling-serve sidecar
+#     │  • clean-slate: destroy any leftover staging app/db
+#     │  • create app + volume + Postgres, attach, set secrets
 #     │  • deploy app from GHCR sha-<commit>
 #     │
 #     ▼
 #   2️⃣  smoke-test-staging
-#     │  • 10 functional checks (health, deep health, docs, auth, API data)
+#     │  • 11 functional checks (health, deep health, docs, auth, API data)
 #     │  • authenticated tests require STAGING_DEV_TOKEN secret
 #     │  ✖ failure → summary alert, prod skipped
 #     │
+#     ├──▶ teardown-staging (always, even on smoke failure)
+#     │      • destroys wikimind-staging + wikimind-staging-db
 #     ▼
 #   3️⃣  deploy-production
 #     │  • environment: production (manual approval gate)
-#     │  • same provisioning as staging
-#     │  • deploy docling-serve sidecar
+#     │  • validates prod infra (never creates it)
+#     │  • deploy docling-serve sidecar + self-hosted Redis
 #     │  • deploy app from same GHCR sha-<commit> tag
 #     │
 #     ▼
@@ -48,21 +49,21 @@
 #        • creates GitHub issue for visibility
 #
 # ---------------------------------------------------------------
-# Infrastructure validation (both environments)
+# Infrastructure model
 # ---------------------------------------------------------------
 #
-#   Resource          │ Behavior
-#   ──────────────────┼─────────────────────────────────────────
-#   Fly app           │ Must exist; deploy fails with setup instructions if missing
-#   Volume            │ Must exist; created as part of initial app setup
-#   Postgres cluster  │ Must exist; deploy fails with setup instructions if missing
-#   Secrets           │ Staged (--stage) from GitHub secrets
-#   Docling sidecar   │ Must exist; deploy fails with setup instructions if missing
-#
-#   Infrastructure is NEVER created at deploy time. All resources
-#   must be provisioned manually before the first deploy. This
-#   prevents accidental creation of empty databases or duplicate
-#   apps during CI/CD runs.
+#   Environment │ Behavior
+#   ────────────┼─────────────────────────────────────────────────
+#   Staging     │ EPHEMERAL — created from scratch by this workflow
+#               │ (app, volume, Postgres) and destroyed after the
+#               │ smoke gate. Fresh empty DB every run; migrations
+#               │ run via the alembic release_command. Queue uses
+#               │ the shared self-hosted Redis on DB index 1;
+#               │ docling uses the production sidecar (stateless,
+#               │ scale-to-zero).
+#   Production  │ PERSISTENT — must exist; deploy fails with setup
+#               │ instructions if missing. Never created at deploy
+#               │ time to prevent accidental empty databases.
 #
 # ---------------------------------------------------------------
 # Required GitHub repository secrets
@@ -84,14 +85,12 @@
 #
 #   App                 │ Config             │ Purpose
 #   ────────────────────┼────────────────────┼──────────────────────────
-#   wikimind-staging    │ fly.staging.toml   │ Pre-prod gate
+#   wikimind-staging    │ fly.staging.toml   │ Pre-prod gate (EPHEMERAL, per-run)
+#   wikimind-staging-db │ (Postgres cluster) │ Staging database (EPHEMERAL, per-run)
 #   wikimind            │ fly.toml           │ Production
-#   wikimind-docling         │ fly.docling.toml   │ PDF sidecar (production)
-#   wikimind-staging-docling │ fly.docling.toml   │ PDF sidecar (staging)
-#   wikimind-staging-db │ (Postgres cluster) │ Staging database
+#   wikimind-docling    │ fly.docling.toml   │ PDF sidecar (shared prod + staging)
 #   wikimind-db         │ (Postgres cluster) │ Production database
-#   wikimind-staging-redis │ (Upstash Redis)  │ Staging queue
-#   wikimind-redis         │ fly.redis.toml   │ Self-hosted Redis queue (production)
+#   wikimind-redis      │ fly.redis.toml     │ Self-hosted Redis (prod = DB 0, staging = DB 1)
 #
 # ---------------------------------------------------------------
 
@@ -117,7 +116,7 @@ jobs:
   deploy-staging:
     name: deploy to staging
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15  # includes ~2min for ephemeral Postgres provisioning
     outputs:
       image_tag: ${{ steps.image.outputs.tag }}
     permissions:
@@ -175,43 +174,38 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
-      # 1️⃣  Validate staging infrastructure exists (never create at deploy time)
-      - name: 🏗️  Validate staging infrastructure
+      # 1️⃣  Provision ephemeral staging from a clean slate.
+      # Destroy-then-create is deliberate: it is immune to partial state
+      # left by a failed teardown (half-attached Postgres, stale DB users,
+      # orphaned volumes) that idempotent create-if-absent guards can't
+      # recover from. The staging DB is empty every run; the alembic
+      # release_command applies the full migration set on deploy.
+      - name: 🏗️  Provision ephemeral staging
         run: |
-          if ! flyctl status --app wikimind-staging 2>/dev/null; then
-            echo "::error::Staging app 'wikimind-staging' does not exist. Create it manually:"
-            echo "::error::  fly apps create wikimind-staging --org personal"
-            echo "::error::  fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes"
-            exit 1
-          fi
+          flyctl apps destroy wikimind-staging --yes 2>/dev/null || true
+          flyctl apps destroy wikimind-staging-db --yes 2>/dev/null || true
 
-          if ! flyctl status --app wikimind-staging-db 2>/dev/null; then
-            echo "::error::Staging Postgres 'wikimind-staging-db' does not exist. Create it manually:"
-            echo "::error::  fly postgres create --name wikimind-staging-db --org personal --region ord --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1"
-            echo "::error::  fly postgres attach wikimind-staging-db --app wikimind-staging"
-            exit 1
-          fi
-
-          # Redis — URL is set manually via `fly secrets set`. Just verify it exists.
-          REDIS_CHECK=$(flyctl secrets list --app wikimind-staging 2>/dev/null | grep -c "WIKIMIND_REDIS_URL" || echo "0")
-          if [ "$REDIS_CHECK" -gt 0 ]; then
-            echo "Redis URL secret exists"
-          else
-            echo "::error::WIKIMIND_REDIS_URL not set — run: fly secrets set WIKIMIND_REDIS_URL='redis://...' --app wikimind-staging"
-            exit 1
-          fi
+          flyctl apps create wikimind-staging --org personal
+          flyctl volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging --yes
+          flyctl postgres create --name wikimind-staging-db --org personal --region ord \
+            --vm-size shared-cpu-1x --volume-size 1 --initial-cluster-size 1 \
+            --password "$(openssl rand -hex 16)"
+          flyctl postgres attach wikimind-staging-db --app wikimind-staging --yes
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      # 2️⃣  Stage secrets (--stage avoids double-restart before deploy)
-      # WIKIMIND_REDIS_URL is managed manually via `fly secrets set` — not staged here.
+      # 2️⃣  Stage secrets (--stage avoids double-restart before deploy).
+      # Staging shares the self-hosted production Redis on DB index 1 —
+      # ARQ queues are fully separated from production's DB 0, and no
+      # per-run Redis app is needed.
       - name: 🔑  Stage secrets for staging
         run: |
           flyctl secrets set --stage --app wikimind-staging \
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
             WIKIMIND_AUTH__JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
             WIKIMIND_AUTH__GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
-            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}"
+            WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
+            WIKIMIND_REDIS_URL="redis://wikimind-redis.internal:6379/1"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -219,18 +213,8 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET }}
 
-      # 3️⃣  Deploy sidecar + app
-      - name: 🧠  Deploy staging docling-serve sidecar
-        run: |
-          if ! flyctl status --app wikimind-staging-docling 2>/dev/null; then
-            echo "::error::Staging docling app 'wikimind-staging-docling' does not exist. Create it manually:"
-            echo "::error::  fly apps create wikimind-staging-docling --org personal"
-            exit 1
-          fi
-          flyctl deploy --config fly.docling.toml --app wikimind-staging-docling --remote-only
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
+      # 3️⃣  Deploy the app. Staging uses the production docling sidecar
+      # (stateless, scale-to-zero) — no per-run sidecar deploy needed.
       - name: 🚀  Deploy to staging
         run: flyctl deploy --config fly.staging.toml --image ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }} --remote-only --yes
         env:
@@ -383,6 +367,32 @@ jobs:
           echo "Production deploy was **skipped** because staging smoke tests did not pass." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Check the failed steps above for details." >> "$GITHUB_STEP_SUMMARY"
+
+  # -----------------------------------------------------------
+  # 🧹  Teardown ephemeral staging (always — pass or fail)
+  # -----------------------------------------------------------
+  # Runs regardless of smoke-test outcome so the staging stack never
+  # outlives the run. `|| true` guards cover the case where
+  # deploy-staging failed before creating anything. Destroying the
+  # apps also destroys their machines and volumes.
+  teardown-staging:
+    name: teardown staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [deploy-staging, smoke-test-staging]
+    if: always() && needs.deploy-staging.result != 'skipped'
+
+    steps:
+      - name: 🪁  Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
+
+      - name: 🧹  Destroy staging app + database
+        run: |
+          flyctl apps destroy wikimind-staging --yes || true
+          flyctl apps destroy wikimind-staging-db --yes || true
+          echo "Ephemeral staging destroyed."
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   # -----------------------------------------------------------
   # 3️⃣  Deploy to production (only if staging passed)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ fly deploy
 fly secrets set OPENAI_API_KEY=sk-...
 ```
 
-CI deploys to staging first, runs smoke tests, then promotes to production. See `.github/workflows/deploy.yml`.
+CI provisions an ephemeral staging stack, runs smoke tests against it, promotes to production, then destroys staging. See `.github/workflows/deploy.yml`.
 
 ## Tech stack
 
@@ -90,7 +90,7 @@ CI deploys to staging first, runs smoke tests, then promotes to production. See 
 | Real-time | WebSocket (compilation progress), SSE (streaming Q&A) |
 | MCP server | stdio + HTTP transports, OAuth 2.1, JWT auth |
 | Browser extension | Chrome + Firefox (Manifest V3) |
-| Deployment | Docker + Fly.io (staging + production) |
+| Deployment | Docker + Fly.io (production + ephemeral staging) |
 | CI/CD | GitHub Actions (16 workflows) |
 | Testing | pytest (1700+ tests), Playwright e2e |
 

--- a/docs/adr/adr-025-docling-serve-sidecar.md
+++ b/docs/adr/adr-025-docling-serve-sidecar.md
@@ -21,8 +21,8 @@ Replace in-process Docling with [docling-serve](https://github.com/docling-proje
 
 The main WikiMind container calls `POST /v1/convert/source` on the sidecar to extract PDF content. The sidecar runs as:
 
-- A Docker Compose service in dev/staging
-- A separate Fly.io app (`wikimind-docling`) on the internal network in production
+- A Docker Compose service in dev
+- A separate Fly.io app (`wikimind-docling`) on the internal network in the cloud, shared by production and the ephemeral CI staging environment (the sidecar is stateless and scale-to-zero, so a dedicated staging copy isn't warranted)
 
 ## Consequences
 

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,20 +1,14 @@
 # fly.staging.toml — Fly.io deployment for WikiMind staging environment.
 #
-# Pre-prod environment used by CI to run smoke tests before promoting
-# to production.  Same machine specs as production (fly.toml).
+# EPHEMERAL pre-prod gate: the deploy workflow creates the staging app,
+# volume, and Postgres from scratch, deploys, smoke-tests, and destroys
+# the whole stack afterwards (see .github/workflows/deploy.yml). Nothing
+# staging-related runs between deploys.  Same machine specs as
+# production (fly.toml).
 #
-# First-time setup:
-#   fly apps create wikimind-staging
-#   fly volumes create wikimind_staging_data --region ord --size 1 --app wikimind-staging
-#   fly postgres attach wikimind-staging-db --app wikimind-staging
-#   fly secrets set --app wikimind-staging \
-#     ANTHROPIC_API_KEY=... \
-#     WIKIMIND_AUTH__JWT_SECRET_KEY=$(openssl rand -hex 32) \
-#     WIKIMIND_AUTH__GOOGLE_CLIENT_ID=... \
-#     WIKIMIND_AUTH__GOOGLE_CLIENT_SECRET=...
-#
-# Manual deploy:
-#   fly deploy --config fly.staging.toml --remote-only
+# There is no manual first-time setup — CI provisions everything,
+# including secrets and the Redis URL (shared self-hosted Redis on
+# DB index 1; production uses DB 0).
 
 app = "wikimind-staging"
 primary_region = "ord"
@@ -25,9 +19,10 @@ primary_region = "ord"
 [env]
   WIKIMIND_SERVER__HOST = "0.0.0.0"
   WIKIMIND_SERVER__PORT = "7842"
-  # Staging uses its own Docling sidecar (wikimind-staging-docling) to avoid
-  # affecting production during smoke tests.
-  WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-staging-docling.internal:5001"
+  # Staging shares the production Docling sidecar — it is stateless and
+  # scale-to-zero, and the smoke tests don't exercise PDF conversion, so
+  # a dedicated per-run sidecar (a 4GB-image deploy) isn't worth it.
+  WIKIMIND_DOCLING_SERVE_URL = "http://wikimind-docling.internal:5001"
 
 [http_service]
   internal_port = 7842


### PR DESCRIPTION
## Problem

The June Fly.io invoice was ~$61/mo. About $25/mo of that was the staging environment: a 24/7 clone of production (web + worker machines, Postgres cluster, volume) plus a leftover managed Upstash Redis — all to serve as a smoke-test gate that's actually exercised for about ten minutes per deploy.

## Solution

Staging now only exists while a deploy is running. The pipeline provisions a fresh staging stack, smoke-tests it, promotes to production, and destroys staging — pass or fail.

- **Clean-slate provisioning**: `deploy-staging` destroys any leftovers, then creates the app, volume, and Postgres, attaches, and sets secrets. Destroy-then-create (rather than create-if-absent) is immune to partial state from a failed teardown.
- **Fresh empty DB per run is safe**: migrations run via the alembic `release_command`; the smoke-test JWT resolves `user_id` from its `sub` claim with no DB lookup (`src/wikimind/api/deps.py`); every checked endpoint returns a valid empty array on a fresh DB.
- **New `teardown-staging` job** with `if: always()` destroys `wikimind-staging` + `wikimind-staging-db` after the smoke gate.
- **Redis**: staging queues on the shared self-hosted `wikimind-redis` at **DB index 1** (prod uses DB 0). No dedicated staging Redis. *(Already live: I repointed the running staging at DB 1 and destroyed the Upstash instance — verified healthy, worker connected, `background_mode: arq`.)*
- **Docling**: staging reuses the prod sidecar (stateless, scale-to-zero) instead of deploying its own 4GB-image copy per run. `wikimind-staging-docling` is no longer referenced and will be destroyed after this merges.

## Changes

- `.github/workflows/deploy.yml` — provision/teardown jobs, staging Redis URL staged by CI, staging docling deploy removed, header docs rewritten
- `fly.staging.toml` — docling URL → prod sidecar; header notes the ephemeral model
- `README.md`, `docs/adr/adr-025-docling-serve-sidecar.md` — deploy-flow descriptions updated

## Notes

- First deploy after merge replaces the current always-on staging stack automatically (clean-slate provision + teardown). I'll destroy `wikimind-staging-docling` manually once this lands.
- Trade-off: ~2 min extra per deploy for Postgres provisioning (`deploy-staging` timeout bumped 10 → 15 min); staging DB state never persists between runs.
- Companion PR #831 handles prod web scale-to-zero + the uptime monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)