### PR TITLE
fix(ci): unblock workflow-only PRs stuck on required Postgres check

### DIFF
--- a/.github/workflows/postgres-integration-skip.yml
+++ b/.github/workflows/postgres-integration-skip.yml
@@ -1,0 +1,41 @@
+# ===============================================================
+# Postgres Integration — path-filter mirror
+# ===============================================================
+#
+# "Postgres integration tests" is a REQUIRED status check on main,
+# but postgres-integration.yml is path-filtered to code paths. A PR
+# that touches none of those paths (workflow-only or docs-only
+# changes) never gets the check reported, so it stays BLOCKED
+# forever — this deadlocked PRs #836 and #832.
+#
+# This is GitHub's documented fix: a mirror workflow with an
+# identically named job that succeeds instantly, triggered by the
+# exact inverse path filter (paths-ignore with the same list the
+# real workflow uses for paths). PRs touching code paths run the
+# real tests; PRs touching nothing relevant get the green check
+# from here. Keep the two path lists in sync.
+
+name: Postgres Integration (skip)
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths-ignore:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/postgres-integration.yml"
+
+permissions: {}
+
+jobs:
+  postgres-integration-skip:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Postgres integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: ✅  No code paths changed — Postgres tests not required
+        run: echo "No src/tests/dependency changes in this PR; reporting success for the required check."


### PR DESCRIPTION
## Problem

`Postgres integration tests` is a **required** status check on main, but `postgres-integration.yml` is path-filtered to `src/**`, `tests/**`, `pyproject.toml`, `uv.lock`. A PR that touches none of those — like #836 (workflow-only) and #832 (workflows + config + docs) — never gets the check reported, so GitHub shows it as *waiting* forever and the PR is BLOCKED even with every triggered check green.

## Solution

GitHub's documented pattern for required-but-path-filtered checks: a mirror workflow with an **identically named job** that succeeds instantly, triggered by the exact inverse filter (`paths-ignore` with the same list the real workflow uses in `paths`).

- PR touches code paths → real Postgres tests run and report the check.
- PR touches nothing relevant → mirror reports the same check name, green.
- The two lists must stay in sync (noted in a header comment in both file's terms).

## Verification

This PR is its own end-to-end test: it's workflow-only, so it deadlocks under the current setup — the mirror workflow it adds is what reports `Postgres integration tests` on it and flips it mergeable.

## Notes

- Once merged, #836 and #832 need a branch update (I'll push a rebase) so the mirror runs on them and clears BLOCKED.
- Alternative considered: dropping the required check — rejected, it's load-bearing for code PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)