### PR TITLE
fix(deps): upgrade mcp 1.27.1 -> 1.28.1 (CVE-2026-52869)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2265,7 +2265,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2283,9 +2283,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458 }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260 },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

CVE-2026-52869 (HIGH) against `mcp 1.27.1` was published to the Trivy vulnerability DB **after** #833 passed on July 16. Result: main's post-merge Docker build failed the CVE scan (so the #833 deploy was skipped — production is untouched), and PR #832's rebased checks fail on the same finding.

## Solution

Lockfile-only bump: `mcp` 1.27.1 → 1.28.1 (covers the 1.27.2 fix). `make verify` passes locally: 2134 tests, all checks green.

## Notes

- Merge before #832/#831; I'll rebase #832 on top so its scan re-runs clean.
- This is the third newly-published-CVE block in four days. If the cadence keeps up, options are: pin Trivy to fail only on CVEs with released fixes older than N days, or accept the friction as the cost of a hard HIGH gate. Worth a think, not urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)