### PR TITLE
fix(ci): stop amd64 builds clobbering the arm64 publish cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -251,7 +251,10 @@ jobs:
     name: publish prod image to GHCR
     needs: [build, scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 min: a cold arm64 build under QEMU takes ~30 min, which sat
+    # exactly at the old limit and cancelled two of three main builds
+    # (skipping their deploys). Warm-cache publishes are much faster.
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -300,8 +303,16 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=prod-${{ steps.cache-key.outputs.week }}
-          cache-to: type=gha,scope=prod-${{ steps.cache-key.outputs.week }},mode=max
+          # Dedicated multi-arch scope: the amd64-only `build` job writes
+          # to the plain weekly scope on every PR/push, clobbering arm64
+          # layers cached there — which forced a full ~30min QEMU rebuild
+          # on every publish. Reading both scopes keeps amd64 layer reuse;
+          # writing only the multiarch scope preserves arm64 layers
+          # between publishes.
+          cache-from: |
+            type=gha,scope=prod-multiarch-${{ steps.cache-key.outputs.week }}
+            type=gha,scope=prod-${{ steps.cache-key.outputs.week }}
+          cache-to: type=gha,scope=prod-multiarch-${{ steps.cache-key.outputs.week }},mode=max
 
   # ---------------------------------------------------------------
   # Alert — auto-create an issue when the deploy pipeline breaks


### PR DESCRIPTION
## Problem

The multi-arch GHCR publish job timed out at exactly 30 minutes on **two of the last three main builds** (#835's and #831's merge builds), cancelling the Docker run and silently skipping the deploy both times. Each needed a manual re-run to ship.

Root cause: the amd64-only `build` job (every PR, every push) writes to the same weekly GHA cache scope the publish job uses, evicting the arm64 layers publish caches there. Result: every publish rebuilds arm64 from scratch under QEMU — ~30 minutes, sitting exactly on the timeout.

## Solution

- Dedicated `prod-multiarch-<week>` cache scope for the publish job. It still reads the shared amd64 scope (layer reuse where arches overlap), but arm64 layers now persist between publishes — subsequent publishes in a week drop from ~30 min to a few minutes.
- Timeout 30 → 45 min so the one genuinely cold build per week clears the line instead of dying at 99%.

## Verification

- YAML validated; the change only touches the publish job (main-only), so PR checks exercise build+scan as usual.
- Real proof is the next two merges to main: the first publish will be cold (~30 min, now within the 45-min budget); the second should be dramatically faster off the preserved arm64 cache.

## Notes

- Alternative considered: dropping arm64 from the publish matrix. Rejected — Apple Silicon machines pull these images locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)