### PR TITLE
chore(ci): 7-day grace period for newly published HIGH CVEs in Trivy scan

### DIFF
--- a/.github/trivy/ignore-policy.rego
+++ b/.github/trivy/ignore-policy.rego
@@ -1,0 +1,28 @@
+# Grace period for freshly published advisories.
+#
+# The Docker workflow fails the build on any HIGH/CRITICAL CVE with an
+# available fix. Advisories are published daily, so a PR that was green
+# at review time can go red at merge time on a finding unrelated to its
+# changes — this happened three times in four days (#833, #835, and the
+# post-#833 deploy that was skipped on main).
+#
+# This policy ignores HIGH vulnerabilities published within the last
+# 7 days, giving a window to bump the dependency in an orderly PR
+# instead of freezing every in-flight merge. After 7 days the scan
+# fails as before, so nothing can be ignored indefinitely.
+#
+# CRITICAL vulnerabilities are never ignored — they block immediately.
+#
+# Findings with no parseable PublishedDate fail closed (not ignored).
+
+package trivy
+
+import rego.v1
+
+default ignore := false
+
+ignore if {
+	input.Severity == "HIGH"
+	published := time.parse_rfc3339_ns(input.PublishedDate)
+	time.now_ns() - published < 7 * 24 * 60 * 60 * 1000000000
+}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,10 @@
 #     Every build runs Trivy on the resulting image and fails the
 #     job on CRITICAL or HIGH CVEs that have a fix available.
 #     `ignore-unfixed: true` avoids noisy failures on upstream bugs
-#     we cannot act on.
+#     we cannot act on. HIGH findings published within the last
+#     7 days are ignored (.github/trivy/ignore-policy.rego) so a
+#     same-week advisory can't freeze unrelated in-flight merges;
+#     CRITICAL findings always block immediately.
 #
 #   Tier 4 — Publish to GHCR on merge
 #     On push to main, build the `prod` target multi-arch
@@ -51,6 +54,8 @@ on:
       - "gunicorn.conf.py"
       - ".github/workflows/docker.yml"
       - ".github/workflows/deploy.yml"
+      - ".trivyignore"
+      - ".github/trivy/**"
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
@@ -72,6 +77,8 @@ on:
       - "gunicorn.conf.py"
       - ".github/workflows/docker.yml"
       - ".github/workflows/deploy.yml"
+      - ".trivyignore"
+      - ".github/trivy/**"
   schedule:
     # Weekly rebuild against the latest base image — catches bit-rot.
     - cron: "0 9 * * 1"
@@ -185,6 +192,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           trivyignores: .trivyignore
+          ignore-policy: .github/trivy/ignore-policy.rego
 
   # ---------------------------------------------------------------
   # Tier 2 — weekly rebuild from scratch against the latest base
@@ -231,6 +239,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           trivyignores: .trivyignore
+          ignore-policy: .github/trivy/ignore-policy.rego
 
   # ---------------------------------------------------------------
   # Tier 4 — publish the prod image to GHCR on merge to main


### PR DESCRIPTION
## Problem

The Trivy scan fails the build the moment a HIGH advisory is published — three times in four days, PRs that were green at review time went red at merge time on findings unrelated to their changes (#833 twice, then CVE-2026-52869/`mcp` blocking both the post-#833 deploy on main and #832's checks). A hard fail-on-publish gate freezes every in-flight merge until an emergency dep-bump PR lands.

## Solution

An OPA ignore policy (`.github/trivy/ignore-policy.rego`) wired into both scan steps:

- **HIGH** findings published within the **last 7 days** are ignored — a window to bump the dependency in an orderly PR instead of a fire drill.
- After 7 days the scan fails exactly as before — nothing can be ignored indefinitely.
- **CRITICAL** findings are never ignored; they block immediately.
- Findings without a parseable `PublishedDate` fail closed (still reported).

## Verification (local, trivy 0.70)

- 7-day policy against `python:3.11-slim`: the 2 known old HIGH CVEs are **still reported** → policy compiles, doesn't over-ignore.
- Same policy with a test 10-year window: **0 findings** → the ignore rule provably keys on `Severity` + `PublishedDate`.

## Changes

- `.github/trivy/ignore-policy.rego` — new policy
- `.github/workflows/docker.yml` — `ignore-policy:` on both scan steps (PR scan + weekly rebuild), Tier 3 header updated, `.trivyignore` + `.github/trivy/**` added to path filters so ignore-rule edits re-trigger the scan

## Notes

- Merging this (or #835) unblocks #832's CVE scan — the `mcp` advisory is 1 day old, inside the grace window. #835 remains the real fix for that CVE and should merge regardless.
- Trade-off: a genuinely exploitable HIGH gets a 7-day quiet period in CI. Dependabot/`Scan dependencies` still surface it immediately; this only changes when the *build gate* trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)